### PR TITLE
Add documentation to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ _Select the type of your PR_
 - Bugfix
 - Enhancement / new feature
 - Refactoring
+- Documentation
 
 ### Description
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Since we are now opening PRs which are often documentation only, I think it would be good to have documentation as one of the options in the PR template. Although the documentation PRs are technically also bugfixes, enhancements or refactorings, I think that having a type documentation would work to better distinguish them from code PRs. WDYT?