### PR TITLE
Trivial fixes on TLS scripts for Kafka

### DIFF
--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -38,7 +38,7 @@ if [ -e $KAFKA_HOME/rack/rack.id ]; then
 fi
 
 # Generate temporary keystore password
-export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32})
+export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 
 mkdir -p /tmp/kafka
 

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -17,7 +17,7 @@ function create_truststore {
 # $5: CA public key to be imported
 # $6: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $HOSTNAME -password pass:$2 -out $1
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $6 -password pass:$2 -out $1
 }
 
 echo "Preparing certificates for internal communication"


### PR DESCRIPTION
Fixed unused parameter for the create_keystore function

### Type of change

- Refactoring

### Description

This trivial PR just fix a useless parameter in password generation for Kafka keystore and trustore and fix an unused parameter for the related create_keystore function.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

