### PR TITLE
remove annotations

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -85,7 +85,6 @@ public abstract class AbstractModel {
     protected String name;
 
     protected final int metricsPort = 9404;
-    private final String metricsPath = "/metrics";
     protected final String metricsPortName = "kafkametrics";
     protected boolean isMetricsEnabled;
 
@@ -159,27 +158,6 @@ public abstract class AbstractModel {
 
     protected Map<String, String> getLabelsWithName(String name) {
         return labels.withName(name).toMap();
-    }
-
-    /**
-     * Returns a map with the prometheus annotations:
-     * <pre><code>
-     * prometheus.io/scrape: "true"
-     * prometheus.io/path: "/metrics"
-     * prometheus.io/port: "9404"
-     * </code></pre>
-     * if metrics are enabled, otherwise returns the empty map.
-     */
-    protected Map<String, String> getPrometheusAnnotations() {
-        if (isMetricsEnabled()) {
-            Map<String, String> annotations = new HashMap<>(3);
-            annotations.put("prometheus.io/scrape", Boolean.toString(isMetricsEnabled()));
-            annotations.put("prometheus.io/path", metricsPath);
-            annotations.put("prometheus.io/port", Integer.toString(metricsPort));
-            return annotations;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     public boolean isMetricsEnabled() {
@@ -510,7 +488,6 @@ public abstract class AbstractModel {
                         .withNewMetadata()
                             .withName(name)
                             .withLabels(getLabelsWithName())
-                            .withAnnotations(getPrometheusAnnotations())
                         .endMetadata()
                         .withNewSpec()
                             .withServiceAccountName(getServiceAccountName())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -246,8 +246,11 @@ public class KafkaCluster extends AbstractModel {
      * @return List with generated ports
      */
     private List<ServicePort> getServicePorts() {
-        List<ServicePort> ports = new ArrayList<>(1);
+        List<ServicePort> ports = new ArrayList<>(2);
         ports.add(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP"));
+        if (isMetricsEnabled()) {
+            ports.add(createServicePort(metricsPortName, metricsPort, metricsPort, "TCP"));
+        }
         return ports;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -31,6 +31,8 @@ public class ZookeeperCluster extends AbstractModel {
     protected static final String CLUSTERING_PORT_NAME = "clustering";
     protected static final int LEADER_ELECTION_PORT = 3888;
     protected static final String LEADER_ELECTION_PORT_NAME = "leader-election";
+    protected static final int METRICS_PORT = 9404;
+    protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-zookeeper";
     private static final String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
@@ -185,9 +187,13 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     public Service generateService() {
+        List<ServicePort> ports = new ArrayList<>(2);
+        if (isMetricsEnabled()) {
+            ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
+        }
+        ports.add(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP"));
 
-        return createService("ClusterIP",
-                Collections.singletonList(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP")));
+        return createService("ClusterIP", ports);
     }
 
     public Service generateHeadlessService() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -121,7 +121,7 @@ public abstract class AbstractAssemblyOperator {
                     ConfigMap cm = configMapOperations.get(namespace, assemblyName);
 
                     if (cm != null) {
-                        log.info("{}: assembly {} should be created or updated", reconciliation, assemblyName);
+                        log.info("{}: Assembly {} should be created or updated", reconciliation, assemblyName);
                         createOrUpdate(reconciliation, cm, createResult -> {
                             lock.release();
                             log.debug("{}: Lock {} released", reconciliation, lockName);
@@ -136,7 +136,7 @@ public abstract class AbstractAssemblyOperator {
                             }
                         });
                     } else {
-                        log.info("{}: assembly {} should be deleted", reconciliation, assemblyName);
+                        log.info("{}: Assembly {} should be deleted", reconciliation, assemblyName);
                         delete(reconciliation, deleteResult -> {
                             lock.release();
                             log.debug("{}: Lock {} released", reconciliation, lockName);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -58,7 +58,7 @@ public class KafkaClusterTest {
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headful.getSpec().getSelector());
-        assertEquals(1, headful.getSpec().getPorts().size());
+        assertEquals(2, headful.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -52,9 +52,11 @@ public class ZookeeperClusterTest {
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster)), headful.getSpec().getSelector());
-        assertEquals(1, headful.getSpec().getPorts().size());
-        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
+        assertEquals(2, headful.getSpec().getPorts().size());
+        assertEquals(ZookeeperCluster.METRICS_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
+        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(ZookeeperCluster.METRICS_PORT), headful.getSpec().getPorts().get(0).getPort());
+        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headful.getSpec().getPorts().get(1).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
     }
 

--- a/metrics/examples/grafana/kafka-dashboard.json
+++ b/metrics/examples/grafana/kafka-dashboard.json
@@ -83,7 +83,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "rate(process_cpu_seconds_total{job=\"kafka_job\"}[1m])",
+                "expr": "rate(process_cpu_seconds_total{job=\"kafka_pod_job\"}[1m])",
                 "intervalFactor": 2,
                 "legendFormat": "{{kubernetes_pod_name}}",
                 "metric": "process_cpu_seconds_total",
@@ -163,7 +163,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum without(area)(jvm_memory_bytes_used{job=\"kafka_job\"})",
+                "expr": "sum without(area)(jvm_memory_bytes_used{job=\"kafka_pod_job\"})",
                 "intervalFactor": 2,
                 "legendFormat": "{{kubernetes_pod_name}}",
                 "metric": "jvm_memory_bytes_used",
@@ -243,7 +243,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum without(gc)(rate(jvm_gc_collection_seconds_sum{job=\"kafka_job\"}[5m]))",
+                "expr": "sum without(gc)(rate(jvm_gc_collection_seconds_sum{job=\"kafka_pod_job\"}[5m]))",
                 "intervalFactor": 2,
                 "legendFormat": "{{kubernetes_pod_name}}",
                 "metric": "jvm_gc_collection_seconds_sum",
@@ -329,7 +329,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_messagesin_total{job=\"kafka_job\",topic!=\"\"}[5m]))",
+                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_messagesin_total{job=\"kafka_pod_job\",topic!=\"\",topic!=\"__consumer_offsets\"}[5m]))",
                 "intervalFactor": 2,
                 "legendFormat": "{{topic}}",
                 "metric": "kafka_server_brokertopicmetrics_messagesin_total",
@@ -407,7 +407,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_bytesin_total{job=\"kafka_job\",topic!=\"\"}[5m]))",
+                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_bytesin_total{job=\"kafka_pod_job\",topic!=\"\",topic!=\"__consumer_offsets\"}[5m]))",
                 "intervalFactor": 2,
                 "legendFormat": "{{topic}}",
                 "metric": "kafka_server_brokertopicmetrics_bytesin_total",
@@ -485,7 +485,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_bytesout_total{job=\"kafka_job\",topic!=\"\"}[5m]))",
+                "expr": "sum without(instance)(rate(kafka_server_brokertopicmetrics_bytesout_total{job=\"kafka_pod_job\",topic!=\"\",topic!=\"__consumer_offsets\"}[5m]))",
                 "intervalFactor": 2,
                 "legendFormat": "{{topic}}",
                 "metric": "kafka_server_brokertopicmetrics_bytesin_total",

--- a/metrics/examples/prometheus/kubernetes.yaml
+++ b/metrics/examples/prometheus/kubernetes.yaml
@@ -43,7 +43,7 @@ data:
       scrape_interval: 15s
       evaluation_interval: 15s
     scrape_configs:
-      - job_name: 'kafka_job'
+      - job_name: 'kafka_pod_job'
         kubernetes_sd_configs:
           - role: pod
         relabel_configs:


### PR DESCRIPTION
### Type of change
- Enhancement / new feature
### Description
Removing prometheus annotations. Improving basic prometheus configuration to provide support for `pod`, `endpoints` and `service` roles.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging https://github.com/strimzi/strimzi-kafka-operator/issues/459

