### PR TITLE
Remove unused variable for specifying ConfigMap labels

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -17,7 +17,6 @@ import static java.util.Collections.unmodifiableSet;
 public class ClusterOperatorConfig {
 
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String STRIMZI_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -25,7 +25,6 @@ public class ClusterOperatorConfigTest {
         labels = Labels.forKind("cluster");
 
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
         envVars.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "30000");
         envVars.put(ClusterOperatorConfig.STRIMZI_OPERATION_TIMEOUT_MS, "30000");
     }
@@ -69,7 +68,6 @@ public class ClusterOperatorConfigTest {
 
         Map<String, String> envVars = new HashMap<>(2);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -124,7 +124,6 @@ public class ClusterOperatorTest {
 
         Map<String, String> env = new HashMap<>();
         env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
-        env.put(ClusterOperatorConfig.STRIMZI_CONFIGMAP_LABELS, STRIMZI_IO_KIND_CLUSTER);
         env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
         Main.run(vertx, client, openShift, ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");

--- a/examples/install/cluster-operator/08-deployment.yaml
+++ b/examples/install/cluster-operator/08-deployment.yaml
@@ -14,8 +14,6 @@ spec:
         - name: strimzi-cluster-operator
           image: strimzi/cluster-operator:latest
           env:
-            - name: STRIMZI_CONFIGMAP_LABELS
-              value: "strimzi.io/kind=cluster"
             - name: STRIMZI_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The CO configuration option `STRIMZI_CONFIGMAP_LABELS` is not used anymore since we removed the ConfigMaps support and the CRs do not need labels to distinguish the type. SInce its not used, it can be removed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally