### PR TITLE
Make sure that Connect and Connect S2I delete their config maps

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -37,7 +37,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-connect";
-    private static final String METRICS_AND_LOG_CONFIG_SUFFIX = KafkaCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
+    private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
     // Configuration defaults
     protected static final String DEFAULT_IMAGE =

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -90,11 +90,11 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator {
     protected void delete(Reconciliation reconciliation, Handler<AsyncResult<Void>> handler) {
         String namespace = reconciliation.namespace();
         String assemblyName = reconciliation.assemblyName();
-        String name = KafkaConnectCluster.kafkaConnectClusterName(assemblyName);
+        String clusterName = KafkaConnectCluster.kafkaConnectClusterName(assemblyName);
 
-        CompositeFuture.join(serviceOperations.reconcile(namespace, name, null),
-            configMapOperations.reconcile(namespace, KafkaConnectCluster.logAndMetricsConfigName(name), null),
-            deploymentOperations.reconcile(namespace, name, null))
+        CompositeFuture.join(serviceOperations.reconcile(namespace, clusterName, null),
+            configMapOperations.reconcile(namespace, KafkaConnectCluster.logAndMetricsConfigName(assemblyName), null),
+            deploymentOperations.reconcile(namespace, clusterName, null))
             .map((Void) null).setHandler(handler);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -112,7 +112,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator {
             String clusterName = KafkaConnectS2ICluster.kafkaConnectClusterName(assemblyName);
 
             CompositeFuture.join(serviceOperations.reconcile(namespace, clusterName, null),
-                configMapOperations.reconcile(namespace, KafkaConnectS2ICluster.logAndMetricsConfigName(clusterName), null),
+                configMapOperations.reconcile(namespace, KafkaConnectS2ICluster.logAndMetricsConfigName(assemblyName), null),
                 deploymentConfigOperations.reconcile(namespace, clusterName, null),
                 imagesStreamOperations.reconcile(namespace, KafkaConnectS2ICluster.getSourceImageStreamName(clusterName), null),
                 imagesStreamOperations.reconcile(namespace, clusterName, null),


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Because of bad naming when trying to delete the config maps with logging properties and metrics, they are not deleted when Kafka Connect and Kafka Connect S2I deployments are deleted. 

There is a general chaos between the assembly name and cluster name which we probably should address at some point, but that is beyond the scope of this PR. This PR just makes things work within the current status quo.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
