### PR TITLE
Fix undesired rolling update when Kafka config field in CR is empty

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -556,7 +556,7 @@ public class KafkaCluster extends AbstractModel {
         heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);
 
-        if (configuration != null) {
+        if (configuration != null && !configuration.getConfiguration().isEmpty()) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_CONFIGURATION, configuration.getConfiguration()));
         }
         // A hack to force rolling when the logging config changes


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

@serrss complained about failing `testRackAware` test. I found out that it was most probably related to the following problem ... When the `spec.kafka.config` fields was empty, the resulting configuration was not null but empty String. Therefore the environment variable with it was set on the StatefulSet. However, it seems to be messing with the rolling update because it is detected as difference (empty String in expected but null in desired). 

```
2018-07-20 23:09:58 DEBUG StatefulSetDiff:85 - StatefulSet kafka-cluster-test/my-cluster-kafka differs: {"op":"add","path":"/spec/template/spec/containers/0/env/4/value","value":""}
2018-07-20 23:09:58 DEBUG StatefulSetDiff:86 - Current StatefulSet path /spec/template/spec/containers/0/env/4/value has value null
2018-07-20 23:09:58 DEBUG StatefulSetDiff:87 - Desired StatefulSet path /spec/template/spec/containers/0/env/4/value has value ""
```

That seems to be triggering permanent rolling update which can mess with some tests. Only same tests were affected because:
* Most of tests have the `spec.kafka.config` field defined
* The race condition would have different probabilities to hit depending on the tests

Hopefully this will help to fix the tests which were occasionally failing.