### PR TITLE
Avoid patching ServiceAccounts to avoid continual token creation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ServiceAccountOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ServiceAccountOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> {
@@ -26,5 +27,11 @@ public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesC
     @Override
     protected MixedOperation<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> operation() {
         return client.serviceAccounts();
+    }
+
+    @Override
+    protected Future<ReconcileResult<ServiceAccount>> internalPatch(String namespace, String name, ServiceAccount current, ServiceAccount desired) {
+        // Patching a SA causes new tokens to be created, which we should avoid
+        return Future.succeededFuture(ReconcileResult.noop());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ServiceAccountOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ServiceAccountOperatorTest.java
@@ -10,10 +10,21 @@ import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> {
@@ -48,5 +59,47 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
     @Override
     protected AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new ServiceAccountOperator(vertx, mockClient);
+    }
+
+    @Override
+    @Test
+    public void createWhenExistsIsAPatch(TestContext context) {
+        createWhenExistsIsAPatch(context, true);
+    }
+    @Override
+    public void createWhenExistsIsAPatch(TestContext context, boolean cascade) {
+        // This is overridden because SA patch is coded as a no op to avoid needless token creation.
+        ServiceAccount resource = resource();
+        Resource mockResource = mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.cascading(cascade)).thenReturn(mockResource);
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        KubernetesClient mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> op = createResourceOperations(vertx, mockClient);
+
+        Async async = context.async();
+        Future<ReconcileResult<ServiceAccount>> fut = op.createOrUpdate(resource);
+        fut.setHandler(ar -> {
+            if (!ar.succeeded()) {
+                ar.cause().printStackTrace();
+            }
+            assertTrue(ar.succeeded());
+            assertTrue(ar.result().equals(ReconcileResult.noop()));
+            verify(mockResource).get();
+            //verify(mockResource).patch(any());
+            verify(mockResource, never()).create(any());
+            verify(mockResource, never()).createNew();
+            verify(mockResource, never()).createOrReplace(any());
+            verify(mockCms, never()).createOrReplace(any());
+            async.complete();
+        });
     }
 }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Patching `ServiceAccounts` seems to cause new tokens to be created, even if the patch ought to be a no op. This PR changes the default behaviour for patching service accounts to avoid patching them.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

