### PR TITLE
Log exceptions from `createOrUpdate` properly

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -199,7 +199,7 @@ public abstract class AbstractAssemblyOperator {
                                         if (createResult.cause() instanceof InvalidConfigMapException) {
                                             log.error(createResult.cause().getMessage());
                                         } else {
-                                            log.error(createResult.cause().toString());
+                                            log.error("{}: createOfUpdate failed", reconciliation, createResult.cause());
                                         }
                                     } else {
                                         handler.handle(createResult);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -199,7 +199,7 @@ public abstract class AbstractAssemblyOperator {
                                         if (createResult.cause() instanceof InvalidConfigMapException) {
                                             log.error(createResult.cause().getMessage());
                                         } else {
-                                            log.error("{}: createOfUpdate failed", reconciliation, createResult.cause());
+                                            log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());
                                         }
                                     } else {
                                         handler.handle(createResult);


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When `createOrUpdate` throws an exception which is not `InvalidConfigMapException`, we should properly log it. The `toString()` method is useless because it only prints the class name but not the stack trace so it is hard to understand what went wrong.
