### PR TITLE
Docs: Added TLS support communication between Kafka, Zookeeper and Topic Operator

### DIFF
--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -101,6 +101,12 @@ The accepted JSON format is described in the <<kafka_rack>> section.
 An object allowing control over how the Kafka pods are scheduled to nodes.
 The format of the corresponding key is the same as the content supported in the Pod `affinity` in {ProductPlatformName}.
 See section <<affinity>> for more details.
+`spec.kafka.tlsSidecar.image`::
+The Docker image to use for the sidecar container which provides TLS support for Kafka brokers.
+Default is determined by the value of the `<<STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE,STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE>>` environment variable of the Cluster Operator.
+`spec.kafka.tlsSidecar.resources`::
+An object configuring the resource limits and requests for the sidecar container which provides TLS support for Kafka brokers.
+The accepted JSON format is described in the <<resources_json_config>> section.
 `spec.zookeeper.replicas`::
 The number of Zookeeper nodes.
 `spec.zookeeper.image`::
@@ -780,6 +786,12 @@ described in the <<resources_json_config>> section.
 `affinity`::
 Node and Pod affinity for the Topic Operator, as described in the <<affinity>> section.
 The format of the corresponding key is the same as the content supported in the Pod `affinity` in {ProductPlatformName}.
+`tlsSidecar.image`::
+The Docker image to use for the sidecar container which provides TLS support for Topic Operator.
+Default is determined by the value of the `<<STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE,STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE>>` environment variable of the Cluster Operator.
+`tlsSidecar.resources`::
+An object configuring the resource limits and requests for the sidecar container which provides TLS support for the Topic Operator.
+The accepted JSON format is described in the <<resources_json_config>> section.
 
 .Example Topic Operator JSON configuration
 [source,json]
@@ -1195,6 +1207,10 @@ no image is specified as the `kafka-image` in the <<kafka_config_map_details,Kaf
 [[STRIMZI_DEFAULT_INIT_KAFKA_IMAGE]] `STRIMZI_DEFAULT_INIT_KAFKA_IMAGE`:: Optional, default `strimzi/init-kafka:latest`.
 The image name to use as default for the init container started before the broker for doing initial configuration work (that is, rack support), if no image is specified as the `init-kafka-image` in the <<kafka_config_map_details,Kafka cluster ConfigMap>>.
 
+[[STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE]] `STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE`:: Optional, default `strimzi/kafka-stunnel:latest`.
+The image name to use as a default when deploying the sidecar container which provides TLS support for Kafka, if
+no image is specified as the `spec.kafka.tlsSidecar.image` in the <<kafka_config_map_details,Kafka cluster ConfigMap>>.
+
 [[STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE]] `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE`:: Optional, default `strimzi/kafka-connect:latest`.
 The image name to use as a default when deploying Kafka Connect, if
 no image is specified as the `image` in the
@@ -1215,6 +1231,10 @@ no image is specified as the `zookeeper-image` in the <<kafka_config_map_details
 
 [[STRIMZI_LOG_LEVEL]] `STRIMZI_LOG_LEVEL`:: Optional, default `INFO`.
 The level for printing logging messages. The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG` and `TRACE`.
+
+[[STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE]] `STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE`:: Optional, default `strimzi/topic-operator-stunnel:latest`.
+The image name to use as a default when deploying the sidecar container which provides TLS support for the Topic Operator, if
+no image is specified as the `spec.topicOperator.tlsSidecar.image` in the <<kafka_config_map_details,Kafka cluster ConfigMap>>.
 
 [[multi-namespace]]
 ==== Watching multiple namespaces

--- a/documentation/book/security.adoc
+++ b/documentation/book/security.adoc
@@ -14,6 +14,7 @@ These broker certificates are signed using different CAs: The "internal-ca" sign
 The CAs themselves use self-signed certificates.
 The "internal-ca" is used across multiple clusters, that is, there is a single "internal-ca" for each instance of a cluster operator. 
 The "clients-ca" is specific to a particular Kafka cluster.
+Finally, the Topic Operator has its own private and public key for encrypting communication with Kafka / Zookeeper.
 
 All the generated certificates are saved as Secrets in the {ProductPlatformName} cluster, named as follows:
 
@@ -22,6 +23,7 @@ All the generated certificates are saved as Secrets in the {ProductPlatformName}
 * `<cluster-name>-kafka-cert`: contains only the public keys, so the self-signed certificate, used for signing broker certificates used for communicating with clients. This Secret should be used by the final Kafka cluster user in order to extract this certificate to put into the the client's truststores for verifying broker identities (server authentication).
 * `<cluster-name>-kafka-brokers-internal`: contains all the brokers private and public keys (certificates signed with "internal-ca") used for interbroker communication.
 * `<cluster-name>-kafka-brokers-clients`: contains all the brokers private and public keys (certificates signed with specific cluster "clients-ca") used for communicating with clients.
+* `<cluster-name>-topic-operator-certs`: contains the private and public keys (certificates signed with specific cluster "internal-ca") used for encrypting communication between the Topic Operator and Kafka / Zookeeper.
 
 All the keys are 2048 bits in size and are valid for 365 days from initial generation.
 

--- a/documentation/book/topic-operator.adoc
+++ b/documentation/book/topic-operator.adoc
@@ -235,6 +235,21 @@ Default `6`.
 – The level for printing logging messages. 
 The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG` and `TRACE`. 
 Default `INFO`.
+* `STRIMZI_TLS_ENABLED`
+- For enabling the TLS support so encrypting the communication with Kafka brokers and Zookeeper nodes.
+Default `true`
+* `STRIMZI_TRUSTSTORE_LOCATION`
+- The path to the truststore containing certificates for enabling TLS based communication.
+This variable is mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+* `STRIMZI_TRUSTSTORE_PASSWORD`
+- The password for accessing the truststore defined by `STRIMZI_TRUSTSTORE_LOCATION`.
+This variable is mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+* `STRIMZI_KEYSTORE_LOCATION`
+- The path to the keystore containing private keys for enabling TLS based communication.
+This variable is mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
+* `STRIMZI_KEYSTORE_PASSWORD`
+- The password for accessing the keystore defined by `STRIMZI_KEYSTORE_LOCATION`.
+This variable is mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
 
 
 If the operator configuration needs to be changed the process must be killed and restarted.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This is documentation about PR #619.

### Checklist

- [x] Update documentation
