### PR TITLE
Add message to TimeoutException in AbstractReadyResourceOperator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractReadyResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractReadyResourceOperator.java
@@ -91,7 +91,8 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
                             long timeLeft = deadline - System.currentTimeMillis();
                             if (timeLeft <= 0) {
                                 log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
-                                fut.fail(new TimeoutException());
+                                String exceptionMessage = String.format("Exceeded timeoutMs of %d ms while waiting for %s %s in namespace %s to be ready", timeoutMs, resourceKind, name, namespace);
+                                fut.fail(new TimeoutException(exceptionMessage));
                             } else {
                                 // Schedule ourselves to run again
                                 vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractReadyResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractReadyResourceOperator.java
@@ -90,8 +90,8 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
                         } else {
                             long timeLeft = deadline - System.currentTimeMillis();
                             if (timeLeft <= 0) {
-                                log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
-                                String exceptionMessage = String.format("Exceeded timeoutMs of %d ms while waiting for %s %s in namespace %s to be ready", timeoutMs, resourceKind, name, namespace);
+                                String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s %s in namespace %s to be ready", timeoutMs, resourceKind, name, namespace);
+                                log.error(exceptionMessage);
                                 fut.fail(new TimeoutException(exceptionMessage));
                             } else {
                                 // Schedule ourselves to run again

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/TimeoutException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/TimeoutException.java
@@ -8,4 +8,11 @@ package io.strimzi.operator.cluster.operator.resource;
  * Thrown to indicate that timeout has been exceeded.
  */
 public class TimeoutException extends RuntimeException {
+    public TimeoutException() {
+        super();
+    }
+
+    public TimeoutException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When some of the clusters (e.g. Kafka fails to start), we get following message in the CO log:

```
2018-07-10 08:35:39 ERROR AbstractAssemblyOperator:212 - Reconciliation #0(watch) Kafka(myproject/my-cluster): createOrUpdate failed
io.strimzi.operator.cluster.operator.resource.TimeoutException: null
	at io.strimzi.operator.cluster.operator.resource.AbstractReadyResourceOperator$1.lambda$handle$1(AbstractReadyResourceOperator.java:94) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:76) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:289) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_171]
```

The `TimeoutException` doesn't help much without any message to clarify the details. Log like this would be more useful:

```
io.strimzi.operator.cluster.operator.resource.TimeoutException: Exceeded timeoutMs of 300000 ms while waiting for Pods my-cluster-kafka-0 in namespace myproject to be ready
	at io.strimzi.operator.cluster.operator.resource.AbstractReadyResourceOperator$1.lambda$handle$1(AbstractReadyResourceOperator.java:95) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:76) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:289) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339) ~[cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [cluster-operator-0.5.0-SNAPSHOT.jar:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_171]
```

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

