### PR TITLE
Move resource tests and template tests to regression test suite

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -114,7 +114,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     @ConnectCluster(name = "jvm-resource", connectConfig = CONNECT_CONFIG,
         nodes = 1,
         config = {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -337,7 +337,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
                             "\"requests\": {\"memory\": \"500M\", \"cpu\": \"300m\"} } }")
     })
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testJvmAndResources() {
         assertResources(NAMESPACE, "jvm-resource-cluster-kafka-0",
                 "2Gi", "400m", "2Gi", "400m");

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
@@ -48,7 +48,7 @@ public class OpenShiftTemplatesIT {
     private KubernetesClient client = new DefaultKubernetesClient();
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testStrimziEphemeral() throws IOException {
         String clusterName = "foo";
         oc.newApp("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
@@ -65,7 +65,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testStrimziPersistent() throws IOException {
         String clusterName = "bar";
         oc.newApp("strimzi-persistent", map("CLUSTER_NAME", clusterName,
@@ -82,7 +82,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testStrimziEphemeralWithCustomParameters() throws IOException {
         String clusterName = "test-ephemeral-with-custom-parameters";
         oc.newApp("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
@@ -108,7 +108,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testStrimziPersistentWithCustomParameters() throws IOException {
         String clusterName = "test-persistent-with-custom-parameters";
         oc.newApp("strimzi-persistent", map("CLUSTER_NAME", clusterName,
@@ -138,7 +138,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testConnect() {
         String clusterName = "test-connect";
         oc.newApp("strimzi-connect", map("CLUSTER_NAME", clusterName,
@@ -151,7 +151,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testS2i() {
         String clusterName = "test-s2i";
         oc.newApp("strimzi-connect-s2i", map("CLUSTER_NAME", clusterName,
@@ -164,7 +164,7 @@ public class OpenShiftTemplatesIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     public void testTopicOperator() {
         String topicName = "test-topic-cm";
         String mapName = "test-topic-cm-foo";


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Lately, the Travis tests seem to be timeouting very often (run into the 50 minute timeout). This PR moves the resource tests from the `acceptance` test group to the `regression` group. It also moves the template tests to `regression` (the templates are anyway always skipped on Travis because it uses Minikube and not Minishift.).

