### PR TITLE
New behaviour for the annotation @JUnitGroup

### DIFF
--- a/api/src/test/java/io/strimzi/test/JUnitGroup.java
+++ b/api/src/test/java/io/strimzi/test/JUnitGroup.java
@@ -14,6 +14,9 @@ import java.lang.annotation.Target;
  *
  * Availible types: acceptance, regression
  *
+ * If no value is set for the system property "junitgroup", then the default value for "junitgroup" will be "all",
+ * which will mark test methods as suitable for execution
+ *
  * To execute an expected group of system tests need to add system property "junitgroup" with following value:
  * -Djunitgroup=integration - to execute one test group
  * -Djunitgroup=acceptance,regression - to execute many test groups

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -118,8 +118,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
     }
 
     private static Collection<String> getEnabledGroups(String key) {
-        Collection<String> enabledGroups = splitProperties(System.getenv().getOrDefault(key, JUnitGroup.ALL_GROUPS));
-        return enabledGroups;
+        return splitProperties((String) System.getProperties().getOrDefault(key, JUnitGroup.ALL_GROUPS));
     }
 
     private static Collection<String> getDeclaredGroups(JUnitGroup testGroup) {

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -118,7 +118,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
     }
 
     private static Collection<String> getEnabledGroups(String key) {
-        Collection<String> enabledGroups = splitProperties(System.getProperty(key));
+        Collection<String> enabledGroups = splitProperties(System.getenv().getOrDefault(key, JUnitGroup.ALL_GROUPS));
         return enabledGroups;
     }
 


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Changed behaviour for annotation `@JUnitGroup`
New rule: Any test must be executed if the value for system property "junitgroup" is not defined.

PS: Thanks @tombentley for the suggestion! If something else seems strange, say about it please.

### Checklist
- [ ] Make sure all tests pass
