### PR TITLE
Move java-base Docker image from separate repo into the main repo

### DIFF
--- a/cluster-operator/Dockerfile
+++ b/cluster-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/java-base:8-3
+FROM strimzi/java-base:latest
 
 ARG strimzi_version=1.0-SNAPSHOT
 ENV STRIMZI_VERSION ${strimzi_version}

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS=kafka-base zookeeper kafka kafka-connect kafka-connect/s2i
+SUBDIRS=java-base kafka-base zookeeper kafka kafka-connect kafka-connect/s2i
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/docker-images/java-base/Dockerfile
+++ b/docker-images/java-base/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+
+RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+
+# Set JAVA_HOME env var
+ENV JAVA_HOME /usr/lib/jvm/java
+
+# Copy scripts for starting Java apps
+COPY scripts/* /bin/

--- a/docker-images/java-base/Makefile
+++ b/docker-images/java-base/Makefile
@@ -1,0 +1,5 @@
+PROJECT_NAME=java-base
+
+include ../../Makefile.docker
+
+.PHONY: build clean release

--- a/docker-images/java-base/scripts/dynamic_resources.sh
+++ b/docker-images/java-base/scripts/dynamic_resources.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+function get_heap_size {
+  CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
+  DEFAULT_MEMORY_CEILING=$((2**60-1))
+  if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
+    if [ -z $CONTAINER_HEAP_PERCENT ]; then
+      CONTAINER_HEAP_PERCENT=0.50
+    fi
+
+    CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
+    CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+
+    echo "${CONTAINER_HEAP_MAX}"
+  fi
+}

--- a/docker-images/java-base/scripts/launch_java.sh
+++ b/docker-images/java-base/scripts/launch_java.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -x
+JAR=$1
+shift
+
+. /bin/dynamic_resources.sh
+
+MAX_HEAP=`get_heap_size`
+if [ -n "$MAX_HEAP" ]; then
+  JAVA_OPTS="-Xms${MAX_HEAP}m -Xmx${MAX_HEAP}m $JAVA_OPTS"
+fi
+
+export MALLOC_ARENA_MAX=2
+
+# Make sure that we use /dev/urandom
+JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
+
+# Enable GC logging for memory tracking
+JAVA_OPTS="${JAVA_OPTS} -XX:NativeMemoryTracking=summary -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+
+exec java $JAVA_OPTS -jar $JAR $JAVA_OPTS $@

--- a/init-kafka/Dockerfile
+++ b/init-kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/java-base:8-3
+FROM strimzi/java-base:latest
 
 ARG strimzi_version=1.0-SNAPSHOT
 ENV STRIMZI_VERSION ${strimzi_version}

--- a/topic-operator/Dockerfile
+++ b/topic-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/java-base:8-3
+FROM strimzi/java-base:latest
 
 ARG strimzi_version=1.0-SNAPSHOT
 ENV STRIMZI_VERSION ${strimzi_version}


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Having the `java-base` in a separate repo makes sometimes things complicated:
* No clean versioning
* No CI
* Need to do things with several separate PRs
* The fact that we are not using `:latest` in master causes sometimes issues with Docker image caching

This PR moves the `java-base` into this main repository. That should solve these issues.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
