### PR TITLE
Mock connect test

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -41,6 +41,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-connect";
+
     private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
     // Configuration defaults

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -61,7 +61,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                                         ConfigMapOperator configMapOperations,
                                         DeploymentOperator deploymentOperations,
                                         ServiceOperator serviceOperations,
-        SecretOperator secretOperations) {
+                                        SecretOperator secretOperations) {
         super(vertx, isOpenShift, AssemblyType.CONNECT, certManager, connectOperator, secretOperations);
         this.configMapOperations = configMapOperations;
         this.serviceOperations = serviceOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -107,7 +107,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
             if (ar.failed()) ar.cause().printStackTrace();
             context.assertTrue(ar.succeeded());
             context.assertNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
-            //FIXME: context.assertNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.metricsConfigName(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.metricsConfigName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
             deleteAsync.complete();
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.operator.cluster.Reconciliation;
+import io.strimzi.operator.cluster.model.AssemblyType;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.Labels;
+import io.strimzi.operator.cluster.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.cluster.operator.resource.DeploymentOperator;
+import io.strimzi.operator.cluster.operator.resource.ServiceOperator;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+import static io.strimzi.operator.cluster.ResourceUtils.map;
+
+@RunWith(VertxUnitRunner.class)
+public class KafkaConnectAssemblyOperatorMockTest {
+
+    private static final Logger LOGGER = LogManager.getLogger(KafkaConnectAssemblyOperatorMockTest.class);
+
+    private static final String NAMESPACE = "my-namespace";
+    private static final String CLUSTER_NAME = "my-connect-cluster";
+
+    private final int replicas = 3;
+
+    private KubernetesClient mockClient;
+
+    private Vertx vertx;
+    private ConfigMap cluster;
+
+    @Before
+    public void before() {
+        this.vertx = Vertx.vertx();
+
+        this.cluster = new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+                .withLabels(Labels.forKind("cluster").withType(AssemblyType.CONNECT).toMap())
+                .endMetadata()
+                .withData(map(KafkaConnectCluster.KEY_REPLICAS, String.valueOf(replicas),
+                        KafkaConnectCluster.KEY_CONNECT_CONFIG, "{}",
+                        KafkaConnectCluster.KEY_METRICS_CONFIG, "{}",
+                        KafkaConnectCluster.KEY_RESOURCES, null))
+                .build();
+        mockClient = new MockKube().withInitialCms(Collections.singleton(cluster)).build();
+    }
+
+    @After
+    public void after() {
+        this.vertx.close();
+    }
+
+    private KafkaConnectAssemblyOperator createConnectCluster(TestContext context) {
+        ConfigMapOperator cmops = new ConfigMapOperator(vertx, mockClient);
+        ServiceOperator svcops = new ServiceOperator(vertx, mockClient);
+        DeploymentOperator depops = new DeploymentOperator(vertx, mockClient);
+        KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, true,
+                cmops, depops, svcops);
+
+        LOGGER.info("Reconciling initially -> create");
+        Async createAsync = context.async();
+        kco.reconcileAssembly(new Reconciliation("test-trigger", AssemblyType.KAFKA, NAMESPACE, CLUSTER_NAME), ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.assertTrue(ar.succeeded());
+            context.assertNotNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.metricsConfigName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            createAsync.complete();
+        });
+        createAsync.await();
+        return kco;
+    }
+
+    /** Create a cluster from a Kafka Cluster CM */
+    @Test
+    public void testCreateUpdateDelete(TestContext context) {
+        KafkaConnectAssemblyOperator kco = createConnectCluster(context);
+        LOGGER.info("Reconciling again -> update");
+        Async updateAsync = context.async();
+        kco.reconcileAssembly(new Reconciliation("test-trigger", AssemblyType.KAFKA, NAMESPACE, CLUSTER_NAME), ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.assertTrue(ar.succeeded());
+            updateAsync.complete();
+        });
+        updateAsync.await();
+        LOGGER.info("Reconciling again -> delete");
+        mockClient.configMaps().inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        Async deleteAsync = context.async();
+        kco.reconcileAssembly(new Reconciliation("test-trigger", AssemblyType.KAFKA, NAMESPACE, CLUSTER_NAME), ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.assertTrue(ar.succeeded());
+            context.assertNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            //FIXME: context.assertNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.metricsConfigName(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            deleteAsync.complete();
+        });
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
@@ -51,8 +51,6 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
-import io.strimzi.api.kafka.DoneableKafkaAssembly;
-import io.strimzi.api.kafka.model.KafkaAssembly;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mockito.invocation.InvocationOnMock;
@@ -80,7 +78,6 @@ public class MockKube {
 
     private static final Logger LOGGER = LogManager.getLogger(MockKube.class);
 
-    private final Map<String, KafkaAssembly> kafkaDb = db(emptySet(), KafkaAssembly.class, DoneableKafkaAssembly.class);
     private final Map<String, ConfigMap> cmDb = db(emptySet(), ConfigMap.class, DoneableConfigMap.class);
     private final Map<String, PersistentVolumeClaim> pvcDb = db(emptySet(), PersistentVolumeClaim.class, DoneablePersistentVolumeClaim.class);
     private final Map<String, Service> svcDb = db(emptySet(), Service.class, DoneableService.class);
@@ -107,11 +104,6 @@ public class MockKube {
 
     public MockKube withInitialSecrets(Set<Secret> initial) {
         this.secretDb.putAll(db(initial, Secret.class, DoneableSecret.class));
-        return this;
-    }
-
-    public MockKube withInitialKafkaAssembly(Set<KafkaAssembly> initial) {
-        this.kafkaDb.putAll(db(initial, KafkaAssembly.class, DoneableKafkaAssembly.class));
         return this;
     }
 
@@ -181,9 +173,6 @@ public class MockKube {
                 when(crds.withName(crd.getMetadata().getName())).thenReturn(crdResource);
                 when(mockClient.customResources(any(CustomResourceDefinition.class), any(Class.class), any(Class.class), any(Class.class))).thenAnswer(invocation -> {
                     CustomResourceDefinition crdArg = invocation.getArgument(0);
-                    Class<? extends CustomResource> crType = invocation.getArgument(1);
-                    Class<? extends KubernetesResourceList> crListType = invocation.getArgument(2);
-                    Class<? extends Doneable> crDoneableType = invocation.getArgument(3);
                     if (crd.getSpec().getGroup().equals(crdArg.getSpec().getGroup())
                             && crd.getSpec().getVersion().equals(crdArg.getSpec().getVersion())) {
                         return buildCrd((MockedCrd) mockedCrd);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This adds a test for the deletion of the Kafka Connect metrics CM. Kyle's fix was since recreated upstream by @stanlyDoge. I think, as a byproduct of his work on logging+metrics.

Fixes #101

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

