### PR TITLE
Implemented apossible way to provide a way to easely discover stimzi …

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -101,7 +101,7 @@
 
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
-            <property name="max" value="45"/>
+            <property name="max" value="46"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -393,11 +393,11 @@ public abstract class AbstractModel {
         return probe;
     }
 
-    protected Service createService(String type, List<ServicePort> ports) {
+    protected Service createService(String type, AssemblySubType assemblySubType, List<ServicePort> ports) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithName())
+                    .withLabels(labels.withName(name).withSubType(assemblySubType).toMap())
                     .withNamespace(namespace)
                 .endMetadata()
                 .withNewSpec()
@@ -410,15 +410,15 @@ public abstract class AbstractModel {
         return service;
     }
 
-    protected Service createHeadlessService(String name, List<ServicePort> ports) {
-        return createHeadlessService(name, ports, Collections.emptyMap());
+    protected Service createHeadlessService(String name, AssemblySubType assemblySubType, List<ServicePort> ports) {
+        return createHeadlessService(name, assemblySubType, ports, Collections.emptyMap());
     }
 
-    protected Service createHeadlessService(String name, List<ServicePort> ports, Map<String, String> annotations) {
+    protected Service createHeadlessService(String name, AssemblySubType assemblySubType, List<ServicePort> ports, Map<String, String> annotations) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithName(name))
+                    .withLabels(labels.withName(name).withSubType(assemblySubType).toMap())
                     .withNamespace(namespace)
                     .withAnnotations(annotations)
                 .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AssemblySubType.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AssemblySubType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+public enum AssemblySubType {
+
+    KAFKA("kafka"),
+    KAFKA_HEADLESS("kafka-headless"),
+    ZOOKEEPER("zookeeper"),
+    ZOOKEEPER_HEADLESS("zookeeper-headless"),
+    KAFKA_CONNECT("kafka-connect"),
+    KAFKA_CONNECT_HEADLESS("kafka-connect-headless"),
+    KAFKA_CONNECT_S2I("kafka-connect-s2i"),
+    KAFKA_CONNECT_S2I_HEADLESS("kafka-connect-s2i-headless");
+
+    public final String name;
+
+    AssemblySubType(String name) {
+        this.name = name;
+    }
+
+    public String toString() {
+        return name;
+    }
+
+    public static AssemblySubType fromName(String name) {
+        switch (name) {
+            case "kafka":
+                return AssemblySubType.KAFKA;
+            case "kafka-headless":
+                return AssemblySubType.KAFKA_HEADLESS;
+            case "zookeeper":
+                return AssemblySubType.ZOOKEEPER;
+            case "zookeeper-headless":
+                return AssemblySubType.ZOOKEEPER_HEADLESS;
+            case "kafka-connect":
+                return AssemblySubType.KAFKA_CONNECT;
+            case "kafka-connect-headless":
+                return AssemblySubType.KAFKA_CONNECT_HEADLESS;
+            case "kafka-connect-s2i":
+                return AssemblySubType.KAFKA_CONNECT_S2I;
+            case "kafka-connect-s2i-headless":
+                return AssemblySubType.KAFKA_CONNECT_S2I_HEADLESS;
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -272,7 +272,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public Service generateService() {
 
-        return createService("ClusterIP", getServicePorts());
+        return createService("ClusterIP", AssemblySubType.KAFKA, getServicePorts());
     }
 
     /**
@@ -281,7 +281,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public Service generateHeadlessService() {
         Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-        return createHeadlessService(headlessName, getHeadlessServicePorts(), annotations);
+        return createHeadlessService(headlessName, AssemblySubType.KAFKA_HEADLESS, getHeadlessServicePorts(), annotations);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -161,7 +161,7 @@ public class KafkaConnectCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createService("ClusterIP", ports);
+        return createService("ClusterIP", AssemblySubType.KAFKA_CONNECT, ports);
     }
 
     public ConfigMap generateMetricsConfigMap() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -9,6 +9,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.openshift.api.model.BinaryBuildSource;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
@@ -29,6 +31,8 @@ import io.fabric8.openshift.api.model.TagReference;
 import io.fabric8.openshift.api.model.TagReferencePolicyBuilder;
 import io.vertx.core.json.JsonObject;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaConnectS2ICluster extends KafkaConnectCluster {
@@ -55,6 +59,17 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     private KafkaConnectS2ICluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
         setImage(DEFAULT_IMAGE);
+    }
+
+    @Override
+    public Service generateService() {
+        List<ServicePort> ports = new ArrayList<>(2);
+        ports.add(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
+        if (isMetricsEnabled()) {
+            ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
+        }
+
+        return createService("ClusterIP", AssemblySubType.KAFKA_CONNECT_S2I, ports);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Labels.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Labels.java
@@ -40,6 +40,12 @@ public class Labels {
     public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "type";
 
     /**
+     * The sub type of Strimzi assembly piece.
+     * @see AssemblySubType
+     */
+    public static final String STRIMZI_SUB_TYPE_LABEL = STRIMZI_DOMAIN + "subtype";
+
+    /**
      * The Strimzi cluster the resource is part of.
      * The value is the cluster name (i.e. the name of the cluster CM)
      */
@@ -73,6 +79,14 @@ public class Labels {
     public static AssemblyType type(HasMetadata resource) {
         String type = resource.getMetadata().getLabels().get(Labels.STRIMZI_TYPE_LABEL);
         return type != null ? AssemblyType.fromName(type) : null;
+    }
+
+    /**
+     * Returns the value of the {@code strimzi.io/subtype} label of the given {@code resource}.
+     */
+    public static AssemblySubType subtype(HasMetadata resource) {
+        String subtype = resource.getMetadata().getLabels().get(Labels.STRIMZI_SUB_TYPE_LABEL);
+        return subtype != null ? AssemblySubType.fromName(subtype) : null;
     }
 
     /**
@@ -132,10 +146,24 @@ public class Labels {
     }
 
     /**
+     * The same labels as this instance, but with the given {@code subtype} for the {@code strimzi.io/subtype} key.
+     */
+    public Labels withSubType(AssemblySubType subtype) {
+        return with(STRIMZI_SUB_TYPE_LABEL, subtype.toString());
+    }
+
+    /**
      * The same labels as this instance, but without any {@code strimzi.io/type} key.
      */
     public Labels withoutType() {
         return without(STRIMZI_TYPE_LABEL);
+    }
+
+    /**
+     * The same labels as this instance, but without any {@code strimzi.io/subtype} key.
+     */
+    public Labels withoutSubType() {
+        return without(STRIMZI_SUB_TYPE_LABEL);
     }
 
     /**
@@ -188,6 +216,13 @@ public class Labels {
     }
 
     /**
+     * A singleton instance with the given {@code subtype} for the {@code strimzi.io/subtype} key.
+     */
+    public static Labels forSubType(AssemblySubType subtype) {
+        return new Labels(singletonMap(STRIMZI_SUB_TYPE_LABEL, subtype.toString()));
+    }
+
+    /**
      * A singleton instance with the given {@code kind} for the {@code strimzi.io/kind} key.
      */
     public static Labels forKind(String kind) {
@@ -200,6 +235,14 @@ public class Labels {
     public AssemblyType type() {
         String type = labels.get(STRIMZI_TYPE_LABEL);
         return type != null ? AssemblyType.fromName(type) : null;
+    }
+
+    /**
+     * Return the value of the {@code strimzi.io/subtype}.
+     */
+    public AssemblySubType subtype() {
+        String subtype = labels.get(STRIMZI_SUB_TYPE_LABEL);
+        return subtype != null ? AssemblySubType.fromName(subtype) : null;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -195,12 +195,12 @@ public class ZookeeperCluster extends AbstractModel {
         }
         ports.add(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP"));
 
-        return createService("ClusterIP", ports);
+        return createService("ClusterIP", AssemblySubType.ZOOKEEPER, ports);
     }
 
     public Service generateHeadlessService() {
         Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-        return createHeadlessService(headlessName, getServicePortList(), annotations);
+        return createHeadlessService(headlessName, AssemblySubType.ZOOKEEPER_HEADLESS, getServicePortList(), annotations);
     }
 
     public StatefulSet generateStatefulSet(boolean isOpenShift) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -137,10 +137,15 @@ public class KafkaConnectClusterTest {
         assertEquals("ClusterIP", svc.getSpec().getType());
         Map<String, String> expectedLabels = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                Labels.STRIMZI_SUB_TYPE_LABEL, "kafka-connect",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        Map<String, String> expectedSelector = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
         assertEquals(expectedLabels, svc.getMetadata().getLabels());
-        assertEquals(expectedLabels, svc.getSpec().getSelector());
+        assertEquals(expectedSelector, svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -145,9 +145,15 @@ public class KafkaConnectS2IClusterTest {
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_CLUSTER_LABEL, cluster,
                 Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i",
+                Labels.STRIMZI_SUB_TYPE_LABEL, "kafka-connect-s2i",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        Map<String, String> expectedSelector = ResourceUtils.labels(
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_CLUSTER_LABEL, cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i",
                 Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
         assertEquals(expectedLabels, svc.getMetadata().getLabels());
-        assertEquals(expectedLabels, svc.getSpec().getSelector());
+        assertEquals(expectedSelector, svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());


### PR DESCRIPTION
…kafka service deployed in an Openshift cluster

fix #504

### Type of change

- Enhancement / new feature


### Description

Implemented apossible way to provide a way to easely discover stimzi kafka service deployed in an Openshift cluster, see #504 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

