### PR TITLE
Added usage of MVN_ARGS

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -51,7 +51,9 @@ environment variables:
 `make all` command can be used to triger all the tasks above - build the 
 Docker images, tag them and push them to the configured repository.
 
-During the make, Maven is used for packaging Java based applications (i.e. Cluster Operator, Topic Operator, ...) and the `mvn` command can be customized setting the `MVN_ARGS` environment variable before launching the `make all`. For example, it can be used to avoid running the unit tests just setting `MVN_ARGS=-DskipTests`.
+`make` invokes Maven for packaging Java based applications (that is, Cluster Operator, Topic Operator, ...). 
+The `mvn` command can be customized by setting the `MVN_ARGS` environment variable when launching `make all`. 
+For example, `MVN_ARGS=-DskipTests make all` can be used to avoid running the unit tests.
 
 ## Pushing images to the cluster's Docker repo
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -51,6 +51,8 @@ environment variables:
 `make all` command can be used to triger all the tasks above - build the 
 Docker images, tag them and push them to the configured repository.
 
+During the make, Maven is used for packaging Java based applications (i.e. Cluster Operator, Topic Operator, ...) and the `mvn` command can be customized setting the `MVN_ARGS` environment variable before launching the `make all`. For example, it can be used to avoid running the unit tests just setting `MVN_ARGS=-DskipTests`.
+
 ## Pushing images to the cluster's Docker repo
 
 When developing locally you might want to push the docker images to the docker


### PR DESCRIPTION
### Type of change

- Hacking documentation

### Description

Just add  a brief description on how the `MVN_ARGS` can be used during the `make all` for customizing Maven behaviour during building Java based applications.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

