### PR TITLE
Update the CRDs to make it work on openShift Origin 3.10-rc0

### DIFF
--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -14,7 +14,6 @@ spec:
     plural: "examples"
   validation:
     openAPIV3Schema:
-      type: "object"
       properties:
         affinity:
           type: "object"
@@ -288,10 +287,8 @@ spec:
           type: "boolean"
         fieldProperty:
           type: "string"
-          description: "Example of field property."
         intProperty:
           type: "integer"
-          description: "An example int property"
           example: "42"
           minimum: 42
           deprecated: true
@@ -344,10 +341,8 @@ spec:
                 - "right"
               leftProperty:
                 type: "string"
-                description: "when descrim=left, the left-hand property"
               rightProperty:
                 type: "string"
-                description: "when descrim=right, the right-hand property"
         listOfRawList:
           type: "array"
           items:
@@ -383,7 +378,6 @@ spec:
               properties: {}
         longProperty:
           type: "integer"
-          description: "An example long property"
           example: "42"
           minimum: 42
         mapProperty:
@@ -407,10 +401,8 @@ spec:
               - "right"
             leftProperty:
               type: "string"
-              description: "when descrim=left, the left-hand property"
             rightProperty:
               type: "string"
-              description: "when descrim=right, the right-hand property"
           required:
           - "discrim"
         rawList:

--- a/examples/install/cluster-operator/07-crd-kafka-connect-s2i.yaml
+++ b/examples/install/cluster-operator/07-crd-kafka-connect-s2i.yaml
@@ -14,7 +14,6 @@ spec:
     plural: kafkaconnects2is
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         spec:
           type: object
@@ -23,57 +22,42 @@ spec:
               type: integer
             image:
               type: string
-              description: The docker image for the pods.
             livenessProbe:
-              description: Pod liveness checking.
               type: object
               properties:
                 additionalProperties:
                   type: object
                 initialDelaySeconds:
                   type: integer
-                  description: The initial delay before first the health is first
-                    checked.
                   minimum: 0
                 timeoutSeconds:
                   type: integer
-                  description: The timeout for each attempted health check.
                   minimum: 0
             readinessProbe:
-              description: Pod readiness checking.
               type: object
               properties:
                 additionalProperties:
                   type: object
                 initialDelaySeconds:
                   type: integer
-                  description: The initial delay before first the health is first
-                    checked.
                   minimum: 0
                 timeoutSeconds:
                   type: integer
-                  description: The timeout for each attempted health check.
                   minimum: 0
             jvmOptions:
-              description: JVM Options for pods
               type: object
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
-                  description: -Xms option to to the JVM
                   pattern: '[0-9]+[mMgG]?'
                 -Xmx:
                   type: string
-                  description: -Xmx option to to the JVM
                   pattern: '[0-9]+[mMgG]?'
                 -server:
                   type: boolean
-                  description: -server option to to the JVM
             affinity:
-              description: Pod affinity rules.
               type: object
               properties:
                 nodeAffinity:
@@ -305,19 +289,13 @@ spec:
                   type: object
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
             additionalProperties:
               type: object
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest.'
             insecureSourceRepository:
               type: boolean
             logging:
-              description: Logging configuration for Kafka Connect
               type: object
               properties:
                 loggers:
@@ -327,38 +305,31 @@ spec:
                 type:
                   type: string
             resources:
-              description: Resource constraints (limits and requests).
               type: object
               properties:
                 additionalProperties:
                   type: object
                 limits:
-                  description: Resource limits applied at runtime.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     cpu:
                       type: string
-                      description: CPU
                       pattern: '[0-9]+m?$'
                     memory:
                       type: string
-                      description: Memory
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 requests:
-                  description: Resource requests applied during pod scheduling.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     cpu:
                       type: string
-                      description: CPU
                       pattern: '[0-9]+m?$'
                     memory:
                       type: string
-                      description: Memory
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
           required:
           - config

--- a/examples/install/cluster-operator/07-crd-kafka-connect.yaml
+++ b/examples/install/cluster-operator/07-crd-kafka-connect.yaml
@@ -14,7 +14,6 @@ spec:
     plural: kafkaconnects
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         spec:
           type: object
@@ -23,57 +22,42 @@ spec:
               type: integer
             image:
               type: string
-              description: The docker image for the pods.
             livenessProbe:
-              description: Pod liveness checking.
               type: object
               properties:
                 additionalProperties:
                   type: object
                 initialDelaySeconds:
                   type: integer
-                  description: The initial delay before first the health is first
-                    checked.
                   minimum: 0
                 timeoutSeconds:
                   type: integer
-                  description: The timeout for each attempted health check.
                   minimum: 0
             readinessProbe:
-              description: Pod readiness checking.
               type: object
               properties:
                 additionalProperties:
                   type: object
                 initialDelaySeconds:
                   type: integer
-                  description: The initial delay before first the health is first
-                    checked.
                   minimum: 0
                 timeoutSeconds:
                   type: integer
-                  description: The timeout for each attempted health check.
                   minimum: 0
             jvmOptions:
-              description: JVM Options for pods
               type: object
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
-                  description: -Xms option to to the JVM
                   pattern: '[0-9]+[mMgG]?'
                 -Xmx:
                   type: string
-                  description: -Xmx option to to the JVM
                   pattern: '[0-9]+[mMgG]?'
                 -server:
                   type: boolean
-                  description: -server option to to the JVM
             affinity:
-              description: Pod affinity rules.
               type: object
               properties:
                 nodeAffinity:
@@ -305,17 +289,11 @@ spec:
                   type: object
             metrics:
               type: object
-              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                for details of the structure of this configuration.
             additionalProperties:
               type: object
             config:
               type: object
-              description: 'The Kafka Connect configuration. Properties with the following
-                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest.'
             logging:
-              description: Logging configuration for Kafka Connect
               type: object
               properties:
                 loggers:
@@ -325,38 +303,31 @@ spec:
                 type:
                   type: string
             resources:
-              description: Resource constraints (limits and requests).
               type: object
               properties:
                 additionalProperties:
                   type: object
                 limits:
-                  description: Resource limits applied at runtime.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     cpu:
                       type: string
-                      description: CPU
                       pattern: '[0-9]+m?$'
                     memory:
                       type: string
-                      description: Memory
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 requests:
-                  description: Resource requests applied during pod scheduling.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     cpu:
                       type: string
-                      description: CPU
                       pattern: '[0-9]+m?$'
                     memory:
                       type: string
-                      description: Memory
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
           required:
           - config

--- a/examples/install/cluster-operator/07-crd-kafka.yaml
+++ b/examples/install/cluster-operator/07-crd-kafka.yaml
@@ -14,102 +14,71 @@ spec:
     plural: kafkas
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         spec:
           type: object
           properties:
             kafka:
-              description: Configuration of the Kafka cluster
               type: object
               properties:
                 replicas:
                   type: integer
-                  description: The number of pods in the cluster.
                   minimum: 1
                 image:
                   type: string
-                  description: The docker image for the pods.
                 storage:
-                  description: Storage configuration (disk). Cannot be updated.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     class:
                       type: string
-                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains a matchLabels field which defines an inner JSON
-                        object with key:value representing labels for selecting such
-                        a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     type:
                       type: string
-                      description: Must be `persistent-claim`
                 brokerRackInitImage:
                   type: string
-                  description: The image of the init container used for initializing
-                    the `broker.rack`.
                 livenessProbe:
-                  description: Pod liveness checking.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     initialDelaySeconds:
                       type: integer
-                      description: The initial delay before first the health is first
-                        checked.
                       minimum: 0
                     timeoutSeconds:
                       type: integer
-                      description: The timeout for each attempted health check.
                       minimum: 0
                 readinessProbe:
-                  description: Pod readiness checking.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     initialDelaySeconds:
                       type: integer
-                      description: The initial delay before first the health is first
-                        checked.
                       minimum: 0
                     timeoutSeconds:
                       type: integer
-                      description: The timeout for each attempted health check.
                       minimum: 0
                 jvmOptions:
-                  description: JVM Options for pods
                   type: object
                   properties:
                     -XX:
                       type: object
-                      description: A map of -XX options to the JVM
                     -Xms:
                       type: string
-                      description: -Xms option to to the JVM
                       pattern: '[0-9]+[mMgG]?'
                     -Xmx:
                       type: string
-                      description: -Xmx option to to the JVM
                       pattern: '[0-9]+[mMgG]?'
                     -server:
                       type: boolean
-                      description: -server option to to the JVM
                 affinity:
-                  description: Pod affinity rules.
                   type: object
                   properties:
                     nodeAffinity:
@@ -341,19 +310,11 @@ spec:
                       type: object
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
                 additionalProperties:
                   type: object
                 config:
                   type: object
-                  description: 'The kafka broker config. Properties with the following
-                    prefixes cannot be set: listeners, advertised., broker., listener.,
-                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
-                    password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user'
                 logging:
-                  description: Logging configuration for Kafka
                   type: object
                   properties:
                     loggers:
@@ -363,143 +324,104 @@ spec:
                     type:
                       type: string
                 rack:
-                  description: Configuration of the `broker.rack` broker config.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     topologyKey:
                       type: string
-                      description: A key that matches labels assigned to the OpenShift
-                        or Kubernetes cluster nodes. The value of the label is used
-                        to set the broker's `broker.rack` config.
                       example: failure-domain.beta.kubernetes.io/zone
                   required:
                   - topologyKey
                 resources:
-                  description: Resource constraints (limits and requests).
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     limits:
-                      description: Resource limits applied at runtime.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                     requests:
-                      description: Resource requests applied during pod scheduling.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
               required:
               - replicas
               - storage
             zookeeper:
-              description: Configuration of the Zookeeper cluster
               type: object
               properties:
                 replicas:
                   type: integer
-                  description: The number of pods in the cluster.
                   minimum: 1
                 image:
                   type: string
-                  description: The docker image for the pods.
                 storage:
-                  description: Storage configuration (disk). Cannot be updated.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     class:
                       type: string
-                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
-                      description: Specifies if the persistent volume claim has to
-                        be deleted when the cluster is un-deployed.
                     selector:
                       type: object
-                      description: Specifies a specific persistent volume to use.
-                        It contains a matchLabels field which defines an inner JSON
-                        object with key:value representing labels for selecting such
-                        a volume.
                     size:
                       type: string
-                      description: When type=persistent-claim, defines the size of
-                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     type:
                       type: string
-                      description: Must be `persistent-claim`
                 livenessProbe:
-                  description: Pod liveness checking.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     initialDelaySeconds:
                       type: integer
-                      description: The initial delay before first the health is first
-                        checked.
                       minimum: 0
                     timeoutSeconds:
                       type: integer
-                      description: The timeout for each attempted health check.
                       minimum: 0
                 readinessProbe:
-                  description: Pod readiness checking.
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     initialDelaySeconds:
                       type: integer
-                      description: The initial delay before first the health is first
-                        checked.
                       minimum: 0
                     timeoutSeconds:
                       type: integer
-                      description: The timeout for each attempted health check.
                       minimum: 0
                 jvmOptions:
-                  description: JVM Options for pods
                   type: object
                   properties:
                     -XX:
                       type: object
-                      description: A map of -XX options to the JVM
                     -Xms:
                       type: string
-                      description: -Xms option to to the JVM
                       pattern: '[0-9]+[mMgG]?'
                     -Xmx:
                       type: string
-                      description: -Xmx option to to the JVM
                       pattern: '[0-9]+[mMgG]?'
                     -server:
                       type: boolean
-                      description: -server option to to the JVM
                 affinity:
-                  description: Pod affinity rules.
                   type: object
                   properties:
                     nodeAffinity:
@@ -731,17 +653,11 @@ spec:
                       type: object
                 metrics:
                   type: object
-                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
-                    for details of the structure of this configuration.
                 additionalProperties:
                   type: object
                 config:
                   type: object
-                  description: 'The zookeeper broker config. Properties with the following
-                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
-                    authProvider, quorum.auth, requireClientAuthScheme'
                 logging:
-                  description: Logging configuration for Zookeeper
                   type: object
                   properties:
                     loggers:
@@ -751,62 +667,49 @@ spec:
                     type:
                       type: string
                 resources:
-                  description: Resource constraints (limits and requests).
                   type: object
                   properties:
                     additionalProperties:
                       type: object
                     limits:
-                      description: Resource limits applied at runtime.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                     requests:
-                      description: Resource requests applied during pod scheduling.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
               required:
               - replicas
               - storage
             topicOperator:
-              description: Configuration of the Topic Operator
               type: object
               properties:
                 watchedNamespace:
                   type: string
-                  description: The namespace the Topic Operator should watch.
                 image:
                   type: string
-                  description: The image to use for the topic operator
                 reconciliationIntervalSeconds:
                   type: integer
-                  description: Interval between periodic reconciliations.
                   minimum: 0
                 zookeeperSessionTimeoutSeconds:
                   type: integer
-                  description: Timeout for the Zookeeper session
                   minimum: 0
                 affinity:
-                  description: Pod affinity rules.
                   type: object
                   properties:
                     nodeAffinity:
@@ -1042,41 +945,33 @@ spec:
                     additionalProperties:
                       type: object
                     limits:
-                      description: Resource limits applied at runtime.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                     requests:
-                      description: Resource requests applied during pod scheduling.
                       type: object
                       properties:
                         additionalProperties:
                           type: object
                         cpu:
                           type: string
-                          description: CPU
                           pattern: '[0-9]+m?$'
                         memory:
                           type: string
-                          description: Memory
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 topicMetadataMaxAttempts:
                   type: integer
-                  description: The number of attempts at getting topic metadata
                   minimum: 0
                 additionalProperties:
                   type: object
                 logging:
-                  description: Logging configuration
                   type: object
                   properties:
                     loggers:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The CRDs do not work on OpenShift 3.10.rc0. IT doesn't like:
* The description fields
* The `type: object` field in the root of the `openAPIV3Schema`

This PR make it work. Some parts of the code are only commented out, since its not clear if this will be fixed in final version of 3.10.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

