### PR TITLE
fix tests, typo in yaml

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -462,7 +462,7 @@ public class KafkaAssemblyOperatorTest {
         int healthDelay = 120;
         int healthTimeout = 30;
         String metricsCmJson = metrics ? METRICS_CONFIG : null;
-        return ResourceUtils.createKafkaCluster(clusterNamespace, clusterName, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfig, zooConfig, storage, tcConfig, null, LOG_ZOOKEEPER_CONFIG, LOG_KAFKA_CONFIG);
+        return ResourceUtils.createKafkaCluster(clusterNamespace, clusterName, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfig, zooConfig, storage, tcConfig, null, LOG_KAFKA_CONFIG, LOG_ZOOKEEPER_CONFIG);
     }
 
     private List<Secret> getInitialSecrets() {
@@ -593,7 +593,7 @@ public class KafkaAssemblyOperatorTest {
     public void testUpdateZkClusterLogConfig(TestContext context) {
         KafkaAssembly kafkaAssembly = getKafkaAssembly("bar");
         InlineLogging logger = new InlineLogging();
-        logger.setLoggers(singletonMap("kafka.root.logger.level", "DEBUG"));
+        logger.setLoggers(singletonMap("zookeeper.root.logger", "DEBUG"));
         kafkaAssembly.getSpec().getZookeeper().setLogging(logger);
         List<Secret> secrets = getClusterSecrets("bar",
                 kafkaAssembly.getSpec().getKafka().getReplicas(),

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -24,12 +24,12 @@ parameters:
   displayName: Number of Zookeeper cluster nodes (odd number of nodes is recommended)
   name: ZOOKEEPER_NODE_COUNT
   required: true
-  value: 3
+  value: "3"
 - description: Number of Kafka cluster nodes which will be deployed
   displayName: Number of Kafka cluster nodes
   name: KAFKA_NODE_COUNT
   required: true
-  value: 3
+  value: "3"
 - description: Number of seconds after the container has started before healthcheck probes are initiated.
   displayName: Zookeeper healthcheck initial delay
   name: ZOOKEEPER_HEALTHCHECK_DELAY


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
There were two typos (kafka switched for zookeeper) and syntax error in the template file.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

