### PR TITLE
Add Prometheus annotations to Kafka, Kafka Connect and Zookeeper services

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -612,12 +612,17 @@ public abstract class AbstractModel {
         return probe;
     }
 
-    protected Service createService(String type, List<ServicePort> ports) {
+    protected Service createService(String name, List<ServicePort> ports) {
+        return createService(name, ports, Collections.emptyMap());
+    }
+
+    protected Service createService(String type, List<ServicePort> ports,  Map<String, String> annotations) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(name)
                     .withLabels(getLabelsWithName())
                     .withNamespace(namespace)
+                    .withAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
                     .withType(type)
@@ -988,5 +993,19 @@ public abstract class AbstractModel {
         } else {
             return false;
         }
+    }
+
+    /**
+     * Generated a Map with Prometheus annotations
+     *
+     * @return Map with Prometheus annotations using the default port (9404) and path (/metrics)
+     */
+    protected Map<String, String> getPrometheusAnnotations()    {
+        Map<String, String> annotations = new HashMap<String, String>(3);
+        annotations.put("prometheus.io/port", "9404");
+        annotations.put("prometheus.io/scrape", "true");
+        annotations.put("prometheus.io/path", "/metrics");
+
+        return annotations;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1002,7 +1002,7 @@ public abstract class AbstractModel {
      */
     protected Map<String, String> getPrometheusAnnotations()    {
         Map<String, String> annotations = new HashMap<String, String>(3);
-        annotations.put("prometheus.io/port", "9404");
+        annotations.put("prometheus.io/port", String.valueOf(metricsPort));
         annotations.put("prometheus.io/scrape", "true");
         annotations.put("prometheus.io/path", "/metrics");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -316,8 +316,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Service
      */
     public Service generateService() {
-
-        return createService("ClusterIP", getServicePorts());
+        return createService("ClusterIP", getServicePorts(), getPrometheusAnnotations());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -140,7 +140,7 @@ public class KafkaConnectCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createService("ClusterIP", ports);
+        return createService("ClusterIP", ports, getPrometheusAnnotations());
     }
 
     public ConfigMap generateMetricsAndLogConfigMap(ConfigMap cm) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -227,7 +227,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
         ports.add(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP"));
 
-        return createService("ClusterIP", ports);
+        return createService("ClusterIP", ports, getPrometheusAnnotations());
     }
 
     public Service generateHeadlessService() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -86,6 +86,7 @@ public class KafkaClusterTest {
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(kc.getPrometheusAnnotations(), headful.getMetadata().getAnnotations());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -137,6 +137,7 @@ public class KafkaConnectClusterTest {
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
         assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(kc.getPrometheusAnnotations(), svc.getMetadata().getAnnotations());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -131,6 +131,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
         assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(kc.getPrometheusAnnotations(), svc.getMetadata().getAnnotations());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -83,6 +83,7 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(ZookeeperCluster.METRICS_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headful.getSpec().getPorts().get(1).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(zc.getPrometheusAnnotations(), headful.getMetadata().getAnnotations());
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR adds back the annotations for Prometheus to Kafka, Zookeeper and Kafka Connect. Thsi was requested in #585 .

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

