### PR TITLE
Making Zookeeper TLS sidecar resources configurable

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Representation of a sidecar container configuration
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Sidecar {
+
+    private String image;
+
+    private Resources resources;
+
+    @Description("The docker image for the container")
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    @Description("Resource constraints (limits and requests).")
+    public Resources getResources() {
+        return resources;
+    }
+
+    public void setResources(Resources resources) {
+        this.resources = resources;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
@@ -39,7 +39,7 @@ public class Zookeeper extends ReplicatedJvmPods {
 
     private Logging logging;
 
-    private String tlsSidecarImage;
+    private Sidecar tlsSidecar;
 
     @Description("The zookeeper broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
     public Map<String, Object> getConfig() {
@@ -70,13 +70,13 @@ public class Zookeeper extends ReplicatedJvmPods {
         this.logging = logging;
     }
 
-    @Description("The Docker image for the TLS sidecar")
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public String getTlsSidecarImage() {
-        return tlsSidecarImage;
+    @Description("TLS sidecar configuration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Sidecar getTlsSidecar() {
+        return tlsSidecar;
     }
 
-    public void setTlsSidecarImage(String tlsSidecarImage) {
-        this.tlsSidecarImage = tlsSidecarImage;
+    public void setTlsSidecar(Sidecar tlsSidecar) {
+        this.tlsSidecar = tlsSidecar;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -809,7 +809,7 @@ public abstract class AbstractModel {
                 (u, v) -> v));
     }
 
-    protected ResourceRequirements resources() {
+    public static ResourceRequirements resources(Resources resources) {
         if (resources != null) {
             ResourceRequirementsBuilder builder = new ResourceRequirementsBuilder();
             CpuMemory limits = resources.getLimits();
@@ -837,6 +837,10 @@ public abstract class AbstractModel {
 
     public void setResources(Resources resources) {
         this.resources = resources;
+    }
+
+    public Resources getResources() {
+        return resources;
     }
 
     public void setJvmOptions(JvmOptions jvmOptions) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -552,7 +552,7 @@ public class KafkaCluster extends AbstractModel {
                 .withPorts(getContainerPortList())
                 .withLivenessProbe(createExecProbe(livenessPath, livenessInitialDelay, livenessTimeout))
                 .withReadinessProbe(createExecProbe(readinessPath, readinessInitialDelay, readinessTimeout))
-                .withResources(resources())
+                .withResources(resources(getResources()))
                 .build());
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -217,7 +217,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 .withLivenessProbe(createHttpProbe(livenessPath, REST_API_PORT_NAME, livenessInitialDelay, livenessTimeout))
                 .withReadinessProbe(createHttpProbe(readinessPath, REST_API_PORT_NAME, readinessInitialDelay, readinessTimeout))
                 .withVolumeMounts(getVolumeMounts())
-                .withResources(resources())
+                .withResources(resources(getResources()))
                 .build();
 
         containers.add(container);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -74,7 +74,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .withLivenessProbe(createHttpProbe(livenessPath, REST_API_PORT_NAME, livenessInitialDelay, livenessTimeout))
                 .withReadinessProbe(createHttpProbe(readinessPath, REST_API_PORT_NAME, readinessInitialDelay, readinessTimeout))
                 .withVolumeMounts(getVolumeMounts())
-                .withResources(resources())
+                .withResources(resources(getResources()))
                 .build();
 
         DeploymentTriggerPolicy configChangeTrigger = new DeploymentTriggerPolicyBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -213,7 +213,7 @@ public class TopicOperator extends AbstractModel {
                 .withPorts(Collections.singletonList(createContainerPort(HEALTHCHECK_PORT_NAME, HEALTHCHECK_PORT, "TCP")))
                 .withLivenessProbe(createHttpProbe(livenessPath + "healthy", HEALTHCHECK_PORT_NAME, livenessInitialDelay, livenessTimeout))
                 .withReadinessProbe(createHttpProbe(readinessPath + "ready", HEALTHCHECK_PORT_NAME, readinessInitialDelay, readinessTimeout))
-                .withResources(resources())
+                .withResources(resources(getResources()))
                 .build();
 
         containers.add(container);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -158,6 +158,6 @@ public class AbstractModelTest {
             }
         };
         abstractModel.setResources(opts);
-        Assert.assertEquals("1", abstractModel.resources().getLimits().get("cpu").getAmount());
+        Assert.assertEquals("1", abstractModel.resources(opts).getLimits().get("cpu").getAmount());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.KafkaAssemblyBuilder;
+import io.strimzi.api.kafka.model.Zookeeper;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.operator.assembly.MockCertManager;
@@ -135,6 +136,7 @@ public class ZookeeperClusterTest {
         assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, containers.get(0).getPorts().get(0).getName());
         assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), containers.get(0).getPorts().get(0).getContainerPort());
         // checks on the TLS sidecar container
+        assertEquals(Zookeeper.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
         assertEquals(new Integer(replicas), Integer.valueOf(AbstractModel.containerEnvVars(containers.get(1)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_NODE_COUNT)));
         assertEquals(ZookeeperCluster.CLUSTERING_PORT_NAME, containers.get(1).getPorts().get(0).getName());
         assertEquals(new Integer(ZookeeperCluster.CLUSTERING_PORT), containers.get(1).getPorts().get(0).getContainerPort());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaAssembly;
+import io.strimzi.api.kafka.model.KafkaAssemblyBuilder;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TopicOperatorBuilder;
@@ -525,7 +526,10 @@ public class KafkaAssemblyOperatorTest {
     @Test
     public void testUpdateZookeeperClusterChangeStunnelImage(TestContext context) {
         KafkaAssembly kafkaAssembly = getKafkaAssembly("bar");
-        kafkaAssembly.getSpec().getZookeeper().setTlsSidecarImage("a-changed-tls-sidecar-image");
+        kafkaAssembly = new KafkaAssemblyBuilder(kafkaAssembly)
+                .editSpec().editZookeeper()
+                    .editOrNewTlsSidecar().withImage("a-changed-tls-sidecar-image")
+                    .endTlsSidecar().endZookeeper().endSpec().build();
         List<Secret> secrets = getClusterSecrets("bar",
                 kafkaAssembly.getSpec().getKafka().getReplicas(),
                 kafkaAssembly.getSpec().getZookeeper().getReplicas());

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -202,7 +202,7 @@ Used in: <<type-Kafka,`Kafka`>>
 [[type-Resources]]
 ### `Resources` type v1alpha1 kafka.strimzi.io
 
-Used in: <<type-Kafka,`Kafka`>>, <<type-KafkaConnectAssemblySpec,`KafkaConnectAssemblySpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-TopicOperator,`TopicOperator`>>, <<type-Zookeeper,`Zookeeper`>>
+Used in: <<type-Kafka,`Kafka`>>, <<type-KafkaConnectAssemblySpec,`KafkaConnectAssemblySpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-Sidecar,`Sidecar`>>, <<type-TopicOperator,`TopicOperator`>>, <<type-Zookeeper,`Zookeeper`>>
 
 
 [options="header"]
@@ -260,8 +260,6 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics               1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|tlsSidecarImage       1.2+<.<|The Docker image for the TLS sidecar
-|string
 |additionalProperties  1.2+<.<|
 |map
 |config                1.2+<.<|The zookeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme
@@ -269,6 +267,23 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |logging               1.2+<.<|Logging configuration for Zookeeper The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources             1.2+<.<|Resource constraints (limits and requests).
+|<<type-Resources,`Resources`>>
+|tlsSidecar            1.2+<.<|TLS sidecar configuration
+|<<type-Sidecar,`Sidecar`>>
+|====
+
+[[type-Sidecar]]
+### `Sidecar` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Zookeeper,`Zookeeper`>>
+
+
+[options="header"]
+|====
+|Field             |Description
+|image      1.2+<.<|The docker image for the container
+|string
+|resources  1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
 |====
 

--- a/examples/install/cluster-operator/07-crd-kafka.yaml
+++ b/examples/install/cluster-operator/07-crd-kafka.yaml
@@ -653,8 +653,6 @@ spec:
                       type: object
                 metrics:
                   type: object
-                tlsSidecarImage:
-                  type: string
                 additionalProperties:
                   type: object
                 config:
@@ -695,6 +693,38 @@ spec:
                         memory:
                           type: string
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        additionalProperties:
+                          type: object
+                        limits:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
               required:
               - replicas
               - storage


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Refactored Kafka CRD for supporting more Zookeeper TLS sidecar options (image and resources).
This fix #584 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

