### PR TITLE
Adding SAN from csr to final certificate

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -55,6 +55,19 @@ public interface CertManager {
      * Generate a certificate signed by a Certificate Authority
      *
      * @param csrFile path to the file containing the certificate sign request
+     * @param caKey path to the file containing the CA private key
+     * @param caCert path to the file containing the CA certificate
+     * @param crtFile path to the file which will contain the signed certificate
+     * @param sbj subject information
+     * @param days certificate duration
+     * @throws IOException
+     */
+    void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException;
+
+    /**
+     * Generate a certificate signed by a Certificate Authority
+     *
+     * @param csrFile path to the file containing the certificate sign request
      * @param caKey CA private key bytes
      * @param caCert CA certificate bytes
      * @param crtFile path to the file which will contain the signed certificate
@@ -62,4 +75,17 @@ public interface CertManager {
      * @throws IOException
      */
     void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException;
+
+    /**
+     * Generate a certificate signed by a Certificate Authority
+     *
+     * @param csrFile path to the file containing the certificate sign request
+     * @param caKey CA private key bytes
+     * @param caCert CA certificate bytes
+     * @param crtFile path to the file which will contain the signed certificate
+     * @param sbj subject information
+     * @param days certificate duration
+     * @throws IOException
+     */
+    void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, Subject sbj, int days) throws IOException;
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockCertManager.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockCertManager.java
@@ -75,6 +75,11 @@ public class MockCertManager implements CertManager {
         write(crtFile, "crt file");
     }
 
+    @Override
+    public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException {
+        write(crtFile, "crt file");
+    }
+
     /**
      * Generate a certificate signed by a Certificate Authority
      *
@@ -87,6 +92,11 @@ public class MockCertManager implements CertManager {
      */
     @Override
     public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException {
+        write(crtFile, "crt file");
+    }
+
+    @Override
+    public void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, Subject sbj, int days) throws IOException {
         write(crtFile, "crt file");
     }
 }


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

This PR is about adding (to the certificate manager library) the possibility to have SAN (Subject Alternative Names) to the final signed certificate when starting from a csr.
It's related to #526 but it doesn't use the "copy-extensions" option anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

