### PR TITLE
The replication interface needs to have TLS client auth set as requir…

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -430,9 +430,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     JsonNodeFactory factory = new JsonNodeFactory(false);
                     ObjectNode resources = new ObjectNode(factory);
                     ObjectNode requests = new ObjectNode(factory);
-                    requests.put("cpu", "200m").put("memory", "128Mi");
+                    requests.put("cpu", "200m").put("memory", "256Mi");
                     ObjectNode limits = new ObjectNode(factory);
-                    limits.put("cpu", "1000m").put("memory", "128Mi");
+                    limits.put("cpu", "1000m").put("memory", "256Mi");
                     resources.set("requests", requests);
                     resources.set("limits", limits);
                     containerNode.replace("resources", resources);

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,28 +1,34 @@
 #!/bin/bash
 
-export KAFKA_SECURITY="listener.name.replication.ssl.keystore.location=/tmp/kafka/replication.keystore.jks
-listener.name.replication.ssl.truststore.location=/tmp/kafka/replication.truststore.jks
-listener.name.clienttls.ssl.keystore.location=/tmp/kafka/clients.keystore.jks
-listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.jks
-ssl.keystore.password=${CERTS_STORE_PASSWORD}
-ssl.truststore.password=${CERTS_STORE_PASSWORD}"
-
 # Write the config file
 cat <<EOF
 broker.id=${KAFKA_BROKER_ID}
 broker.rack=${KAFKA_RACK}
+
 # Listeners
 listeners=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:9091,CLIENTTLS://0.0.0.0:9093
 advertised.listeners=CLIENT://$(hostname -f):9092,REPLICATION://$(hostname -f):9091,CLIENTTLS://$(hostname -f):9093
 listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:SSL,CLIENTTLS:SSL
 inter.broker.listener.name=REPLICATION
+
 # Zookeeper
 zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper:2181}
 zookeeper.connection.timeout.ms=6000
+
 # Logs
 log.dirs=${KAFKA_LOG_DIRS}
-# Security
-${KAFKA_SECURITY}
+
+# TLS / SSL
+ssl.keystore.password=${CERTS_STORE_PASSWORD}
+ssl.truststore.password=${CERTS_STORE_PASSWORD}
+
+listener.name.replication.ssl.keystore.location=/tmp/kafka/replication.keystore.jks
+listener.name.replication.ssl.truststore.location=/tmp/kafka/replication.truststore.jks
+listener.name.replication.ssl.client.auth=required
+
+listener.name.clienttls.ssl.keystore.location=/tmp/kafka/clients.keystore.jks
+listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.jks
+
 # Provided configuration
 ${KAFKA_CONFIGURATION}
 EOF


### PR DESCRIPTION
…ed. Without required TLS auth everyone can connect there.

### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The replication interface needs to be configured to require TLS client auth using

```
listener.name.replication.ssl.client.auth=required
```

Otherwise it will be completely unsecure and everyone can connect there.

Additionally, since the security config is now generated in here, we do not need to set it in variable. We can move it directly to the `cat` section.