### PR TITLE
Detect openshift with okhttp

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>zjsonpatch</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -118,7 +118,7 @@ public class Main {
             Future<Boolean> fut = Future.future();
 
             vertx.executeBlocking(request -> {
-                try (Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "/oapi").build()).execute()) {
+                try (Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "oapi").build()).execute()) {
                     if (resp.code() == 200) {
                         log.debug("{} returned {}. We are on OpenShift.", resp.request().url(), resp.code());
                         // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -7,35 +7,35 @@ package io.strimzi.operator.cluster;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
-
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
-import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
-import io.strimzi.operator.cluster.operator.resource.SecretOperator;
-import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.strimzi.operator.cluster.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.cluster.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.cluster.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.cluster.operator.resource.DeploymentOperator;
 import io.strimzi.operator.cluster.operator.resource.ImageStreamOperator;
+import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.PvcOperator;
+import io.strimzi.operator.cluster.operator.resource.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.ServiceOperator;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
-
-import java.net.URL;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Main {
     private static final Logger log = LogManager.getLogger(Main.class.getName());
@@ -113,38 +113,35 @@ public class Main {
     }
 
     static Future<Boolean> isOnOpenShift(Vertx vertx, KubernetesClient client)  {
-        URL kubernetesApi = client.getMasterUrl();
-        Future<Boolean> fut = Future.future();
+        if (client.isAdaptable(OkHttpClient.class)) {
+            OkHttpClient ok = client.adapt(OkHttpClient.class);
+            Future<Boolean> fut = Future.future();
 
-        HttpClientOptions httpClientOptions = new HttpClientOptions();
-        httpClientOptions.setDefaultHost(kubernetesApi.getHost());
+            vertx.executeBlocking(request -> {
+                try {
+                    Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "/oapi").build()).execute();
 
-        if (kubernetesApi.getPort() == -1) {
-            httpClientOptions.setDefaultPort(kubernetesApi.getDefaultPort());
+                    if (resp.code() == 200) {
+                        log.debug("{} returned {}. We are on OpenShift.", resp.request().url(), resp.code());
+                        // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.
+                        Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
+                        request.complete(isOpenShift);
+                    } else {
+                        log.debug("{} returned {}. We are not on OpenShift.", resp.request().url(), resp.code());
+                        request.complete(Boolean.FALSE);
+                    }
+
+                } catch (IOException e) {
+                    log.error("OpenShift detection failed", e);
+                    request.fail(e);
+                }
+            }, fut.completer());
+
+            return fut;
         } else {
-            httpClientOptions.setDefaultPort(kubernetesApi.getPort());
+            log.error("Cannot adapt KubernetesClient to OkHttpClient");
+            return Future.failedFuture("Cannot adapt KubernetesClient to OkHttpClient");
         }
-
-        if (kubernetesApi.getProtocol().equals("https")) {
-            httpClientOptions.setSsl(true);
-            httpClientOptions.setTrustAll(true);
-        }
-
-        HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
-
-        httpClient.getNow("/oapi", res -> {
-            if (res.statusCode() == 200) {
-                log.debug("{} returned {}. We are on OpenShift.", res.request().absoluteURI(), res.statusCode());
-                // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.
-                Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-                fut.complete(isOpenShift);
-            } else {
-                log.debug("{} returned {}. We are not on OpenShift.", res.request().absoluteURI(), res.statusCode());
-                fut.complete(Boolean.FALSE);
-            }
-        });
-
-        return fut;
     }
 
     static void printEnvInfo() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -118,9 +118,7 @@ public class Main {
             Future<Boolean> fut = Future.future();
 
             vertx.executeBlocking(request -> {
-                try {
-                    Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "/oapi").build()).execute();
-
+                try (Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "/oapi").build()).execute()) {
                     if (resp.code() == 200) {
                         log.debug("{} returned {}. We are on OpenShift.", resp.request().url(), resp.code());
                         // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.
@@ -130,7 +128,6 @@ public class Main {
                         log.debug("{} returned {}. We are not on OpenShift.", resp.request().url(), resp.code());
                         request.complete(Boolean.FALSE);
                     }
-
                 } catch (IOException e) {
                     log.error("OpenShift detection failed", e);
                     request.fail(e);

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <fabric8.openshift-client.version>3.1.0</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>2.0.4</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
+        <okhttp.version>3.9.1</okhttp.version>
         <vertx.version>3.5.1</vertx.version>
         <log4j.version>2.11.0</log4j.version>
         <junit.version>4.12</junit.version>
@@ -72,6 +73,11 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>zjsonpatch</artifactId>
                 <version>${fabric8.zjsonpatch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Currently, the OpenShift detection is using the Vert.x HttpClient. This means that it doesn't respect the every configuration option of the Fabric8 Kubernetes client. As a result, the suer cannot really configure the things like TLS certificates, security etc. 

As an example of what it can cause is the issue #544 - while we can disable certificate validation in the Fabric8 client (environment variable `KUBERNETES_TRUST_CERTIFICATES`), we cannot do this for the Vert.x HttpClient. This PR moves the OpenShift detection from using the Vert.x HttpClient to using the OkHttp client used by Fabric8 Kube client. This client is configured in the same way as the Fabric8 client. Thanks to that if we disable certificate validation for Fabric8, we disable it also for the OpenShift detection.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

