### PR TITLE
Removed all KEY constants for old ConfigMap support

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -89,21 +89,6 @@ public class KafkaCluster extends AbstractModel {
     // Kafka configuration defaults
     private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper:2181";
 
-    // Configuration keys (in ConfigMap)
-    public static final String KEY_IMAGE = "kafka-image";
-    public static final String KEY_REPLICAS = "kafka-nodes";
-    public static final String KEY_HEALTHCHECK_DELAY = "kafka-healthcheck-delay";
-    public static final String KEY_HEALTHCHECK_TIMEOUT = "kafka-healthcheck-timeout";
-    public static final String KEY_METRICS_CONFIG = "kafka-metrics-config";
-    public static final String KEY_STORAGE = "kafka-storage";
-    public static final String KEY_KAFKA_CONFIG = "kafka-config";
-    public static final String KEY_JVM_OPTIONS = "kafka-jvmOptions";
-    public static final String KEY_RESOURCES = "kafka-resources";
-    public static final String KEY_RACK = "kafka-rack";
-    public static final String KEY_INIT_IMAGE = "init-kafka-image";
-    public static final String KEY_AFFINITY = "kafka-affinity";
-    public static final String KEY_KAFKA_LOG_CONFIG = "kafka-logging";
-
     // Kafka configuration keys (EnvVariables)
     public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
     private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -52,18 +52,6 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     protected static final boolean DEFAULT_KAFKA_CONNECT_METRICS_ENABLED = false;
 
-    // Configuration keys (in ConfigMap)
-    public static final String KEY_IMAGE = "image";
-    public static final String KEY_REPLICAS = "nodes";
-    public static final String KEY_HEALTHCHECK_DELAY = "healthcheck-delay";
-    public static final String KEY_HEALTHCHECK_TIMEOUT = "healthcheck-timeout";
-    public static final String KEY_METRICS_CONFIG = "metrics-config";
-    public static final String KEY_JVM_OPTIONS = "jvmOptions";
-    public static final String KEY_RESOURCES = "resources";
-    public static final String KEY_CONNECT_CONFIG = "connect-config";
-    public static final String KEY_AFFINITY = "affinity";
-    public static final String KEY_CONNECT_LOG_CONFIG = "logging";
-
     // Kafka Connect configuration keys (EnvVariables)
     protected static final String ENV_VAR_KAFKA_CONNECT_CONFIGURATION = "KAFKA_CONNECT_CONFIGURATION";
     protected static final String ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED = "KAFKA_CONNECT_METRICS_ENABLED";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -39,9 +39,6 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     // Configuration defaults
     protected static final String DEFAULT_IMAGE = System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
 
-    // Configuration keys (in ConfigMap)
-    public static final String KEY_INSECURE_SOURCE_REPO = "insecure-source-repo";
-
     /**
      * Constructor
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -37,18 +37,14 @@ public class TopicOperator extends AbstractModel {
     // Configuration defaults
 
 
-    // Configuration keys
-    public static final String KEY_CONFIG = "topic-operator-config";
-
     // Topic Operator configuration keys
-    public static final String KEY_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
-    public static final String KEY_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
-    public static final String KEY_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
-    public static final String KEY_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String KEY_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
-    public static final String KEY_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
-    public static final String KEY_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
-    public static final String KEY_TOPIC_LOG_CONFIG = "topic-logging";
+    public static final String ENV_VAR_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
+    public static final String ENV_VAR_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
+    public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    public static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
+    public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
+    public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON
     private String kafkaBootstrapServers;
@@ -228,13 +224,13 @@ public class TopicOperator extends AbstractModel {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-        varList.add(buildEnvVar(KEY_CONFIGMAP_LABELS, topicConfigMapLabels));
-        varList.add(buildEnvVar(KEY_KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers));
-        varList.add(buildEnvVar(KEY_ZOOKEEPER_CONNECT, zookeeperConnect));
-        varList.add(buildEnvVar(KEY_WATCHED_NAMESPACE, watchedNamespace));
-        varList.add(buildEnvVar(KEY_FULL_RECONCILIATION_INTERVAL_MS, Integer.toString(reconciliationIntervalMs)));
-        varList.add(buildEnvVar(KEY_ZOOKEEPER_SESSION_TIMEOUT_MS, Integer.toString(zookeeperSessionTimeoutMs)));
-        varList.add(buildEnvVar(KEY_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
+        varList.add(buildEnvVar(ENV_VAR_CONFIGMAP_LABELS, topicConfigMapLabels));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers));
+        varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(ENV_VAR_WATCHED_NAMESPACE, watchedNamespace));
+        varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Integer.toString(reconciliationIntervalMs)));
+        varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Integer.toString(zookeeperSessionTimeoutMs)));
+        varList.add(buildEnvVar(ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -61,19 +61,6 @@ public class ZookeeperCluster extends AbstractModel {
     private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     private static final boolean DEFAULT_ZOOKEEPER_METRICS_ENABLED = false;
 
-    // Configuration keys (ConfigMap)
-    public static final String KEY_IMAGE = "zookeeper-image";
-    public static final String KEY_REPLICAS = "zookeeper-nodes";
-    public static final String KEY_HEALTHCHECK_DELAY = "zookeeper-healthcheck-delay";
-    public static final String KEY_HEALTHCHECK_TIMEOUT = "zookeeper-healthcheck-timeout";
-    public static final String KEY_METRICS_CONFIG = "zookeeper-metrics-config";
-    public static final String KEY_STORAGE = "zookeeper-storage";
-    public static final String KEY_JVM_OPTIONS = "zookeeper-jvmOptions";
-    public static final String KEY_RESOURCES = "zookeeper-resources";
-    public static final String KEY_ZOOKEEPER_CONFIG = "zookeeper-config";
-    public static final String KEY_AFFINITY = "zookeeper-affinity";
-    public static final String KEY_ZOOKEEPER_LOG_CONFIG = "zookeeper-logging";
-
     // Zookeeper configuration keys (EnvVariables)
     public static final String ENV_VAR_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
     public static final String ENV_VAR_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -64,13 +64,13 @@ public class TopicOperatorTest {
 
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_CONFIGMAP_LABELS).withValue(TopicOperator.defaultTopicConfigMapLabels(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_KAFKA_BOOTSTRAP_SERVERS).withValue(TopicOperator.defaultBootstrapServers(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_ZOOKEEPER_CONNECT).withValue(TopicOperator.defaultZookeeperConnect(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_WATCHED_NAMESPACE).withValue(tcWatchedNamespace).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(tcReconciliationInterval * 1000)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(tcZookeeperSessionTimeout * 1000)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.KEY_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_CONFIGMAP_LABELS).withValue(TopicOperator.defaultTopicConfigMapLabels(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_KAFKA_BOOTSTRAP_SERVERS).withValue(TopicOperator.defaultBootstrapServers(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(TopicOperator.defaultZookeeperConnect(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(tcWatchedNamespace).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(tcReconciliationInterval * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(tcZookeeperSessionTimeout * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
 
         return expected;
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR remove all the `KEY*` constants from model used in the old ConfigMap support.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

