### PR TITLE
Removed unused logState method

### DIFF
--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectAssembly;
 import io.strimzi.test.k8s.BaseKubeClient;
 import io.strimzi.test.k8s.KubeClient;
-import io.strimzi.test.k8s.KubeClusterException;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Minishift;
 import io.strimzi.test.k8s.OpenShift;
@@ -453,28 +452,6 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 }
             };
         }
-    }
-
-    private void logState(Throwable t) {
-        LOGGER.info("The test is failing/erroring due to {}, here's some diagnostic output{}{}",
-                t, System.lineSeparator(), "----------------------------------------------------------------------");
-        for (String pod : ccFirst(kubeClient().list("pod"))) {
-            LOGGER.info("Logs from pod {}:{}{}", pod, System.lineSeparator(), indent(kubeClient().logs(pod)));
-        }
-        asList("pod", "deployment", "statefulset", "kafka", "kafkaconnect", "kafkaconnects2i").stream().forEach(resourceType -> {
-            try {
-                for (String resourceName : kubeClient().list(resourceType)) {
-                    LOGGER.info("Description of {} '{}':{}{}", resourceType, resourceName,
-                            System.lineSeparator(), indent(kubeClient().getResourceAsYaml(resourceType, resourceName)));
-                }
-            } catch (KubeClusterException e) {
-                t.addSuppressed(e);
-            }
-        });
-
-        LOGGER.info("That's all the diagnostic info, the exception {} will now propagate and the test will fail{}{}",
-                t,
-                t, System.lineSeparator(), "----------------------------------------------------------------------");
     }
 
     private Statement withConnectS2IClusters(Annotatable element,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Trivial PR for removing an unused `logState` method from `StrimziRunner` after latest improvements on getting pods/containers logs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

