### PR TITLE
Fix OpenShiftTemplatesIT

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -165,13 +165,14 @@ public class ExamplesTest {
         }
         for (JsonNode object : rootNode.get("objects")) {
             String s = object.toString();
-            Pattern p = Pattern.compile("\\$\\{(.+?)\\}");
+            Pattern p = Pattern.compile("\\$\\{\\{(.+?)\\}?\\}");
             Matcher matcher = p.matcher(s);
             StringBuilder sb = new StringBuilder();
             int last = 0;
             while (matcher.find()) {
                 sb.append(s, last, matcher.start());
-                sb.append(params.get(matcher.group(1)));
+                String paramName = matcher.group(1);
+                sb.append(params.get(paramName));
                 last = matcher.end();
             }
             sb.append(s.substring(last));

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -78,13 +78,13 @@ objects:
     labels:
       type: kafka-connect
   spec:
-    replicas: ${INSTANCES}
+    replicas: ${{INSTANCES}}
     livenessProbe:
-      initialDelaySeconds: ${HEALTHCHECK_DELAY}
-      timeoutSeconds: ${HEALTHCHECK_TIMEOUT}
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
     readinessProbe:
-      initialDelaySeconds: ${HEALTHCHECK_DELAY}
-      timeoutSeconds: ${HEALTHCHECK_TIMEOUT}
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
     config:
       bootstrap.servers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
       group.id: "${KAFKA_CONNECT_GROUP_ID}"
@@ -93,10 +93,10 @@ objects:
       status.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-status"
       key.converter: "${KAFKA_CONNECT_KEY_CONVERTER}"
       value.converter: "${KAFKA_CONNECT_VALUE_CONVERTER}"
-      key.converter.schemas.enable: ${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}
-      value.converter.schemas.enable: ${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}
-      config.storage.replication.factor: ${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}
-      offset.storage.replication.factor: ${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}
-      status.storage.replication.factor: ${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}
+      key.converter.schemas.enable: ${{KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}}
+      value.converter.schemas.enable: ${{KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}}
+      config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
+      offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
+      status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
     metrics:
       lowercaseOutputName: true

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -77,13 +77,13 @@ objects:
     labels:
       type: kafka-connect
   spec:
-    replicas: ${INSTANCES}
+    replicas: ${{INSTANCES}}
     livenessProbe:
-      initialDelaySeconds: ${HEALTHCHECK_DELAY}
-      timeoutSeconds: ${HEALTHCHECK_TIMEOUT}
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
     readinessProbe:
-      initialDelaySeconds: ${HEALTHCHECK_DELAY}
-      timeoutSeconds: ${HEALTHCHECK_TIMEOUT}
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
     config:
       bootstrap.servers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
       group.id: "${KAFKA_CONNECT_GROUP_ID}"
@@ -92,10 +92,10 @@ objects:
       status.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-status"
       key.converter: "${KAFKA_CONNECT_KEY_CONVERTER}"
       value.converter: "${KAFKA_CONNECT_VALUE_CONVERTER}"
-      key.converter.schemas.enable: ${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}
-      value.converter.schemas.enable: ${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}
-      config.storage.replication.factor: ${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}
-      offset.storage.replication.factor: ${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}
-      status.storage.replication.factor: ${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}
+      key.converter.schemas.enable: ${{KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}}
+      value.converter.schemas.enable: ${{KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}}
+      config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
+      offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
+      status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
     metrics:
       lowercaseOutputName: true

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -65,17 +65,17 @@ objects:
     name: ${CLUSTER_NAME}
   spec:
     kafka:
-      replicas: ${KAFKA_NODE_COUNT}
+      replicas: ${{KAFKA_NODE_COUNT}}
       image: "strimzi/kafka:latest"
       resources:
         limits:
           memory: "5Gi"
       livenessProbe:
-        initialDelaySeconds: ${KAFKA_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${KAFKA_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
       readinessProbe:
-        initialDelaySeconds: ${KAFKA_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${KAFKA_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
       storage:
         type: ephemeral
       config:
@@ -83,14 +83,14 @@ objects:
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
     zookeeper:
-      replicas: ${ZOOKEEPER_NODE_COUNT}
+      replicas: ${{ZOOKEEPER_NODE_COUNT}}
       image: "strimzi/zookeeper:latest"
       livenessProbe:
-        initialDelaySeconds: ${ZOOKEEPER_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${ZOOKEEPER_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
       readinessProbe:
-        initialDelaySeconds: ${ZOOKEEPER_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${ZOOKEEPER_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
       storage:
         type: ephemeral
-    topicOperator:
+    topicOperator: {}

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -71,17 +71,17 @@ objects:
     name: ${CLUSTER_NAME}
   spec:
     kafka:
-      replicas: ${KAFKA_NODE_COUNT}
+      replicas: ${{KAFKA_NODE_COUNT}}
       image: "strimzi/kafka:latest"
       resources:
         limits:
           memory: "5Gi"
       livenessProbe:
-        initialDelaySeconds: ${KAFKA_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${KAFKA_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
       readinessProbe:
-        initialDelaySeconds: ${KAFKA_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${KAFKA_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
       storage:
         type: "persistent-claim"
         size: "${KAFKA_VOLUME_CAPACITY}"
@@ -91,16 +91,16 @@ objects:
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
     zookeeper:
-      replicas: ${ZOOKEEPER_NODE_COUNT}
+      replicas: ${{ZOOKEEPER_NODE_COUNT}}
       image: "strimzi/zookeeper:latest"
       livenessProbe:
-        initialDelaySeconds: ${ZOOKEEPER_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${ZOOKEEPER_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
       readinessProbe:
-        initialDelaySeconds: ${ZOOKEEPER_HEALTHCHECK_DELAY}
-        timeoutSeconds: ${ZOOKEEPER_HEALTHCHECK_TIMEOUT}
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
       storage:
         type: persistent-claim
         size: "${ZOOKEEPER_VOLUME_CAPACITY}"
         deleteClaim: false
-    topicOperator:
+    topicOperator: {}

--- a/systemtest/src/rbac/role-edit-kafka.yaml
+++ b/systemtest/src/rbac/role-edit-kafka.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: strimzi-edit-kafka
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kafka-editors
+  labels:
+    app: strimzi
+subjects:
+  - kind: User
+    name: developer
+roleRef:
+  kind: Role
+  name: strimzi-edit-kafka
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
@@ -6,12 +6,18 @@ package io.strimzi.systemtest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.DoneableKafkaAssembly;
+import io.strimzi.api.kafka.DoneableKafkaConnectAssembly;
+import io.strimzi.api.kafka.DoneableKafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.KafkaAssemblyList;
+import io.strimzi.api.kafka.KafkaConnectAssemblyList;
+import io.strimzi.api.kafka.KafkaConnectS2IAssemblyList;
 import io.strimzi.api.kafka.model.KafkaAssembly;
+import io.strimzi.api.kafka.model.KafkaConnectAssembly;
+import io.strimzi.api.kafka.model.KafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.test.JUnitGroup;
 import io.strimzi.test.Namespace;
@@ -41,6 +47,10 @@ import static org.junit.Assert.assertNotNull;
 @Namespace(OpenShiftTemplatesIT.NAMESPACE)
 @Resources(value = "../examples/templates/cluster-operator", asAdmin = true)
 @Resources(value = "../examples/templates/topic-operator", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/04-crd-kafka.yaml", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/04-crd-kafka-connect.yaml", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/04-crd-kafka-connect-s2i.yaml", asAdmin = true)
+@Resources(value = "src/rbac/role-edit-kafka.yaml", asAdmin = true)
 public class OpenShiftTemplatesIT {
 
     public static final String NAMESPACE = "template-test";
@@ -53,9 +63,15 @@ public class OpenShiftTemplatesIT {
     private KubernetesClient client = new DefaultKubernetesClient();
 
     private KafkaAssembly getKafkaWithName(String clusterName) {
-        CustomResourceDefinition crd = client.customResourceDefinitions().withName(KafkaAssembly.CRD_NAME).get();
-        KafkaAssembly kafka = client.customResources(crd, KafkaAssembly.class, KafkaAssemblyList.class, DoneableKafkaAssembly.class).inNamespace(NAMESPACE).withName(clusterName).get();
-        return kafka;
+        return client.customResources(Crds.kafka(), KafkaAssembly.class, KafkaAssemblyList.class, DoneableKafkaAssembly.class).inNamespace(NAMESPACE).withName(clusterName).get();
+    }
+
+    private KafkaConnectAssembly getKafkaConnectWithName(String clusterName) {
+        return client.customResources(Crds.kafkaConnect(), KafkaConnectAssembly.class, KafkaConnectAssemblyList.class, DoneableKafkaConnectAssembly.class).inNamespace(NAMESPACE).withName(clusterName).get();
+    }
+
+    private KafkaConnectS2IAssembly getKafkaConnectS2IWithName(String clusterName) {
+        return client.customResources(Crds.kafkaConnectS2I(), KafkaConnectS2IAssembly.class, KafkaConnectS2IAssemblyList.class, DoneableKafkaConnectS2IAssembly.class).inNamespace(NAMESPACE).withName(clusterName).get();
     }
 
     @Test
@@ -108,14 +124,14 @@ public class OpenShiftTemplatesIT {
         KafkaAssembly kafka = getKafkaWithName(clusterName);
         assertNotNull(kafka);
 
-        assertEquals("30", kafka.getSpec().getZookeeper().getLivenessProbe().getInitialDelaySeconds());
-        assertEquals("30", kafka.getSpec().getZookeeper().getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("10", kafka.getSpec().getZookeeper().getLivenessProbe().getTimeoutSeconds());
-        assertEquals("10", kafka.getSpec().getZookeeper().getReadinessProbe().getTimeoutSeconds());
-        assertEquals("30", kafka.getSpec().getKafka().getLivenessProbe().getInitialDelaySeconds());
-        assertEquals("30", kafka.getSpec().getKafka().getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("10", kafka.getSpec().getKafka().getLivenessProbe().getTimeoutSeconds());
-        assertEquals("10", kafka.getSpec().getKafka().getReadinessProbe().getTimeoutSeconds());
+        assertEquals(30, kafka.getSpec().getZookeeper().getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(30, kafka.getSpec().getZookeeper().getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(10, kafka.getSpec().getZookeeper().getLivenessProbe().getTimeoutSeconds());
+        assertEquals(10, kafka.getSpec().getZookeeper().getReadinessProbe().getTimeoutSeconds());
+        assertEquals(30, kafka.getSpec().getKafka().getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(30, kafka.getSpec().getKafka().getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(10, kafka.getSpec().getKafka().getLivenessProbe().getTimeoutSeconds());
+        assertEquals(10, kafka.getSpec().getKafka().getReadinessProbe().getTimeoutSeconds());
         assertEquals("2", kafka.getSpec().getKafka().getConfig().get("default.replication.factor"));
         assertEquals("5", kafka.getSpec().getKafka().getConfig().get("offsets.topic.replication.factor"));
         assertEquals("5", kafka.getSpec().getKafka().getConfig().get("transaction.state.log.replication.factor"));
@@ -140,14 +156,14 @@ public class OpenShiftTemplatesIT {
         KafkaAssembly kafka = getKafkaWithName(clusterName);
         assertNotNull(kafka);
 
-        assertEquals("30", kafka.getSpec().getZookeeper().getLivenessProbe().getInitialDelaySeconds());
-        assertEquals("30", kafka.getSpec().getZookeeper().getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("10", kafka.getSpec().getZookeeper().getLivenessProbe().getTimeoutSeconds());
-        assertEquals("10", kafka.getSpec().getZookeeper().getReadinessProbe().getTimeoutSeconds());
-        assertEquals("30", kafka.getSpec().getKafka().getLivenessProbe().getInitialDelaySeconds());
-        assertEquals("30", kafka.getSpec().getKafka().getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("10", kafka.getSpec().getKafka().getLivenessProbe().getTimeoutSeconds());
-        assertEquals("10", kafka.getSpec().getKafka().getReadinessProbe().getTimeoutSeconds());
+        assertEquals(30, kafka.getSpec().getZookeeper().getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(30, kafka.getSpec().getZookeeper().getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(10, kafka.getSpec().getZookeeper().getLivenessProbe().getTimeoutSeconds());
+        assertEquals(10, kafka.getSpec().getZookeeper().getReadinessProbe().getTimeoutSeconds());
+        assertEquals(30, kafka.getSpec().getKafka().getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(30, kafka.getSpec().getKafka().getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(10, kafka.getSpec().getKafka().getLivenessProbe().getTimeoutSeconds());
+        assertEquals(10, kafka.getSpec().getKafka().getReadinessProbe().getTimeoutSeconds());
         assertEquals("2", kafka.getSpec().getKafka().getConfig().get("default.replication.factor"));
         assertEquals("5", kafka.getSpec().getKafka().getConfig().get("offsets.topic.replication.factor"));
         assertEquals("5", kafka.getSpec().getKafka().getConfig().get("transaction.state.log.replication.factor"));
@@ -162,10 +178,9 @@ public class OpenShiftTemplatesIT {
         oc.newApp("strimzi-connect", map("CLUSTER_NAME", clusterName,
                 "INSTANCES", "1"));
 
-        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
-        assertNotNull(cm);
-        Map<String, String> cmData = cm.getData();
-        assertEquals("1", cmData.get("nodes"));
+        KafkaConnectAssembly connect = getKafkaConnectWithName(clusterName);
+        assertNotNull(connect);
+        assertEquals(1, connect.getSpec().getReplicas());
     }
 
     @Test
@@ -175,10 +190,9 @@ public class OpenShiftTemplatesIT {
         oc.newApp("strimzi-connect-s2i", map("CLUSTER_NAME", clusterName,
                 "INSTANCES", "1"));
 
-        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
+        KafkaConnectS2IAssembly cm = getKafkaConnectS2IWithName(clusterName);
         assertNotNull(cm);
-        Map<String, String> cmData = cm.getData();
-        assertEquals("1", cmData.get("nodes"));
+        assertEquals(1, cm.getSpec().getReplicas());
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes OpenShiftTemplatesIT. There were mutliple problems:
1. `${}` interpolation in a template assumes a string typed argument. to substitute other JSON types you need to use `${{}}`. See https://docs.openshift.org/latest/dev_guide/templates.html#writing-parameters
2. We need the CRDs installed in order to be able to execute templates including them in `objects`.
3. The k8s user via which the templates are executed need RBAC permissions to create the CRs. For this I just used a static role and role binding.

### Checklist

- [x] Make sure all tests pass
