### PR TITLE
Use a MockCertManager in the tests, pass the same instances to places…

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -30,6 +30,8 @@ public class OpenSslCertManager implements CertManager {
 
     private static final Logger log = LogManager.getLogger(OpenSslCertManager.class);
 
+    public OpenSslCertManager() {}
+
     @Override
     public void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException {
         generateSelfSignedCert(keyFile, certFile, null, days);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
@@ -69,8 +70,9 @@ public class Main {
         DeploymentOperator deploymentOperations = new DeploymentOperator(vertx, client);
         SecretOperator secretOperations = new SecretOperator(vertx, client);
 
-        KafkaAssemblyOperator kafkaClusterOperations = new KafkaAssemblyOperator(vertx, isOpenShift, config.getOperationTimeoutMs(), configMapOperations, serviceOperations, zookeeperSetOperations, kafkaSetOperations, pvcOperations, deploymentOperations, secretOperations);
-        KafkaConnectAssemblyOperator kafkaConnectClusterOperations = new KafkaConnectAssemblyOperator(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations, secretOperations);
+        OpenSslCertManager certManager = new OpenSslCertManager();
+        KafkaAssemblyOperator kafkaClusterOperations = new KafkaAssemblyOperator(vertx, isOpenShift, config.getOperationTimeoutMs(), certManager, configMapOperations, serviceOperations, zookeeperSetOperations, kafkaSetOperations, pvcOperations, deploymentOperations, secretOperations);
+        KafkaConnectAssemblyOperator kafkaConnectClusterOperations = new KafkaConnectAssemblyOperator(vertx, isOpenShift, certManager, configMapOperations, deploymentOperations, serviceOperations, secretOperations);
 
         DeploymentConfigOperator deploymentConfigOperations = null;
         ImageStreamOperator imagesStreamOperations = null;
@@ -81,6 +83,7 @@ public class Main {
             buildConfigOperations = new BuildConfigOperator(vertx, client.adapt(OpenShiftClient.class));
             deploymentConfigOperations = new DeploymentConfigOperator(vertx, client.adapt(OpenShiftClient.class));
             kafkaConnectS2IClusterOperations = new KafkaConnectS2IAssemblyOperator(vertx, isOpenShift,
+                    certManager,
                     configMapOperations, deploymentConfigOperations,
                     serviceOperations, imagesStreamOperations, buildConfigOperations, secretOperations);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.certs.CertManager;
-import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.strimzi.operator.cluster.Reconciliation;
@@ -55,6 +54,7 @@ public abstract class AbstractAssemblyOperator {
     protected final AssemblyType assemblyType;
     protected final ConfigMapOperator configMapOperations;
     protected final SecretOperator secretOperations;
+    protected final CertManager certManager;
 
     /**
      * @param vertx The Vertx instance
@@ -64,10 +64,12 @@ public abstract class AbstractAssemblyOperator {
      * @param secretOperations For operating on Secrets
      */
     protected AbstractAssemblyOperator(Vertx vertx, boolean isOpenShift, AssemblyType assemblyType,
+                                       CertManager certManager,
                                        ConfigMapOperator configMapOperations, SecretOperator secretOperations) {
         this.vertx = vertx;
         this.isOpenShift = isOpenShift;
         this.assemblyType = assemblyType;
+        this.certManager = certManager;
         this.configMapOperations = configMapOperations;
         this.secretOperations = secretOperations;
     }
@@ -124,7 +126,6 @@ public abstract class AbstractAssemblyOperator {
                     File internalCAkeyFile = null;
                     File internalCAcertFile = null;
                     try {
-                        CertManager certManager = new OpenSslCertManager();
                         internalCAkeyFile = File.createTempFile("tls", "internal-ca-key");
                         internalCAcertFile = File.createTempFile("tls", "internal-ca-cert");
                         certManager.generateSelfSignedCert(internalCAkeyFile, internalCAcertFile, CERTS_EXPIRATION_DAYS);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.Reconciliation;
 import io.strimzi.operator.cluster.model.AssemblyType;
 import io.strimzi.operator.cluster.model.ExternalLogging;
@@ -70,6 +71,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator {
      */
     public KafkaAssemblyOperator(Vertx vertx, boolean isOpenShift,
                                  long operationTimeoutMs,
+                                 CertManager certManager,
                                  ConfigMapOperator configMapOperations,
                                  ServiceOperator serviceOperations,
                                  ZookeeperSetOperator zkSetOperations,
@@ -77,7 +79,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator {
                                  PvcOperator pvcOperations,
                                  DeploymentOperator deploymentOperations,
                                  SecretOperator secretOperations) {
-        super(vertx, isOpenShift, AssemblyType.KAFKA, configMapOperations, secretOperations);
+        super(vertx, isOpenShift, AssemblyType.KAFKA, certManager, configMapOperations, secretOperations);
         this.operationTimeoutMs = operationTimeoutMs;
         this.zkSetOperations = zkSetOperations;
         this.serviceOperations = serviceOperations;
@@ -187,7 +189,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator {
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
             future -> {
                 try {
-                    KafkaCluster kafka = KafkaCluster.fromConfigMap(assemblyCm, assemblySecrets);
+                    KafkaCluster kafka = KafkaCluster.fromConfigMap(certManager, assemblyCm, assemblySecrets);
 
                     ConfigMap logAndMetricsConfigMap = kafka.generateMetricsAndLogConfigMap(
                             kafka.getLogging() instanceof ExternalLogging ?

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.Reconciliation;
 import io.strimzi.operator.cluster.model.AssemblyType;
 import io.strimzi.operator.cluster.model.ExternalLogging;
@@ -49,11 +50,12 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator {
      * @param secretOperations For operating on Secrets
      */
     public KafkaConnectAssemblyOperator(Vertx vertx, boolean isOpenShift,
+                                        CertManager certManager,
                                         ConfigMapOperator configMapOperations,
                                         DeploymentOperator deploymentOperations,
                                         ServiceOperator serviceOperations,
                                         SecretOperator secretOperations) {
-        super(vertx, isOpenShift, AssemblyType.CONNECT, configMapOperations, secretOperations);
+        super(vertx, isOpenShift, AssemblyType.CONNECT, certManager, configMapOperations, secretOperations);
         this.serviceOperations = serviceOperations;
         this.deploymentOperations = deploymentOperations;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.Reconciliation;
 import io.strimzi.operator.cluster.model.AssemblyType;
 import io.strimzi.operator.cluster.model.ExternalLogging;
@@ -57,13 +58,14 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator {
      * @param secretOperations           For operating on Secrets
      */
     public KafkaConnectS2IAssemblyOperator(Vertx vertx, boolean isOpenShift,
+                                           CertManager certManager,
                                            ConfigMapOperator configMapOperations,
                                            DeploymentConfigOperator deploymentConfigOperations,
                                            ServiceOperator serviceOperations,
                                            ImageStreamOperator imagesStreamOperations,
                                            BuildConfigOperator buildConfigOperations,
                                            SecretOperator secretOperations) {
-        super(vertx, isOpenShift, AssemblyType.CONNECT_S2I, configMapOperations, secretOperations);
+        super(vertx, isOpenShift, AssemblyType.CONNECT_S2I, certManager, configMapOperations, secretOperations);
         this.serviceOperations = serviceOperations;
         this.deploymentConfigOperations = deploymentConfigOperations;
         this.imagesStreamOperations = imagesStreamOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -9,8 +9,10 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.operator.assembly.MockCertManager;
 import io.vertx.core.json.JsonObject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +60,7 @@ public class KafkaConnectClusterTest {
             "internal.value.converter.schemas.enable=false\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
 
+    private CertManager certManager = new MockCertManager();
     private final ConfigMap cm = ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
             healthDelay, healthTimeout, metricsCmJson, configurationJson);
     private final KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(cm);
@@ -186,7 +189,7 @@ public class KafkaConnectClusterTest {
         // type mismatch
         cm.getData().put("kafka-healthcheck-delay", "1z");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals(e.getKey(), "kafka-healthcheck-delay");
@@ -196,7 +199,7 @@ public class KafkaConnectClusterTest {
         cm.getData().clear();
         cm.getData().put("kafka-storage", "{ \"type\": \"zidan\" }");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals(e.getKey(), "kafka-storage");
@@ -210,7 +213,7 @@ public class KafkaConnectClusterTest {
                 "\"num.io.threads\": \"1\"" +
                 "}");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("default.replication.factor", e.getKey());
@@ -222,7 +225,7 @@ public class KafkaConnectClusterTest {
                 "\"num.recovery.threads.per.data.dir\": \"1\",\n" +
                 "\"num.io.threads\": \"1\"");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("JSON bracing", e.getKey());
@@ -241,7 +244,7 @@ public class KafkaConnectClusterTest {
                 "\"bool.value\": tru" +
                 "}");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("bool.value", e.getKey());
@@ -346,7 +349,7 @@ public class KafkaConnectClusterTest {
                 "\"transaction.state.log.min.isr\": ,\n" +
                 "\"default.replication.factor\": 2 }");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("Unexpected character - ,", e.getKey());
@@ -359,7 +362,7 @@ public class KafkaConnectClusterTest {
                 "\"transaction.state.log.min.isr\": 7,\n" +
                 "\"default.replication.factor\": }");
         try {
-            KafkaCluster.fromConfigMap(cm, Collections.emptyList());
+            KafkaCluster.fromConfigMap(certManager, cm, Collections.emptyList());
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
             assertEquals("Unexpected character - }", e.getKey());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -207,6 +207,7 @@ public class KafkaAssemblyOperatorMockTest {
         PvcOperator pvcops = new PvcOperator(vertx, mockClient);
         SecretOperator secretops = new SecretOperator(vertx, mockClient);
         KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+                new MockCertManager(),
                 cmops, svcops, zksops, ksops, pvcops, depops, secretops);
 
         LOGGER.info("Reconciling initially -> create");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -90,6 +90,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
@@ -157,6 +158,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -233,6 +235,7 @@ public class KafkaConnectAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -306,6 +309,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -350,6 +354,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -396,6 +401,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -432,6 +438,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
 
         Async async = context.async();
@@ -494,6 +501,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Async async = context.async(3);
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps) {
 
             @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -103,6 +103,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
@@ -204,6 +205,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -307,6 +309,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -410,6 +413,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -463,6 +467,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockBcOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -518,6 +523,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockBcOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -566,6 +572,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
 
         Async async = context.async();
@@ -645,6 +652,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Async async = context.async(3);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+                new MockCertManager(),
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps) {
 
             @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockCertManager.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockCertManager.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.certs.CertManager;
+import io.strimzi.certs.Subject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class MockCertManager implements CertManager {
+
+    private void write(File keyFile, String str) throws IOException {
+        try (FileWriter writer = new FileWriter(keyFile)) {
+            writer.write(str);
+        }
+    }
+
+    /**
+     * Generate a self-signed certificate
+     *
+     * @param keyFile  path to the file which will contain the private key
+     * @param certFile path to the file which will contain the self signed certificate
+     * @param sbj      subject information
+     * @param days     certificate duration
+     * @throws IOException
+     */
+    @Override
+    public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
+        write(keyFile, "key file for self-signed cert");
+        write(certFile, "cert file for self-signed cert");
+    }
+
+    /**
+     * Generate a self-signed certificate
+     *
+     * @param keyFile  path to the file which will contain the private key
+     * @param certFile path to the file which will contain the self signed certificate
+     * @param days     certificate duration
+     * @throws IOException
+     */
+    @Override
+    public void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException {
+        write(keyFile, "key file for self-signed cert");
+        write(certFile, "cert file for self-signed cert");
+    }
+
+    /**
+     * Generate a certificate sign request
+     *
+     * @param keyFile path to the file which will contain the private key
+     * @param csrFile path to the file which will contain the certificate sign request
+     * @param sbj     subject information
+     */
+    @Override
+    public void generateCsr(File keyFile, File csrFile, Subject sbj) throws IOException {
+        write(csrFile, "csr file");
+    }
+
+    /**
+     * Generate a certificate signed by a Certificate Authority
+     *
+     * @param csrFile path to the file containing the certificate sign request
+     * @param caKey   path to the file containing the CA private key
+     * @param caCert  path to the file containing the CA certificate
+     * @param crtFile path to the file which will contain the signed certificate
+     * @param days    certificate duration
+     * @throws IOException
+     */
+    @Override
+    public void generateCert(File csrFile, File caKey, File caCert, File crtFile, int days) throws IOException {
+        write(crtFile, "crt file");
+    }
+
+    /**
+     * Generate a certificate signed by a Certificate Authority
+     *
+     * @param csrFile path to the file containing the certificate sign request
+     * @param caKey   CA private key bytes
+     * @param caCert  CA certificate bytes
+     * @param crtFile path to the file which will contain the signed certificate
+     * @param days    certificate duration
+     * @throws IOException
+     */
+    @Override
+    public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException {
+        write(crtFile, "crt file");
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -103,6 +103,7 @@ public class PartialRollingUpdateTest {
         pvcops = new PvcOperator(vertx, bootstrapClient);
         secretops = new SecretOperator(vertx, bootstrapClient);
         KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+                new MockCertManager(),
                 cmops, svcops, zksops, ksops, pvcops, depops, secretops);
 
         LOGGER.info("bootstrap reconciliation");
@@ -142,6 +143,7 @@ public class PartialRollingUpdateTest {
         secretops = new SecretOperator(vertx, mockClient);
 
         this.kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+                new MockCertManager(),
                 cmops, svcops, zksops, ksops, pvcops, depops, secretops);
         LOGGER.info("Started test KafkaAssemblyOperator");
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.operator.assembly.MockCertManager;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,8 +34,9 @@ public class KafkaSetOperatorTest {
 
     @Before
     public void before() {
-        a = KafkaCluster.fromConfigMap(getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
-        b = KafkaCluster.fromConfigMap(getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
+        MockCertManager certManager = new MockCertManager();
+        a = KafkaCluster.fromConfigMap(certManager, getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
+        b = KafkaCluster.fromConfigMap(certManager, getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
     }
 
     private ConfigMap getConfigMap() {


### PR DESCRIPTION
… that need a CertManager via parameters

Fixes #535

### Type of change

- Bugfix

### Description

Make the unit tests run quicker by using a different impl of `CertManager` when running unit tests.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

