### PR TITLE
Added TLS support communication between Kafka, Zookeeper and Topic Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
   * `xxx-zookeeper-headless` -> `xxx-zookeeper-nodes`
   * `xxx-connect` -> `xxx-connect-api`
 * Cluster Operator moving to Custom Resources instead of Config Maps
-* TLS support has been added to Kafka, Zookeeper and Topic Operator. The current channels are now encrypted.
-    * Zookeeper nodes (ports 2888 and 3888)
-    * Kafka brokers and Zookeeper nodes (port 2181)
-    * Topic Operator and Kafka brokers (port 9091) and Zookeeper nodes (port 2181)
+* TLS support has been added to Kafka, Zookeeper and Topic Operator. The following channels are now encrypted:
+    * Zookeeper cluster communication
+    * Kafka cluster commbunication
+    * Communication between Kafka and Zookeeper
+    * Communication between Topic Operator and Kafka / Zookeeper
 * Logging configuration for Kafka, Kafka Connect and Zookeeper
 * Add support for Pod Affinity and Anti-Affinity
 * Configuring different JVM options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
   * `xxx-zookeeper-headless` -> `xxx-zookeeper-nodes`
   * `xxx-connect` -> `xxx-connect-api`
 * Cluster Operator moving to Custom Resources instead of Config Maps
-* TLS support has been added to Kafka and Zookeeper
+* TLS support has been added to Kafka, Zookeeper and Topic Operator. The current channels are now encrypted.
+    * Zookeeper nodes (ports 2888 and 3888)
+    * Kafka brokers and Zookeeper nodes (port 2181)
+    * Topic Operator and Kafka brokers (port 9091) and Zookeeper nodes (port 2181)
 * Logging configuration for Kafka, Kafka Connect and Zookeeper
 * Add support for Pod Affinity and Anti-Affinity
 * Configuring different JVM options

--- a/HACKING.md
+++ b/HACKING.md
@@ -102,6 +102,10 @@ you can push the images to OpenShift's Docker repo like this:
   value: 172.30.1.1:5000/myproject/init-kafka:latest
 - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
   value: 172.30.1.1:5000/myproject/zookeeper-stunnel:latest
+- name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+  value: 172.30.1.1:5000/myproject/kafka-stunnel:latest
+- name: STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE
+  value: 172.30.1.1:5000/myproject/topic-operator-stunnel:latest
 ```
 
 5. Then you can deploy the Cluster Operator running:

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -22,13 +22,15 @@ import java.util.Map;
         builderPackage = "io.strimzi.api.kafka.model"
 )
 @JsonPropertyOrder({ "replicas", "image", "storage", "rackConfig", "brokerRackInitImage",
-        "livenessProbe", "readinessProbe", "jvmOptions", "affinity", "metrics"})
+        "livenessProbe", "readinessProbe", "jvmOptions", "affinity", "metrics", "tlsSidecar"})
 public class Kafka extends ReplicatedJvmPods {
 
     public static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_IMAGE", "strimzi/kafka:latest");
     public static final String DEFAULT_INIT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_INIT_KAFKA_IMAGE", "strimzi/init-kafka:latest");
+    public static final String DEFAULT_TLS_SIDECAR_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE", "strimzi/kafka-stunnel:latest");
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, authorizer., super.user";
@@ -42,6 +44,8 @@ public class Kafka extends ReplicatedJvmPods {
     private Rack rack;
 
     private Logging logging;
+
+    private Sidecar tlsSidecar;
 
     @Description("The kafka broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
     public Map<String, Object> getConfig() {
@@ -91,5 +95,15 @@ public class Kafka extends ReplicatedJvmPods {
 
     public void setLogging(Logging logging) {
         this.logging = logging;
+    }
+
+    @Description("TLS sidecar configuration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Sidecar getTlsSidecar() {
+        return tlsSidecar;
+    }
+
+    public void setTlsSidecar(Sidecar tlsSidecar) {
+        this.tlsSidecar = tlsSidecar;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperator.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperator.java
@@ -28,17 +28,19 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"watchedNamespace", "image",
         "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
-        "affinity", "resources", "topicMetadataMaxAttempts"})
+        "affinity", "resources", "topicMetadataMaxAttempts", "tlsSidecar"})
 public class TopicOperator {
 
     public static final String DEFAULT_IMAGE = System.getenv().getOrDefault(
             "STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE",
             "strimzi/topic-operator:latest");
+    public static final String DEFAULT_TLS_SIDECAR_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator-stunnel:latest");
     public static final int DEFAULT_REPLICAS = 1;
     public static final int DEFAULT_HEALTHCHECK_DELAY = 10;
     public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
-    public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9092;
+    public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
     public static final int DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 90;
     public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 20;
     public static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 6;
@@ -51,6 +53,7 @@ public class TopicOperator {
     private Resources resources;
     private Affinity affinity;
     private Logging logging;
+    private Sidecar tlsSidecar;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The namespace the Topic Operator should watch.")
@@ -128,6 +131,16 @@ public class TopicOperator {
 
     public void setLogging(Logging logging) {
         this.logging = logging;
+    }
+
+    @Description("TLS sidecar configuration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Sidecar getTlsSidecar() {
+        return tlsSidecar;
+    }
+
+    public void setTlsSidecar(Sidecar tlsSidecar) {
+        this.tlsSidecar = tlsSidecar;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Zookeeper.java
@@ -23,7 +23,7 @@ import java.util.Map;
 )
 @JsonPropertyOrder({ "replicas", "image", "storage",
         "livenessProbe", "readinessProbe", "jvmOptions",
-        "affinity", "metrics", "tlsSidecarImage"})
+        "affinity", "metrics", "tlsSidecar"})
 public class Zookeeper extends ReplicatedJvmPods {
     public static final String FORBIDDEN_PREFIXES = "server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -290,6 +290,7 @@ public class KafkaCluster extends AbstractModel {
         List<ServicePort> ports = new ArrayList<>(2);
         ports.add(createServicePort(CLIENT_PORT_NAME, CLIENT_PORT, CLIENT_PORT, "TCP"));
         ports.add(createServicePort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, CLIENT_TLS_PORT, "TCP"));
+        ports.add(createServicePort(REPLICATION_PORT_NAME, REPLICATION_PORT, REPLICATION_PORT, "TCP"));
         if (isMetricsEnabled()) {
             ports.add(createServicePort(metricsPortName, metricsPort, metricsPort, "TCP"));
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -194,7 +194,7 @@ public class TopicOperator extends AbstractModel {
     }
 
     protected static String defaultBootstrapServers(String cluster) {
-        return KafkaCluster.headlessServiceName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_BOOTSTRAP_SERVERS_PORT;
+        return KafkaCluster.serviceName(cluster) + ":" + io.strimzi.api.kafka.model.TopicOperator.DEFAULT_BOOTSTRAP_SERVERS_PORT;
     }
 
     protected static String defaultTopicConfigMapLabels(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -290,7 +290,8 @@ public class ZookeeperCluster extends AbstractModel {
                 .withEnv(singletonList(buildEnvVar(ENV_VAR_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas))))
                 .withVolumeMounts(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT))
                 .withPorts(asList(createContainerPort(CLUSTERING_PORT_NAME, CLUSTERING_PORT, "TCP"),
-                                createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, "TCP")))
+                                createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, "TCP"),
+                                createContainerPort(CLIENT_PORT_NAME, CLIENT_PORT, "TCP")))
                 .build();
 
         containers.add(container);
@@ -324,7 +325,6 @@ public class ZookeeperCluster extends AbstractModel {
 
     private List<ContainerPort> getContainerPortList() {
         List<ContainerPort> portList = new ArrayList<>();
-        portList.add(createContainerPort(CLIENT_PORT_NAME, CLIENT_PORT, "TCP"));
         if (isMetricsEnabled) {
             portList.add(createContainerPort(metricsPortName, metricsPort, "TCP"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.KafkaAssemblyBuilder;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
@@ -186,13 +187,21 @@ public class KafkaClusterTest {
         // ... with these labels
         assertEquals(expectedLabels(), ss.getMetadata().getLabels());
 
+        List<Container> containers = ss.getSpec().getTemplate().getSpec().getContainers();
+
+        assertEquals(2, containers.size());
+
+        // checks on the main Kafka container
         assertEquals(new Integer(replicas), ss.getSpec().getReplicas());
-        assertEquals(image, ss.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
-        assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
-        assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
-        assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
-        assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
+        assertEquals(image, containers.get(0).getImage());
+        assertEquals(new Integer(healthTimeout), containers.get(0).getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(healthDelay), containers.get(0).getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
+        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
+        // checks on the TLS sidecar
+        assertEquals(Kafka.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
+        assertEquals(ZookeeperCluster.serviceName(cluster) + ":2181", AbstractModel.containerEnvVars(containers.get(1)).get(KafkaCluster.ENV_VAR_KAFKA_ZOOKEEPER_CONNECT));
 
         if (cm.getSpec().getKafka().getStorage() != null) {
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -84,7 +84,7 @@ public class KafkaClusterTest {
     private void checkService(Service headful) {
         assertEquals("ClusterIP", headful.getSpec().getType());
         assertEquals(expectedLabels(), headful.getSpec().getSelector());
-        assertEquals(3, headful.getSpec().getPorts().size());
+        assertEquals(4, headful.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -14,7 +15,9 @@ import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TopicOperatorBuilder;
+import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.operator.assembly.MockCertManager;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,18 +70,20 @@ public class TopicOperatorTest {
             .build();
 
 
+    private final CertManager certManager = new MockCertManager();
     private final KafkaAssembly resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig, storage, topicOperator, kafkaLogJson, zooLogJson);
-    private final TopicOperator tc = TopicOperator.fromCrd(resource);
+    private final TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
 
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_CONFIGMAP_LABELS).withValue(TopicOperator.defaultTopicConfigMapLabels(cluster)).build());
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_KAFKA_BOOTSTRAP_SERVERS).withValue(TopicOperator.defaultBootstrapServers(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(TopicOperator.defaultZookeeperConnect(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(String.format("%s:%d", "localhost", io.strimzi.api.kafka.model.TopicOperator.DEFAULT_ZOOKEEPER_PORT)).build());
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(tcWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(tcReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(tcZookeeperSessionTimeout * 1000)).build());
         expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_TLS_ENABLED).withValue(Boolean.toString(true)).build());
 
         return expected;
     }
@@ -87,7 +92,7 @@ public class TopicOperatorTest {
     public void testFromConfigMapNoConfig() {
         KafkaAssembly resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, null, kafkaLogJson, zooLogJson);
-        TopicOperator tc = TopicOperator.fromCrd(resource);
+        TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
         assertNull(tc);
     }
 
@@ -96,7 +101,7 @@ public class TopicOperatorTest {
         KafkaAssembly resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
                 storage, new io.strimzi.api.kafka.model.TopicOperator(), kafkaLogJson, zooLogJson);
-        TopicOperator tc = TopicOperator.fromCrd(resource);
+        TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
         Assert.assertEquals(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_IMAGE, tc.getImage());
         assertEquals(namespace, tc.getWatchedNamespace());
         assertEquals(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS * 1000, tc.getReconciliationIntervalMs());
@@ -136,23 +141,31 @@ public class TopicOperatorTest {
 
         Deployment dep = tc.generateDeployment();
 
+        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
+
+        assertEquals(2, containers.size());
+
         Assert.assertEquals(tc.topicOperatorName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
         assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
-        assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
-        Assert.assertEquals(tc.topicOperatorName(cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
-        assertEquals(tc.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
-        assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
-        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_DELAY), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
-        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_TIMEOUT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
-        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_DELAY), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_TIMEOUT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
-        assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
-        assertEquals(new Integer(TopicOperator.HEALTHCHECK_PORT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
-        assertEquals(TopicOperator.HEALTHCHECK_PORT_NAME, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getName());
-        assertEquals("TCP", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getProtocol());
+        Assert.assertEquals(TopicOperator.TOPIC_OPERATOR_NAME, containers.get(0).getName());
+
+        // checks on the main Topic Operator container
+        assertEquals(tc.image, containers.get(0).getImage());
+        assertEquals(getExpectedEnvVars(), containers.get(0).getEnv());
+        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_DELAY), containers.get(0).getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_TIMEOUT), containers.get(0).getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_DELAY), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_HEALTHCHECK_TIMEOUT), containers.get(0).getReadinessProbe().getTimeoutSeconds());
+        assertEquals(1, containers.get(0).getPorts().size());
+        assertEquals(new Integer(TopicOperator.HEALTHCHECK_PORT), containers.get(0).getPorts().get(0).getContainerPort());
+        assertEquals(TopicOperator.HEALTHCHECK_PORT_NAME, containers.get(0).getPorts().get(0).getName());
+        assertEquals("TCP", containers.get(0).getPorts().get(0).getProtocol());
         assertEquals("Recreate", dep.getSpec().getStrategy().getType());
         assertLoggingConfig(dep);
+        // checks on the TLS sidecar container
+        assertEquals(io.strimzi.api.kafka.model.TopicOperator.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
+        assertEquals(TopicOperator.defaultZookeeperConnect(cluster), AbstractModel.containerEnvVars(containers.get(1)).get(TopicOperator.ENV_VAR_ZOOKEEPER_CONNECT));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -134,8 +134,6 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
         assertEquals("timeTick=2000\nautopurge.purgeInterval=1\nsyncLimit=2\ninitLimit=5\nfoo=bar\n", AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
-        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, containers.get(0).getPorts().get(0).getName());
-        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), containers.get(0).getPorts().get(0).getContainerPort());
         // checks on the TLS sidecar container
         assertEquals(Zookeeper.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
         assertEquals(new Integer(replicas), Integer.valueOf(AbstractModel.containerEnvVars(containers.get(1)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_NODE_COUNT)));
@@ -143,6 +141,8 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(ZookeeperCluster.CLUSTERING_PORT), containers.get(1).getPorts().get(0).getContainerPort());
         assertEquals(ZookeeperCluster.LEADER_ELECTION_PORT_NAME, containers.get(1).getPorts().get(1).getName());
         assertEquals(new Integer(ZookeeperCluster.LEADER_ELECTION_PORT), containers.get(1).getPorts().get(1).getContainerPort());
+        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, containers.get(1).getPorts().get(2).getName());
+        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), containers.get(1).getPorts().get(2).getContainerPort());
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -235,6 +235,7 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(AbstractModel.getClusterCaName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(TopicOperator.secretName(CLUSTER_NAME)).get());
             createAsync.complete();
         });
         createAsync.await();
@@ -267,6 +268,7 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterPublicKeyName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get());
             context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
+            context.assertNull(mockClient.secrets().inNamespace(NAMESPACE).withName(TopicOperator.secretName(CLUSTER_NAME)).get());
             deleteAsync.complete();
         });
     }
@@ -327,7 +329,8 @@ public class KafkaAssemblyOperatorMockTest {
                 KafkaCluster.clientsPublicKeyName(CLUSTER_NAME),
                 KafkaCluster.clusterPublicKeyName(CLUSTER_NAME),
                 KafkaCluster.brokersSecretName(CLUSTER_NAME),
-                ZookeeperCluster.nodesSecretName(CLUSTER_NAME));
+                ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
+                TopicOperator.secretName(CLUSTER_NAME));
     }
 
     private void updateClusterWithoutSecrets(TestContext context, String... secrets) {

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS=java-base kafka-base zookeeper kafka kafka-connect kafka-connect/s2i stunnel-base zookeeper-stunnel
+SUBDIRS=java-base kafka-base zookeeper kafka kafka-connect kafka-connect/s2i stunnel-base zookeeper-stunnel kafka-stunnel topic-operator-stunnel
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/docker-images/kafka-stunnel/Dockerfile
+++ b/docker-images/kafka-stunnel/Dockerfile
@@ -1,8 +1,5 @@
 FROM strimzi/stunnel-base:latest
 
-# exposing Zookeeper ports
-EXPOSE 2181 2888 3888
-
 # copy scripts for starting Stunnel
 COPY ./scripts/ $STUNNEL_HOME
 

--- a/docker-images/kafka-stunnel/Makefile
+++ b/docker-images/kafka-stunnel/Makefile
@@ -1,0 +1,5 @@
+PROJECT_NAME=kafka-stunnel
+
+include ../../Makefile.docker
+
+.PHONY: build clean release

--- a/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# path were the Secret with certificates is mounted
+CERTS=/etc/tls-sidecar/certs
+
+CURRENT=${BASE_HOSTNAME}-${KAFKA_BROKER_ID}
+
+echo "pid = /usr/local/var/run/stunnel.pid"
+echo "foreground = yes"
+echo "debug = info"
+
+cat <<-EOF
+[zookeeper-2181]
+client = yes
+CAfile = ${CERTS}/cluster-ca.crt
+cert = ${CERTS}/${CURRENT}.crt
+key = ${CERTS}/${CURRENT}.key
+accept = 127.0.0.1:2181
+connect = ${KAFKA_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+verify = 2
+
+EOF

--- a/docker-images/kafka-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export BASE_HOSTNAME=$(hostname | rev | cut -d "-" -f2- | rev)
+export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')
+
+# Generate and print the config file
+echo "Starting Stunnel with configuration:"
+./stunnel_config_generator.sh | tee /tmp/stunnel.conf
+echo ""
+
+# starting Stunnel with final configuration
+exec /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -12,7 +12,7 @@ listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:SSL,CLIENTTLS:SSL
 inter.broker.listener.name=REPLICATION
 
 # Zookeeper
-zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+zookeeper.connect=localhost:2181
 zookeeper.connection.timeout.ms=6000
 
 # Logs

--- a/docker-images/topic-operator-stunnel/Dockerfile
+++ b/docker-images/topic-operator-stunnel/Dockerfile
@@ -1,8 +1,5 @@
 FROM strimzi/stunnel-base:latest
 
-# exposing Zookeeper ports
-EXPOSE 2181 2888 3888
-
 # copy scripts for starting Stunnel
 COPY ./scripts/ $STUNNEL_HOME
 

--- a/docker-images/topic-operator-stunnel/Makefile
+++ b/docker-images/topic-operator-stunnel/Makefile
@@ -1,0 +1,5 @@
+PROJECT_NAME=topic-operator-stunnel
+
+include ../../Makefile.docker
+
+.PHONY: build clean release

--- a/docker-images/topic-operator-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/topic-operator-stunnel/scripts/stunnel_config_generator.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# path were the Secret with certificates is mounted
+CERTS=/etc/tls-sidecar/certs
+
+echo "pid = /usr/local/var/run/stunnel.pid"
+echo "foreground = yes"
+echo "debug = info"
+
+cat <<-EOF
+[zookeeper-2181]
+client = yes
+CAfile = ${CERTS}/cluster-ca.crt
+cert = ${CERTS}/topic-operator.crt
+key = ${CERTS}/topic-operator.key
+accept = 127.0.0.1:2181
+connect = ${STRIMZI_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+verify = 2
+
+EOF

--- a/docker-images/topic-operator-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/topic-operator-stunnel/scripts/stunnel_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Generate and print the config file
+echo "Starting Stunnel with configuration:"
+./stunnel_config_generator.sh | tee /tmp/stunnel.conf
+echo ""
+
+# starting Stunnel with final configuration
+exec /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
@@ -52,3 +52,16 @@ do
 
 	EOF
 done
+
+# Zookeeper client port where stunnel forwards received traffic
+CLIENT_PORT=$(expr 21810 + $ZOOKEEPER_ID - 1)
+
+cat <<-EOF
+[listener-2181]
+client = no
+CAfile = ${CERTS}/cluster-ca.crt
+cert = ${CERTS}/${CURRENT}.crt
+key = ${CERTS}/${CURRENT}.key
+accept = 2181
+connect = 127.0.0.1:$CLIENT_PORT
+EOF

--- a/docker-images/zookeeper/Dockerfile
+++ b/docker-images/zookeeper/Dockerfile
@@ -1,7 +1,7 @@
 FROM strimzi/kafka-base:latest
 
 # exposing Zookeeper client port and the one for JMX exporter
-EXPOSE 2181 9404
+EXPOSE 9404
 
 # copy scripts for starting Zookeeper
 COPY ./scripts/ $KAFKA_HOME

--- a/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
@@ -4,7 +4,7 @@
 cat <<EOF
 # the directory where the snapshot is stored.
 dataDir=${ZOOKEEPER_DATA_DIR}
-clientPort=2181
+clientPort=$(expr 10 \* 2181 + $ZOOKEEPER_ID - 1)
 
 # Provided configuration
 ${ZOOKEEPER_CONFIGURATION}

--- a/docker-images/zookeeper/scripts/zookeeper_healthcheck.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_healthcheck.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-OK=$(echo ruok | nc 127.0.0.1 2181)
+ZOOKEEPER_ID=$(hostname | awk -F'-' '{print $NF+1}')
+CLIENT_PORT=$(expr 21810 + $ZOOKEEPER_ID - 1)
+
+OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 if [ "$OK" == "imok" ]; then
     exit 0
 else

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -60,6 +60,8 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics               1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
+|tlsSidecar            1.2+<.<|TLS sidecar configuration
+|<<type-Sidecar,`Sidecar`>>
 |additionalProperties  1.2+<.<|
 |map
 |config                1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user
@@ -150,6 +152,55 @@ Used in: <<type-Kafka,`Kafka`>>, <<type-KafkaConnectAssemblySpec,`KafkaConnectAs
 |boolean
 |====
 
+[[type-Sidecar]]
+### `Sidecar` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Kafka,`Kafka`>>, <<type-TopicOperator,`TopicOperator`>>, <<type-Zookeeper,`Zookeeper`>>
+
+
+[options="header"]
+|====
+|Field             |Description
+|image      1.2+<.<|The docker image for the container
+|string
+|resources  1.2+<.<|Resource constraints (limits and requests).
+|<<type-Resources,`Resources`>>
+|====
+
+[[type-Resources]]
+### `Resources` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Kafka,`Kafka`>>, <<type-KafkaConnectAssemblySpec,`KafkaConnectAssemblySpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-Sidecar,`Sidecar`>>, <<type-TopicOperator,`TopicOperator`>>, <<type-Zookeeper,`Zookeeper`>>
+
+
+[options="header"]
+|====
+|Field                        |Description
+|additionalProperties  1.2+<.<|
+|map
+|limits                1.2+<.<|Resource limits applied at runtime.
+|<<type-CpuMemory,`CpuMemory`>>
+|requests              1.2+<.<|Resource requests applied during pod scheduling.
+|<<type-CpuMemory,`CpuMemory`>>
+|====
+
+[[type-CpuMemory]]
+### `CpuMemory` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Resources,`Resources`>>
+
+
+[options="header"]
+|====
+|Field                        |Description
+|additionalProperties  1.2+<.<|
+|map
+|cpu                   1.2+<.<|CPU
+|string
+|memory                1.2+<.<|Memory
+|string
+|====
+
 [[type-InlineLogging]]
 ### `InlineLogging` type v1alpha1 kafka.strimzi.io
 
@@ -199,40 +250,6 @@ Used in: <<type-Kafka,`Kafka`>>
 |string
 |====
 
-[[type-Resources]]
-### `Resources` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-Kafka,`Kafka`>>, <<type-KafkaConnectAssemblySpec,`KafkaConnectAssemblySpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-Sidecar,`Sidecar`>>, <<type-TopicOperator,`TopicOperator`>>, <<type-Zookeeper,`Zookeeper`>>
-
-
-[options="header"]
-|====
-|Field                        |Description
-|additionalProperties  1.2+<.<|
-|map
-|limits                1.2+<.<|Resource limits applied at runtime.
-|<<type-CpuMemory,`CpuMemory`>>
-|requests              1.2+<.<|Resource requests applied during pod scheduling.
-|<<type-CpuMemory,`CpuMemory`>>
-|====
-
-[[type-CpuMemory]]
-### `CpuMemory` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-Resources,`Resources`>>
-
-
-[options="header"]
-|====
-|Field                        |Description
-|additionalProperties  1.2+<.<|
-|map
-|cpu                   1.2+<.<|CPU
-|string
-|memory                1.2+<.<|Memory
-|string
-|====
-
 [[type-Zookeeper]]
 ### `Zookeeper` type v1alpha1 kafka.strimzi.io
 
@@ -260,6 +277,8 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics               1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
+|tlsSidecar            1.2+<.<|TLS sidecar configuration
+|<<type-Sidecar,`Sidecar`>>
 |additionalProperties  1.2+<.<|
 |map
 |config                1.2+<.<|The zookeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme
@@ -267,23 +286,6 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |logging               1.2+<.<|Logging configuration for Zookeeper The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources             1.2+<.<|Resource constraints (limits and requests).
-|<<type-Resources,`Resources`>>
-|tlsSidecar            1.2+<.<|TLS sidecar configuration
-|<<type-Sidecar,`Sidecar`>>
-|====
-
-[[type-Sidecar]]
-### `Sidecar` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-Zookeeper,`Zookeeper`>>
-
-
-[options="header"]
-|====
-|Field             |Description
-|image      1.2+<.<|The docker image for the container
-|string
-|resources  1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
 |====
 
@@ -312,6 +314,8 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |<<type-Resources,`Resources`>>
 |topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata
 |integer
+|tlsSidecar                      1.2+<.<|TLS sidecar configuration
+|<<type-Sidecar,`Sidecar`>>
 |additionalProperties            1.2+<.<|
 |map
 |logging                         1.2+<.<|Logging configuration The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -310,6 +310,38 @@ spec:
                       type: object
                 metrics:
                   type: object
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        additionalProperties:
+                          type: object
+                        limits:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 additionalProperties:
                   type: object
                 config:
@@ -653,6 +685,38 @@ spec:
                       type: object
                 metrics:
                   type: object
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        additionalProperties:
+                          type: object
+                        limits:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 additionalProperties:
                   type: object
                 config:
@@ -693,38 +757,6 @@ spec:
                         memory:
                           type: string
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                tlsSidecar:
-                  type: object
-                  properties:
-                    image:
-                      type: string
-                    resources:
-                      type: object
-                      properties:
-                        additionalProperties:
-                          type: object
-                        limits:
-                          type: object
-                          properties:
-                            additionalProperties:
-                              type: object
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                        requests:
-                          type: object
-                          properties:
-                            additionalProperties:
-                              type: object
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
               required:
               - replicas
               - storage
@@ -1001,6 +1033,38 @@ spec:
                 topicMetadataMaxAttempts:
                   type: integer
                   minimum: 0
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        additionalProperties:
+                          type: object
+                        limits:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            additionalProperties:
+                              type: object
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
                 additionalProperties:
                   type: object
                 logging:

--- a/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
@@ -36,6 +36,10 @@ spec:
               value: strimzi/init-kafka:latest
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
               value: strimzi/zookeeper-stunnel:latest
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+              value: strimzi/kafka-stunnel:latest
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE
+              value: strimzi/topic-operator-stunnel:latest
             - name: STRIMZI_LOG_LEVEL
               value: INFO
           livenessProbe:

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Parameters:
+# $1: Path to the new truststore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Alias of the certificate
+function create_truststore {
+   keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
+}
+
+# Parameters:
+# $1: Path to the new keystore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Private key to be imported
+# $5: CA public key to be imported
+# $6: Alias of the certificate
+function create_keystore {
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name topic-operator -password pass:$2 -out $1
+}
+
+echo "CERTS_STORE_PASSWORD=${CERTS_STORE_PASSWORD}"
+
+echo "Preparing certificates for internal communication"
+create_truststore /tmp/topic-operator/replication.truststore.p12 $CERTS_STORE_PASSWORD /etc/tls-sidecar/certs/cluster-ca.crt cluster-ca
+create_keystore /tmp/topic-operator/replication.keystore.p12 $CERTS_STORE_PASSWORD /etc/tls-sidecar/certs/topic-operator.crt /etc/tls-sidecar/certs/topic-operator.key /etc/tls-sidecar/certs/cluster-ca.crt topic-operator
+echo "Preparing certificates for internal communication is complete"

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -6,4 +6,22 @@ then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/topic-operator/custom-config/log4j2.properties"
 fi
 
+if [ "$STRIMZI_TLS_ENABLED" = "true" ]; then
+
+    # Generate temporary keystore password
+    export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
+
+    mkdir -p /tmp/topic-operator
+
+    # Import certificates into keystore and truststore
+    /bin/tls_prepare_certificates.sh
+
+    export STRIMZI_TRUSTSTORE_LOCATION=/tmp/topic-operator/replication.truststore.p12
+    export STRIMZI_TRUSTSTORE_PASSWORD=$CERTS_STORE_PASSWORD
+
+    export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
+    export STRIMZI_KEYSTORE_PASSWORD=$CERTS_STORE_PASSWORD
+
+fi
+
 exec /bin/launch_java.sh $1

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -99,6 +99,12 @@ public class Config {
     public static final String TC_REASSIGN_VERIFY_INTERVAL_MS = "STRIMZI_REASSIGN_VERIFY_INTERVAL_MS";
     public static final String TC_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
 
+    public static final String TC_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    public static final String TC_TLS_TRUSTSTORE_LOCATION = "STRIMZI_TRUSTSTORE_LOCATION";
+    public static final String TC_TLS_TRUSTSTORE_PASSWORD = "STRIMZI_TRUSTSTORE_PASSWORD";
+    public static final String TC_TLS_KEYSTORE_LOCATION = "STRIMZI_KEYSTORE_LOCATION";
+    public static final String TC_TLS_KEYSTORE_PASSWORD = "STRIMZI_KEYSTORE_PASSWORD";
+
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
     /** A comma-separated list of key=value pairs for selecting ConfigMaps that describe topics. */
@@ -131,6 +137,17 @@ public class Config {
     /** The maximum number of retries for getting topic metadata from the Kafka cluster */
     public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, POSITIVE_INTEGER, "6");
 
+    /** If the connection with Kafka has to be encrypted by TLS protocol */
+    public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
+    /** The truststore with CA certificate for Kafka broker/server authentication */
+    public static final Value<String> TLS_TRUSTSTORE_LOCATION = new Value<>(TC_TLS_TRUSTSTORE_LOCATION, STRING, "");
+    /** The password for the truststore with CA certificate for Kafka broker/server authentication */
+    public static final Value<String> TLS_TRUSTSTORE_PASSWORD = new Value<>(TC_TLS_TRUSTSTORE_PASSWORD, STRING, "");
+    /** The keystore with private key and certificate for client authentication against Kafka broker */
+    public static final Value<String> TLS_KEYSTORE_LOCATION = new Value<>(TC_TLS_KEYSTORE_LOCATION, STRING, "");
+    /** The password for keystore with private key and certificate for client authentication against Kafka broker */
+    public static final Value<String> TLS_KEYSTORE_PASSWORD = new Value<>(TC_TLS_KEYSTORE_PASSWORD, STRING, "");
+
     static {
         Map<String, Value<?>> configValues = CONFIG_VALUES;
         addConfigValue(configValues, LABELS);
@@ -142,6 +159,11 @@ public class Config {
         addConfigValue(configValues, REASSIGN_THROTTLE);
         addConfigValue(configValues, REASSIGN_VERIFY_INTERVAL_MS);
         addConfigValue(configValues, TOPIC_METADATA_MAX_ATTEMPTS);
+        addConfigValue(configValues, TLS_ENABLED);
+        addConfigValue(configValues, TLS_TRUSTSTORE_LOCATION);
+        addConfigValue(configValues, TLS_TRUSTSTORE_PASSWORD);
+        addConfigValue(configValues, TLS_KEYSTORE_LOCATION);
+        addConfigValue(configValues, TLS_KEYSTORE_PASSWORD);
     }
 
     static void addConfigValue(Map<String, Value<?>> configValues, Value<?> cv) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -110,6 +110,15 @@ public class Session extends AbstractVerticle {
         LOGGER.info("Starting");
         Properties adminClientProps = new Properties();
         adminClientProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(Config.KAFKA_BOOTSTRAP_SERVERS));
+
+        if (Boolean.valueOf(config.get(Config.TLS_ENABLED))) {
+            adminClientProps.setProperty("security.protocol", "SSL");
+            adminClientProps.setProperty("ssl.truststore.location", config.get(Config.TLS_TRUSTSTORE_LOCATION));
+            adminClientProps.setProperty("ssl.truststore.password", config.get(Config.TLS_TRUSTSTORE_PASSWORD));
+            adminClientProps.setProperty("ssl.keystore.location", config.get(Config.TLS_KEYSTORE_LOCATION));
+            adminClientProps.setProperty("ssl.keystore.password", config.get(Config.TLS_KEYSTORE_PASSWORD));
+        }
+
         this.adminClient = AdminClient.create(adminClientProps);
         LOGGER.debug("Using AdminClient {}", adminClient);
         this.kafka = new OperatorAssignedKafkaImpl(adminClient, vertx, config);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is about adding TLS support to these cases : 

- communication between Kafka and Zookeeper on client port 2181. Now this port is encrypted on the Zookeeper side and I added a TLS sidecar (stunnel based) to the Kafka broker for handling encryption
- communication between Topic Operator and Zookeeper on client port 2181. It's achieved in the same way as the above point. A TLS sidecar is used for that because the zkClient used in the Topic Operator doesn't have support for TLS.
- communication between Topic Operator and Kafka on port 9091 (we are using the encrypted replication port for this, as an internal client port). In this case the TLS is handled through the AdminClient which supports TLS (initially I started to use the TLS sidecar for that but the problem on proxying Kafka protocol came in).

On the Topic Operator, the TLS support is enabled by default if deployed by the Cluster Operator but it can be disabled for users who want to deploy the Topic Operator by themselves without using the Cluster Operator.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

