### PR TITLE
Manual authentication and authorization

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -34,7 +34,7 @@ public class Kafka extends ReplicatedJvmPods {
 
     /*
     // Forbidden prefixes were temporarily modified to allow configuration of Authentication and Authorization before we
-    // have UserOeprator implemented.
+    // have UserOperator implemented.
 
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -31,9 +31,20 @@ public class Kafka extends ReplicatedJvmPods {
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_INIT_IMAGE", "strimzi/kafka-init:latest");
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE", "strimzi/kafka-stunnel:latest");
+
+    /*
+    // Forbidden prefixes were temporarily modified to allow configuration of Authentication and Authorization before we
+    // have UserOeprator implemented.
+
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, authorizer., super.user";
+    */
+
+    public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener.name.replication., "
+            + "listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, "
+            + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
+            + "zookeeper.connect, zookeeper.set.acl, super.user";
 
     protected Storage storage;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1039,7 +1039,7 @@ public abstract class AbstractModel {
 
             Subject sbj = new Subject();
             sbj.setOrganizationName("io.strimzi");
-            sbj.setCommonName(podName.apply(cluster, i));
+            sbj.setCommonName(getName());
 
             certManager.generateCsr(brokerKeyFile, brokerCsrFile, sbj);
             certManager.generateCert(brokerCsrFile, caCert.key(), caCert.cert(), brokerCertFile, CERTS_EXPIRATION_DAYS);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -102,7 +102,6 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
     protected static final String ENV_VAR_KAFKA_CONFIGURATION = "KAFKA_CONFIGURATION";
     protected static final String ENV_VAR_KAFKA_LOG_CONFIGURATION = "KAFKA_LOG_CONFIGURATION";
-    protected static final String ENV_VAR_KAFKA_NODE_COUNT = "KAFKA_NODE_COUNT";
 
     private CertAndKey clientsCA;
     /**
@@ -561,7 +560,6 @@ public class KafkaCluster extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
-        varList.add(buildEnvVar(ENV_VAR_KAFKA_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -102,6 +102,7 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
     protected static final String ENV_VAR_KAFKA_CONFIGURATION = "KAFKA_CONFIGURATION";
     protected static final String ENV_VAR_KAFKA_LOG_CONFIGURATION = "KAFKA_LOG_CONFIGURATION";
+    protected static final String ENV_VAR_KAFKA_NODE_COUNT = "KAFKA_NODE_COUNT";
 
     private CertAndKey clientsCA;
     /**
@@ -560,6 +561,7 @@ public class KafkaCluster extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);

--- a/design/manual-authn-and-authz/AUTHENTICATION.md
+++ b/design/manual-authn-and-authz/AUTHENTICATION.md
@@ -1,0 +1,117 @@
+# Manual Authentication
+
+## Requiring authentication in Kafka
+
+To make sure the clients are always authenticated the Kafka brokers need to be configured to enforce TLS client authentication on the `clienttls` listener.
+To do so, the option `listener.name.clienttls.ssl.client.auth` needs to be set to `required`.
+It can be set in the `Kafka` resource:
+
+```
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    ...
+    config:
+      listener.name.clienttls.ssl.client.auth: required
+    ...
+  zookeeper:
+    ...
+```
+
+## Downloading CA private and public keys
+
+The public and private keys for the clients Certification authority (CA) can be downloaded from the `Secret` created by the Cluster Operator (CO).
+The `Secret` is names `<cluster-name>-clients-ca` where the `<cluster-name>` has to be replaced by the name of your cluster (for example `my-cluster-clients-ca`).
+Following commands can be used to download both keys _(adapt the secret name according to your actual configuration)_:
+
+```
+oc get secret my-cluster-clients-ca -o jsonpath='{.data.clients-ca\.crt}' | base64 -d > clients-ca.crt
+oc get secret my-cluster-clients-ca -o jsonpath='{.data.clients-ca\.key}' | base64 -d > clients-ca.key
+```
+
+These keys will be used to sign the user certificates.
+The private key should be kept secret as it can be used to generate another user certificates.
+
+## Signing user certificates
+
+For the manual authentication process, the end-user has to download the client CA certificate and use it to sign user certificates.
+That can be done using many different tools.
+This document shows example of how to do it using [CFSSL](https://github.com/cloudflare/cfssl).
+Using CFSSL is not mandatory and other tools can be used as well (OpenSSL, ...).
+
+To generate a new user certificate, follow these steps:
+
+* Create JSON file describing the details of the user certificate:
+```json
+{
+   "CN": "user1",
+   "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "CZ",
+            "L": "Prague"
+        }
+    ]
+}
+```
+* Generate new signed key usign `cfssl` utility (the example command assumes the JSON files was names `user1.json`):
+```
+cfssl gencert -ca clients-ca.crt -ca-key clients-ca.key user1.json | cfssljson -bare user1
+```
+* The command above generated 3 new files:
+  * `user1.csr` with the Certificate Signing Request
+  * `user1.pem` with the `user1` public key
+  * `user1-key.pem` wit the `user1` private key
+  
+## Creating `Secret` using the new user certificate
+
+This step assumes that they new USer certificate is in files named `user1.pem` and `user1-key.pem`.
+Should the files be named differently, you can either rename them or change the file names in the `oc` command.
+To create a `Secret` containing the new certificate, use the following command:
+
+```
+oc create secret generic user1 --from-file=./user1.pem --from-file=./user1-key.pem
+```
+
+## Using `Secret` in Kafka client
+
+Any application which wants to connect using the TLS client authentication has to mount the new `user1` `Secret`.
+It also has to mount the `<cluster-name>-cluster-ca-cert` `Secret` which contains the public key of the CA which was used to sign the broker server certificates.
+This is required to verify the identity od the Kafka brokers.
+The `Secrets` can be mounted into the `Pods` either as environment variables or as volumes.
+For more details how to mount it visit [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/).
+
+Once you have the certificates inside the pod, you have to convert tham from the PEM format into PKCS12 or Java Kaystore formats so that they can be used inside Java applications.
+That can be donw using the following two commands:
+
+```
+// Truststore
+keytool -keystore /tmp/truststore -storepass secretpass -noprompt -alias cluster-ca -import -file ca.crt -storetype PKCS12
+
+// Keystore
+RANDFILE=/tmp/.rnd openssl pkcs12 -export -in user1.pem -inkey user1-key.pem -name user1 -password pass:secretpass -out /tmp/keystore
+```  
+
+Once the truststore and keystore files are prepared, you can start you Java application.
+To use them from the KAfka Consumer or Producer APIs, you have to enable and configure SSL for them:
+
+```
+Map<String, String> config = new HashMap<>();
+config.put("bootstrap.servers", "my-cluster-kafka-bootstrap:9093");
+config.put("security.protocol", "SSL");
+config.put("ssl.truststore.type", "PKCS12");
+config.put("ssl.truststore.password", "secretpass");
+config.put("ssl.truststore.location", "/tmp/truststore");
+config.put("ssl.keystore.type", "PKCS12");
+config.put("ssl.keystore.password", "secretpass");
+config.put("ssl.keystore.location", "/tmp/keystore");
+
+KafkaConsumer<String, String> consumer = new KafkaConsumer<String, String>(props);
+```
+ 

--- a/design/manual-authn-and-authz/AUTHENTICATION.md
+++ b/design/manual-authn-and-authz/AUTHENTICATION.md
@@ -4,7 +4,7 @@
 **The long term plan for Strimzi is to have custom resources to define User for Authentication.**
 **Until this is available, this temporary workaround will be available.**
 **There is no long term commitment to support this workaround.**
-**After the final implementation of the operator for Authentication is implemented, this workaround will be disabled and and it will not be possible to use it any more.**
+**After the final implementation of the operator for Authentication this workaround will be disabled and it will not be possible to use it any more.**
 
 ## Requiring authentication in Kafka
 
@@ -88,7 +88,7 @@ The `Secrets` can be mounted into the `Pods` either as environment variables or 
 For more details how to mount it visit [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/).
 
 Once you have the certificates inside the pod, you have to convert tham from the PEM format into PKCS12 or Java Keystore formats so that they can be used inside Java applications.
-That can be donw using the following two commands:
+That can be done using the following two commands:
 
 ```
 // Truststore

--- a/design/manual-authn-and-authz/AUTHENTICATION.md
+++ b/design/manual-authn-and-authz/AUTHENTICATION.md
@@ -47,17 +47,11 @@ To generate a new user certificate, follow these steps:
 * Create JSON file describing the details of the user certificate:
 ```json
 {
-   "CN": "user1",
+   "CN": "User1",
    "key": {
         "algo": "rsa",
         "size": 2048
-    },
-    "names": [
-        {
-            "C": "CZ",
-            "L": "Prague"
-        }
-    ]
+    }
 }
 ```
 * Generate new signed key usign `cfssl` utility (the example command assumes the JSON files was names `user1.json`):
@@ -68,7 +62,7 @@ cfssl gencert -ca clients-ca.crt -ca-key clients-ca.key user1.json | cfssljson -
   * `user1.csr` with the Certificate Signing Request
   * `user1.pem` with the `user1` public key
   * `user1-key.pem` wit the `user1` private key
-  
+
 ## Creating `Secret` using the new user certificate
 
 This step assumes that they new USer certificate is in files named `user1.pem` and `user1-key.pem`.
@@ -114,4 +108,9 @@ config.put("ssl.keystore.location", "/tmp/keystore");
 
 KafkaConsumer<String, String> consumer = new KafkaConsumer<String, String>(props);
 ```
- 
+
+## User principal
+
+The subjects of the users are created based on the subject of their certificates.
+In the example used in this document, the resulting Principal will be `CN=User1`.
+In case the subject contains more items they will be all added to the user principal in following format: `CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown`.

--- a/design/manual-authn-and-authz/AUTHORIZATION.md
+++ b/design/manual-authn-and-authz/AUTHORIZATION.md
@@ -2,6 +2,12 @@
 
 _Note: This guide expects that Authentication was set up as describe in the [AUTHENTICATION.md](AUTHENTICATION.md) guide_
 
+**This document describes a temporary workaround for handling Authorization manually.** 
+**The long term plan for Strimzi is to have custom resources to define ACL rules for Authorization.**
+**Until this is available, this temporary workaround will be available.**
+**There is no long term commitment to support this workaround.**
+**After the final implementation of the operator for Authorization is implemented, this workaround will be disabled and and it will not be possible to use it any more.**
+
 ## Enabling Authorization in the Kafka
 
 Authorization has to be enabled in Kafka brokers.
@@ -36,9 +42,9 @@ For example:
 * pod `my-cluster-zookeeper-1` will be listening on port `21811`
 * etc.
 
-Once execes into the pod, the rules can be manages as described in [Kafka documentation](http://kafka.apache.org/documentation/#security_authz).
+The rules can be manages as described in [Kafka documentation](http://kafka.apache.org/documentation/#security_authz).
 
-For example, to add out User1 rights to write and read from a topic `my-topic` with consumer group `my-group` you could use following examples:
+For example, to add our User1 rights to write and read from a topic `my-topic` with consumer group `my-group` you could use following examples:
 
 ```
 oc exec my-cluster-zookeeper-0 -c zookeeper -t -i -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:21810 --add --allow-principal User:CN=User1 --producer --topic my-topic

--- a/design/manual-authn-and-authz/AUTHORIZATION.md
+++ b/design/manual-authn-and-authz/AUTHORIZATION.md
@@ -1,0 +1,46 @@
+# Manual Authorization
+
+_Note: This guide expects that Authentication was set up as describe in the [AUTHENTICATION.md](AUTHENTICATION.md) guide_
+
+## Enabling Authorization in the Kafka
+
+Authorization has to be enabled in Kafka brokers.
+To do so, the option `authorizer.class.name` needs to be set to `kafka.security.auth.SimpleAclAuthorizer`.
+It can be set in the `Kafka` resource:
+
+```
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    ...
+    config:
+      authorizer.class.name: "kafka.security.auth.SimpleAclAuthorizer"
+    ...
+  zookeeper:
+    ...
+```
+
+## Managing ACL rules
+
+The ACL rules used by the default `SimpleAclAuthorizer` plugin are stored in Zookeeper.
+Since Zookeeper is not exposed to the outside, the management of the ACL rules has to be done from inside one of the zookeeper pods.
+To add or remove any ACL rules, you have to exec into the pod and call the `bin/kafka_acls.sh` utility.
+Since Zookeeper encryption is implemented using a sidecar pod, you can internally connect to the unencrypted Zookeeper port.
+This port differs in different pods.
+It is calculated using following formula: `2181 * 10 + "the number of the pod"`.
+For example:
+* pod `my-cluster-zookeeper-0` will be listening on port `21810`
+* pod `my-cluster-zookeeper-1` will be listening on port `21811`
+* etc.
+
+Once execes into the pod, the rules can be manages as described in [Kafka documentation](http://kafka.apache.org/documentation/#security_authz).
+
+For example, to add out User1 rights to write and read from a topic `my-topic` with consumer group `my-group` you could use following examples:
+
+```
+oc exec my-cluster-zookeeper-0 -c zookeeper -t -i -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:21810 --add --allow-principal User:CN=User1 --producer --topic my-topic
+oc exec my-cluster-zookeeper-0 -c zookeeper -t -i -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:21810 --add --allow-principal User:CN=User1 --consumer --topic my-topic --group my-group
+```

--- a/design/manual-authn-and-authz/AUTHORIZATION.md
+++ b/design/manual-authn-and-authz/AUTHORIZATION.md
@@ -6,7 +6,7 @@ _Note: This guide expects that Authentication was set up as describe in the [AUT
 **The long term plan for Strimzi is to have custom resources to define ACL rules for Authorization.**
 **Until this is available, this temporary workaround will be available.**
 **There is no long term commitment to support this workaround.**
-**After the final implementation of the operator for Authorization is implemented, this workaround will be disabled and and it will not be possible to use it any more.**
+**After the final implementation of the operator for Authorization this workaround will be disabled and it will not be possible to use it any more.**
 
 ## Enabling Authorization in the Kafka
 
@@ -33,7 +33,7 @@ spec:
 
 The ACL rules used by the default `SimpleAclAuthorizer` plugin are stored in Zookeeper.
 Since Zookeeper is not exposed to the outside, the management of the ACL rules has to be done from inside one of the zookeeper pods.
-To add or remove any ACL rules, you have to exec into the pod and call the `bin/kafka_acls.sh` utility.
+To add or remove any ACL rules, you have to exec into the pod and call the `bin/kafka-acls.sh` utility.
 Since Zookeeper encryption is implemented using a sidecar pod, you can internally connect to the unencrypted Zookeeper port.
 This port differs in different pods.
 It is calculated using following formula: `2181 * 10 + "the number of the pod"`.

--- a/design/manual-authn-and-authz/README.md
+++ b/design/manual-authn-and-authz/README.md
@@ -47,14 +47,14 @@ The workaround would support only the built in `kafka.security.auth.SimpleAclAut
 The default authorization plugin stores the ACL rules in Zookeeper.
 Once the Authorization plugin is enabled, ACL rules can be managed with the `kafka-acls.sh` utility.
 
-User who want to use manual setup of authorization will be able to do so in the following steps:
+User who wants to use manual setup of authorization will be able to do so in the following steps:
 
 * Modify the Kafka cluster resource and add configuration options to enable authorization (option `authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer`)
-* Since Zookeeper is not expose to the outside of the OpenShift cluster, the `kafka_acls.sh` utility has to be run from inside.
+* Since Zookeeper is not expose to the outside of the OpenShift cluster, the `kafka-acls.sh` utility has to be run from inside.
   Ideally, one of the Zookeeper pods can be used for it.
   For example:
   ```
-  kubectl exec my-cluster-zookepeer-0 -i -t -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown --operation Write --topic my-topic
+  kubectl exec my-cluster-zookepeer-0 -c zookeeper -i -t -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:21810 --add --allow-principal User:CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown --operation Write --topic my-topic
   ```
 
 ### Required changes to Cluster Operator

--- a/design/manual-authn-and-authz/README.md
+++ b/design/manual-authn-and-authz/README.md
@@ -1,0 +1,65 @@
+# Manual Authentication and Authorization workaround
+
+* Status: **Implemented**
+* Discussion: [GitHub PR](https://github.com/strimzi/strimzi-kafka-operator/pull/623)
+
+## Motivation
+
+The long term plan for Strimzi is to have custom resources to define Users for Authentication and Authorization rules.
+The custom resources should be read by operator style application which would be responsible for the setup of the users or ACL rules.
+Until such operator (User Operator - UO) is available, it would be useful to have a way how to setup Authentication and Authorization at least in manual / semi-manual way.
+This proposal covers such workaround.
+There is no long term commitment to support the mechanisms suggested in this proposal.
+After the final implementation of the operator for Authorization and Authentication is implemented, it will not be possible anymore to use this workaround.
+
+## Authentication
+
+The Cluster Operator (CO) maintains a _Clients CA_.
+This Client CA is set as truststore for the TLS enabled Kafka interface which is designated for client connections (port 9093).
+Currently, this _Clients CA_ does not enforce client authentication.
+And enabling such configuration through `spec.kafka.config` is not possible because the required options are in the _forbidden options_ list.
+This proposal suggests to modify the list of forbidden options to allow end-users to enable or disable the TLS client authentication.
+This change will be only temporary and will be removed once the actual UO is in place with the needed configuration.
+
+User who want to use manual setup of authentication will be able to do so in the following steps:
+
+* Modify the Kafka cluster resource and add configuration options to enable TLS client authentication for the clients port (option `listener.name.clienttls.ssl.client.auth=required`)
+* Use the Clients CA to manually issue user certificates.
+  The CA public and private key can be downloaded from the Kubernetes / OpenShift secret and the user certificates can be signed separately.
+  The CA private key should be kept secret.
+* The authenticated users will be given the Principal name based on the subject of their certificate (e.g. `CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown`)
+
+Alternatively, the end-user can bring own CA for user authentication.
+The CO will accept the CA if the secret exists before the cluster is created.
+
+### Required changes to Cluster Operator
+
+To implement this we will need following changes in the Cluster Operator:
+
+* Make sure the Clients CA is used only for client authentication
+* Change the forbidden options to allow end-users to enable or disable Authentication
+
+## Authorization
+
+To use Authorization, the Authentication needs to be enabled first.
+Authorization can be enabled by setting the ACL Authorizer class in `authorizer.class.name`.
+The workaround would support only the built in `kafka.security.auth.SimpleAclAuthorizer`
+The default authorization plugin stores the ACL rules in Zookeeper.
+Once the Authorization plugin is enabled, ACL rules can be managed with the `kafka-acls.sh` utility.
+
+User who want to use manual setup of authorization will be able to do so in the following steps:
+
+* Modify the Kafka cluster resource and add configuration options to enable authorization (option `authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer`)
+* Since Zookeeper is not expose to the outside of the OpenShift cluster, the `kafka_acls.sh` utility has to be run from inside.
+  Ideally, one of the Zookeeper pods can be used for it.
+  For example:
+  ```
+  kubectl exec my-cluster-zookepeer-0 -i -t -- bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown --operation Write --topic my-topic
+  ```
+
+### Required changes to Cluster Operator
+
+To implement this we will need following changes in the Cluster Operator:
+
+* Change the forbidden options to allow end-users to enable or disable Authentication
+* Configure the Kafka cluster nodes as _super users_ so that they can do the replication (option `super.users=User:Bob;User:Alice`)

--- a/design/manual-authn-and-authz/README.md
+++ b/design/manual-authn-and-authz/README.md
@@ -7,10 +7,10 @@
 
 The long term plan for Strimzi is to have custom resources to define Users for Authentication and Authorization rules.
 The custom resources should be read by operator style application which would be responsible for the setup of the users or ACL rules.
-Until such operator (User Operator - UO) is available, it would be useful to have a way how to setup Authentication and Authorization at least in manual / semi-manual way.
-This proposal covers such workaround.
+Until such an operator (User Operator - UO) is available, it would be useful to have a way to setup Authentication and Authorization at least in a manual / semi-manual way.
+This proposal covers such a workaround.
 There is no long term commitment to support the mechanisms suggested in this proposal.
-After the final implementation of the operator for Authorization and Authentication is implemented, it will not be possible anymore to use this workaround.
+After the final implementation of the operator for Authorization and Authentication is implemented, it will not be possible to use this workaround any more.
 
 ## Authentication
 

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # Prepare super.users field
-BASE_HOSTNAME=$(hostname | rev | cut -d "-" -f2- | rev)
+KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
+ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
 NODE=1
-SUPER_USERS="super.users="
+SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator;"
 while [ $NODE -le $KAFKA_NODE_COUNT ]; do
-    SUPER_USERS=$SUPER_USERS + "User:CN=${BASE_HOSTNAME}-$((NODE-1));"
+    SUPER_USERS="${SUPER_USERS}User:CN=${KAFKA_NAME}-$((NODE-1));"
     let NODE=NODE+1
 done
 

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -4,9 +4,9 @@
 KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
 ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
 NODE=1
-SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator;"
+SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;"
 while [ $NODE -le $KAFKA_NODE_COUNT ]; do
-    SUPER_USERS="${SUPER_USERS}User:CN=${KAFKA_NAME}-$((NODE-1));"
+    SUPER_USERS="${SUPER_USERS}User:CN=${KAFKA_NAME}-$((NODE-1)),O=io.strimzi;"
     let NODE=NODE+1
 done
 

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -3,12 +3,7 @@
 # Prepare super.users field
 KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
 ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
-NODE=1
-SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;"
-while [ $NODE -le $KAFKA_NODE_COUNT ]; do
-    SUPER_USERS="${SUPER_USERS}User:CN=${KAFKA_NAME}-$((NODE-1)),O=io.strimzi;"
-    let NODE=NODE+1
-done
+SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;User:CN=${KAFKA_NAME},O=io.strimzi"
 
 # Write the config file
 cat <<EOF

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Prepare super.users field
+BASE_HOSTNAME=$(hostname | rev | cut -d "-" -f2- | rev)
+NODE=1
+SUPER_USERS="super.users="
+while [ $NODE -le $KAFKA_NODE_COUNT ]; do
+    SUPER_USERS=$SUPER_USERS + "User:CN=${BASE_HOSTNAME}-$((NODE-1));"
+    let NODE=NODE+1
+done
+
 # Write the config file
 cat <<EOF
 broker.id=${KAFKA_BROKER_ID}
@@ -30,6 +39,9 @@ listener.name.replication.ssl.client.auth=required
 
 listener.name.clienttls.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.p12
+
+# ACL Super users (all nodes for replication)
+${SUPER_USERS}
 
 # Provided configuration
 ${KAFKA_CONFIGURATION}

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -64,7 +64,7 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |<<type-Sidecar,`Sidecar`>>
 |additionalProperties  1.2+<.<|
 |map
-|config                1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user
+|config                1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener.name.replication., listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, super.user
 |map
 |logging               1.2+<.<|Logging configuration for Kafka The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~
- Hack

### Description

This PR delivers the hack which will allow to enable authentication and authorization and handle them manually until we have our User operator available. It does so by:
* Modifying the list of forbidden options to allow enabling TLS client auth on the client interface and enabling authorizer
* Setting super.users list to allow TO and other brokers to talk with each other even when ACLs are enabled
* Documentation how to do the things manually (not part of regular documentation since it is temporary only)

The `super.users` field will be needed even once we have our own user Operator. However, all brokers need to be listed in the `super.users` list in order for the cluster to work properly. With the previous certificates, each Kafka broker had certificate with subject `CN=my-cluster-kafka-0`, `CN=my-cluster-kafka-1` etc. That means that when a new node is added, we need to do rolling update of all brokers. That seems very ugly and undesired. Therefore I modified the subjects of the broker certificates to use only the name of the StatefulSet as the CN. That means that we do not need anymore to do rolling update for scale up. I trade-off is worth it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
