### PR TITLE
Some minor fixes to test runner and system tests

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -30,7 +30,7 @@ public abstract class AbstractCrdIT {
         RuntimeException thrown2 = null;
         try {
             try {
-                cluster.client().createContent(ssStr);
+                cluster.client().applyContent(ssStr);
             } catch (RuntimeException t) {
                 thrown = t;
             }

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -493,7 +493,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     protected void before() {
                         LOGGER.info("Creating connect cluster '{}' before test per @ConnectCluster annotation on {}", clusterName, name(element));
                         // create cm
-                        kubeClient().clientWithAdmin().createContent(yaml);
+                        kubeClient().clientWithAdmin().applyContent(yaml);
                         // wait for deployment
                         kubeClient().waitForDeployment(deploymentName);
                     }
@@ -542,7 +542,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     protected void before() {
                         LOGGER.info("Creating kafka cluster '{}' before test per @KafkaCluster annotation on {}", kafkaAssembly.getMetadata().getName(), name(element));
                         // create cm
-                        kubeClient().clientWithAdmin().createContent(yaml);
+                        kubeClient().clientWithAdmin().applyContent(yaml);
                         // wait for ss
                         LOGGER.info("Waiting for Zookeeper SS");
                         kubeClient().waitForStatefulSet(zookeeperStatefulSetName, kafkaAssembly.getSpec().getZookeeper().getReplicas());
@@ -797,7 +797,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 protected void before() {
                     LOGGER.info("Creating Topic {} {}", topic.name(), name(element));
                     // create cm
-                    kubeClient().createContent(configMap);
+                    kubeClient().applyContent(configMap);
                     kubeClient().waitForResourceCreation(BaseKubeClient.CM, topic.name());
                 }
                 @Override

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -645,7 +645,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     for (Map.Entry<File, String> entry: yamls.entrySet()) {
                         LOGGER.info("creating possible modified version of {}", entry.getKey());
                         deletable.push(entry.getValue());
-                        kubeClient().clientWithAdmin().createContent(entry.getValue());
+                        kubeClient().clientWithAdmin().applyContent(entry.getValue());
                     }
                     kubeClient().waitForDeployment(CO_DEPLOYMENT_NAME);
                 }

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -495,7 +495,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                         // create cm
                         kubeClient().clientWithAdmin().applyContent(yaml);
                         // wait for deployment
-                        kubeClient().waitForDeployment(deploymentName);
+                        kubeClient().waitForDeployment(deploymentName, kafkaAssembly.getSpec().getReplicas());
                     }
 
                     @Override
@@ -551,7 +551,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                         kubeClient().waitForStatefulSet(kafkaStatefulSetName, kafkaAssembly.getSpec().getKafka().getReplicas());
                         // wait for TOs
                         LOGGER.info("Waiting for TC Deployment");
-                        kubeClient().waitForDeployment(tcDeploymentName);
+                        kubeClient().waitForDeployment(tcDeploymentName, 1);
                     }
 
                     @Override
@@ -647,7 +647,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                         deletable.push(entry.getValue());
                         kubeClient().clientWithAdmin().applyContent(entry.getValue());
                     }
-                    kubeClient().waitForDeployment(CO_DEPLOYMENT_NAME);
+                    kubeClient().waitForDeployment(CO_DEPLOYMENT_NAME, 1);
                 }
 
                 @Override

--- a/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -247,17 +247,6 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     }
 
     @Override
-    public K waitForDeployment(String name) {
-        return waitFor("deployment", name, actualObj -> {
-            JsonNode replicasNode = actualObj.get("status").get("replicas");
-            JsonNode readyReplicasName = actualObj.get("status").get("readyReplicas");
-            return replicasNode != null && readyReplicasName != null
-                    && replicasNode.asInt() == readyReplicasName.asInt();
-
-        });
-    }
-
-    @Override
     public K waitForPod(String name) {
         // wait when all pods are ready
         return waitFor("pod", name,

--- a/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -172,14 +172,6 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     }
 
     @Override
-    public K createContent(String yamlContent) {
-        try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(CREATE, "-f", "-"));
-            return (K) this;
-        }
-    }
-
-    @Override
     public K applyContent(String yamlContent) {
         try (Context context = defaultContext()) {
             Exec.exec(yamlContent, namespacedCommand(APPLY, "-f", "-"));

--- a/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
@@ -74,6 +74,8 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     K createContent(String yamlContent);
 
+    K applyContent(String yamlContent);
+
     K deleteContent(String yamlContent);
 
     K createNamespace(String name);
@@ -95,6 +97,15 @@ public interface KubeClient<K extends KubeClient<K>> {
      * @return This kube client.
      */
     K waitForDeployment(String name);
+
+    /**
+     * Wait for the deployment with the given {@code name} to
+     * have replicas==readyReplicas && replicas==expected.
+     * @param name The deployment name.
+     * @param expected Number of expected pods
+     * @return This kube client.
+     */
+    K waitForDeployment(String name, int expected);
 
     /**
      * Wait for the pod with the given {@code name} to be in the ready state.

--- a/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
@@ -90,14 +90,6 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     /**
      * Wait for the deployment with the given {@code name} to
-     * have replicas==readyReplicas.
-     * @param name The deployment name.
-     * @return This kube client.
-     */
-    K waitForDeployment(String name);
-
-    /**
-     * Wait for the deployment with the given {@code name} to
      * have replicas==readyReplicas && replicas==expected.
      * @param name The deployment name.
      * @param expected Number of expected pods

--- a/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
@@ -72,8 +72,6 @@ public interface KubeClient<K extends KubeClient<K>> {
     /** Returns an equivalent client, but logged in as cluster admin. */
     K clientWithAdmin();
 
-    K createContent(String yamlContent);
-
     K applyContent(String yamlContent);
 
     K deleteContent(String yamlContent);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -128,7 +128,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         replaceKafkaConnectResource(CONNECT_CLUSTER_NAME, c -> {
             c.getSpec().setReplicas(initialReplicas + 1);
         });
-        kubeClient.waitForDeployment(kafkaConnectName(CONNECT_CLUSTER_NAME));
+        kubeClient.waitForDeployment(kafkaConnectName(CONNECT_CLUSTER_NAME), 2);
         connectPods = kubeClient.listResourcesByLabel("pod", "strimzi.io/kind=KafkaConnect");
         assertEquals(scaleTo, connectPods.size());
         for (String pod : connectPods) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -81,7 +81,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         oc.newApp("strimzi-connect", map("CLUSTER_NAME", clusterName,
                 "KAFKA_CONNECT_BOOTSTRAP_SERVERS", KAFKA_CONNECT_BOOTSTRAP_SERVERS));
         String deploymentName = clusterName + "-connect";
-        oc.waitForDeployment(deploymentName);
+        oc.waitForDeployment(deploymentName, 1);
         testDockerImagesForKafkaConnect();
         oc.deleteByName("cm", clusterName);
         oc.waitForResourceDeletion("deployment", deploymentName);
@@ -174,7 +174,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
             c.getSpec().getReadinessProbe().setTimeoutSeconds(6);
         });
 
-        kubeClient.waitForDeployment(kafkaConnectName(CONNECT_CLUSTER_NAME));
+        kubeClient.waitForDeployment(kafkaConnectName(CONNECT_CLUSTER_NAME), 1);
         for (int i = 0; i < connectPods.size(); i++) {
             kubeClient.waitForResourceDeletion("pod", connectPods.get(i));
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
@@ -42,7 +42,7 @@ public class RecoveryClusterIT extends AbstractClusterIT {
         kubeClient.waitForResourceDeletion(DEPLOYMENT, topicOperatorDeploymentName);
 
         LOGGER.info("Waiting for recovery {}", topicOperatorDeploymentName);
-        kubeClient.waitForDeployment(topicOperatorDeploymentName);
+        kubeClient.waitForDeployment(topicOperatorDeploymentName, 1);
 
         //Test that CO doesn't have any exceptions in log
         assertNoCoErrorsLogged(stopwatch.runtime(SECONDS));


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR delivers two separate improvements to the `StirmziRunner` and to one system test:
* Running the tests from IDE doesn't seem to work properly after the CRDs. The problem seems to be that Minikube doesn't like when we call `kubectl create -f` on the CRDs multiple times. And when running tests individually this is called it tries to call `kubectl create -f` every time. This PR changes the behaviour to use `kubectl apply -f` which can be called many times.
* Additionally, the test `testKafkaConnectScaleUpScaleDown` seems to contain a race condition. It scales Kafka Connect and calls `waitForDeployment` which sometimes seems to return while there is still only 1 pod (i.e. the CO didn't scaled the Deployment yet) and fails. This PR adds new method `waitForDeployment(String name, int expected)` which waits for the deployment not only to have the same numbner of pods and ready pods but also to have the expected number of pods. That should stabilize the test.