### PR TITLE
Replace the Kafka healthcheck with a simple TCP socket probe

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -600,6 +600,20 @@ public abstract class AbstractModel {
         return probe;
     }
 
+    protected Probe createTcpSocketProbe(int port, int initialDelay, int timeout) {
+        Probe probe = new ProbeBuilder()
+                .withNewTcpSocket()
+                    .withNewPort()
+                        .withIntVal(port)
+                    .endPort()
+                .endTcpSocket()
+                .withInitialDelaySeconds(initialDelay)
+                .withTimeoutSeconds(timeout)
+                .build();
+        log.trace("Created TCP socket probe {}", probe);
+        return probe;
+    }
+
     protected Probe createHttpProbe(String path, String port, int initialDelay, int timeout) {
         Probe probe = new ProbeBuilder().withNewHttpGet()
                 .withPath(path)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -121,8 +121,6 @@ public class KafkaCluster extends AbstractModel {
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.image = Kafka.DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
-        this.readinessPath = "/opt/kafka/kafka_healthcheck.sh";
-        this.livenessPath = this.readinessPath;
         this.readinessTimeout = DEFAULT_HEALTHCHECK_TIMEOUT;
         this.readinessInitialDelay = DEFAULT_HEALTHCHECK_DELAY;
         this.livenessTimeout = DEFAULT_HEALTHCHECK_TIMEOUT;
@@ -549,8 +547,8 @@ public class KafkaCluster extends AbstractModel {
                 .withEnv(getEnvVars())
                 .withVolumeMounts(getVolumeMounts())
                 .withPorts(getContainerPortList())
-                .withLivenessProbe(createExecProbe(livenessPath, livenessInitialDelay, livenessTimeout))
-                .withReadinessProbe(createExecProbe(readinessPath, readinessInitialDelay, readinessTimeout))
+                .withLivenessProbe(createTcpSocketProbe(REPLICATION_PORT, livenessInitialDelay, livenessTimeout))
+                .withReadinessProbe(createTcpSocketProbe(REPLICATION_PORT, readinessInitialDelay, readinessTimeout))
                 .withResources(resources(getResources()))
                 .build());
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
@@ -307,5 +308,16 @@ public class KafkaClusterTest {
     public void withRackAndAffinity() throws IOException {
         resourceTester.assertDesiredResource("-SS.yaml",
             kc -> kc.generateStatefulSet(true).getSpec().getTemplate().getSpec().getAffinity());
+    }
+
+
+    @Test
+    public void testCreateTcpSocketProbe()  {
+        Probe probe = kc.createTcpSocketProbe(1234, 10, 20);
+
+        assertEquals(new Integer(1234), probe.getTcpSocket().getPort().getIntVal());
+        assertEquals(new Integer(10), probe.getInitialDelaySeconds());
+        assertEquals(new Integer(20), probe.getTimeoutSeconds());
+
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -318,6 +318,5 @@ public class KafkaClusterTest {
         assertEquals(new Integer(1234), probe.getTcpSocket().getPort().getIntVal());
         assertEquals(new Integer(10), probe.getInitialDelaySeconds());
         assertEquals(new Integer(20), probe.getTimeoutSeconds());
-
     }
 }

--- a/docker-images/kafka/scripts/kafka_healthcheck.sh
+++ b/docker-images/kafka/scripts/kafka_healthcheck.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9092


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The current Kafka healthcheck seems to be problematic: 
* It is based on Java so it is relatively expensive to start / run
* It seems to depend on other nodes of the cluster - it fails when the cluster is undergoing changes (metadata updates?)

This PR replaces it with TCP Socket probe which is less sophisticated, but should provide better stability.

This should also help with situations as described in #518 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

