### PR TITLE
Fixed passing null logmetrics name if TO is not deployed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -523,7 +523,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(desc -> desc.withVoid(roleBindingOperator.reconcile(namespace,
                         TopicOperator.TO_ROLE_BINDING_NAME,
                         desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateRoleBinding(namespace) : null)))
-                .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace, desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().getAncillaryConfigName() : null, desc.metricsAndLogsConfigMap())))
+                .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace,
+                        desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().getAncillaryConfigName() : TopicOperator.metricAndLogConfigsName(name),
+                        desc.metricsAndLogsConfigMap())))
                 .compose(desc -> desc.withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), desc.deployment())))
                 .compose(desc -> desc.withVoid(secretOperations.reconcile(namespace, TopicOperator.secretName(name), desc.topicOperatorSecret())))
                 .compose(desc -> chainFuture.complete(), chainFuture);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If Topic Operator is not deployed by Cluster Operator, the name for the log/metrics file cannot be `null` otherwise a low level exception from fabric8 API is raised. This PR uses the default one (because we don't have a Topic Operator in place for getting the real one).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

