### PR TITLE
Disabling TLS in the stand alone Topic Operator deployment

### DIFF
--- a/examples/install/topic-operator/04-deployment.yaml
+++ b/examples/install/topic-operator/04-deployment.yaml
@@ -28,6 +28,8 @@ spec:
               value: "6"
             - name: STRIMZI_LOG_LEVEL
               value: INFO
+            - name: STRIMZI_TLS_ENABLED
+              value: "false"
             - name: STRIMZI_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Now that the Topic Operator supports TLS for Kafka communication natively, we have it enabled by default if deployed by the Cluster Operator but we want to disable it in the stand alone deployment.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

