### PR TITLE
Increase CO memeory in system tests to 256Mi. 128Mi seems not to be e…

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -430,9 +430,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     JsonNodeFactory factory = new JsonNodeFactory(false);
                     ObjectNode resources = new ObjectNode(factory);
                     ObjectNode requests = new ObjectNode(factory);
-                    requests.put("cpu", "200m").put("memory", "128Mi");
+                    requests.put("cpu", "200m").put("memory", "256Mi");
                     ObjectNode limits = new ObjectNode(factory);
-                    limits.put("cpu", "1000m").put("memory", "128Mi");
+                    limits.put("cpu", "1000m").put("memory", "256Mi");
                     resources.set("requests", requests);
                     resources.set("limits", limits);
                     containerNode.replace("resources", resources);


### PR DESCRIPTION
…nough after TLS support.

### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The system test seem to be failing because after adding TLS support, 128Mi is not enough for CO to operate. This PR increases the CO memory in system tests to 256Mi.