### PR TITLE
remove logging hack

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -130,7 +130,7 @@ public class Kafka implements Serializable {
     @Description("Logging configuration for Kafka")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
-        return logging;
+        return logging == null ? new InlineLogging() : logging;
     }
 
     public void setLogging(Logging logging) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
@@ -71,7 +71,7 @@ public class KafkaConnectAssemblySpec implements Serializable {
     @Description("Logging configuration for Kafka Connect")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
-        return logging;
+        return logging == null ? new InlineLogging() : logging;
     }
 
     public void setLogging(Logging logging) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
@@ -29,19 +28,5 @@ public abstract class Logging implements Serializable {
     @Description("Logging type, must be either 'inline' or 'external'.")
     @JsonIgnore
     public abstract String getType();
-
-    // Hack
-    private ConfigMap cm;
-
-    @JsonIgnore
-    @Deprecated
-    public ConfigMap getCm() {
-        return cm;
-    }
-
-    @Deprecated
-    public void setCm(ConfigMap cm) {
-        this.cm = cm;
-    }
 }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
@@ -88,7 +88,7 @@ public class Zookeeper implements Serializable {
     @Description("Logging configuration for Zookeeper")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
-        return logging;
+        return logging == null ? new InlineLogging() : logging;
     }
 
     public void setLogging(Logging logging) {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
@@ -55,6 +55,9 @@ spec:
         name: "kafka_server_$1_$2_total"
         labels:
           topic: "$3"
+    logging:
+      type: "inline"
+      loggers: {}
   zookeeper:
     replicas: 3
     image: "strimzi/zookeeper:latest"
@@ -83,6 +86,9 @@ spec:
       limits:
         memory: "512Mi"
     metrics: {}
+    logging:
+      type: "inline"
+      loggers: {}
   topicOperator:
     watchedNamespace: "my-ns"
     image: "strimzi/topic-operator:latest"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
@@ -17,6 +17,9 @@ spec:
     key: "key2"
     operator: "Equal"
     value: "value2"
+  logging:
+    type: "inline"
+    loggers: {}
   metrics: {}
   config:
     name: "bar"

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -313,7 +313,7 @@ public abstract class AbstractModel {
                     }
                 } else {
                     // incorrect logger
-                    log.warn(key + " is not valid logger");
+                    log.warn(key + " is not a valid logger");
                     return;
                 }
                 if (key.toString().contains("log4j.appender.CONSOLE")) {
@@ -383,11 +383,7 @@ public abstract class AbstractModel {
             data.put(ANCILLARY_CM_KEY_METRICS, new JsonObject(m).toString());
         }
 
-        ConfigMap configMap = createConfigMap(getAncillaryConfigName(), data);
-        if (getLogging() != null) {
-            getLogging().setCm(configMap);
-        }
-        return configMap;
+        return createConfigMap(getAncillaryConfigName(), data);
     }
 
     public String getLogConfigName() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -602,10 +602,6 @@ public class KafkaCluster extends AbstractModel {
         if (configuration != null && !configuration.getConfiguration().isEmpty()) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_CONFIGURATION, configuration.getConfiguration()));
         }
-        // A hack to force rolling when the logging config changes
-        if (getLogging() != null && getLogging().getCm() != null) {
-            varList.add(buildEnvVar(ENV_VAR_KAFKA_LOG_CONFIGURATION, getLogging().getCm().toString()));
-        }
 
         if (listeners != null)  {
             if (listeners.getPlain() != null)   {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -168,7 +168,7 @@ public class KafkaConnectCluster extends AbstractModel {
         return volumeMountList;
     }
 
-    public Deployment generateDeployment() {
+    public Deployment generateDeployment(Map<String, String> annotations) {
         DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
                 .withType("RollingUpdate")
                 .withRollingUpdate(new RollingUpdateDeploymentBuilder()
@@ -180,12 +180,11 @@ public class KafkaConnectCluster extends AbstractModel {
         return createDeployment(
                 updateStrategy,
                 Collections.emptyMap(),
-                Collections.emptyMap(),
+                annotations,
                 getMergedAffinity(),
                 getInitContainers(),
                 getContainers(),
-                getVolumes()
-                );
+                getVolumes());
     }
 
     @Override
@@ -216,9 +215,6 @@ public class KafkaConnectCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);
-        if (getLogging() != null && getLogging().getCm() != null) {
-            varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_LOGGING, getLogging().getCm().toString()));
-        }
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -29,6 +29,8 @@ import io.strimzi.api.kafka.model.KafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectS2IAssemblySpec;
 import io.strimzi.operator.common.model.Labels;
 
+import java.util.Map;
+
 public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
     // Kafka Connect S2I configuration
@@ -66,7 +68,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
      *
      * @return      Source ImageStream resource definition
      */
-    public DeploymentConfig generateDeploymentConfig() {
+    public DeploymentConfig generateDeploymentConfig(Map<String, String> annotations) {
         Container container = new ContainerBuilder()
                 .withName(name)
                 .withImage(image)
@@ -112,6 +114,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                     .withReplicas(replicas)
                     .withNewTemplate()
                         .withNewMetadata()
+                            .withAnnotations(annotations)
                             .withLabels(getLabelsWithName())
                         .endMetadata()
                         .withNewSpec()
@@ -125,7 +128,6 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .withStrategy(updateStrategy)
                 .endSpec()
                 .build();
-
         return dc;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -308,9 +308,6 @@ public class ZookeeperCluster extends AbstractModel {
         heapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));
-        if (getLogging() != null && getLogging().getCm() != null) {
-            varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_LOG_CONFIGURATION, getLogging().getCm().toString()));
-        }
         return varList;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -147,7 +148,7 @@ public class KafkaConnectClusterTest {
 
     @Test
     public void testGenerateDeployment()   {
-        Deployment dep = kc.generateDeployment();
+        Deployment dep = kc.generateDeployment(new HashMap<String, String>());
 
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
@@ -175,12 +176,12 @@ public class KafkaConnectClusterTest {
     @Test
     public void withAffinity() throws IOException {
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment().getSpec().getTemplate().getSpec().getAffinity());
+            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<String, String>()).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withTolerations() throws IOException {
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment().getSpec().getTemplate().getSpec().getTolerations());
+            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<String, String>()).getSpec().getTemplate().getSpec().getTolerations());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -144,7 +145,7 @@ public class KafkaConnectS2IClusterTest {
 
     @Test
     public void testGenerateDeploymentConfig()   {
-        DeploymentConfig dep = kc.generateDeploymentConfig();
+        DeploymentConfig dep = kc.generateDeploymentConfig(new HashMap<String, String>());
 
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
@@ -248,12 +249,12 @@ public class KafkaConnectS2IClusterTest {
     @Test
     public void withAffinity() throws IOException {
         resourceTester
-            .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig().getSpec().getTemplate().getSpec().getAffinity());
+            .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig(new HashMap<String, String>()).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withTolerations() throws IOException {
         resourceTester
-            .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig().getSpec().getTemplate().getSpec().getTolerations());
+            .assertDesiredResource("-DeploymentConfig.yaml", kcc -> kcc.generateDeploymentConfig(new HashMap<String, String>()).getSpec().getTemplate().getSpec().getTolerations());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -68,6 +68,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -228,11 +229,11 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<StatefulSet> ssCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockZsOps.reconcile(anyString(), anyString(), ssCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         when(mockZsOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockZsOps.maybeRollingUpdate(any())).thenReturn(Future.succeededFuture());
+        when(mockZsOps.maybeRollingUpdate(any(), anyBoolean())).thenReturn(Future.succeededFuture());
         when(mockZsOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockKsOps.reconcile(anyString(), anyString(), ssCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         when(mockKsOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockKsOps.maybeRollingUpdate(any())).thenReturn(Future.succeededFuture());
+        when(mockKsOps.maybeRollingUpdate(any(), anyBoolean())).thenReturn(Future.succeededFuture());
         when(mockKsOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         //ArgumentCaptor<String> secretsCaptor = ArgumentCaptor.forClass(String.class);
         //when(mockSecretOps.reconcile(anyString(), secretsCaptor.capture(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
@@ -651,7 +652,6 @@ public class KafkaAssemblyOperatorTest {
                     kafkaAssembly.getSpec().getKafka().getReplicas(),
                     kafkaAssembly.getSpec().getZookeeper().getReplicas());
             updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
-
         }
     }
 
@@ -790,8 +790,8 @@ public class KafkaAssemblyOperatorTest {
             StatefulSet ss = invocation.getArgument(2);
             return Future.succeededFuture(ReconcileResult.patched(ss));
         });
-        when(mockZsOps.maybeRollingUpdate(any())).thenReturn(Future.succeededFuture());
-        when(mockKsOps.maybeRollingUpdate(any())).thenReturn(Future.succeededFuture());
+        when(mockZsOps.maybeRollingUpdate(any(), anyBoolean())).thenReturn(Future.succeededFuture());
+        when(mockKsOps.maybeRollingUpdate(any(), anyBoolean())).thenReturn(Future.succeededFuture());
 
         // Mock StatefulSet scaleUp
         ArgumentCaptor<String> scaledUpCaptor = ArgumentCaptor.forClass(String.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -41,8 +41,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -63,6 +65,16 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
     protected static Vertx vertx;
     public static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
+    public static final String LOGGING_CONFIG = "#Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.\n" +
+            "\n" +
+            "log4j.rootLogger=${connect.root.logger.level}, CONSOLE\n" +
+            "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
+            "log4j.logger.org.reflections=ERROR\n" +
+            "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+            "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+            "connect.root.logger.level=INFO\n" +
+            "log4j.logger.org.apache.zookeeper=ERROR\n" +
+            "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n";
 
     @BeforeClass
     public static void before() {
@@ -129,7 +141,9 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             context.assertEquals(1, capturedDc.size());
             DeploymentConfig dc = capturedDc.get(0);
             context.assertEquals(connect.getName(), dc.getMetadata().getName());
-            context.assertEquals(connect.generateDeploymentConfig(), dc, "Deployment Configs are not equal");
+            Map annotations = new HashMap();
+            annotations.put("strimzi.io/logging", LOGGING_CONFIG);
+            context.assertEquals(connect.generateDeploymentConfig(annotations), dc, "Deployment Configs are not equal");
 
             // Verify Build Config
             List<BuildConfig> capturedBc = bcCaptor.getAllValues();
@@ -173,7 +187,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm);
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
@@ -263,7 +277,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
@@ -340,7 +354,9 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             context.assertEquals(1, capturedDc.size());
             DeploymentConfig dc = capturedDc.get(0);
             context.assertEquals(compareTo.getName(), dc.getMetadata().getName());
-            context.assertEquals(compareTo.generateDeploymentConfig(), dc, "Deployment Configs are not equal");
+            Map annotations = new HashMap();
+            annotations.put("strimzi.io/logging", LOGGING_CONFIG);
+            context.assertEquals(compareTo.generateDeploymentConfig(annotations), dc, "Deployment Configs are not equal");
 
             // Verify Build Config
             List<BuildConfig> capturedBc = bcCaptor.getAllValues();
@@ -386,7 +402,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
@@ -459,7 +475,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
@@ -517,7 +533,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
@@ -570,7 +586,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(ResourceUtils.createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName));
 
-        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>()));
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
 
         ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
@@ -653,18 +669,18 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         // providing the list of ALL DeploymentConfigs for all the Kafka Connect S2I clusters
         Labels newLabels = Labels.forKind(KafkaConnectS2IAssembly.RESOURCE_KIND);
         when(mockDcOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
-                asList(KafkaConnectS2ICluster.fromCrd(bar).generateDeploymentConfig(),
-                        KafkaConnectS2ICluster.fromCrd(baz).generateDeploymentConfig()));
+                asList(KafkaConnectS2ICluster.fromCrd(bar).generateDeploymentConfig(new HashMap<String, String>()),
+                        KafkaConnectS2ICluster.fromCrd(baz).generateDeploymentConfig(new HashMap<String, String>())));
 
         // providing the list DeploymentConfigs for already "existing" Kafka Connect S2I clusters
         Labels barLabels = Labels.forCluster("bar");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
-                asList(KafkaConnectS2ICluster.fromCrd(bar).generateDeploymentConfig())
+                asList(KafkaConnectS2ICluster.fromCrd(bar).generateDeploymentConfig(new HashMap<String, String>()))
         );
 
         Labels bazLabels = Labels.forCluster("baz");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
-                asList(KafkaConnectS2ICluster.fromCrd(baz).generateDeploymentConfig())
+                asList(KafkaConnectS2ICluster.fromCrd(baz).generateDeploymentConfig(new HashMap<String, String>()))
         );
 
         when(mockSecretOps.reconcile(eq(clusterCmNamespace), any(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -274,6 +275,7 @@ public class MockKube {
                         String podName = argument.getMetadata().getName() + "-" + podNum;
                         LOGGER.debug("create Pod {} because it's in StatefulSet {}", podName, resourceName);
                         Pod pod = new PodBuilder().withNewMetadataLike(argument.getSpec().getTemplate().getMetadata())
+                                .withUid(UUID.randomUUID().toString())
                                 .withNamespace(argument.getMetadata().getNamespace())
                                 .withName(podName)
                                 .endMetadata()
@@ -375,6 +377,7 @@ public class MockKube {
                         ObjectMeta templateMeta = statefulSet.getSpec().getTemplate().getMetadata();
                         Pod copy = new DoneablePod(resource)
                                 .withNewMetadataLike(templateMeta)
+                                .withUid(UUID.randomUUID().toString())
                                 .withNamespace(podNamespace)
                                 .withNamespace(podName)
                                 .endMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import org.junit.Test;
 
+import java.util.UUID;
 import java.util.function.BiPredicate;
 
 import static org.junit.Assert.assertTrue;
@@ -140,12 +141,12 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            protected Future<Integer> getGeneration(String namespace, String podName) {
-                return Future.succeededFuture(1);
+            protected Future<String> getUid(String namespace, String podName) {
+                return Future.succeededFuture(UUID.randomUUID().toString());
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0");
+        Future result = op.maybeRestartPod(resource, "my-pod-0", false);
         assertTrue(result.succeeded());
     }
     @Test
@@ -180,13 +181,13 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            protected Future<Integer> getGeneration(String namespace, String podName) {
-                return Future.succeededFuture(1);
+            protected Future<String> getUid(String namespace, String podName) {
+                return Future.succeededFuture(UUID.randomUUID().toString());
             }
 
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0");
+        Future result = op.maybeRestartPod(resource, "my-pod-0", false);
         assertTrue(result.failed());
         assertTrue(result.cause() instanceof TimeoutException);
     }
@@ -223,12 +224,12 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            protected Future<Integer> getGeneration(String namespace, String podName) {
-                return Future.succeededFuture(1);
+            protected Future<String> getUid(String namespace, String podName) {
+                return Future.succeededFuture(UUID.randomUUID().toString());
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0");
+        Future result = op.maybeRestartPod(resource, "my-pod-0", false);
         assertTrue(result.failed());
         assertTrue(result.cause() instanceof TimeoutException);
     }
@@ -265,12 +266,12 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            protected Future<Integer> getGeneration(String namespace, String podName) {
-                return Future.succeededFuture(1);
+            protected Future<String> getUid(String namespace, String podName) {
+                return Future.succeededFuture(UUID.randomUUID().toString());
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0");
+        Future result = op.maybeRestartPod(resource, "my-pod-0", false);
         assertTrue(result.failed());
         assertTrue(result.cause().getMessage().equals("reconcile failed"));
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public abstract class AbstractResourceOperator<C extends KubernetesClient, T extends HasMetadata,
         L extends KubernetesResourceList/*<T>*/, D, R extends Resource<T, D>> {
 
-    private final Logger log = LogManager.getLogger(getClass());
+    protected final Logger log = LogManager.getLogger(getClass());
     protected final Vertx vertx;
     protected final C client;
     protected final String resourceKind;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
@@ -10,7 +10,11 @@ import io.fabric8.kubernetes.api.model.DoneableConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Operations for {@code ConfigMap}s.
@@ -28,5 +32,32 @@ public class ConfigMapOperator extends AbstractResourceOperator<KubernetesClient
     @Override
     protected MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> operation() {
         return client.configMaps();
+    }
+
+    @Override
+    protected Future<ReconcileResult<ConfigMap>> internalPatch(String namespace, String name, ConfigMap current, ConfigMap desired) {
+        try {
+            if (compareObjects(current.getData(), desired.getData())
+                    && compareObjects(current.getMetadata().getName(), desired.getMetadata().getName())
+                    && compareObjects(current.getMetadata().getNamespace(), desired.getMetadata().getNamespace())
+                    && compareObjects(current.getMetadata().getAnnotations(), desired.getMetadata().getAnnotations())
+                    && compareObjects(current.getMetadata().getLabels(), desired.getMetadata().getLabels())) {
+                // Checking some metadata. We cannot check entire metadata object because it contains
+                // timestamps which would cause restarting loop
+                log.debug("{} {} in namespace {} has not been patched because resources are equal", resourceKind, name, namespace);
+                return Future.succeededFuture(ReconcileResult.noop());
+            } else {
+                return super.internalPatch(namespace, name, current, desired);
+            }
+        } catch (Exception e) {
+            log.error("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    private boolean compareObjects(Object a, Object b) {
+        if (a == null && b instanceof Map && ((Map) b).size() == 0)
+            return true;
+        return !(a instanceof Map ^ b instanceof Map) && Objects.equals(a, b);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
@@ -99,7 +99,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         AbstractResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        Future<ReconcileResult<T>> fut = op.createOrUpdate(resource);
+        Future<ReconcileResult<T>> fut = op.createOrUpdate(resource());
         fut.setHandler(ar -> {
             if (!ar.succeeded()) {
                 ar.cause().printStackTrace();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
@@ -13,6 +13,8 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
 
+import java.util.Random;
+
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +48,7 @@ public class ConfigMapOperatorTest extends AbstractResourceOperatorTest<Kubernet
                 .withNamespace(NAMESPACE)
                 .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
-                .withData(singletonMap("FOO", "BAR"))
+                .withData(singletonMap("FOO", Integer.toString(new Random().nextInt())))
                 .build();
     }
 }


### PR DESCRIPTION
Removing hack which used EndVars to restart the pods when the logging configuration has been changed. Now it uses `internalPatch` to determine if the resource (in this case CM) has been changed or not. 