### PR TITLE
Fix Windows build for crd-generator and api modules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files we want to always be normalized and converted 
+# to native line endings on checkout.
+*.java text
+
+# Always lf ending
+*.sh text eol=lf
+*.bash text eol=lf
+*.properties text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -97,12 +97,12 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}/target/classes:${pom.basedir}/../crd-generator/target/crd-generator-${project.version}.jar</argument>
+                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaAssembly=${pom.basedir}/../examples/install/cluster-operator/07-crd-kafka.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaConnectAssembly=${pom.basedir}/../examples/install/cluster-operator/07-crd-kafka-connect.yaml</argument>
-                                <argument>io.strimzi.api.kafka.model.KafkaConnectS2IAssembly=${pom.basedir}/../examples/install/cluster-operator/07-crd-kafka-connect-s2i.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaAssembly=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}07-crd-kafka.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnectAssembly=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}07-crd-kafka-connect.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnectS2IAssembly=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}07-crd-kafka-connect-s2i.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -116,7 +116,7 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-classpath</argument>
-                                <argument>${pom.basedir}/target/classes:${pom.basedir}/../crd-generator/target/crd-generator-${project.version}.jar</argument>
+                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.DocGenerator</argument>
                                 <argument>--linker</argument>
                                 <argument>io.strimzi.crdgenerator.KubeLinker</argument>
@@ -126,7 +126,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectAssembly</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectS2IAssembly</argument>
                             </arguments>
-                            <workingDirectory>${pom.basedir}/../documentation/book</workingDirectory>
+                            <workingDirectory>${pom.basedir}${file.separator}..${file.separator}documentation${file.separator}book</workingDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement 

### Description

This PR resolves Windows build issues for crd-generator and api modules.
Tests in TO try to run reassigm.sh script and they fail.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

