### PR TITLE
Fix persistent Kafka example YAML file

### DIFF
--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -31,11 +31,11 @@ spec:
   zookeeper:
     replicas: 3
     readinessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     livenessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     storage:
       type: persistent-claim
       size: 1Gi


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The example YAML file for persisitent KAfka cluster is not working because it has some values as Strings instead of Integers:

```
[jscholz@jscholz strimzi]$ oc apply -f examples/kafka/kafka-persistent.yaml 
The Kafka "my-cluster" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"kafka.strimzi.io/v1alpha1", "kind":"Kafka", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"kafka.strimzi.io/v1alpha1\",\"kind\":\"Kafka\",\"metadata\":{\"annotations\":{},\"name\":\"my-cluster\",\"namespace\":\"myproject\"},\"spec\":{\"kafka\":{\"config\":{\"offsets.topic.replication.factor\":3,\"transaction.state.log.min.isr\":2,\"transaction.state.log.replication.factor\":3},\"livenessProbe\":{\"initialDelaySeconds\":15,\"timeoutSeconds\":5},\"metrics\":{\"lowercaseOutputName\":true,\"rules\":[{\"name\":\"kafka_server_$1_$2_total\",\"pattern\":\"kafka.server\\u003ctype=(.+), name=(.+)PerSec\\\\w*\\u003e\\u003c\\u003eCount\"},{\"labels\":{\"topic\":\"$3\"},\"name\":\"kafka_server_$1_$2_total\",\"pattern\":\"kafka.server\\u003ctype=(.+), name=(.+)PerSec\\\\w*, topic=(.+)\\u003e\\u003c\\u003eCount\"}]},\"readinessProbe\":{\"initialDelaySeconds\":15,\"timeoutSeconds\":5},\"replicas\":3,\"storage\":{\"deleteClaim\":false,\"size\":\"1Gi\",\"type\":\"persistent-claim\"}},\"topicOperator\":{},\"zookeeper\":{\"livenessProbe\":{\"initialDelaySeconds\":\"15\",\"timeoutSeconds\":\"5\"},\"metrics\":{\"lowercaseOutputName\":true},\"readinessProbe\":{\"initialDelaySeconds\":\"15\",\"timeoutSeconds\":\"5\"},\"replicas\":3,\"storage\":{\"deleteClaim\":false,\"size\":\"1Gi\",\"type\":\"persistent-claim\"}}}}\n"}, "name":"my-cluster", "namespace":"myproject", "creationTimestamp":"2018-07-10T14:11:37Z", "uid":"28b17e75-844b-11e8-808a-54e1ad8f71b6", "selfLink":"", "clusterName":""}, "spec":map[string]interface {}{"zookeeper":map[string]interface {}{"replicas":3, "storage":map[string]interface {}{"deleteClaim":false, "size":"1Gi", "type":"persistent-claim"}, "livenessProbe":map[string]interface {}{"initialDelaySeconds":"15", "timeoutSeconds":"5"}, "metrics":map[string]interface {}{"lowercaseOutputName":true}, "readinessProbe":map[string]interface {}{"initialDelaySeconds":"15", "timeoutSeconds":"5"}}, "kafka":map[string]interface {}{"config":map[string]interface {}{"offsets.topic.replication.factor":3, "transaction.state.log.min.isr":2, "transaction.state.log.replication.factor":3}, "livenessProbe":map[string]interface {}{"initialDelaySeconds":15, "timeoutSeconds":5}, "metrics":map[string]interface {}{"lowercaseOutputName":true, "rules":[]interface {}{map[string]interface {}{"pattern":"kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count", "name":"kafka_server_$1_$2_total"}, map[string]interface {}{"pattern":"kafka.server<type=(.+), name=(.+)PerSec\\w*, topic=(.+)><>Count", "labels":map[string]interface {}{"topic":"$3"}, "name":"kafka_server_$1_$2_total"}}}, "readinessProbe":map[string]interface {}{"initialDelaySeconds":15, "timeoutSeconds":5}, "replicas":3, "storage":map[string]interface {}{"deleteClaim":false, "size":"1Gi", "type":"persistent-claim"}}, "topicOperator":map[string]interface {}{}}}: validation failure list:
spec.zookeeper.readinessProbe.timeoutSeconds in body must be of type integer: "string"
spec.zookeeper.readinessProbe.initialDelaySeconds in body must be of type integer: "string"
spec.zookeeper.livenessProbe.initialDelaySeconds in body must be of type integer: "string"
spec.zookeeper.livenessProbe.timeoutSeconds in body must be of type integer: "string"
```

This PR should fix this.
