### PR TITLE
Fixes some broken unit tests due to TLS support

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -184,7 +184,7 @@ public class OpenSslCertManager implements CertManager {
             ProcessBuilder processBuilder = new ProcessBuilder(cmd)
                     .redirectOutput(out)
                     .redirectErrorStream(true);
-            log.info("Running command {}", processBuilder.command());
+            log.debug("Running command {}", processBuilder.command());
 
             Process proc = processBuilder.start();
 
@@ -196,7 +196,7 @@ public class OpenSslCertManager implements CertManager {
             String stdout = new String(Files.readAllBytes(out.toPath()), Charset.defaultCharset());
 
             log.debug(stdout);
-            log.info("result {}", result);
+            log.debug("result {}", result);
 
         } catch (InterruptedException ignored) {
         } finally {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -296,7 +296,7 @@ public class KafkaCluster extends AbstractModel {
      * @param secrets The Secrets storing certificates
      */
     public void generateCertificates(List<Secret> secrets) {
-        log.info("Generating certificates");
+        log.debug("Generating certificates");
 
         try {
 
@@ -345,9 +345,9 @@ public class KafkaCluster extends AbstractModel {
                 int replicasInternalSecret = !internalSecret.isPresent() ? 0 : (internalSecret.get().getData().size() - 1) / 2;
                 int replicasClientsSecret = !clientsSecret.isPresent() ? 0 : (clientsSecret.get().getData().size() - 2) / 2;
 
-                log.info("Internal communication certificates");
+                log.debug("Internal communication certificates");
                 maybeCopyOrGenerateCerts(internalCerts, internalSecret, replicasInternalSecret, internalCA);
-                log.info("Clients communication certificates");
+                log.debug("Clients communication certificates");
                 maybeCopyOrGenerateCerts(clientsCerts, clientsSecret, replicasClientsSecret, clientsCA);
             } else {
                 throw new NoCertificateSecretException("The internal CA certificate Secret is missing");
@@ -357,7 +357,7 @@ public class KafkaCluster extends AbstractModel {
             e.printStackTrace();
         }
 
-        log.info("End generating certificates");
+        log.debug("End generating certificates");
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -37,7 +37,7 @@ public class KafkaClusterTest {
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson);
-    private final KafkaCluster kc = KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+    private final KafkaCluster kc = KafkaCluster.fromConfigMap(cm, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
     @Rule
     public ResourceTester<KafkaCluster> resourceTester = new ResourceTester<>(KafkaCluster::fromConfigMap);
 
@@ -63,7 +63,7 @@ public class KafkaClusterTest {
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headful.getSpec().getSelector());
-        assertEquals(2, headful.getSpec().getPorts().size());
+        assertEquals(3, headful.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
@@ -83,7 +83,7 @@ public class KafkaClusterTest {
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headless.getSpec().getSelector());
-        assertEquals(2, headless.getSpec().getPorts().size());
+        assertEquals(3, headless.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headless.getSpec().getPorts().get(0).getProtocol());
@@ -105,7 +105,7 @@ public class KafkaClusterTest {
                 ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout,
                         metricsCmJson, configurationJson, "{}", "{\"type\": \"ephemeral\"}",
                         null, "{\"topologyKey\": \"rack-key\"}");
-        KafkaCluster kc = KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+        KafkaCluster kc = KafkaCluster.fromConfigMap(cm, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
         StatefulSet ss = kc.generateStatefulSet(true);
         checkStatefulSet(ss, cm, true);
     }
@@ -117,7 +117,7 @@ public class KafkaClusterTest {
                 ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout,
                         metricsCmJson, configurationJson, "{}", "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\" }",
                         null, "{\"topologyKey\": \"rack-key\"}");
-        KafkaCluster kc = KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+        KafkaCluster kc = KafkaCluster.fromConfigMap(cm, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
         StatefulSet ss = kc.generateStatefulSet(false);
         checkStatefulSet(ss, cm, false);
     }
@@ -224,7 +224,7 @@ public class KafkaClusterTest {
     public void testCorruptedConfigMap() {
         try {
             ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, "{\"key.name\": oops}");
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(cm, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("key.name", e.getKey());
@@ -236,7 +236,7 @@ public class KafkaClusterTest {
         try {
             ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout,
                     "", configurationJson);
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(cm, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("JSON - empty value", e.getKey());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.operator.cluster.ResourceUtils;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -19,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -41,7 +41,7 @@ class ResourceTester<M extends AbstractModel> implements MethodRule {
 
     ResourceTester(BiFunction<ConfigMap, List<Secret>, M> fromConfigMap) {
         this.fromConfigMap = cm -> {
-            return fromConfigMap.apply(cm, Collections.emptyList());
+            return fromConfigMap.apply(cm, ResourceUtils.createKafkaClusterInitialSecrets(cm.getMetadata().getNamespace()));
         };
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The TLS support PR took a last change where an exception is raised when the internal-ca cert isn't found. This change broke the `KafkaCluster` unit tests, fixed with this PR.
This PR also set DEBUG level for TLS stuff because the INFO level drives Travis CI to have a too big log file (more than 4 MB as limit).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

