### PR TITLE
Add support for Tolerations and fix affinity for Connect S2I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG
 
-## 0.6.0 (Work in Progress)
-
-* Add support for [Tolerations](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#toleration-v1-core)
-
 ## 0.5.0 (Work in Progress)
 
 * The Cluster Operator now manages RBAC resource for managed resources:
@@ -23,7 +19,8 @@
     * Communication between Kafka and Zookeeper
     * Communication between Topic Operator and Kafka / Zookeeper
 * Logging configuration for Kafka, Kafka Connect and Zookeeper
-* Add support for Pod Affinity and Anti-Affinity
+* Add support for [Pod Affinity and Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+* Add support for [Tolerations](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#toleration-v1-core)
 * Configuring different JVM options
 * Support for broker rack in Kafka
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.6.0 (Work in Progress)
+
+* Add support for [Tolerations](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#toleration-v1-core)
+
 ## 0.5.0 (Work in Progress)
 
 * The Cluster Operator now manages RBAC resource for managed resources:

--- a/api/src/main/java/io/strimzi/api/kafka/model/ReplicatedJvmPods.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ReplicatedJvmPods.java
@@ -12,9 +12,12 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.sundr.builder.annotations.Buildable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,6 +44,8 @@ public abstract class ReplicatedJvmPods {
     private Map<String, Object> metrics = new HashMap<>(0);
 
     private Affinity affinity;
+
+    private List<Toleration> tolerations;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -125,6 +130,17 @@ public abstract class ReplicatedJvmPods {
 
     public void setAffinity(Affinity affinity) {
         this.affinity = affinity;
+    }
+
+    @Description("Pod's tolerations.")
+    @KubeLink(group = "core", version = "v1", kind = "tolerations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<Toleration> getTolerations() {
+        return tolerations;
+    }
+
+    public void setTolerations(List<Toleration> tolerations) {
+        this.tolerations = tolerations;
     }
 
     @JsonAnyGetter

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
@@ -37,6 +37,15 @@ spec:
     resources:
       limits:
         memory: "5Gi"
+    tolerations:
+    - effect: "NoSchedule"
+      key: "key1"
+      operator: "Equal"
+      value: "value1"
+    - effect: "NoSchedule"
+      key: "key2"
+      operator: "Equal"
+      value: "value2"
     config:
       min.insync.replicas: 3
   zookeeper:
@@ -57,6 +66,15 @@ spec:
     resources:
       limits:
         memory: "512Mi"
+    tolerations:
+    - effect: "NoSchedule"
+      key: "key1"
+      operator: "Equal"
+      value: "value1"
+    - effect: "NoSchedule"
+      key: "key2"
+      operator: "Equal"
+      value: "value2"
     config: {}
   topicOperator:
     watchedNamespace: "my-ns"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
@@ -11,6 +11,15 @@ spec:
     resources:
       limits:
         memory: "5Gi"
+    tolerations:
+      - key: "key1"
+        operator: "Equal"
+        value: "value1"
+        effect: "NoSchedule"
+      - key: "key2"
+        operator: "Equal"
+        value: "value2"
+        effect: "NoSchedule"
     livenessProbe:
       initialDelaySeconds: 5
       timeoutSeconds: 1
@@ -50,6 +59,15 @@ spec:
     resources:
       limits:
         memory: "512Mi"
+    tolerations:
+      - key: "key1"
+        operator: "Equal"
+        value: "value1"
+        effect: "NoSchedule"
+      - key: "key2"
+        operator: "Equal"
+        value: "value2"
+        effect: "NoSchedule"
     livenessProbe:
       initialDelaySeconds: 5
       timeoutSeconds: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
@@ -9,5 +9,14 @@ spec:
   replicas: 6
   image: "foo"
   metrics: {}
+  tolerations:
+  - effect: "NoSchedule"
+    key: "key1"
+    operator: "Equal"
+    value: "value1"
+  - effect: "NoSchedule"
+    key: "key2"
+    operator: "Equal"
+    value: "value2"
   config:
     name: "bar"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.yaml
@@ -7,3 +7,12 @@ spec:
   replicas: 6
   config:
     name: bar
+  tolerations:
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
+    - key: "key2"
+      operator: "Equal"
+      value: "value2"
+      effect: "NoSchedule"

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -36,6 +36,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -144,6 +145,7 @@ public abstract class AbstractModel {
     private JvmOptions jvmOptions;
     private Resources resources;
     private Affinity userAffinity;
+    private List<Toleration> tolerations;
 
     protected Map validLoggerFields;
     private String[] validLoggerValues = new String[]{"INFO", "ERROR", "WARN", "TRACE", "DEBUG", "FATAL", "OFF" };
@@ -471,7 +473,7 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Sets the affinity as configured by the user in the cluster CM
+     * Sets the affinity as configured by the user in the cluster CR
      * @param affinity
      */
     protected void setUserAffinity(Affinity affinity) {
@@ -479,10 +481,26 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Gets the affinity as configured by the user in the cluster CM
+     * Gets the affinity as configured by the user in the cluster CR
      */
     protected Affinity getUserAffinity() {
         return this.userAffinity;
+    }
+
+    /**
+     * Gets the tolerations as configured by the user in the cluster CR
+     */
+    public List<Toleration> getTolerations() {
+        return tolerations;
+    }
+
+    /**
+     * Sets the tolerations as configured by the user in the cluster CR
+     *
+     * @param tolerations
+     */
+    public void setTolerations(List<Toleration> tolerations) {
+        this.tolerations = tolerations;
     }
 
     /**
@@ -778,6 +796,7 @@ public abstract class AbstractModel {
                             .withInitContainers(initContainersInternal)
                             .withContainers(containers)
                             .withVolumes(volumes)
+                            .withTolerations(getTolerations())
                         .endSpec()
                     .endTemplate()
                     .withVolumeClaimTemplates(volumeClaims)
@@ -817,6 +836,7 @@ public abstract class AbstractModel {
                             .withInitContainers(initContainers)
                             .withContainers(containers)
                             .withVolumes(volumes)
+                            .withTolerations(getTolerations())
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -214,6 +214,7 @@ public class KafkaCluster extends AbstractModel {
         result.setStorage(kafka.getStorage());
         result.setUserAffinity(kafka.getAffinity());
         result.setResources(kafka.getResources());
+        result.setTolerations(kafka.getTolerations());
 
         result.generateCertificates(certManager, secrets);
         result.setTlsSidecar(kafka.getTlsSidecar());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -130,6 +130,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 kafkaConnect.setMetricsConfig(metrics.entrySet());
             }
             kafkaConnect.setUserAffinity(spec.getAffinity());
+            kafkaConnect.setTolerations(spec.getTolerations());
         }
         return kafkaConnect;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -116,6 +116,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                         .withNewSpec()
                             .withContainers(container)
                             .withVolumes(getVolumes())
+                            .withTolerations(getTolerations())
+                            .withAffinity(getMergedAffinity())
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -173,6 +173,7 @@ public class ZookeeperCluster extends AbstractModel {
         zk.setResources(zookeeper.getResources());
         zk.setJvmOptions(zookeeper.getJvmOptions());
         zk.setUserAffinity(zookeeper.getAffinity());
+        zk.setTolerations(zookeeper.getTolerations());
         zk.generateCertificates(certManager, secrets);
         zk.setTlsSidecar(zookeeper.getTlsSidecar());
         return zk;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -319,6 +319,11 @@ public class KafkaClusterTest {
             kc -> kc.generateStatefulSet(true).getSpec().getTemplate().getSpec().getAffinity());
     }
 
+    @Test
+    public void withTolerations() throws IOException {
+        resourceTester.assertDesiredResource("-SS.yaml",
+            kc -> kc.generateStatefulSet(true).getSpec().getTemplate().getSpec().getTolerations());
+    }
 
     @Test
     public void testCreateTcpSocketProbe()  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -173,6 +173,12 @@ public class KafkaConnectClusterTest {
     @Test
     public void withAffinity() throws IOException {
         resourceTester
-                .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment().getSpec().getTemplate().getSpec().getAffinity());
+            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment().getSpec().getTemplate().getSpec().getAffinity());
+    }
+
+    @Test
+    public void withTolerations() throws IOException {
+        resourceTester
+            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment().getSpec().getTemplate().getSpec().getTolerations());
     }
 }

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withTolerations-Kafka.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withTolerations-Kafka.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    tolerations:
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
+    - key: "key2"
+      operator: "Equal"
+      value: "value2"
+      effect: "NoSchedule"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withTolerations-SS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withTolerations-SS.yaml
@@ -1,0 +1,9 @@
+---
+- effect: "NoSchedule"
+  key: "key1"
+  operator: "Equal"
+  value: "value1"
+- effect: "NoSchedule"
+  key: "key2"
+  operator: "Equal"
+  value: "value2"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.withTolerations-Deployment.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.withTolerations-Deployment.yaml
@@ -1,0 +1,9 @@
+---
+- effect: "NoSchedule"
+  key: "key1"
+  operator: "Equal"
+  value: "value1"
+- effect: "NoSchedule"
+  key: "key2"
+  operator: "Equal"
+  value: "value2"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.withTolerations-KafkaConnect.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.withTolerations-KafkaConnect.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+  - key: "key2"
+    operator: "Equal"
+    value: "value2"
+    effect: "NoSchedule"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withAffinity-DeploymentConfig.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withAffinity-DeploymentConfig.yaml
@@ -1,0 +1,18 @@
+---
+nodeAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - preference:
+      matchExpressions:
+      - key: "another-node-label-key"
+        operator: "In"
+        values:
+        - "another-node-label-value"
+    weight: 1
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: "kubernetes.io/e2e-az-name"
+        operator: "In"
+        values:
+        - "e2e-az1"
+        - "e2e-az2"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withAffinity-KafkaConnectS2I.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withAffinity-KafkaConnectS2I.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: KafkaConnectS2I
+metadata:
+  name: my-connect-cluster
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/e2e-az-name
+            operator: In
+            values:
+            - e2e-az1
+            - e2e-az2
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+          - key: another-node-label-key
+            operator: In
+            values:
+            - another-node-label-value

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withTolerations-DeploymentConfig.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withTolerations-DeploymentConfig.yaml
@@ -1,0 +1,9 @@
+---
+- effect: "NoSchedule"
+  key: "key1"
+  operator: "Equal"
+  value: "value1"
+- effect: "NoSchedule"
+  key: "key2"
+  operator: "Equal"
+  value: "value2"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withTolerations-KafkaConnectS2I.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.withTolerations-KafkaConnectS2I.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: KafkaConnectS2I
+metadata:
+  name: my-connect-cluster
+spec:
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+  - key: "key2"
+    operator: "Equal"
+    value: "value2"
+    effect: "NoSchedule"

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -72,6 +72,10 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |<<type-Rack,`Rack`>>
 |resources             1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
+|tolerations           1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 
 [[type-EphemeralStorage]]
@@ -287,6 +291,10 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources             1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
+|tolerations           1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 
 [[type-TopicOperator]]
@@ -369,6 +377,10 @@ Used in: <<kind-KafkaConnect,`KafkaConnectAssembly`>>
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources             1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
+|tolerations           1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 
 [[kind-KafkaConnectS2I]]
@@ -420,5 +432,9 @@ Used in: <<kind-KafkaConnectS2I,`KafkaConnectS2IAssembly`>>
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources                 1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
+|tolerations               1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -392,6 +392,23 @@ spec:
                         memory:
                           type: string
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                      additionalProperties:
+                        type: object
               required:
               - replicas
               - storage
@@ -757,6 +774,23 @@ spec:
                         memory:
                           type: string
                           pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                      additionalProperties:
+                        type: object
               required:
               - replicas
               - storage

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -329,6 +329,23 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+                  additionalProperties:
+                    type: object
           required:
           - config
         additionalProperties:

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -331,6 +331,23 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+                  additionalProperties:
+                    type: object
           required:
           - config
         additionalProperties:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~
- ~~Documentation~~

### Description

This PR adds support for [Tolerations](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#toleration-v1-core). Tolerations are needed for dedicated hosts. Tolerations should be supported in Kafka, Zookeeper, Kafka Connect and Kafka Connect S2I.

Additionally, this PR adds Affinity to Kafka Connect S2I. That was supported in the CR but was never set in the code.

This should close issue #510 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

