### PR TITLE
Fix Windows build for certificate-manager, topic-operator, cluster-op…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 RELEASE_VERSION ?= latest
 
-SUBDIRS=docker-images certificate-manager crd-generator api cluster-operator topic-operator kafka-init examples
+SUBDIRS=docker-images crd-generator api certificate-manager cluster-operator topic-operator kafka-init examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/api/src/test/java/io/strimzi/test/TestUtils.java
+++ b/api/src/test/java/io/strimzi/test/TestUtils.java
@@ -31,9 +31,10 @@ import java.util.function.BooleanSupplier;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 public final class TestUtils {
-
+    public static final String LINE_SEPARATOR = System.getProperty("line.separator");
     private static final Logger LOGGER = LogManager.getLogger(TestUtils.class);
 
     private TestUtils() {
@@ -266,5 +267,9 @@ public final class TestUtils {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void assumeLinux() {
+        assumeTrue(System.getProperty("os.name").contains("nux"));
     }
 }

--- a/certificate-manager/pom.xml
+++ b/certificate-manager/pom.xml
@@ -30,6 +30,13 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.strimzi</groupId>
+      <artifactId>api</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.certs;
 
+import io.strimzi.test.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -31,6 +32,7 @@ public class OpenSslCertManagerTest {
 
     @BeforeClass
     public static void before() throws CertificateException {
+        TestUtils.assumeLinux();
         certFactory = CertificateFactory.getInstance("X.509");
         ssl = new OpenSslCertManager();
     }

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.certs;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.test.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ public class SecretCertProviderTest {
 
     @BeforeClass
     public static void before() {
+        TestUtils.assumeLinux();
         ssl = new OpenSslCertManager();
         secretCertProvider = new SecretCertProvider();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -11,13 +11,14 @@ import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
+import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractConfigurationTest {
-    final private String defaultConfiguration = "default.option=hello\n";
+    final private String defaultConfiguration = "default.option=hello" + LINE_SEPARATOR;
 
     @Test
     public void testConfigurationStringDefaults()  {
@@ -27,16 +28,16 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testConfigurationStringOverridingDefaults()  {
-        AbstractConfiguration config = new TestConfiguration("default.option=world\n");
-        assertEquals("default.option=world\n", config.getConfiguration());
+        AbstractConfiguration config = new TestConfiguration("default.option=world" + LINE_SEPARATOR);
+        assertEquals("default.option=world" + LINE_SEPARATOR, config.getConfiguration());
     }
 
     @Test
     public void testConfigurationStringOverridingDefaultsWithMore()  {
-        AbstractConfiguration config = new TestConfiguration("default.option=world\nvar1=aaa\n");
+        AbstractConfiguration config = new TestConfiguration("default.option=world" + LINE_SEPARATOR + "var1=aaa" + LINE_SEPARATOR);
 
-        String expectedConfiguration = "default.option=world\n" +
-                "var1=aaa\n";
+        String expectedConfiguration = "default.option=world" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         assertEquals(expectedConfiguration, config.getConfiguration());
     }
@@ -50,15 +51,15 @@ public class AbstractConfigurationTest {
     @Test
     public void testJsonOverridingDefaults()  {
         AbstractConfiguration config = new TestConfiguration(new JsonObject().put("default.option", "world"));
-        assertEquals("default.option=world\n", config.getConfiguration());
+        assertEquals("default.option=world" + LINE_SEPARATOR, config.getConfiguration());
     }
 
     @Test
     public void testJsonOverridingDefaultsWithMore()  {
         AbstractConfiguration config = new TestConfiguration(new JsonObject().put("default.option", "world").put("var1", "aaa"));
 
-        String expectedConfiguration = "default.option=world\n" +
-                "var1=aaa\n";
+        String expectedConfiguration = "default.option=world" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         assertEquals(expectedConfiguration, config.getConfiguration());
     }
@@ -79,13 +80,13 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testNonEmptyConfigurationString() {
-        String configuration = "var1=aaa\n" +
-                "var2=bbb\n" +
-                "var3=ccc\n";
+        String configuration = "var1=aaa" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var3=ccc" + LINE_SEPARATOR;
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -95,9 +96,9 @@ public class AbstractConfigurationTest {
     public void testNonEmptyJson() {
         JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc");
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -105,14 +106,14 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testConfigurationStringWithDuplicates() {
-        String configuration = "var1=aaa\n" +
-                "var2=bbb\n" +
-                "var3=ccc\n" +
-                "var2=ddd\n";
+        String configuration = "var1=aaa" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=ddd" + LINE_SEPARATOR;
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=ddd\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=ddd" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -122,9 +123,9 @@ public class AbstractConfigurationTest {
     public void testJsonWithDuplicates() {
         JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("var2", "ddd");
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=ddd\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=ddd" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -132,14 +133,14 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testConfigurationStringWithForbiddenKeys() {
-        String configuration = "var1=aaa\n" +
-                "var2=bbb\n" +
-                "var3=ccc\n" +
-                "forbidden.option=ddd\n";
+        String configuration = "var1=aaa" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var3=ccc" + LINE_SEPARATOR +
+                "forbidden.option=ddd" + LINE_SEPARATOR;
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -147,14 +148,14 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testConfigurationStringWithForbiddenKeysInUpperCase() {
-        String configuration = "var1=aaa\n" +
-                "var2=bbb\n" +
-                "var3=ccc\n" +
-                "FORBIDDEN.OPTION=ddd\n";
+        String configuration = "var1=aaa" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var3=ccc" + LINE_SEPARATOR +
+                "FORBIDDEN.OPTION=ddd" + LINE_SEPARATOR;
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -164,9 +165,9 @@ public class AbstractConfigurationTest {
     public void testJsonWithForbiddenKeys() {
         JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("forbidden.option", "ddd");
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -176,9 +177,9 @@ public class AbstractConfigurationTest {
     public void testJsonWithForbiddenKeysPrefix() {
         JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("forbidden.option.first", "ddd").put("forbidden.option.second", "ddd");
         String expectedConfiguration = defaultConfiguration +
-                "var3=ccc\n" +
-                "var2=bbb\n" +
-                "var1=aaa\n";
+                "var3=ccc" + LINE_SEPARATOR +
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=aaa" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());
@@ -188,8 +189,8 @@ public class AbstractConfigurationTest {
     public void testJsonWithDifferentTypes() {
         JsonObject configuration = new JsonObject().put("var1", 1).put("var2", "bbb").put("var3", new JsonObject().put("xxx", "yyy"));
         String expectedConfiguration = defaultConfiguration +
-                "var2=bbb\n" +
-                "var1=1\n";
+                "var2=bbb" + LINE_SEPARATOR +
+                "var1=1" + LINE_SEPARATOR;
         try {
             AbstractConfiguration config = new TestConfiguration(configuration);
             fail("Expected it to throw an exception");
@@ -202,7 +203,7 @@ public class AbstractConfigurationTest {
     public void testWithHostPort() {
         JsonObject configuration = new JsonObject().put("option.with.port", "my-server:9092");
         String expectedConfiguration = defaultConfiguration +
-                "option.with.port=my-server\\:9092\n";
+                "option.with.port=my-server\\:9092" + LINE_SEPARATOR;
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.getConfiguration());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -198,7 +199,7 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthDelay), containers.get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
+        assertEquals("foo=bar" + LINE_SEPARATOR, AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
         assertEquals(KafkaCluster.BROKER_CERTS_VOLUME, containers.get(0).getVolumeMounts().get(1).getName());
         assertEquals(KafkaCluster.BROKER_CERTS_VOLUME_MOUNT, containers.get(0).getVolumeMounts().get(1).getMountPath());
         assertEquals(KafkaCluster.CLIENT_CA_CERTS_VOLUME, containers.get(0).getVolumeMounts().get(2).getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 
 public class KafkaConnectClusterTest {
@@ -35,27 +36,27 @@ public class KafkaConnectClusterTest {
     private final int healthTimeout = 10;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
-    private final String expectedConfiguration = "group.id=connect-cluster\n" +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.key.converter.schemas.enable=false\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "foo=bar\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
-    private final String defaultConfiguration = "group.id=connect-cluster\n" +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.key.converter.schemas.enable=false\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
+    private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
+            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
+            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
+            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
+            "foo=bar" + LINE_SEPARATOR +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
+    private final String defaultConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
+            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
+            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
+            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
 
     private CertManager certManager = new MockCertManager();
     private final KafkaConnectAssembly resource = new KafkaConnectAssemblyBuilder(ResourceUtils.createEmptyKafkaConnectCluster(namespace, cluster))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -40,27 +41,27 @@ public class KafkaConnectS2IClusterTest {
     private final int healthTimeout = 10;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
-    private final String expectedConfiguration = "group.id=connect-cluster\n" +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.key.converter.schemas.enable=false\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "foo=bar\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
-    private final String defaultConfiguration = "group.id=connect-cluster\n" +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.key.converter.schemas.enable=false\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
+    private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
+            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
+            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
+            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
+            "foo=bar" + LINE_SEPARATOR +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
+    private final String defaultConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
+            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
+            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
+            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
+            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
     private final boolean insecureSourceRepo = false;
 
     private final KafkaConnectS2IAssembly cm = ResourceUtils.createKafkaConnectS2ICluster(namespace, cluster, replicas, image,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -133,7 +134,12 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(healthDelay), containers.get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("timeTick=2000\nautopurge.purgeInterval=1\nsyncLimit=2\ninitLimit=5\nfoo=bar\n", AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
+        String expectedConfig = "timeTick=2000" + LINE_SEPARATOR +
+                        "autopurge.purgeInterval=1" + LINE_SEPARATOR +
+                        "syncLimit=2" + LINE_SEPARATOR +
+                        "initLimit=5" + LINE_SEPARATOR +
+                        "foo=bar" + LINE_SEPARATOR;
+        assertEquals(expectedConfig, AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
         // checks on the TLS sidecar container
         assertEquals(Zookeeper.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
         assertEquals(new Integer(replicas), Integer.valueOf(AbstractModel.containerEnvVars(containers.get(1)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_NODE_COUNT)));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
@@ -4,11 +4,13 @@
  */
 package io.strimzi.operator.topic;
 
+import io.strimzi.test.TestUtils;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -104,6 +106,11 @@ public class TopicOperatorAssignedKafkaImplTest {
             args.add(script);
             args.addAll(this.args.get(i++));
         }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        TestUtils.assumeLinux();
     }
 
     @Test


### PR DESCRIPTION
…erator

### Type of change

- Enhancement / new feature

### Description

This is the 2nd and last part of the changes which allow to build and run non-IT tests of strimzi on Windows machine.  Related issue: https://github.com/strimzi/strimzi-kafka-operator/issues/605

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

