### PR TITLE
Fix Connect S2I deployment

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -116,9 +116,12 @@ public class KafkaConnectCluster extends AbstractModel {
      */
     protected static <C extends KafkaConnectCluster> C fromSpec(KafkaConnectAssemblySpec spec, C kafkaConnect) {
         kafkaConnect.setReplicas(spec != null && spec.getReplicas() > 0 ? spec.getReplicas() : DEFAULT_REPLICAS);
-        kafkaConnect.setImage(spec != null && spec.getImage() != null ? spec.getImage() : DEFAULT_IMAGE);
         kafkaConnect.setConfiguration(new KafkaConnectConfiguration(spec != null ? spec.getConfig().entrySet() : emptySet()));
         if (spec != null) {
+            if (spec.getImage() != null) {
+                kafkaConnect.setImage(spec.getImage());
+            }
+
             kafkaConnect.setResources(spec.getResources());
             kafkaConnect.setLogging(spec.getLogging());
             kafkaConnect.setJvmOptions(spec.getJvmOptions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -37,6 +37,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     protected boolean insecureSourceRepository = false;
 
     // Configuration defaults
+    protected static final String DEFAULT_IMAGE = System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
 
     // Configuration keys (in ConfigMap)
     public static final String KEY_INSECURE_SOURCE_REPO = "insecure-source-repo";
@@ -254,7 +255,6 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         this.sourceImageBaseName = image.substring(0, image.lastIndexOf(":"));
         this.sourceImageTag = image.substring(image.lastIndexOf(":") + 1);
         this.image = name + ":" + tag;
-
     }
 
     /**

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -1,5 +1,5 @@
 apiVersion: kafka.strimzi.io/v1alpha1
-kind: KafkaConnect
+kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
 spec:


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Kafka Connect S2I currently doesn't work:
* The example YAML has a wrong kind
* There is no configuration for default S2I image. Instead it uses regular KAfka Connect image

This PR tries to check these.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

