### PR TITLE
Delegate the containers creation to the derived models

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import static java.util.Collections.singletonList;
+
 public class KafkaCluster extends AbstractModel {
 
     public static final String KAFKA_SERVICE_ACCOUNT = "strimzi-kafka";
@@ -480,15 +482,12 @@ public class KafkaCluster extends AbstractModel {
     public StatefulSet generateStatefulSet(boolean isOpenShift) {
 
         return createStatefulSet(
-                getContainerPortList(),
                 getVolumes(),
                 getVolumeClaims(),
                 getVolumeMounts(),
-                createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
-                createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
-                resources(),
                 getMergedAffinity(),
                 getInitContainers(),
+                getContainers(),
                 isOpenShift);
     }
 
@@ -680,6 +679,21 @@ public class KafkaCluster extends AbstractModel {
         }
 
         return initContainers;
+    }
+
+    @Override
+    protected List<Container> getContainers() {
+
+        return singletonList(new ContainerBuilder()
+                .withName(name)
+                .withImage(getImage())
+                .withEnv(getEnvVars())
+                .withVolumeMounts(getVolumeMounts())
+                .withPorts(getContainerPortList())
+                .withLivenessProbe(createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout))
+                .withReadinessProbe(createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout))
+                .withResources(resources())
+                .build());
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import org.junit.Test;
 
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -39,6 +41,11 @@ public class AbstractModelTest {
             @Override
             protected Properties getDefaultLogConfig() {
                 return new Properties();
+            }
+
+            @Override
+            protected List<Container> getContainers() {
+                return emptyList();
             }
         };
         am.setJvmOptions(jvmOptions(xmx, xms));
@@ -99,6 +106,11 @@ public class AbstractModelTest {
             @Override
             protected Properties getDefaultLogConfig() {
                 return new Properties();
+            }
+
+            @Override
+            protected List<Container> getContainers() {
+                return emptyList();
             }
         };
         am.setJvmOptions(opts);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourcesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourcesTest.java
@@ -4,10 +4,13 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Container;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Properties;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 
 public class ResourcesTest {
@@ -25,6 +28,11 @@ public class ResourcesTest {
             @Override
             protected Properties getDefaultLogConfig() {
                 return new Properties();
+            }
+
+            @Override
+            protected List<Container> getContainers() {
+                return emptyList();
             }
         };
         abstractModel.setResources(opts);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

Now that we are going to add a sidecar container with `stunnel' we have to support multi-containers pods. With this PR, the containers creation for StatefulSet and Deployment is delegated to the derived model classes which know how many (and what containers) they need.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

