### PR TITLE
Fix the memeory resources specified in templates and the parsing of n…

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CpuMemory.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CpuMemory.java
@@ -65,7 +65,7 @@ public class CpuMemory {
     /** The CPUs in "millicpus". */
     @JsonIgnore
     public int milliCpuAsInt() {
-        return MilliCpuDeserializer.parse(milliCpu);
+        return milliCpu == null ? 0 : MilliCpuDeserializer.parse(milliCpu);
     }
 
     public void milliCpuAsInt(int milliCpu) {

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -75,8 +75,6 @@ objects:
   kind: KafkaConnectS2I
   metadata:
     name: ${CLUSTER_NAME}
-    labels:
-      type: kafka-connect
   spec:
     replicas: ${{INSTANCES}}
     livenessProbe:

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -74,8 +74,6 @@ objects:
   kind: KafkaConnect
   metadata:
     name: ${CLUSTER_NAME}
-    labels:
-      type: kafka-connect
   spec:
     replicas: ${{INSTANCES}}
     livenessProbe:

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -67,9 +67,6 @@ objects:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
       image: "strimzi/kafka:latest"
-      resources:
-        limits:
-          memory: "5Gi"
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -73,9 +73,6 @@ objects:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
       image: "strimzi/kafka:latest"
-      resources:
-        limits:
-          memory: "5Gi"
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}


### PR DESCRIPTION
…ull CPU resources - Closes #602

### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

This PR fixes several separate problems:
* The OpenShift templates for Kafka contain memory request of 5GB for Kafka which should not be there
* The OpenShift templates for KafkaConnect contain type label which is not needed
* The resource request / limit specifies only memeory, the decoding of CPU request fails with NPE

This PR should close #602 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

