### PR TITLE
Adding Kafka Connect metrics (#101)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -532,15 +532,19 @@ public abstract class AbstractModel {
             Map<String, String> podAnnotations,
             ResourceRequirements resources,
             Affinity affinity,
-            List<Container> initContainers) {
+            List<Container> initContainers,
+            List<Volume> volumes,
+            List<VolumeMount> volumeMounts,
+            List<EnvVar> envVars) {
 
         Container container = new ContainerBuilder()
                 .withName(name)
                 .withImage(getImage())
-                .withEnv(getEnvVars())
+                .withEnv(envVars)
                 .withPorts(ports)
                 .withLivenessProbe(livenessProbe)
                 .withReadinessProbe(readinessProbe)
+                .withVolumeMounts(volumeMounts)
                 .withResources(resources)
                 .build();
 
@@ -564,6 +568,7 @@ public abstract class AbstractModel {
                             .withServiceAccountName(getServiceAccountName())
                             .withInitContainers(initContainers)
                             .withContainers(container)
+                            .withVolumes(volumes)
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -6,13 +6,18 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
 import io.fabric8.kubernetes.api.model.extensions.RollingUpdateDeploymentBuilder;
+import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,8 +29,11 @@ public class KafkaConnectCluster extends AbstractModel {
     // Port configuration
     protected static final int REST_API_PORT = 8083;
     protected static final String REST_API_PORT_NAME = "rest-api";
+    protected static final int METRICS_PORT = 9404;
+    protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-connect";
+    private static final String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
 
     // Configuration defaults
     protected static final String DEFAULT_IMAGE =
@@ -33,12 +41,14 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final int DEFAULT_REPLICAS = 3;
     protected static final int DEFAULT_HEALTHCHECK_DELAY = 60;
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    protected static final boolean DEFAULT_KAFKA_CONNECT_METRICS_ENABLED = false;
 
     // Configuration keys (in ConfigMap)
     public static final String KEY_IMAGE = "image";
     public static final String KEY_REPLICAS = "nodes";
     public static final String KEY_HEALTHCHECK_DELAY = "healthcheck-delay";
     public static final String KEY_HEALTHCHECK_TIMEOUT = "healthcheck-timeout";
+    public static final String KEY_METRICS_CONFIG = "metrics-config";
     public static final String KEY_JVM_OPTIONS = "jvmOptions";
     public static final String KEY_RESOURCES = "resources";
     public static final String KEY_CONNECT_CONFIG = "connect-config";
@@ -46,10 +56,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
     // Kafka Connect configuration keys (EnvVariables)
     protected static final String ENV_VAR_KAFKA_CONNECT_CONFIGURATION = "KAFKA_CONNECT_CONFIGURATION";
-
-    public static String kafkaConnectClusterName(String cluster) {
-        return cluster + KafkaConnectCluster.NAME_SUFFIX;
-    }
+    protected static final String ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED = "KAFKA_CONNECT_METRICS_ENABLED";
 
     /**
      * Constructor
@@ -60,11 +67,25 @@ public class KafkaConnectCluster extends AbstractModel {
     protected KafkaConnectCluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
         this.name = kafkaConnectClusterName(cluster);
+        this.metricsConfigName = metricsConfigName(cluster);
         this.image = DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
         this.healthCheckPath = "/";
         this.healthCheckTimeout = DEFAULT_HEALTHCHECK_TIMEOUT;
         this.healthCheckInitialDelay = DEFAULT_HEALTHCHECK_DELAY;
+        this.isMetricsEnabled = DEFAULT_KAFKA_CONNECT_METRICS_ENABLED;
+
+        this.mountPath = "/var/lib/kafka";
+        this.metricsConfigVolumeName = "metrics-config";
+        this.metricsConfigMountPath = "/opt/prometheus/config/";
+    }
+
+    public static String kafkaConnectClusterName(String cluster) {
+        return cluster + KafkaConnectCluster.NAME_SUFFIX;
+    }
+
+    public static String metricsConfigName(String cluster) {
+        return cluster + KafkaConnectCluster.METRICS_CONFIG_SUFFIX;
     }
 
     /**
@@ -85,6 +106,12 @@ public class KafkaConnectCluster extends AbstractModel {
         kafkaConnect.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
+
+        JsonObject metricsConfig = Utils.getJson(data, KEY_METRICS_CONFIG);
+        kafkaConnect.setMetricsEnabled(metricsConfig != null);
+        if (kafkaConnect.isMetricsEnabled()) {
+            kafkaConnect.setMetricsConfig(metricsConfig);
+        }
 
         kafkaConnect.setConfiguration(Utils.getKafkaConnectConfiguration(data, KEY_CONNECT_CONFIG));
         kafkaConnect.setUserAffinity(Utils.getAffinity(data.get(KEY_AFFINITY)));
@@ -117,14 +144,61 @@ public class KafkaConnectCluster extends AbstractModel {
 
         String connectConfiguration = containerEnvVars(container).getOrDefault(ENV_VAR_KAFKA_CONNECT_CONFIGURATION, "");
         kafkaConnect.setConfiguration(new KafkaConnectConfiguration(connectConfiguration));
+        Map<String, String> vars = containerEnvVars(container);
+
+        kafkaConnect.setMetricsEnabled(Utils.getBoolean(vars, ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED, DEFAULT_KAFKA_CONNECT_METRICS_ENABLED));
+        if (kafkaConnect.isMetricsEnabled()) {
+            kafkaConnect.setMetricsConfigName(metricsConfigName(cluster));
+        }
 
         return kafkaConnect;
     }
 
     public Service generateService() {
+        List<ServicePort> ports = new ArrayList<>(2);
+        ports.add(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
+        if (isMetricsEnabled()) {
+            ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
+        }
 
-        return createService("ClusterIP",
-                Collections.singletonList(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP")));
+        return createService("ClusterIP", ports);
+    }
+
+    public ConfigMap generateMetricsConfigMap() {
+        if (isMetricsEnabled()) {
+            Map<String, String> data = Collections.singletonMap(METRICS_CONFIG_FILE, getMetricsConfig().toString());
+            return createConfigMap(getMetricsConfigName(), data);
+        } else {
+            return null;
+        }
+    }
+
+    protected List<ContainerPort> getContainerPortList() {
+        List<ContainerPort> portList = new ArrayList<>(2);
+        portList.add(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP"));
+        if (isMetricsEnabled) {
+            portList.add(createContainerPort(metricsPortName, metricsPort, "TCP"));
+        }
+
+        return portList;
+    }
+
+    protected List<Volume> getVolumes() {
+        List<Volume> volumeList = new ArrayList<>(1);
+        if (isMetricsEnabled) {
+            volumeList.add(createConfigMapVolume(metricsConfigVolumeName, metricsConfigName));
+        }
+
+        return volumeList;
+    }
+
+    protected List<VolumeMount> getVolumeMounts() {
+        List<VolumeMount> volumeMountList = new ArrayList<>(1);
+        if (isMetricsEnabled) {
+            volumeMountList.add(createVolumeMount(metricsConfigVolumeName, metricsConfigMountPath));
+        }
+
+        return volumeMountList;
     }
 
     public Deployment generateDeployment() {
@@ -137,7 +211,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
-                Collections.singletonList(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP")),
+                getContainerPortList(),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 updateStrategy,
@@ -145,13 +219,18 @@ public class KafkaConnectCluster extends AbstractModel {
                 Collections.emptyMap(),
                 resources(),
                 getMergedAffinity(),
-                getInitContainers());
+                getInitContainers(),
+                getVolumes(),
+                getVolumeMounts(),
+                getEnvVars()
+                );
     }
 
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_CONFIGURATION, configuration.getConfiguration()));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -245,7 +245,11 @@ public class TopicOperator extends AbstractModel {
                 Collections.emptyMap(),
                 resources(),
                 getMergedAffinity(),
-                getInitContainers());
+                getInitContainers(),
+                null,
+                null,
+                getEnvVars()
+                );
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -129,13 +129,14 @@ public class ResourceUtils {
      * Generate ConfigMap for Kafka Connect S2I cluster
      */
     public static ConfigMap createKafkaConnectS2IClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                                  String image, int healthDelay, int healthTimeout, String connectConfig,
-                                                                  boolean insecureSourceRepo) {
+                                                                  String image, int healthDelay, int healthTimeout, String metricsCmJson,
+                                                                  String connectConfig, boolean insecureSourceRepo) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaConnectS2ICluster.KEY_IMAGE, image);
         cmData.put(KafkaConnectS2ICluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
+        cmData.put(KafkaConnectCluster.KEY_METRICS_CONFIG, metricsCmJson);
         if (connectConfig != null) {
             cmData.put(KafkaConnectS2ICluster.KEY_CONNECT_CONFIG, connectConfig);
         }
@@ -169,14 +170,15 @@ public class ResourceUtils {
      * Generate ConfigMap for Kafka Connect cluster
      */
     public static ConfigMap createKafkaConnectClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                                  String image, int healthDelay, int healthTimeout, String connectConfig) {
+                                                                  String image, int healthDelay, int healthTimeout, String metricsCmJson, String connectConfig) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaConnectCluster.KEY_IMAGE, image);
         cmData.put(KafkaConnectCluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
+        cmData.put(KafkaConnectCluster.KEY_METRICS_CONFIG, metricsCmJson);
         if (connectConfig != null) {
-            cmData.put(KafkaConnectS2ICluster.KEY_CONNECT_CONFIG, connectConfig);
+            cmData.put(KafkaConnectCluster.KEY_CONNECT_CONFIG, connectConfig);
         }
 
         ConfigMap cm = createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);

--- a/docker-images/kafka-connect/Dockerfile
+++ b/docker-images/kafka-connect/Dockerfile
@@ -1,6 +1,6 @@
 FROM strimzi/kafka-base:latest
 
-EXPOSE 8083
+EXPOSE 8083 9404
 
 # copy configs for Kafka Connect
 COPY ./config/ $KAFKA_HOME/config/

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -25,6 +25,11 @@ fi
 # directory avoids trying to create it (and logging a permission denied error)
 export LOG_DIR="$KAFKA_HOME"
 
+# enabling Prometheus JMX exporter as Java agent
+if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
+  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:/opt/prometheus/config/config.yml"
+fi
+
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then
     . ./dynamic_resources.sh
     # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -77,7 +77,7 @@ A JSON string with Kafka configuration. See section <<kafka_configuration_json_c
 A JSON string representing the storage configuration for the Kafka broker nodes. See section <<storage_configuration_json_config>> for more details.
 `kafka-metrics-config`::
 A JSON string representing the JMX exporter configuration for exposing metrics from Kafka broker nodes.
- Removing this field means having no metrics exposed.
+When this field is absent no metrics will be exposed.
 `kafka-resources`::
 A JSON string configuring the resource limits and requests for Kafka broker containers. The accepted JSON format is
 described in the <<resources_json_config>> section.
@@ -105,7 +105,8 @@ A JSON string with Zookeeper configuration. See section <<zookeeper_configuratio
 `zookeeper-storage`::
 A JSON string representing the storage configuration for the Zookeeper nodes. See section <<storage_configuration_json_config>> for more details.
 `zookeeper-metrics-config`::
-A JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes. Removing this field
+A JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes.
+When this field is absent no metrics will be exposed.
  eans having no metrics exposed.
 `zookeeper-resources`::
 A JSON string configuring the resource limits and requests for Zookeeper broker containers. The accepted JSON format is
@@ -679,6 +680,8 @@ If S2I is used (only on {OpenShiftName}), then it should be the related S2I imag
 `healthcheck-timeout`:: The timeout on the liveness and readiness probes for each Kafka Connect worker node. Default is 5.
 `connect-config`:: A JSON string with Kafka Connect configuration. See section <<kafka_connect_configuration_json_config>>
 for more details.
+`metrics-config`:: A JSON string representing the JMX exporter configuration for exposing metrics from Kafka Connect nodes.
+When this field is absent no metrics will be exposed.
 `resources`:: A JSON string configuring the resource limits and requests for Kafka Connect containers.
 The accepted JSON format is described in the <<resources_json_config>> section.
 `jvmOptions`:: A JSON string allowing the JVM running Kafka Connect to be configured.
@@ -714,6 +717,7 @@ The resources created by the Cluster Operator into the {ProductPlatformName} clu
 
 * [connect-cluster-name]-connect Deployment which is in charge to create the Kafka Connect worker node pods
 * [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
+* [connect-cluster-name]-metrics-config ConfigMap which contains the Kafka Connect metrics configuration and is mounted as a volume by the Kafka Connect pods
 
 [[kafka_connect_configuration_json_config]]
 ===== Kafka Connect configuration

--- a/examples/configmaps/cluster-operator/kafka-connect-s2i.yaml
+++ b/examples/configmaps/cluster-operator/kafka-connect-s2i.yaml
@@ -13,3 +13,7 @@ data:
     {
       "bootstrap.servers": "my-cluster-kafka:9092"
     }
+  metrics-config: |-
+    {
+      "lowercaseOutputName": true
+    }

--- a/examples/configmaps/cluster-operator/kafka-connect.yaml
+++ b/examples/configmaps/cluster-operator/kafka-connect.yaml
@@ -13,3 +13,7 @@ data:
     {
       "bootstrap.servers": "my-cluster-kafka:9092"
     }
+  metrics-config: |-
+    {
+      "lowercaseOutputName": true
+    }

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -97,3 +97,7 @@ objects:
         "offset.storage.replication.factor": "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}",
         "status.storage.replication.factor": "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
       }
+    metrics-config: |-
+      {
+        "lowercaseOutputName": true
+      }

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -96,3 +96,7 @@ objects:
         "offset.storage.replication.factor": "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}",
         "status.storage.replication.factor": "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
       }
+    metrics-config: |-
+      {
+        "lowercaseOutputName": true
+      }


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

### Type of change

- Enhancement / new feature

### Description

Configures cluster operator to allow prometheus to scrape metrics from Kafka Connect pods

Not completed yet, still need to make changes for Kafka Connect S2I metrics

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

