### PR TITLE
Added Zookeeper TLS certificates generation

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -92,7 +92,7 @@
         </module>
         <module name="ClassDataAbstractionCoupling">
             <!-- default is 7 -->
-            <property name="max" value="24"/>
+            <property name="max" value="26"/>
         </module>
         <module name="BooleanExpressionComplexity">
             <!-- default is 3 -->
@@ -102,7 +102,7 @@
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
 
-            <property name="max" value="58"/>
+            <property name="max" value="65"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -227,8 +227,9 @@ public class KafkaAssemblyOperatorMockTest {
             assertResourceRequirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCASecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsPublicKeyName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(AbstractAssemblyOperator.INTERNAL_CA_NAME).get());
             createAsync.complete();
         });
@@ -259,8 +260,9 @@ public class KafkaAssemblyOperatorMockTest {
             assertPvcs(context, expectedClaims);
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCASecretName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsPublicKeyName(CLUSTER_NAME)).get());
-            context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
             deleteAsync.complete();
         });
     }
@@ -320,8 +322,9 @@ public class KafkaAssemblyOperatorMockTest {
         updateClusterWithoutSecrets(context,
                 KafkaCluster.clientsCASecretName(CLUSTER_NAME),
                 KafkaCluster.clientsPublicKeyName(CLUSTER_NAME),
-                KafkaCluster.brokersClientsSecret(CLUSTER_NAME),
-                KafkaCluster.brokersInternalSecretName(CLUSTER_NAME));
+                KafkaCluster.brokersClientsSecretName(CLUSTER_NAME),
+                KafkaCluster.brokersInternalSecretName(CLUSTER_NAME),
+                ZookeeperCluster.nodesSecretName(CLUSTER_NAME));
     }
 
     private void updateClusterWithoutSecrets(TestContext context, String... secrets) {
@@ -738,7 +741,7 @@ public class KafkaAssemblyOperatorMockTest {
         Async updateAsync = context.async();
 
         int brokersInternalCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get().getData().size();
-        int brokersClientsCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get().getData().size();
+        int brokersClientsCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get().getData().size();
 
         int newScale = kafkaReplicas - 1;
         String deletedPod = KafkaCluster.kafkaPodName(CLUSTER_NAME, newScale);
@@ -763,7 +766,7 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertEquals(brokersInternalCerts - 2,
                     mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get().getData().size());
             context.assertEquals(brokersClientsCerts - 2,
-                    mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get().getData().size());
+                    mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get().getData().size());
 
             // TODO assert no rolling update
             updateAsync.complete();
@@ -779,7 +782,7 @@ public class KafkaAssemblyOperatorMockTest {
         Async updateAsync = context.async();
 
         int brokersInternalCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get().getData().size();
-        int brokersClientsCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get().getData().size();
+        int brokersClientsCerts = mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get().getData().size();
 
         int newScale = kafkaReplicas + 1;
         String newPod = KafkaCluster.kafkaPodName(CLUSTER_NAME, kafkaReplicas);
@@ -804,7 +807,7 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertEquals(brokersInternalCerts + 2,
                     mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersInternalSecretName(CLUSTER_NAME)).get().getData().size());
             context.assertEquals(brokersClientsCerts + 2,
-                    mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecret(CLUSTER_NAME)).get().getData().size());
+                    mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersClientsSecretName(CLUSTER_NAME)).get().getData().size());
 
             // TODO assert no rolling update
             updateAsync.complete();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
@@ -6,13 +6,16 @@ package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.assembly.MockCertManager;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.AbstractModel.containerEnvVars;
@@ -31,8 +34,9 @@ public class ZookeeperSetOperatiorTest {
 
     @Before
     public void before() {
-        a = ZookeeperCluster.fromConfigMap(getConfigMap()).generateStatefulSet(true);
-        b = ZookeeperCluster.fromConfigMap(getConfigMap()).generateStatefulSet(true);
+        MockCertManager certManager = new MockCertManager();
+        a = ZookeeperCluster.fromConfigMap(certManager, getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
+        b = ZookeeperCluster.fromConfigMap(certManager, getConfigMap(), getInitialSecrets()).generateStatefulSet(true);
     }
 
     private ConfigMap getConfigMap() {
@@ -43,6 +47,11 @@ public class ZookeeperSetOperatiorTest {
         int healthDelay = 120;
         int healthTimeout = 30;
         return ResourceUtils.createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, METRICS_CONFIG, LOG_KAFKA_CONFIG, LOG_ZOOKEEPER_CONFIG);
+    }
+
+    private List<Secret> getInitialSecrets() {
+        String clusterCmNamespace = "test";
+        return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace);
     }
 
     private StatefulSetDiff diff() {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR implement just the certificates generation for enabling Zookeeper TLS support.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

