### PR TITLE
Renaming services for Kafka, Kafka Connect and Zookeeper

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,5 @@ _Please go through this checklist and make sure all applicable tasks have been d
 - [ ] Check RBAC rights for Kubernetes / OpenShift roles
 - [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
 - [ ] Reference relevant issue(s) and close them after merging
+- [ ] Update CHANGELOG.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# CHANGELOG
+
+## 0.5.0 (Work in Progress)
+
+* Renaming of Kubernetes services (Backwards incompatible!)
+  * Kubernetes services for Kafka, Kafka Connect and Zookeeper have been renamed to better correspond to their purpose
+  * `xxx-kafka` -> `xxx-kafka-bootstrap`
+  * `xxx-kafka-headless` -> `xxx-kafka-brokers`
+  * `xxx-zookeeper` -> `xxx-zookeeper-client`
+  * `xxx-zookeeper-headless` -> `xxx-zookeeper-nodes`
+  * `xxx-connect` -> `xxx-connect-api`
+* Cluster Operator moving to Custom Resources instead of Config Maps
+* TLS support has been added to Kafka and Zookeeper
+* Logging configuration for Kafka, Kafka Connect and Zookeeper
+* Add support for Pod Affinity and Anti-Affinity
+* Configuring different JVM options
+* Support for broker rack in Kafka
+
+## 0.4.0
+
+* Better configurability of Kafka, Kafka Connect, Zookeeper
+* Support for Kubernetes request and limits
+* Support for JVM memory configuration of all components
+* Controllers renamed to operators
+* Improved log verbosity of Cluster Operator
+* Update to Kafka 1.1.0

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -118,7 +118,8 @@ public abstract class AbstractModel {
     protected int livenessTimeout;
     protected int livenessInitialDelay;
 
-    protected String headlessName;
+    protected String serviceName;
+    protected String headlessServiceName;
     protected String name;
 
     protected final int metricsPort = 9404;
@@ -202,8 +203,12 @@ public abstract class AbstractModel {
         return name;
     }
 
-    public String getHeadlessName() {
-        return headlessName;
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getHeadlessServiceName() {
+        return headlessServiceName;
     }
 
     protected Map<String, String> getLabelsWithName() {
@@ -615,8 +620,8 @@ public abstract class AbstractModel {
     protected Service createService(String type, List<ServicePort> ports) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
-                    .withName(name)
-                    .withLabels(getLabelsWithName())
+                    .withName(serviceName)
+                    .withLabels(getLabelsWithName(serviceName))
                     .withNamespace(namespace)
                 .endMetadata()
                 .withNewSpec()
@@ -629,15 +634,15 @@ public abstract class AbstractModel {
         return service;
     }
 
-    protected Service createHeadlessService(String name, List<ServicePort> ports) {
-        return createHeadlessService(name, ports, Collections.emptyMap());
+    protected Service createHeadlessService(List<ServicePort> ports) {
+        return createHeadlessService(ports, Collections.emptyMap());
     }
 
-    protected Service createHeadlessService(String name, List<ServicePort> ports, Map<String, String> annotations) {
+    protected Service createHeadlessService(List<ServicePort> ports, Map<String, String> annotations) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
-                    .withName(name)
-                    .withLabels(getLabelsWithName(name))
+                    .withName(headlessServiceName)
+                    .withLabels(getLabelsWithName(headlessServiceName))
                     .withNamespace(namespace)
                     .withAnnotations(annotations)
                 .endMetadata()
@@ -708,7 +713,7 @@ public abstract class AbstractModel {
                     .withPodManagementPolicy("Parallel")
                     .withUpdateStrategy(new StatefulSetUpdateStrategyBuilder().withType("OnDelete").build())
                     .withSelector(new LabelSelectorBuilder().withMatchLabels(getLabelsWithName()).build())
-                    .withServiceName(headlessName)
+                    .withServiceName(headlessServiceName)
                     .withReplicas(replicas)
                     .withNewTemplate()
                         .withNewMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -66,7 +66,8 @@ public class KafkaCluster extends AbstractModel {
     protected static final String CLIENT_TLS_PORT_NAME = "clientstls";
 
     private static final String NAME_SUFFIX = "-kafka";
-    private static final String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
+    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-bootstrap";
+    private static final String HEADLESS_SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-brokers";
 
     private static final String CLIENTS_CA_SUFFIX = NAME_SUFFIX + "-clients-ca";
     private static final String BROKERS_INTERNAL_SUFFIX = NAME_SUFFIX + "-brokers-internal";
@@ -87,7 +88,7 @@ public class KafkaCluster extends AbstractModel {
     private static final boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
 
     // Kafka configuration defaults
-    private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper:2181";
+    private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper-client:2181";
 
     // Kafka configuration keys (EnvVariables)
     public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
@@ -117,7 +118,8 @@ public class KafkaCluster extends AbstractModel {
 
         super(namespace, cluster, labels);
         this.name = kafkaClusterName(cluster);
-        this.headlessName = headlessName(cluster);
+        this.serviceName = serviceName(cluster);
+        this.headlessServiceName = headlessServiceName(cluster);
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.image = Kafka.DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
@@ -146,8 +148,12 @@ public class KafkaCluster extends AbstractModel {
         return cluster + KafkaCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
     }
 
-    public static String headlessName(String cluster) {
-        return cluster + KafkaCluster.HEADLESS_NAME_SUFFIX;
+    public static String serviceName(String cluster) {
+        return cluster + KafkaCluster.SERVICE_NAME_SUFFIX;
+    }
+
+    public static String headlessServiceName(String cluster) {
+        return cluster + KafkaCluster.HEADLESS_SERVICE_NAME_SUFFIX;
     }
 
     public static String kafkaPodName(String cluster, int pod) {
@@ -204,7 +210,7 @@ public class KafkaCluster extends AbstractModel {
             result.setMetricsEnabled(true);
             result.setMetricsConfig(metrics.entrySet());
         }
-        result.setZookeeperConnect(kafkaAssembly.getMetadata().getName() + "-zookeeper:2181");
+        result.setZookeeperConnect(ZookeeperCluster.serviceName(kafkaAssembly.getMetadata().getName()) + ":2181");
         result.setStorage(kafka.getStorage());
         result.setUserAffinity(kafka.getAffinity());
         result.setResources(kafka.getResources());
@@ -326,7 +332,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public Service generateHeadlessService() {
         Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-        return createHeadlessService(headlessName, getHeadlessServicePorts(), annotations);
+        return createHeadlessService(getHeadlessServicePorts(), annotations);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -77,7 +77,7 @@ public class KafkaCluster extends AbstractModel {
     protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
     // Kafka configuration
-    private String zookeeperConnect = DEFAULT_KAFKA_ZOOKEEPER_CONNECT;
+    private String zookeeperConnect;
     private Rack rack;
     private String initImage;
 
@@ -86,9 +86,6 @@ public class KafkaCluster extends AbstractModel {
     private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     private static final boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
-
-    // Kafka configuration defaults
-    private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper-client:2181";
 
     // Kafka configuration keys (EnvVariables)
     public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
@@ -115,7 +112,6 @@ public class KafkaCluster extends AbstractModel {
      * @param cluster  overall cluster name
      */
     private KafkaCluster(String namespace, String cluster, Labels labels) {
-
         super(namespace, cluster, labels);
         this.name = kafkaClusterName(cluster);
         this.serviceName = serviceName(cluster);
@@ -130,6 +126,8 @@ public class KafkaCluster extends AbstractModel {
         this.livenessTimeout = DEFAULT_HEALTHCHECK_TIMEOUT;
         this.livenessInitialDelay = DEFAULT_HEALTHCHECK_DELAY;
         this.isMetricsEnabled = DEFAULT_KAFKA_METRICS_ENABLED;
+
+        setZookeeperConnect(ZookeeperCluster.serviceName(cluster) + ":2181");
 
         this.mountPath = "/var/lib/kafka";
 
@@ -210,7 +208,6 @@ public class KafkaCluster extends AbstractModel {
             result.setMetricsEnabled(true);
             result.setMetricsConfig(metrics.entrySet());
         }
-        result.setZookeeperConnect(ZookeeperCluster.serviceName(kafkaAssembly.getMetadata().getName()) + ":2181");
         result.setStorage(kafka.getStorage());
         result.setUserAffinity(kafka.getAffinity());
         result.setResources(kafka.getResources());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -41,6 +41,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-connect";
+    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-api";
 
     private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
@@ -66,6 +67,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected KafkaConnectCluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
         this.name = kafkaConnectClusterName(cluster);
+        this.serviceName = serviceName(cluster);
         this.validLoggerFields = getDefaultLogConfig();
         this.ancillaryConfigName = logAndMetricsConfigName(cluster);
         this.image = DEFAULT_IMAGE;
@@ -85,6 +87,10 @@ public class KafkaConnectCluster extends AbstractModel {
 
     public static String kafkaConnectClusterName(String cluster) {
         return cluster + KafkaConnectCluster.NAME_SUFFIX;
+    }
+
+    public static String serviceName(String cluster) {
+        return cluster + KafkaConnectCluster.SERVICE_NAME_SUFFIX;
     }
 
     public static String logAndMetricsConfigName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -145,11 +145,11 @@ public class TopicOperator extends AbstractModel {
     }
 
     protected static String defaultZookeeperConnect(String cluster) {
-        return ZookeeperCluster.zookeeperClusterName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_ZOOKEEPER_PORT;
+        return ZookeeperCluster.serviceName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_ZOOKEEPER_PORT;
     }
 
     protected static String defaultBootstrapServers(String cluster) {
-        return KafkaCluster.kafkaClusterName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_BOOTSTRAP_SERVERS_PORT;
+        return KafkaCluster.serviceName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_BOOTSTRAP_SERVERS_PORT;
     }
 
     protected static String defaultTopicConfigMapLabels(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -57,7 +57,8 @@ public class ZookeeperCluster extends AbstractModel {
     protected static final String TLS_SIDECAR_VOLUME_NAME = "tls-sidecar-certs";
     protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
     private static final String NAME_SUFFIX = "-zookeeper";
-    private static final String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
+    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-client";
+    private static final String HEADLESS_SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-nodes";
     private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
     private static final String LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-logging";
     private static final String NODES_CERTS_SUFFIX = NAME_SUFFIX + "-nodes";
@@ -94,8 +95,12 @@ public class ZookeeperCluster extends AbstractModel {
         return cluster + ZookeeperCluster.LOG_CONFIG_SUFFIX;
     }
 
-    public static String zookeeperHeadlessName(String cluster) {
-        return cluster + ZookeeperCluster.HEADLESS_NAME_SUFFIX;
+    public static String serviceName(String cluster) {
+        return cluster + ZookeeperCluster.SERVICE_NAME_SUFFIX;
+    }
+
+    public static String headlessServiceName(String cluster) {
+        return cluster + ZookeeperCluster.HEADLESS_SERVICE_NAME_SUFFIX;
     }
 
     public static String zookeeperPodName(String cluster, int pod) {
@@ -120,7 +125,8 @@ public class ZookeeperCluster extends AbstractModel {
 
         super(namespace, cluster, labels);
         this.name = zookeeperClusterName(cluster);
-        this.headlessName = zookeeperHeadlessName(cluster);
+        this.serviceName = serviceName(cluster);
+        this.headlessServiceName = headlessServiceName(cluster);
         this.ancillaryConfigName = zookeeperMetricAndLogConfigsName(cluster);
         this.image = Zookeeper.DEFAULT_IMAGE;
         this.replicas = Zookeeper.DEFAULT_REPLICAS;
@@ -232,7 +238,7 @@ public class ZookeeperCluster extends AbstractModel {
 
     public Service generateHeadlessService() {
         Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-        return createHeadlessService(headlessName, getServicePortList(), annotations);
+        return createHeadlessService(getServicePortList(), annotations);
     }
 
     public StatefulSet generateStatefulSet(boolean isOpenShift) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -299,8 +299,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<Void> chainFuture = Future.future();
         getKafkaClusterDescription(assemblyCm, assemblySecrets)
                 .compose(desc -> desc.withVoid(kafkaSetOperations.scaleDown(namespace, desc.kafka().getName(), desc.kafka().getReplicas())))
-                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.kafka().getName(), desc.service())))
-                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.kafka().getHeadlessName(), desc.headlessService())))
+                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.kafka().getServiceName(), desc.service())))
+                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.kafka().getHeadlessServiceName(), desc.headlessService())))
                 .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace, desc.kafka().getAncillaryConfigName(), desc.metricsAndLogsConfigMap())))
                 .compose(desc -> desc.withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCASecretName(name), desc.clientsCASecret())))
                 .compose(desc -> desc.withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsPublicKeyName(name), desc.clientsPublicKeySecret())))
@@ -326,8 +326,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         List<Future> result = new ArrayList<>(8 + (deleteClaims ? ss.getSpec().getReplicas() : 0));
 
         result.add(configMapOperations.reconcile(namespace, KafkaCluster.metricAndLogConfigsName(name), null));
-        result.add(serviceOperations.reconcile(namespace, KafkaCluster.kafkaClusterName(name), null));
-        result.add(serviceOperations.reconcile(namespace, KafkaCluster.headlessName(name), null));
+        result.add(serviceOperations.reconcile(namespace, KafkaCluster.serviceName(name), null));
+        result.add(serviceOperations.reconcile(namespace, KafkaCluster.headlessServiceName(name), null));
         result.add(kafkaSetOperations.reconcile(namespace, KafkaCluster.kafkaClusterName(name), null));
         result.add(secretOperations.reconcile(namespace, KafkaCluster.clientsCASecretName(name), null));
         result.add(secretOperations.reconcile(namespace, KafkaCluster.clientsPublicKeyName(name), null));
@@ -386,8 +386,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<Void> chainFuture = Future.future();
         getZookeeperClusterDescription(kafkaAssembly, assemblySecrets)
                 .compose(desc -> desc.withVoid(zkSetOperations.scaleDown(namespace, desc.zookeeper().getName(), desc.zookeeper().getReplicas())))
-                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.zookeeper().getName(), desc.service())))
-                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.zookeeper().getHeadlessName(), desc.headlessService())))
+                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.zookeeper().getServiceName(), desc.service())))
+                .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.zookeeper().getHeadlessServiceName(), desc.headlessService())))
                 .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace, desc.zookeeper().getAncillaryConfigName(), desc.metricsAndLogsConfigMap())))
                 .compose(desc -> desc.withVoid(secretOperations.reconcile(namespace, ZookeeperCluster.nodesSecretName(name), desc.nodesSecret())))
                 .compose(desc -> desc.withDiff(zkSetOperations.reconcile(namespace, desc.zookeeper().getName(), desc.statefulSet())))
@@ -410,8 +410,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         List<Future> result = new ArrayList<>(4 + (deleteClaims ? ss.getSpec().getReplicas() : 0));
 
         result.add(configMapOperations.reconcile(namespace, ZookeeperCluster.zookeeperMetricAndLogConfigsName(name), null));
-        result.add(serviceOperations.reconcile(namespace, zkSsName, null));
-        result.add(serviceOperations.reconcile(namespace, ZookeeperCluster.zookeeperHeadlessName(name), null));
+        result.add(serviceOperations.reconcile(namespace, ZookeeperCluster.serviceName(name), null));
+        result.add(serviceOperations.reconcile(namespace, ZookeeperCluster.headlessServiceName(name), null));
         result.add(zkSetOperations.reconcile(namespace, zkSsName, null));
         result.add(secretOperations.reconcile(namespace, ZookeeperCluster.nodesSecretName(name), null));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -86,7 +86,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
         log.debug("{}: Updating Kafka Connect cluster", reconciliation, name, namespace);
         Future<Void> chainFuture = Future.future();
         deploymentOperations.scaleDown(namespace, connect.getName(), connect.getReplicas())
-                .compose(scale -> serviceOperations.reconcile(namespace, connect.getName(), connect.generateService()))
+                .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))
                 .compose(i -> configMapOperations.reconcile(namespace, connect.getAncillaryConfigName(), logAndMetricsConfigMap))
                 .compose(i -> deploymentOperations.reconcile(namespace, connect.getName(), connect.generateDeployment()))
                 .compose(i -> deploymentOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()).map((Void) null))
@@ -100,7 +100,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
         String assemblyName = reconciliation.assemblyName();
         String clusterName = KafkaConnectCluster.kafkaConnectClusterName(assemblyName);
 
-        CompositeFuture.join(serviceOperations.reconcile(namespace, clusterName, null),
+        CompositeFuture.join(serviceOperations.reconcile(namespace, KafkaConnectCluster.serviceName(assemblyName), null),
             configMapOperations.reconcile(namespace, KafkaConnectCluster.logAndMetricsConfigName(assemblyName), null),
             deploymentOperations.reconcile(namespace, clusterName, null))
             .map((Void) null).setHandler(handler);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -98,7 +98,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                     null);
 
             deploymentConfigOperations.scaleDown(namespace, connect.getName(), connect.getReplicas())
-                    .compose(scale -> serviceOperations.reconcile(namespace, connect.getName(), connect.generateService()))
+                    .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))
                     .compose(i -> configMapOperations.reconcile(namespace, connect.getAncillaryConfigName(), logAndMetricsConfigMap))
                     .compose(i -> deploymentConfigOperations.reconcile(namespace, connect.getName(), connect.generateDeploymentConfig()))
                     .compose(i -> imagesStreamOperations.reconcile(namespace, connect.getSourceImageStreamName(), connect.generateSourceImageStream()))
@@ -119,7 +119,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
             String assemblyName = reconciliation.assemblyName();
             String clusterName = KafkaConnectS2ICluster.kafkaConnectClusterName(assemblyName);
 
-            CompositeFuture.join(serviceOperations.reconcile(namespace, clusterName, null),
+            CompositeFuture.join(serviceOperations.reconcile(namespace, KafkaConnectS2ICluster.serviceName(assemblyName), null),
                 configMapOperations.reconcile(namespace, KafkaConnectS2ICluster.logAndMetricsConfigName(assemblyName), null),
                 deploymentConfigOperations.reconcile(namespace, clusterName, null),
                 imagesStreamOperations.reconcile(namespace, KafkaConnectS2ICluster.getSourceImageStreamName(clusterName), null),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -95,7 +95,7 @@ public class KafkaClusterTest {
     }
 
     private void checkHeadlessService(Service headless) {
-        assertEquals(KafkaCluster.headlessName(cluster), headless.getMetadata().getName());
+        assertEquals(KafkaCluster.headlessServiceName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
         assertEquals(expectedLabels(), headless.getSpec().getSelector());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -83,8 +83,12 @@ public class KafkaConnectClusterTest {
         assertEquals(metricsCmJson, metricsCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS));
     }
 
+    private Map<String, String> expectedLabels(String name)    {
+        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, name, Labels.STRIMZI_KIND_LABEL, KafkaConnectAssembly.RESOURCE_KIND);
+    }
+
     private Map<String, String> expectedLabels()    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster), Labels.STRIMZI_KIND_LABEL, KafkaConnectAssembly.RESOURCE_KIND);
+        return expectedLabels(kc.kafkaConnectClusterName(cluster));
     }
 
     protected List<EnvVar> getExpectedEnvVars() {
@@ -130,9 +134,8 @@ public class KafkaConnectClusterTest {
         Service svc = kc.generateService();
 
         assertEquals("ClusterIP", svc.getSpec().getType());
-        Map<String, String> expectedLabels = expectedLabels();
-        assertEquals(expectedLabels, svc.getMetadata().getLabels());
-        assertEquals(expectedLabels, svc.getSpec().getSelector());
+        assertEquals(expectedLabels(kc.getServiceName()), svc.getMetadata().getLabels());
+        assertEquals(expectedLabels(), svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -124,9 +124,8 @@ public class KafkaConnectS2IClusterTest {
         Service svc = kc.generateService();
 
         assertEquals("ClusterIP", svc.getSpec().getType());
-        Map<String, String> expectedLabels = expectedLabels(kc.kafkaConnectClusterName(cluster));
-        assertEquals(expectedLabels, svc.getMetadata().getLabels());
-        assertEquals(expectedLabels, svc.getSpec().getSelector());
+        assertEquals(expectedLabels(kc.serviceName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(expectedLabels(kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -92,7 +92,7 @@ public class ZookeeperClusterTest {
     }
 
     private void checkHeadlessService(Service headless) {
-        assertEquals(ZookeeperCluster.zookeeperHeadlessName(cluster), headless.getMetadata().getName());
+        assertEquals(ZookeeperCluster.headlessServiceName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
         assertEquals(expectedLabels(), headless.getSpec().getSelector());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -390,15 +390,15 @@ public class KafkaAssemblyOperatorMockTest {
     @Test
     public void testUpdateClusterWithoutZkServices(TestContext context) {
         updateClusterWithoutServices(context,
-                ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME),
-                ZookeeperCluster.zookeeperHeadlessName(CLUSTER_NAME));
+                ZookeeperCluster.serviceName(CLUSTER_NAME),
+                ZookeeperCluster.headlessServiceName(CLUSTER_NAME));
     }
 
     @Test
     public void testUpdateClusterWithoutKafkaServices(TestContext context) {
         updateClusterWithoutServices(context,
-                KafkaCluster.kafkaClusterName(CLUSTER_NAME),
-                KafkaCluster.headlessName(CLUSTER_NAME));
+                KafkaCluster.serviceName(CLUSTER_NAME),
+                KafkaCluster.headlessServiceName(CLUSTER_NAME));
     }
 
     @Test
@@ -492,14 +492,14 @@ public class KafkaAssemblyOperatorMockTest {
     public void testDeleteClusterWithoutZkServices(TestContext context) {
         deleteClusterWithoutServices(context,
                 ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME),
-                ZookeeperCluster.zookeeperHeadlessName(CLUSTER_NAME));
+                ZookeeperCluster.headlessServiceName(CLUSTER_NAME));
     }
 
     @Test
     public void testDeleteClusterWithoutKafkaServices(TestContext context) {
         deleteClusterWithoutServices(context,
                 KafkaCluster.kafkaClusterName(CLUSTER_NAME),
-                KafkaCluster.headlessName(CLUSTER_NAME));
+                KafkaCluster.headlessServiceName(CLUSTER_NAME));
     }
 
     private void deleteClusterWithoutStatefulSet(TestContext context, String... statefulSets) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -94,7 +94,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
             context.assertTrue(ar.succeeded());
             context.assertNotNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.logAndMetricsConfigName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.serviceName(CLUSTER_NAME)).get());
             createAsync.complete();
         });
         createAsync.await();
@@ -124,7 +124,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
             // TODO: Should verify that all resources were removed from MockKube
             context.assertNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.logAndMetricsConfigName(CLUSTER_NAME)).get());
-            context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.serviceName(CLUSTER_NAME)).get());
             deleteAsync.complete();
         });
     }
@@ -142,6 +142,6 @@ public class KafkaConnectAssemblyOperatorMockTest {
         // TODO: Should verify that all resources were removed from MockKube
         context.assertNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
         context.assertNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.logAndMetricsConfigName(CLUSTER_NAME)).get());
-        context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+        context.assertNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.serviceName(CLUSTER_NAME)).get());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -115,7 +115,7 @@ public class KafkaConnectAssemblyOperatorTest {
             List<Service> capturedServices = serviceCaptor.getAllValues();
             context.assertEquals(1, capturedServices.size());
             Service service = capturedServices.get(0);
-            context.assertEquals(connect.getName(), service.getMetadata().getName());
+            context.assertEquals(connect.getServiceName(), service.getMetadata().getName());
             context.assertEquals(connect.generateService(), service, "Services are not equal");
 
             // Verify Deployment
@@ -258,7 +258,7 @@ public class KafkaConnectAssemblyOperatorTest {
             List<Service> capturedServices = serviceCaptor.getAllValues();
             context.assertEquals(1, capturedServices.size());
             Service service = capturedServices.get(0);
-            context.assertEquals(compareTo.getName(), service.getMetadata().getName());
+            context.assertEquals(compareTo.getServiceName(), service.getMetadata().getName());
             context.assertEquals(compareTo.generateService(), service, "Services are not equal");
 
             // Verify Deployment
@@ -468,7 +468,7 @@ public class KafkaConnectAssemblyOperatorTest {
             // Vertify service
             context.assertEquals(1, serviceNameCaptor.getAllValues().size());
             context.assertEquals(clusterCmNamespace, serviceNamespaceCaptor.getValue());
-            context.assertEquals(connect.getName(), serviceNameCaptor.getValue());
+            context.assertEquals(connect.getServiceName(), serviceNameCaptor.getValue());
 
             // Vertify Deployment
             context.assertEquals(1, dcNameCaptor.getAllValues().size());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -121,7 +121,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             List<Service> capturedServices = serviceCaptor.getAllValues();
             context.assertEquals(1, capturedServices.size());
             Service service = capturedServices.get(0);
-            context.assertEquals(connect.getName(), service.getMetadata().getName());
+            context.assertEquals(connect.getServiceName(), service.getMetadata().getName());
             context.assertEquals(connect.generateService(), service, "Services are not equal");
 
             // Verify Deployment Config
@@ -332,7 +332,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             List<Service> capturedServices = serviceCaptor.getAllValues();
             context.assertEquals(1, capturedServices.size());
             Service service = capturedServices.get(0);
-            context.assertEquals(compareTo.getName(), service.getMetadata().getName());
+            context.assertEquals(compareTo.getServiceName(), service.getMetadata().getName());
             context.assertEquals(compareTo.generateService(), service, "Services are not equal");
 
             // Verify Deployment Config
@@ -603,7 +603,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             // Verify service
             context.assertEquals(1, serviceNameCaptor.getAllValues().size());
             context.assertEquals(clusterCmNamespace, serviceNamespaceCaptor.getValue());
-            context.assertEquals(connect.getName(), serviceNameCaptor.getValue());
+            context.assertEquals(connect.getServiceName(), serviceNameCaptor.getValue());
 
             // Vertify deployment Config
             context.assertEquals(1, dcNameCaptor.getAllValues().size());

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -12,7 +12,7 @@ listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:SSL,CLIENTTLS:SSL
 inter.broker.listener.name=REPLICATION
 
 # Zookeeper
-zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper:2181}
+zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
 zookeeper.connection.timeout.ms=6000
 
 # Logs

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -215,10 +215,10 @@ The resources created by the Cluster Operator in the {ProductPlatformName} clust
 
 `[cluster-name]-zookeeper`:: StatefulSet which is in charge of managing the Zookeeper node pods
 `[cluster-name]-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods
-`[cluster-name]-zookeeper-headless`:: Service needed to have DNS resolve the Zookeeper pods IP addresses directly
-`[cluster-name]-kafka-headless`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly
-`[cluster-name]-zookeeper`:: Service used by Kafka brokers to connect to Zookeeper nodes as clients
-`[cluster-name]-kafka`:: Service can be used as bootstrap servers for Kafka clients
+`[cluster-name]-zookeeper-nodes`:: Service needed to have DNS resolve the Zookeeper pods IP addresses directly
+`[cluster-name]-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly
+`[cluster-name]-zookeeper-client`:: Service used by Kafka brokers to connect to Zookeeper nodes as clients
+`[cluster-name]-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients
 `[cluster-name]-zookeeper-metrics-config`:: ConfigMap which contains the Zookeeper metrics configuration and mounted as a volume by the Zookeeper node pods
 `[cluster-name]-kafka-metrics-config`:: ConfigMap which contains the Kafka metrics configuration and mounted as a volume by the Kafka broker pods
 `[cluster-name]-zookeeper-config`:: 
@@ -858,14 +858,14 @@ spec:
     initialDelaySeconds: 60
     timeoutSeconds: 5
   config: 
-    bootstrap.servers: my-cluster-kafka:9092
+    bootstrap.servers: my-cluster-kafka-bootstrap:9092
 ----
 
 The resources created by the Cluster Operator into the {ProductPlatformName} cluster will be the following :
 
 [connect-cluster-name]-connect::
 Deployment which is in charge to create the Kafka Connect worker node pods.
-[connect-cluster-name]-connect::
+[connect-cluster-name]-connect-api::
 Service which exposes the REST interface for managing the Kafka Connect cluster.
 [connect-cluster-name]-metrics-config::
 ConfigMap which contains the Kafka Connect metrics configuration and is mounted as a volume by the Kafka Connect pods.

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -11,6 +11,6 @@ spec:
     initialDelaySeconds: 60
     timeoutSeconds: 5
   config:
-    bootstrap.servers: my-cluster-kafka:9092
+    bootstrap.servers: my-cluster-kafka-bootstrap:9092
   metrics:
     lowercaseOutputName: true

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -11,6 +11,6 @@ spec:
     initialDelaySeconds: 60
     timeoutSeconds: 5
   config:
-    bootstrap.servers: my-cluster-kafka:9092
+    bootstrap.servers: my-cluster-kafka-bootstrap:9092
   metrics:
     lowercaseOutputName: true

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -26,7 +26,7 @@ parameters:
   displayName: Kafka bootstrap servers
   name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
   required: true
-  value: my-cluster-kafka:9092
+  value: my-cluster-kafka-bootstrap:9092
 - description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
   displayName: Group ID
   name: KAFKA_CONNECT_GROUP_ID

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -25,7 +25,7 @@ parameters:
   displayName: Kafka bootstrap servers
   name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
   required: true
-  value: my-cluster-kafka:9092
+  value: my-cluster-kafka-bootstrap:9092
 - description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
   displayName: Group ID
   name: KAFKA_CONNECT_GROUP_ID

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -81,7 +81,6 @@ public class AbstractClusterIT {
     static KubernetesClient client = new DefaultKubernetesClient();
     KubeClient<?> kubeClient = cluster.client();
 
-    // can be used as kafka stateful set or service names
     static String kafkaClusterName(String clusterName) {
         return clusterName + "-kafka";
     }
@@ -94,15 +93,18 @@ public class AbstractClusterIT {
         return kafkaClusterName(clusterName) + "-" + podId;
     }
 
+    static String kafkaServiceName(String clusterName) {
+        return kafkaClusterName(clusterName) + "-bootstrap";
+    }
+
     static String kafkaHeadlessServiceName(String clusterName) {
-        return kafkaClusterName(clusterName) + "-headless";
+        return kafkaClusterName(clusterName) + "-brokers";
     }
 
     static String kafkaMetricsConfigName(String clusterName) {
         return kafkaClusterName(clusterName) + "-config";
     }
 
-    // can be used as zookeeper stateful set or service names
     static String zookeeperClusterName(String clusterName) {
         return clusterName + "-zookeeper";
     }
@@ -111,8 +113,12 @@ public class AbstractClusterIT {
         return zookeeperClusterName(clusterName) + "-" + podId;
     }
 
+    static String zookeeperServiceName(String clusterName) {
+        return zookeeperClusterName(clusterName) + "-client";
+    }
+
     static String zookeeperHeadlessServiceName(String clusterName) {
-        return zookeeperClusterName(clusterName) + "-headless";
+        return zookeeperClusterName(clusterName) + "-nodes";
     }
 
     static String zookeeperMetricsConfigName(String clusterName) {
@@ -228,7 +234,7 @@ public class AbstractClusterIT {
     public void sendMessages(String clusterName, String topic, int messagesCount, int kafkaPodID) {
         LOGGER.info("Sending messages");
         String command = "sh bin/kafka-verifiable-producer.sh --broker-list " +
-                clusterName + "-kafka:9092 --topic " + topic + " --max-messages " + messagesCount + "";
+                clusterName + "-kafka-bootstrap:9092 --topic " + topic + " --max-messages " + messagesCount + "";
 
         LOGGER.info("Command for kafka-verifiable-producer.sh {}", command);
 
@@ -239,7 +245,7 @@ public class AbstractClusterIT {
         LOGGER.info("Consuming messages");
         String output = kubeClient.exec(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
                 "bin/kafka-verifiable-consumer.sh --broker-list " + clusterName +
-                        "-kafka:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
+                        "-kafka-bootstrap:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
                         + timeout + "; kill %1").out();
         output = "[" + output.replaceAll("\n", ",") + "]";
         LOGGER.info("Output for kafka-verifiable-consumer.sh {}", output);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -310,28 +310,28 @@ public class AbstractClusterIT {
 
     public List<String> listTopicsUsingPodCLI(String clusterName, String podName) {
         return asList(kubeClient.exec(podName, "/bin/bash", "-c",
-                "bin/kafka-topics.sh --list --zookeeper " + clusterName + "-zookeeper:2181").out().split("\\s+"));
+                "bin/kafka-topics.sh --list --zookeeper " + clusterName + "-zookeeper-client:2181").out().split("\\s+"));
     }
 
     public String createTopicUsingPodCLI(String clusterName, String podName, String topic, int replicationFactor, int partitions) {
         return kubeClient.exec(podName, "/bin/bash", "-c",
-                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper:2181  --create " + " --topic " + topic +
+                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper-client:2181  --create " + " --topic " + topic +
                         " --replication-factor " + replicationFactor + " --partitions " + partitions).out();
     }
 
     public String deleteTopicUsingPodCLI(String clusterName, String podName, String topic) {
         return kubeClient.exec(podName, "/bin/bash", "-c",
-                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper:2181 --delete --topic " + topic).out();
+                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper-client:2181 --delete --topic " + topic).out();
     }
 
     public List<String>  describeTopicUsingPodCLI(String clusterName, String podName, String topic) {
         return asList(kubeClient.exec(podName, "/bin/bash", "-c",
-                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper:2181 --describe --topic " + topic).out().split("\\s+"));
+                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper-client:2181 --describe --topic " + topic).out().split("\\s+"));
     }
 
     public String updateTopicPartitionsCountUsingPodCLI(String clusterName, String podName, String topic, int partitions) {
         return kubeClient.exec(podName, "/bin/bash", "-c",
-                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper:2181 --alter --topic " + topic + " --partitions " + partitions).out();
+                "bin/kafka-topics.sh --zookeeper " + clusterName + "-zookeeper-client:2181 --alter --topic " + topic + " --partitions " + partitions).out();
     }
 
     public Map<String, String> getImagesFromConfig(String configJson) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -51,8 +51,8 @@ public class ConnectClusterIT extends AbstractClusterIT {
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
     public static final String CONNECT_CLUSTER_NAME = "my-cluster";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka:9092";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED = KAFKA_CLUSTER_NAME + "-kafka\\:9092";
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka-bootstrap:9092";
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED = KAFKA_CLUSTER_NAME + "-kafka-bootstrap\\:9092";
     public static final String CONNECT_CONFIG = "{\n" +
             "      \"bootstrap.servers\": \"" + KAFKA_CONNECT_BOOTSTRAP_SERVERS + "\"" +
             "    }";

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
@@ -83,7 +83,7 @@ public class RecoveryClusterIT extends AbstractClusterIT {
     @Test
     public void testRecoveryFromKafkaServiceDeletion() {
         // kafka cluster already deployed via annotation
-        String kafkaServiceName = kafkaClusterName(CLUSTER_NAME);
+        String kafkaServiceName = kafkaServiceName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaService with cluster {}", CLUSTER_NAME);
 
         kubeClient.deleteByName(SERVICE, kafkaServiceName);
@@ -98,7 +98,7 @@ public class RecoveryClusterIT extends AbstractClusterIT {
     @Test
     public void testRecoveryFromZookeeperServiceDeletion() {
         // kafka cluster already deployed via annotation
-        String zookeeperServiceName = zookeeperClusterName(CLUSTER_NAME);
+        String zookeeperServiceName = zookeeperServiceName(CLUSTER_NAME);
 
         LOGGER.info("Running deleteKafkaService with cluster {}", CLUSTER_NAME);
 

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testDeployUndeploy.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testDeployUndeploy.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   replicas: 1
   config:
-    bootstrap.servers: connect-tests-kafka:9092
+    bootstrap.servers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testForUpdateValuesInConnectCM.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testForUpdateValuesInConnectCM.yaml
@@ -11,4 +11,4 @@ spec:
     initialDelaySeconds: 15
     timeoutSeconds: 5
   config:
-    bootstrap.servers: connect-tests-kafka:9092
+    bootstrap.servers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testJvmAndResources.yaml
@@ -19,4 +19,4 @@ spec:
       "UseG1GC": "true"
     }
   config:
-    bootstrap.servers: connect-tests-kafka:9092
+    bootstrap.servers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testKafkaConnectScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testKafkaConnectScaleUpScaleDown.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   replicas: 1
   config:
-    bootstrap.servers: connect-tests-kafka:9092
+    bootstrap.servers: connect-tests-kafka-bootstrap:9092


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR renames the services as discussed in #55.

`xxx-kafka` -> `xxx-kafka-bootstrap`
`xxx-kafka-headless` -> `xxx-kafka-brokers`
`xxx-zookeeper` -> `xxx-zookeeper-client`
`xxx-zookeeper-headless` -> `xxx-zookeeper-nodes`
`xxx-connect` -> `xxx-connect-api`

It also adds new `CHANGELOG.md` file with the list of latest updates and important changes.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

