### PR TITLE
Map custom config file into a custom path and not into the default config/

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -138,7 +138,7 @@ public class KafkaCluster extends AbstractModel {
         this.mountPath = "/var/lib/kafka";
 
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/kafka/config/";
+        this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
 
         this.initImage = DEFAULT_INIT_IMAGE;
         this.validLoggerFields = getDefaultLogConfig();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -83,7 +83,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
         this.mountPath = "/var/lib/kafka";
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/kafka/config/";
+        this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
     }
 
     public static String kafkaConnectClusterName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -117,7 +117,7 @@ public class ZookeeperCluster extends AbstractModel {
         this.mountPath = "/var/lib/zookeeper";
 
         this.logAndMetricsConfigVolumeName = "zookeeper-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/kafka/config/";
+        this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
         this.validLoggerFields = getDefaultLogConfig();
     }
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -18,7 +18,7 @@ if [ -z "$KAFKA_CONNECT_LOG_LEVEL" ]; then
 KAFKA_CONNECT_LOG_LEVEL="INFO"
 fi
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties"
+export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
 # We don't need LOG_DIR because we write no log files, but setting it to a
@@ -27,7 +27,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/config/metrics-config.yml"
+  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -20,12 +20,12 @@ export GC_LOG_ENABLED="false"
 export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/config/metrics-config.yml"
+  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 # We don't need LOG_DIR because we write no log files, but setting it to a

--- a/docker-images/zookeeper/scripts/zookeeper_run.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_run.sh
@@ -30,12 +30,12 @@ echo "Starting Zookeeper with configuration:"
 echo ""
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$ZOOKEEPER_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/config/metrics-config.yml"
+  export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The logging and metrics configuration files are currently mapped into `/opt/kafka/config`. Since this directory exists, these files will overwrite the whole directory. That causes other config files being lost and that can trigger errors in different utilities (see #538 for more details).

Kubernetes allow to map files into a directory without destroing other files in that directory using so called `subPath` mounts. But such mount are not updated when config map updates. And AFAIK this is what we rely on for Prometheus metrics where the Prometheus agent automatically reloads this file. So we cannot use it without breaking this feature.

Therefore as a result I updated the images and Cluster operator to mount these files into `/opt/kafka/custom-config`. As a separate directory, it doesn't overwrite any other files and doesn't cause any problems.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

