### PR TITLE
Fix log message which might cause confusion

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -70,7 +70,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         String namespace = ss.getMetadata().getNamespace();
         String name = ss.getMetadata().getName();
         final int replicas = ss.getSpec().getReplicas();
-        log.info("Starting rolling update of {}/{}", namespace, name);
+        log.debug("Considering rolling update of {}/{}", namespace, name);
         Future<Void> f = Future.succeededFuture();
         // Then for each replica, maybe restart it
         for (int i = 0; i < replicas; i++) {


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Today the CO is regularly printing following message:

```
2018-07-06 20:27:29 INFO  StatefulSetOperator:73 - Starting rolling update of myproject/my-cluster-kafka
```

This message can be very confusing. It suggests that its starting the RU. But in reality the method is  `maybeRollingUpdate`. So it is in fact not necessarily doing the RU. Therefore we should change from _Starting_ -> _Considering_.

Additionally, it is logging on `info` level. But we have no other `info` level message when we don't do the RU. So in most cases we just say _Considering rolling update_. That doesn't have any added value. Therefore I would suggest to move it to `debug` level. On `info` level, the information about reconciliation should be sufficient.