### PR TITLE
Add new default options for Kafka brokers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -8,6 +8,7 @@ package io.strimzi.operator.cluster.model;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
+import java.util.Properties;
 
 import static java.util.Arrays.asList;
 
@@ -16,6 +17,7 @@ import static java.util.Arrays.asList;
  */
 public class KafkaConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_OPTIONS;
+    private static final Properties DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(
@@ -36,6 +38,10 @@ public class KafkaConfiguration extends AbstractConfiguration {
                 "zookeeper.set.acl",
                 "authorizer.",
                 "super.user");
+
+        DEFAULTS = new Properties();
+        DEFAULTS.setProperty("controlled.shutdown.enable", "true");
+        DEFAULTS.setProperty("auto.leader.rebalance.enable", "true");
     }
 
     /**
@@ -46,7 +52,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
      *                      pairs.
      */
     public KafkaConfiguration(String configuration) {
-        super(configuration, FORBIDDEN_OPTIONS);
+        super(configuration, FORBIDDEN_OPTIONS, DEFAULTS);
     }
 
     /**
@@ -56,6 +62,6 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConfiguration(JsonObject jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -13,11 +13,12 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.vertx.core.json.JsonObject;
-import org.junit.Rule;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import static io.strimzi.operator.cluster.ResourceUtils.labels;
 import static junit.framework.TestCase.fail;
@@ -138,7 +139,7 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
+        assertEquals("controlled.shutdown.enable=true\nauto.leader.rebalance.enable=true\nfoo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
 
         if (cm.getData().get("kafka-storage") != null) {
 

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -261,6 +261,13 @@ below.
 }
 ----
 
+Selected options have default values:
+
+* `controlled.shutdown.enable` with default value `true`
+* `auto.leader.rebalance.enable` with default value `true`
+
+These options will be automatically configured in case they are not present in the `kafka-config` field.
+
 NOTE:: The Cluster Operator doesn't validate the provided configuration. When invalid configuration is provided, the
 Kafka cluster might not start or might become unstable. In such cases, the configuration in the `kafka-config` field
 should be fixed and the cluster operator will roll out the new configuration to all Kafka brokers.

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -17,13 +17,6 @@ import io.strimzi.test.Resources;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.Topic;
 import io.strimzi.test.k8s.Oc;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -31,6 +24,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static io.strimzi.systemtest.k8s.Events.Created;
 import static io.strimzi.systemtest.k8s.Events.Failed;
@@ -239,7 +238,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("transaction.state.log.replication.factor=1\\ndefault.replication.factor=1\\noffsets.topic.replication.factor=1\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
+            assertEquals("transaction.state.log.replication.factor=1\\ncontrolled.shutdown.enable=true\\ndefault.replication.factor=1\\nauto.leader.rebalance.enable=true\\noffsets.topic.replication.factor=1\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_CONFIGURATION")));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(30)));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.timeoutSeconds", hasItem(10)));
@@ -282,7 +281,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("transaction.state.log.replication.factor=2\\ndefault.replication.factor=2\\noffsets.topic.replication.factor=2\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
+            assertEquals("transaction.state.log.replication.factor=2\\ncontrolled.shutdown.enable=true\\ndefault.replication.factor=2\\nauto.leader.rebalance.enable=true\\noffsets.topic.replication.factor=2\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_CONFIGURATION")));
 
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(31)));


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR adds two new default values to Kafka Configuration:
* `controlled.shutdown.enable` with default value `true`
* `auto.leader.rebalance.enable` with default value `true`

These default should improve the default user experience. For more details about these options please see [here](http://kafka.apache.org/documentation/#basic_ops_restarting) and [here](http://kafka.apache.org/documentation/#basic_ops_leader_balancing).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

