### PR TITLE
ST: Updated paths to templates and removed deletion by cm

### DIFF
--- a/api/src/test/java/io/strimzi/test/k8s/OpenShift.java
+++ b/api/src/test/java/io/strimzi/test/k8s/OpenShift.java
@@ -36,7 +36,6 @@ public class OpenShift implements KubeCluster {
                             return true;
                         } catch (KubeClusterException e2) {
                             LOGGER.trace("oc cluster still not up");
-                            LOGGER.info("Status for oc: {}", e2.result.out());
                             return false;
                         }
                     });

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -66,7 +66,6 @@ objects:
   spec:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
-      image: "strimzi/kafka:latest"
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
@@ -81,7 +80,6 @@ objects:
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
-      image: "strimzi/zookeeper:latest"
       livenessProbe:
         initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -72,7 +72,6 @@ objects:
   spec:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
-      image: "strimzi/kafka:latest"
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
@@ -89,7 +88,6 @@ objects:
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
-      image: "strimzi/zookeeper:latest"
       livenessProbe:
         initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -83,7 +83,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         String deploymentName = clusterName + "-connect";
         oc.waitForDeployment(deploymentName, 1);
         testDockerImagesForKafkaConnect();
-        oc.deleteByName("cm", clusterName);
+        oc.deleteByName("deployment", deploymentName);
         oc.waitForResourceDeletion("deployment", deploymentName);
     }
 
@@ -200,7 +200,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
                 "deployment", "strimzi-cluster-operator"));
         //Verifying docker image for kafka connect
         String connectImageName = getContainerImageNameFromPod(kubeClient.listResourcesByLabel("pod",
-                "type=kafka-connect").get(0));
+                "strimzi.io/kind=KafkaConnect").get(0));
 
         assertEquals(imgFromDeplConf.get(CONNECT_IMAGE), connectImageName);
         LOGGER.info("Docker images verified");

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -53,9 +53,6 @@ public class ConnectClusterIT extends AbstractClusterIT {
     public static final String CONNECT_CLUSTER_NAME = "my-cluster";
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka-bootstrap:9092";
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED = KAFKA_CLUSTER_NAME + "-kafka-bootstrap\\:9092";
-    public static final String CONNECT_CONFIG = "{\n" +
-            "      \"bootstrap.servers\": \"" + KAFKA_CONNECT_BOOTSTRAP_SERVERS + "\"" +
-            "    }";
 
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
@@ -68,8 +65,6 @@ public class ConnectClusterIT extends AbstractClusterIT {
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
             "internal.value.converter.schemas.enable=false\\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\\n";
-    private static final String CO_DEPLOYMENT_CONFIG = "../examples/install/cluster-operator/08-deployment.yaml";
-
 
     @Test
     @JUnitGroup(name = "regression")
@@ -83,7 +78,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         String deploymentName = clusterName + "-connect";
         oc.waitForDeployment(deploymentName, 1);
         testDockerImagesForKafkaConnect();
-        oc.deleteByName("deployment", deploymentName);
+        oc.deleteByName("KafkaConnect", clusterName);
         oc.waitForResourceDeletion("deployment", deploymentName);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -393,7 +393,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-//    @JUnitGroup(name = "regression")
+    @JUnitGroup(name = "regression")
     @KafkaFromClasspathYaml
     public void testRackAware() {
         testDockerImagesForKafkaCluster(CLUSTER_NAME, 1, 1, true);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -87,8 +87,9 @@ public class KafkaClusterIT extends AbstractClusterIT {
         //Testing docker images
         testDockerImagesForKafkaCluster(clusterName, 3, 3, false);
 
-        oc.deleteByName("cm", clusterName);
+        oc.deleteByName("statefulset", kafkaClusterName(clusterName));
         oc.waitForResourceDeletion("statefulset", kafkaClusterName(clusterName));
+        oc.deleteByName("statefulset", zookeeperClusterName(clusterName));
         oc.waitForResourceDeletion("statefulset", zookeeperClusterName(clusterName));
     }
 
@@ -392,7 +393,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @JUnitGroup(name = "regression")
+//    @JUnitGroup(name = "regression")
     @KafkaFromClasspathYaml
     public void testRackAware() {
         testDockerImagesForKafkaCluster(CLUSTER_NAME, 1, 1, true);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -65,7 +65,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     public static final String NAMESPACE = "kafka-cluster-test";
     private static final String CLUSTER_NAME = "my-cluster";
     private static final String TOPIC_NAME = "test-topic";
-    private static final String CO_DEPLOYMENT_CONFIG = "../examples/install/cluster-operator/08-deployment.yaml";
 
     @BeforeClass
     public static void waitForCc() {
@@ -397,7 +396,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     public void testRackAware() {
         testDockerImagesForKafkaCluster(CLUSTER_NAME, 1, 1, true);
 
-        kubeClient.waitForStatefulSet(kafkaClusterName(CLUSTER_NAME), 1);
         String kafkaPodName = kafkaPodName(CLUSTER_NAME, 0);
         kubeClient.waitForPod(kafkaPodName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -87,9 +87,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         //Testing docker images
         testDockerImagesForKafkaCluster(clusterName, 3, 3, false);
 
-        oc.deleteByName("statefulset", kafkaClusterName(clusterName));
+        oc.deleteByName("Kafka", clusterName);
         oc.waitForResourceDeletion("statefulset", kafkaClusterName(clusterName));
-        oc.deleteByName("statefulset", zookeeperClusterName(clusterName));
         oc.waitForResourceDeletion("statefulset", zookeeperClusterName(clusterName));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesIT.java
@@ -47,9 +47,9 @@ import static org.junit.Assert.assertNotNull;
 @Namespace(OpenShiftTemplatesIT.NAMESPACE)
 @Resources(value = "../examples/templates/cluster-operator", asAdmin = true)
 @Resources(value = "../examples/templates/topic-operator", asAdmin = true)
-@Resources(value = "../examples/install/cluster-operator/04-crd-kafka.yaml", asAdmin = true)
-@Resources(value = "../examples/install/cluster-operator/04-crd-kafka-connect.yaml", asAdmin = true)
-@Resources(value = "../examples/install/cluster-operator/04-crd-kafka-connect-s2i.yaml", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/07-crd-kafka.yaml", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/07-crd-kafka-connect.yaml", asAdmin = true)
+@Resources(value = "../examples/install/cluster-operator/07-crd-kafka-connect-s2i.yaml", asAdmin = true)
 @Resources(value = "src/rbac/role-edit-kafka.yaml", asAdmin = true)
 public class OpenShiftTemplatesIT {
 


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Removed the deletion of `staefulset` and `deployment` by cm
2. Updated label for Kafka Connect `"type=kafka-connect"` -> `"strimzi.io/kind=KafkaConnect"`
3. Updated path to templates

### Checklist
- [x] Write tests
- [x] Make sure all tests pass
