### PR TITLE
Print Kubernetes resources in JSON when ST fails

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -314,7 +314,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         for (String resourceType : asList("pod", "deployment", "statefulset", "cm")) {
             for (String resourceName : ccFirst(kubeClient().list(resourceType))) {
                 LOGGER.info("Description of {} '{}':{}{}", resourceType, resourceName,
-                        System.lineSeparator(), indent(kubeClient().describe(resourceType, resourceName)));
+                        System.lineSeparator(), indent(kubeClient().getResourceAsJson(resourceType, resourceName)));
             }
         }
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Today, when the system test fails, the `StrimziRunner` prints all resources into the log file for analysis purposes. For Pods it is using `kubectl describe`. That prints lot of useful information, but it doesn't print everything. This PR uses instead `kubectl get -o json` to print the details. It contains more useful information and since JSON is also used inside many tests to gather and validate information it allows immediate comparison with the test results.