### PR TITLE
Added Buildable to logging API classes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
@@ -4,7 +4,16 @@
  */
 package io.strimzi.api.kafka.model;
 
-/** Logging config comes from an existing, user-supplied config map*/
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Logging config comes from an existing, user-supplied config map
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
 public class ExternalLogging extends Logging {
 
     /** The name of the configmap from which to get the logging config */

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -4,12 +4,19 @@
  */
 package io.strimzi.api.kafka.model;
 
+import io.sundr.builder.annotations.Buildable;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Logging config is given inline with the resource
  */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
 public class InlineLogging extends Logging {
 
     /** A Map from logger name to logger level */


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As from a chat with @tombentley while adding `Sidecar` to the api, the logging classes lack of `@Buildable` attribute for providing a corresponding builder. This PR addresses this lack.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

