### PR TITLE
Refactoring for consistent naming of assembly parameters

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -92,11 +92,11 @@ public class KafkaConnectCluster extends AbstractModel {
         return cluster + KafkaConnectCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
     }
 
-    public static KafkaConnectCluster fromCrd(KafkaConnectAssembly crd) {
-        return fromSpec(crd.getSpec(),
-                new KafkaConnectCluster(crd.getMetadata().getNamespace(),
-                    crd.getMetadata().getName(),
-                    Labels.fromResource(crd).withKind(crd.getKind())));
+    public static KafkaConnectCluster fromCrd(KafkaConnectAssembly kafkaConnectAssembly) {
+        return fromSpec(kafkaConnectAssembly.getSpec(),
+                new KafkaConnectCluster(kafkaConnectAssembly.getMetadata().getNamespace(),
+                    kafkaConnectAssembly.getMetadata().getName(),
+                    Labels.fromResource(kafkaConnectAssembly).withKind(kafkaConnectAssembly.getKind())));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -51,11 +51,11 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         this.validLoggerFields = getDefaultLogConfig();
     }
 
-    public static KafkaConnectS2ICluster fromCrd(KafkaConnectS2IAssembly crd) {
-        KafkaConnectS2IAssemblySpec spec = crd.getSpec();
-        KafkaConnectS2ICluster cluster = fromSpec(spec, new KafkaConnectS2ICluster(crd.getMetadata().getNamespace(),
-                crd.getMetadata().getName(),
-                Labels.fromResource(crd).withKind(crd.getKind())));
+    public static KafkaConnectS2ICluster fromCrd(KafkaConnectS2IAssembly kafkaConnectS2IAssembly) {
+        KafkaConnectS2IAssemblySpec spec = kafkaConnectS2IAssembly.getSpec();
+        KafkaConnectS2ICluster cluster = fromSpec(spec, new KafkaConnectS2ICluster(kafkaConnectS2IAssembly.getMetadata().getNamespace(),
+                kafkaConnectS2IAssembly.getMetadata().getName(),
+                Labels.fromResource(kafkaConnectS2IAssembly).withKind(kafkaConnectS2IAssembly.getKind())));
         cluster.setInsecureSourceRepository(spec != null ? spec.isInsecureSourceRepository() : false);
         return cluster;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -211,19 +211,19 @@ public class TopicOperator extends AbstractModel {
      * Create a Topic Operator from given desired resource
      *
      * @param certManager Certificate manager for certificates generation
-     * @param resource desired resource with cluster configuration containing the topic operator one
+     * @param kafkaAssembly desired resource with cluster configuration containing the topic operator one
      * @param secrets Secrets containing already generated certificates
      * @return Topic Operator instance, null if not configured in the ConfigMap
      */
-    public static TopicOperator fromCrd(CertManager certManager, KafkaAssembly resource, List<Secret> secrets) {
+    public static TopicOperator fromCrd(CertManager certManager, KafkaAssembly kafkaAssembly, List<Secret> secrets) {
         TopicOperator result;
-        if (resource.getSpec().getTopicOperator() != null) {
-            String namespace = resource.getMetadata().getNamespace();
+        if (kafkaAssembly.getSpec().getTopicOperator() != null) {
+            String namespace = kafkaAssembly.getMetadata().getNamespace();
             result = new TopicOperator(
                     namespace,
-                    resource.getMetadata().getName(),
-                    Labels.fromResource(resource).withKind(resource.getKind()));
-            io.strimzi.api.kafka.model.TopicOperator tcConfig = resource.getSpec().getTopicOperator();
+                    kafkaAssembly.getMetadata().getName(),
+                    Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
+            io.strimzi.api.kafka.model.TopicOperator tcConfig = kafkaAssembly.getSpec().getTopicOperator();
             result.setImage(tcConfig.getImage());
             result.setWatchedNamespace(tcConfig.getWatchedNamespace() != null ? tcConfig.getWatchedNamespace() : namespace);
             result.setReconciliationIntervalMs(tcConfig.getReconciliationIntervalSeconds() * 1_000);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -69,13 +69,13 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
     }
 
     @Override
-    protected void createOrUpdate(Reconciliation reconciliation, KafkaConnectAssembly assemblyCm, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> handler) {
+    protected void createOrUpdate(Reconciliation reconciliation, KafkaConnectAssembly kafkaConnectAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> handler) {
 
         String namespace = reconciliation.namespace();
         String name = reconciliation.assemblyName();
         KafkaConnectCluster connect;
         try {
-            connect = KafkaConnectCluster.fromCrd(assemblyCm);
+            connect = KafkaConnectCluster.fromCrd(kafkaConnectAssembly);
         } catch (Exception e) {
             handler.handle(Future.failedFuture(e));
             return;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -81,12 +81,12 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
     }
 
     @Override
-    public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2IAssembly assemblyCm, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> handler) {
+    public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2IAssembly kafkaConnectS2IAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> handler) {
         String namespace = reconciliation.namespace();
         if (isOpenShift) {
             KafkaConnectS2ICluster connect;
             try {
-                connect = KafkaConnectS2ICluster.fromCrd(assemblyCm);
+                connect = KafkaConnectS2ICluster.fromCrd(kafkaConnectS2IAssembly);
             } catch (Exception e) {
                 handler.handle(Future.failedFuture(e));
                 return;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -928,8 +928,8 @@ public class KafkaAssemblyOperatorTest {
                 certManager,
                 supplier) {
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaAssembly assemblyCm, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
-                createdOrUpdated.add(assemblyCm.getMetadata().getName());
+            public void createOrUpdate(Reconciliation reconciliation, KafkaAssembly kafkaAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+                createdOrUpdated.add(kafkaAssembly.getMetadata().getName());
                 async.countDown();
                 h.handle(Future.succeededFuture());
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -527,8 +527,8 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps) {
 
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaConnectAssembly assemblyCm, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
-                createdOrUpdated.add(assemblyCm.getMetadata().getName());
+            public void createOrUpdate(Reconciliation reconciliation, KafkaConnectAssembly kafkaConnectAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+                createdOrUpdated.add(kafkaConnectAssembly.getMetadata().getName());
                 async.countDown();
                 h.handle(Future.succeededFuture());
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -679,8 +679,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps) {
 
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2IAssembly assemblyCm, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
-                createdOrUpdated.add(assemblyCm.getMetadata().getName());
+            public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2IAssembly kafkaConnectS2IAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+                createdOrUpdated.add(kafkaConnectS2IAssembly.getMetadata().getName());
                 async.countDown();
                 h.handle(Future.succeededFuture());
             }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

A trivial PR for refactoring assembly parameter names now that ConfigMaps are not used anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

