### PR TITLE
Integrate crd-generator into make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 RELEASE_VERSION ?= latest
 
-SUBDIRS=docker-images certificate-manager api cluster-operator topic-operator init-kafka examples
+SUBDIRS=docker-images certificate-manager crd-generator api cluster-operator topic-operator init-kafka examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/crd-generator/Makefile
+++ b/crd-generator/Makefile
@@ -1,0 +1,11 @@
+PROJECT_NAME=crd-generator
+
+docker_build: java_install
+docker_push:
+docker_tag:
+all: docker_build docker_push
+clean: java_clean
+
+include ../Makefile.maven
+
+.PHONY: build clean release


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The `crd-generator` subproject needs to be integrated into the `make` build.