### PR TITLE
Only build a label selector for PVC if there's one provided

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -502,6 +502,10 @@ public abstract class AbstractModel {
         PersistentClaimStorage storage = (PersistentClaimStorage) this.storage;
         Map<String, Quantity> requests = new HashMap<>();
         requests.put("storage", new Quantity(storage.getSize(), null));
+        LabelSelector selector = null;
+        if (storage.getSelector() != null && !storage.getSelector().isEmpty()) {
+            selector = new LabelSelector(null, storage.getSelector());
+        }
 
         PersistentVolumeClaimBuilder pvcb = new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
@@ -513,11 +517,8 @@ public abstract class AbstractModel {
                 .withRequests(requests)
                 .endResources()
                 .withStorageClassName(storage.getStorageClass())
+                .withSelector(selector)
                 .endSpec();
-
-        if (!storage.getSelector().isEmpty()) {
-            pvcb.editSpec().withSelector(new LabelSelector(null, storage.getSelector())).endSpec();
-        }
 
         return pvcb.build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
@@ -502,7 +503,7 @@ public abstract class AbstractModel {
         Map<String, Quantity> requests = new HashMap<>();
         requests.put("storage", new Quantity(storage.getSize(), null));
 
-        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+        PersistentVolumeClaimBuilder pvcb = new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
                 .withName(name)
                 .endMetadata()
@@ -512,11 +513,13 @@ public abstract class AbstractModel {
                 .withRequests(requests)
                 .endResources()
                 .withStorageClassName(storage.getStorageClass())
-                .withNewSelector().withMatchLabels(storage.getSelector()).endSelector()
-                .endSpec()
-                .build();
+                .endSpec();
 
-        return pvc;
+        if (!storage.getSelector().isEmpty()) {
+            pvcb.editSpec().withSelector(new LabelSelector(null, storage.getSelector())).endSpec();
+        }
+
+        return pvcb.build();
     }
 
     protected Volume createEmptyDirVolume(String name) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -112,6 +112,37 @@ public class KafkaClusterTest {
     }
 
     @Test
+    public void testGenerateStatefulSetWithSetStorageSelector() {
+        Map<String, String> selector = TestUtils.map("foo", "bar");
+        KafkaAssembly kafkaAssembly = new KafkaAssemblyBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withNewPersistentClaimStorageStorage().withSelector(selector).endPersistentClaimStorageStorage()
+                .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
+        StatefulSet ss = kc.generateStatefulSet(false);
+        assertEquals(selector, ss.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector().getMatchLabels());
+    }
+
+    @Test
+    public void testGenerateStatefulSetWithEmptyStorageSelector() {
+        KafkaAssembly kafkaAssembly = new KafkaAssemblyBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withNewPersistentClaimStorageStorage().withSelector(emptyMap()).endPersistentClaimStorageStorage()
+                .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace));
+        StatefulSet ss = kc.generateStatefulSet(false);
+        assertEquals(null, ss.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector());
+    }
+
+    @Test
     public void testGenerateStatefulSetWithRack() {
         KafkaAssembly kafkaAssembly = new KafkaAssemblyBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When trying to use strimzi with dynamically allocated volumes via PersistentVolumeClaims on AWS I saw the following errors in the controller-manager:

```
Failed to provision volume with StorageClass "gp2": claim.Spec.Selector is not supported for dynamic provisioning on AWS
```

This is because the selector generated in the PVC ends up being set to an empty object instead of being not set: `"spec": { "selector": {} }`

This likely originated from this change: https://github.com/strimzi/strimzi-kafka-operator/commit/9f697ff4a11f1e76e5aec43f7366014b2e16e52f#diff-2a9350887fe59eb3c605753efd97e985R515

This PR will check if there is label selectors provided via storage, and if there isn't any it will null the selector.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
