### PR TITLE
ST: The fix for system tests about the checking of updated values for Kafka cluster 

### DIFF
--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
-      initialDelaySeconds: "30"
-      timeoutSeconds: "10"
-    liveness:
-      initialDelaySeconds: "30"
-      timeoutSeconds: "10"
+    readinessProbe:
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
     config:
       default.replication.factor: 1
       offsets.topic.replication.factor: 1
@@ -19,12 +19,12 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 2
-    readiness:
-      initialDelaySeconds: "30"
-      timeoutSeconds: "10"
-    liveness:
-      initialDelaySeconds: "30"
-      timeoutSeconds: "10"
+    readinessProbe:
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
     storage:
       type: ephemeral
     config:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
@@ -18,7 +18,7 @@ spec:
     storage:
       type: ephemeral
   zookeeper:
-    replicas: 1
+    replicas: 2
     readiness:
       initialDelaySeconds: "30"
       timeoutSeconds: "10"

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testForTopicOperator.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testForTopicOperator.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
-    liveness:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -19,12 +19,12 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
-    liveness:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     storage:
       type: ephemeral
   topicOperator: {}


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
Issues were fixed:
1. Updated number of zookeeper replicas because we have a different value in test and .yaml file
2. Removed checks for config map which are not relevant for now
3. Added the updating of zookeper config (Set InitialDelaySeconds and TimeoutSeconds)
4. Updated types in `yamls` and renamed keys `readiness` -> `readinessProbe`

### Checklist
- [ ] Make sure all tests pass
