### PR TITLE
ST: Port for zookeeper

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -193,13 +193,13 @@ public class AbstractClusterIT {
         return versions.get();
     }
 
-    void waitForZkMntr(String pod, Pattern pattern) {
+    void waitForZkMntr(String pod, String port, Pattern pattern) {
         long timeoutMs = 120_000L;
         long pollMs = 1_000L;
         TestUtils.waitFor("mntr", pollMs, timeoutMs, () -> {
             try {
                 String output = kubeClient.exec(pod,
-                    "/bin/bash", "-c", "echo mntr | nc localhost 2181").out();
+                    "/bin/bash", "-c", "echo mntr | nc localhost " + port).out();
 
                 if (pattern.matcher(output).find()) {
                     return true;
@@ -212,7 +212,7 @@ public class AbstractClusterIT {
             () -> LOGGER.info("zookeeper `mntr` output at the point of timeout does not match {}:{}{}",
                 pattern.pattern(),
                 System.lineSeparator(),
-                indent(kubeClient.exec(pod, "/bin/bash", "-c", "echo mntr | nc localhost 2181").out()))
+                indent(kubeClient.exec(pod, "/bin/bash", "-c", "echo mntr | nc localhost 21810").out()))
         );
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -212,7 +212,7 @@ public class AbstractClusterIT {
             () -> LOGGER.info("zookeeper `mntr` output at the point of timeout does not match {}:{}{}",
                 pattern.pattern(),
                 System.lineSeparator(),
-                indent(kubeClient.exec(pod, "/bin/bash", "-c", "echo mntr | nc localhost 21810").out()))
+                indent(kubeClient.exec(pod, "/bin/bash", "-c", "echo mntr | nc localhost " + port).out()))
         );
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -178,9 +178,9 @@ public class KafkaClusterIT extends AbstractClusterIT {
         kubeClient.waitForPod(newZkPodName[1]);
 
         // check the new node is either in leader or follower state
-        waitForZkMntr(firstZkPodName, Pattern.compile("zk_server_state\\s+(leader|follower)"));
-        waitForZkMntr(newZkPodName[0], Pattern.compile("zk_server_state\\s+(leader|follower)"));
-        waitForZkMntr(newZkPodName[1], Pattern.compile("zk_server_state\\s+(leader|follower)"));
+        waitForZkMntr(firstZkPodName, "21810", Pattern.compile("zk_server_state\\s+(leader|follower)"));
+        waitForZkMntr(newZkPodName[0], "21811", Pattern.compile("zk_server_state\\s+(leader|follower)"));
+        waitForZkMntr(newZkPodName[1], "21812", Pattern.compile("zk_server_state\\s+(leader|follower)"));
 
         //Test that first pod does not have errors or failures in events
         List<Event> eventsForFirstPod = getEvents("Pod", newZkPodName[0]);
@@ -202,7 +202,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         });
         kubeClient.waitForResourceDeletion("po", zookeeperPodName(CLUSTER_NAME,  1));
         // Wait for the one remaining node to enter standalone mode
-        waitForZkMntr(firstZkPodName, Pattern.compile("zk_server_state\\s+standalone"));
+        waitForZkMntr(firstZkPodName, "21810", Pattern.compile("zk_server_state\\s+standalone"));
 
         //Test that the second pod has event 'Killing'
         assertThat(getEvents("Pod", newZkPodName[1]), hasAllOfReasons(Killing));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -63,7 +63,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     private static final Logger LOGGER = LogManager.getLogger(KafkaClusterIT.class);
 
     public static final String NAMESPACE = "kafka-cluster-test";
-    private static final String CLUSTER_NAME = "my-cluster";
     private static final String TOPIC_NAME = "test-topic";
 
     @BeforeClass
@@ -178,9 +177,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         kubeClient.waitForPod(newZkPodName[1]);
 
         // check the new node is either in leader or follower state
-        waitForZkMntr(firstZkPodName, "21810", Pattern.compile("zk_server_state\\s+(leader|follower)"));
-        waitForZkMntr(newZkPodName[0], "21811", Pattern.compile("zk_server_state\\s+(leader|follower)"));
-        waitForZkMntr(newZkPodName[1], "21812", Pattern.compile("zk_server_state\\s+(leader|follower)"));
+        waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2);
 
         //Test that first pod does not have errors or failures in events
         List<Event> eventsForFirstPod = getEvents("Pod", newZkPodName[0]);
@@ -202,7 +199,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         });
         kubeClient.waitForResourceDeletion("po", zookeeperPodName(CLUSTER_NAME,  1));
         // Wait for the one remaining node to enter standalone mode
-        waitForZkMntr(firstZkPodName, "21810", Pattern.compile("zk_server_state\\s+standalone"));
+        waitForZkMntr(Pattern.compile("zk_server_state\\s+standalone"), 0);
 
         //Test that the second pod has event 'Killing'
         assertThat(getEvents("Pod", newZkPodName[1]), hasAllOfReasons(Killing));

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     config:
@@ -19,10 +19,10 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:
@@ -28,10 +28,10 @@ spec:
         UseG1GC: "true"
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
-    liveness:
+    livenessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
@@ -29,11 +29,11 @@ spec:
   zookeeper:
     replicas: 1
     readinessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     livenessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     storage:
       type: ephemeral
     resources:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
@@ -6,11 +6,11 @@ spec:
   kafka:
     replicas: 3
     readinessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     livenessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -20,11 +20,11 @@ spec:
   zookeeper:
     replicas: 1
     readinessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     livenessProbe:
-      initialDelaySeconds: "15"
-      timeoutSeconds: "5"
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     storage:
       type: ephemeral
   topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
+    readinessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
-    liveness:
+    livenessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
     config:
@@ -19,10 +19,10 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
-    liveness:
+    livenessProbe:
       initialDelaySeconds: "15"
       timeoutSeconds: "5"
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testRackAware.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testRackAware.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     rack:
@@ -17,10 +17,10 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testSendMessages.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testSendMessages.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     config:
@@ -19,10 +19,10 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testZookeeperScaleUpScaleDown.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     config:
@@ -19,10 +19,10 @@ spec:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryClusterIT.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryClusterIT.yaml
@@ -5,20 +5,20 @@ metadata:
 spec:
   kafka:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:
       type: ephemeral
   zookeeper:
     replicas: 1
-    readiness:
+    readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    liveness:
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Updated ports for zookeeper after implementing TLS.
2. Renamed keys in .yamls `readiness` -> `readinessProbe` and `liveness` -> `livenessProbe`

### Checklist
- [x] Write tests
- [x] Make sure all tests pass