### PR TITLE
We should use directly PKCS12 keystores in KAfka. It will save us one…

### DIFF
--- a/docker-images/kafka/scripts/kafka_clients_certs_import.sh
+++ b/docker-images/kafka/scripts/kafka_clients_certs_import.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-keytool -keystore /tmp/kafka/clients.truststore.jks -storepass $CERTS_STORE_PASSWORD -noprompt -alias clients-ca -import -file /opt/kafka/clients-certs/clients-ca.crt
-keytool -keystore /tmp/kafka/clients.truststore.jks -storepass $CERTS_STORE_PASSWORD -noprompt -alias internal-ca -import -file /opt/kafka/internal-certs/internal-ca.crt
-openssl pkcs12 -export -in /opt/kafka/clients-certs/$HOSTNAME.crt -inkey /opt/kafka/clients-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/clients-certs/clients-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/$HOSTNAME-clients.p12
-keytool -importkeystore -deststorepass $CERTS_STORE_PASSWORD -destkeystore /tmp/kafka/clients.keystore.jks -srcstorepass $CERTS_STORE_PASSWORD -srckeystore /tmp/kafka/$HOSTNAME-clients.p12 -srcstoretype PKCS12
+keytool -keystore /tmp/kafka/clients.truststore.p12 -storepass $CERTS_STORE_PASSWORD -noprompt -alias clients-ca -import -file /opt/kafka/clients-certs/clients-ca.crt -storetype PKCS12
+RANDFILE=/tmp/.rnd openssl pkcs12 -export -in /opt/kafka/internal-certs/$HOSTNAME.crt -inkey /opt/kafka/internal-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/internal-certs/internal-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/clients.keystore.p12

--- a/docker-images/kafka/scripts/kafka_clients_certs_import.sh
+++ b/docker-images/kafka/scripts/kafka_clients_certs_import.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-keytool -keystore /tmp/kafka/clients.truststore.p12 -storepass $CERTS_STORE_PASSWORD -noprompt -alias clients-ca -import -file /opt/kafka/clients-certs/clients-ca.crt -storetype PKCS12
-RANDFILE=/tmp/.rnd openssl pkcs12 -export -in /opt/kafka/internal-certs/$HOSTNAME.crt -inkey /opt/kafka/internal-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/internal-certs/internal-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/clients.keystore.p12

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -21,13 +21,15 @@ log.dirs=${KAFKA_LOG_DIRS}
 # TLS / SSL
 ssl.keystore.password=${CERTS_STORE_PASSWORD}
 ssl.truststore.password=${CERTS_STORE_PASSWORD}
+ssl.keystore.type=PKCS12
+ssl.truststore.type=PKCS12
 
-listener.name.replication.ssl.keystore.location=/tmp/kafka/replication.keystore.jks
-listener.name.replication.ssl.truststore.location=/tmp/kafka/replication.truststore.jks
+listener.name.replication.ssl.keystore.location=/tmp/kafka/replication.keystore.p12
+listener.name.replication.ssl.truststore.location=/tmp/kafka/replication.truststore.p12
 listener.name.replication.ssl.client.auth=required
 
-listener.name.clienttls.ssl.keystore.location=/tmp/kafka/clients.keystore.jks
-listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.jks
+listener.name.clienttls.ssl.keystore.location=/tmp/kafka/clients.keystore.p12
+listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.p12
 
 # Provided configuration
 ${KAFKA_CONFIGURATION}

--- a/docker-images/kafka/scripts/kafka_internal_certs_import.sh
+++ b/docker-images/kafka/scripts/kafka_internal_certs_import.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-keytool -keystore /tmp/kafka/replication.truststore.jks -storepass $CERTS_STORE_PASSWORD -noprompt -alias internal-ca -import -file /opt/kafka/internal-certs/internal-ca.crt
-openssl pkcs12 -export -in /opt/kafka/internal-certs/$HOSTNAME.crt -inkey /opt/kafka/internal-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/internal-certs/internal-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/$HOSTNAME-internal.p12
-keytool -importkeystore -deststorepass $CERTS_STORE_PASSWORD -destkeystore /tmp/kafka/replication.keystore.jks -srcstorepass $CERTS_STORE_PASSWORD -srckeystore /tmp/kafka/$HOSTNAME-internal.p12 -srcstoretype PKCS12
+keytool -keystore /tmp/kafka/replication.truststore.p12 -storepass $CERTS_STORE_PASSWORD -noprompt -alias internal-ca -import -file /opt/kafka/internal-certs/internal-ca.crt -storetype PKCS12
+RANDFILE=/tmp/.rnd openssl pkcs12 -export -in /opt/kafka/internal-certs/$HOSTNAME.crt -inkey /opt/kafka/internal-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/internal-certs/internal-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/replication.keystore.p12

--- a/docker-images/kafka/scripts/kafka_internal_certs_import.sh
+++ b/docker-images/kafka/scripts/kafka_internal_certs_import.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-keytool -keystore /tmp/kafka/replication.truststore.p12 -storepass $CERTS_STORE_PASSWORD -noprompt -alias internal-ca -import -file /opt/kafka/internal-certs/internal-ca.crt -storetype PKCS12
-RANDFILE=/tmp/.rnd openssl pkcs12 -export -in /opt/kafka/internal-certs/$HOSTNAME.crt -inkey /opt/kafka/internal-certs/$HOSTNAME.key -chain -CAfile /opt/kafka/internal-certs/internal-ca.crt -name $HOSTNAME -password pass:$CERTS_STORE_PASSWORD -out /tmp/kafka/replication.keystore.p12

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -48,11 +48,11 @@ mkdir -p /tmp/kafka
 # Import certificates into keystore and truststore
 echo "Preparing certificates for internal communication"
 ./kafka_internal_certs_import.sh
-echo "Preparing certificates for internal communication is compelete"
+echo "Preparing certificates for internal communication is complete"
 
 echo "Preparing certificates for clients communication"
 ./kafka_clients_certs_import.sh
-echo "Preparing certificates for clients communication is compelete"
+echo "Preparing certificates for clients communication is complete"
 
 # Generate and print the config file
 echo "Starting Kafka with configuration:"

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -46,13 +46,13 @@ echo "CERTS_STORE_PASSWORD" $CERTS_STORE_PASSWORD
 mkdir -p /tmp/kafka
 
 # Import certificates into keystore and truststore
-echo "Importing certificates for internal communication"
+echo "Preparing certificates for internal communication"
 ./kafka_internal_certs_import.sh
-echo "End importing certificates"
+echo "Preparing certificates for internal communication is compelete"
 
-echo "Importing certificates for clients communication"
+echo "Preparing certificates for clients communication"
 ./kafka_clients_certs_import.sh
-echo "End importing certificates"
+echo "Preparing certificates for clients communication is compelete"
 
 # Generate and print the config file
 echo "Starting Kafka with configuration:"

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -39,7 +39,6 @@ fi
 
 # Generate temporary keystore password
 export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32})
-echo "CERTS_STORE_PASSWORD" $CERTS_STORE_PASSWORD
 
 mkdir -p /tmp/kafka
 

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -37,22 +37,14 @@ if [ -e $KAFKA_HOME/rack/rack.id ]; then
   export KAFKA_RACK=$(cat $KAFKA_HOME/rack/rack.id)
 fi
 
-
-# set up for encryption support
-
+# Generate temporary keystore password
 export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32})
 echo "CERTS_STORE_PASSWORD" $CERTS_STORE_PASSWORD
 
 mkdir -p /tmp/kafka
 
 # Import certificates into keystore and truststore
-echo "Preparing certificates for internal communication"
-./kafka_internal_certs_import.sh
-echo "Preparing certificates for internal communication is complete"
-
-echo "Preparing certificates for clients communication"
-./kafka_clients_certs_import.sh
-echo "Preparing certificates for clients communication is complete"
+./kafka_tls_prepare_certificates.sh
 
 # Generate and print the config file
 echo "Starting Kafka with configuration:"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Parameters:
+# $1: Path to the new truststore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Alias of the certificate
+function create_truststore {
+   keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
+}
+
+# Parameters:
+# $1: Path to the new keystore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Private key to be imported
+# $5: CA public key to be imported
+# $6: Alias of the certificate
+function create_keystore {
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $HOSTNAME -password pass:$2 -out $1
+}
+
+echo "Preparing certificates for internal communication"
+create_truststore /tmp/kafka/replication.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/internal-certs/internal-ca.crt internal-ca
+create_keystore /tmp/kafka/replication.keystore.p12 $CERTS_STORE_PASSWORD /opt/kafka/internal-certs/$HOSTNAME.crt /opt/kafka/internal-certs/$HOSTNAME.key /opt/kafka/internal-certs/internal-ca.crt $HOSTNAME
+echo "Preparing certificates for internal communication is complete"
+
+echo "Preparing certificates for clients communication"
+create_truststore /tmp/kafka/clients.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/clients-certs/internal-ca.crt clients-ca
+create_keystore /tmp/kafka/clients.keystore.p12 $CERTS_STORE_PASSWORD /opt/kafka/clients-certs/$HOSTNAME.crt /opt/kafka/clients-certs/$HOSTNAME.key /opt/kafka/clients-certs/clients-ca.crt $HOSTNAME
+echo "Preparing certificates for clients communication is complete"

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -26,6 +26,6 @@ create_keystore /tmp/kafka/replication.keystore.p12 $CERTS_STORE_PASSWORD /opt/k
 echo "Preparing certificates for internal communication is complete"
 
 echo "Preparing certificates for clients communication"
-create_truststore /tmp/kafka/clients.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/clients-certs/internal-ca.crt clients-ca
+create_truststore /tmp/kafka/clients.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/clients-certs/clients-ca.crt clients-ca
 create_keystore /tmp/kafka/clients.keystore.p12 $CERTS_STORE_PASSWORD /opt/kafka/clients-certs/$HOSTNAME.crt /opt/kafka/clients-certs/$HOSTNAME.key /opt/kafka/clients-certs/clients-ca.crt $HOSTNAME
 echo "Preparing certificates for clients communication is complete"


### PR DESCRIPTION
… conversion step and will get rid of some silly warnings about propriatery JKS formats

### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Currently, the Kafka log contains following ugly message:

```
Warning:
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /tmp/kafka/replication.keystore.jks -destkeystore /tmp/kafka/replication.keystore.jks -deststoretype pkcs12".
```

I guess that is some OpenJDK stuff. This PR stops using JKS stores in KAfka and instead uses PKCS12 directly.

Additionally, it removes another error message:

```
unable to write 'random state'
```

This is cased by OpenSSL being unable to write to `~/.rnd`. This has been addressed by setting `RANDFILE=/tmp/.rnd` before calling OpenSSL.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

