### PR TITLE
Add initial support for the KafkaUser CRD

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -104,6 +104,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectAssembly=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkaconnect.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectS2IAssembly=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkaconnects2i.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaTopic=${pom.basedir}/../examples/install/topic-operator/04-Crd-kafkatopic.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaUser=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkauser.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -127,6 +128,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectAssembly</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectS2IAssembly</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaTopic</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaUser</argument>
                             </arguments>
                             <workingDirectory>${pom.basedir}${file.separator}..${file.separator}documentation${file.separator}book</workingDirectory>
                         </configuration>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.KafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -101,7 +100,7 @@ public class Crds {
             listKind = KafkaUser.RESOURCE_LIST_KIND;
             group = KafkaUser.RESOURCE_GROUP;
             version = KafkaUser.VERSION;
-            shortNames = Collections.singletonList(KafkaUser.SHORT_NAME);
+            shortNames = KafkaUser.RESOURCE_SHORTNAMES;
         } else {
             throw new RuntimeException();
         }
@@ -155,6 +154,7 @@ public class Crds {
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> topicOperation(KubernetesClient client) {
         return client.customResources(topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+    }
 
     public static CustomResourceDefinition kafkaUser() {
         return crd(KafkaUser.class);

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -17,7 +17,9 @@ import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
 
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -33,7 +35,8 @@ public class Crds {
         KafkaAssembly.class,
         KafkaConnectAssembly.class,
         KafkaConnectS2IAssembly.class,
-        KafkaTopic.class
+        KafkaTopic.class,
+        KafkaUser.class
     };
 
     private Crds() {
@@ -90,6 +93,15 @@ public class Crds {
             group = KafkaTopic.RESOURCE_GROUP;
             version = KafkaTopic.VERSION;
             shortNames = KafkaTopic.RESOURCE_SHORTNAMES;
+        } else if (cls.equals(KafkaUser.class)) {
+            kind = KafkaUser.RESOURCE_KIND;
+            crdApiVersion = KafkaUser.CRD_API_VERSION;
+            plural = KafkaUser.RESOURCE_PLURAL;
+            singular = KafkaUser.RESOURCE_SINGULAR;
+            listKind = KafkaUser.RESOURCE_LIST_KIND;
+            group = KafkaUser.RESOURCE_GROUP;
+            version = KafkaUser.VERSION;
+            shortNames = Collections.singletonList(KafkaUser.SHORT_NAME);
         } else {
             throw new RuntimeException();
         }
@@ -143,6 +155,13 @@ public class Crds {
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> topicOperation(KubernetesClient client) {
         return client.customResources(topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+
+    public static CustomResourceDefinition kafkaUser() {
+        return crd(KafkaUser.class);
+    }
+
+    public static MixedOperation<KafkaUser, KafkaUserList, DoneableKafkaUser, Resource<KafkaUser, DoneableKafkaUser>> kafkaUserOperation(KubernetesClient client) {
+        return client.customResources(kafkaUser(), KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
     }
 
     public static <T extends CustomResource, L extends CustomResourceList<T>, D extends CustomResourceDoneable<T>> MixedOperation<T, L, D, Resource<T, D>>

--- a/api/src/main/java/io/strimzi/api/kafka/DoneableKafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/DoneableKafkaUser.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka;
+
+import io.strimzi.api.kafka.model.KafkaUser;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+/**
+ * A {@code CustomResourceDoneable<KafkaUser>} required for using Fabric8 CRD support.
+ */
+public class DoneableKafkaUser extends CustomResourceDoneable<KafkaUser> {
+    public DoneableKafkaUser(KafkaUser resource, Function<KafkaUser, KafkaUser> function) {
+        super(resource, function);
+    }
+    public DoneableKafkaUser(KafkaUser resource) {
+        super(resource, x -> x);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaUserList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaUserList.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka;
+
+import io.strimzi.api.kafka.model.KafkaUser;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+/**
+ * A {@code CustomResourceList<KafkaUser>} required for using Fabric8 CRD support.
+ */
+public class KafkaUserList extends CustomResourceList<KafkaUser> {
+    private static final long serialVersionUID = 1L;
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,7 +57,7 @@ public class KafkaUser extends CustomResource {
     public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
     public static final String RESOURCE_GROUP = "kafka.strimzi.io";
     public static final String RESOURCE_PLURAL = "kafkausers";
-    public static final String RESOURCE_SINGULAR = "kafkazser";
+    public static final String RESOURCE_SINGULAR = "kafkauser";
     public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "ku";

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Crd;
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.sundr.builder.annotations.Buildable;
+
+import static java.util.Collections.emptyMap;
+
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+@Crd(
+        apiVersion = KafkaUser.CRD_API_VERSION,
+        spec = @Crd.Spec(
+                names = @Crd.Spec.Names(
+                        kind = KafkaUser.RESOURCE_KIND,
+                        plural = KafkaUser.RESOURCE_PLURAL,
+                        shortNames = {KafkaUser.SHORT_NAME}
+                ),
+                group = KafkaUser.RESOURCE_GROUP,
+                scope = "Namespaced",
+                version = KafkaUser.VERSION
+        )
+)
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+public class KafkaUser extends CustomResource {
+    private static final long serialVersionUID = 1L;
+
+    public static final String VERSION = "v1alpha1";
+    public static final String RESOURCE_KIND = "KafkaUser";
+    public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
+    public static final String RESOURCE_GROUP = "kafka.strimzi.io";
+    public static final String RESOURCE_PLURAL = "kafkausers";
+    public static final String RESOURCE_SINGULAR = "kafkazser";
+    public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
+    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
+    public static final String SHORT_NAME = "ku";
+
+    private String apiVersion;
+    private ObjectMeta metadata;
+    private KafkaUserSpec spec;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Override
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    @Override
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @Override
+    public ObjectMeta getMetadata() {
+        return super.getMetadata();
+    }
+
+    @Override
+    public void setMetadata(ObjectMeta metadata) {
+        super.setMetadata(metadata);
+    }
+
+    @Description("The specification of the user.")
+    @JsonProperty(required = true)
+    public KafkaUserSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(KafkaUserSpec spec) {
+        this.spec = spec;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        YAMLMapper mapper = new YAMLMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -7,7 +7,6 @@ package io.strimzi.api.kafka.model;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -8,6 +8,7 @@ import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -23,7 +24,9 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.sundr.builder.annotations.Buildable;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableList;
 
 @JsonDeserialize(
         using = JsonDeserializer.None.class
@@ -60,6 +63,7 @@ public class KafkaUser extends CustomResource {
     public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
     public static final String SHORT_NAME = "ku";
+    public static final List<String> RESOURCE_SHORTNAMES = unmodifiableList(asList(SHORT_NAME));
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaUserAuthentication implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+    private TlsClientAuthentication tls;
+
+    @Description("Enables TLS client authentication for given Kafka user")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public TlsClientAuthentication getTls() {
+        return tls;
+    }
+
+    public void setTls(TlsClientAuthentication tls) {
+        this.tls = tls;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -12,30 +12,25 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.sundr.builder.annotations.Buildable;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@Buildable(
-        editableEnabled = false,
-        generateBuilderPackage = true,
-        builderPackage = "io.strimzi.api.kafka.model"
-)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = KafkaUserTlsClientAuthentication.TYPE_TLS, value = KafkaUserTlsClientAuthentication.class),
+})
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class KafkaUserAuthentication implements Serializable {
+public abstract class KafkaUserAuthentication implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Map<String, Object> additionalProperties;
-    private TlsClientAuthentication tls;
 
-    @Description("Enables TLS client authentication for given Kafka user")
-    @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public TlsClientAuthentication getTls() {
-        return tls;
-    }
-
-    public void setTls(TlsClientAuthentication tls) {
-        this.tls = tls;
-    }
+    @Description("Authentication type. " +
+            "Currently the only supported type is `tls` for TLS Client Authentication.")
+    @JsonIgnore
+    public abstract String getType();
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "authentication" })
+public class KafkaUserSpec  implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private KafkaUserAuthentication authentication;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Authentication mechanisms enabled for this Kafka user")
+    @JsonProperty(required = true)
+    public KafkaUserAuthentication getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(KafkaUserAuthentication authentication) {
+        this.authentication = authentication;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -32,7 +32,7 @@ public class KafkaUserSpec  implements Serializable {
     private KafkaUserAuthentication authentication;
     private Map<String, Object> additionalProperties;
 
-    @Description("Authentication mechanisms enabled for this Kafka user")
+    @Description("Authentication mechanism enabled for this Kafka user")
     @JsonProperty(required = true)
     public KafkaUserAuthentication getAuthentication() {
         return authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_TLS = "tls";
+
+
+
+    @Description("Must be `" + TYPE_TLS + "`")
+    @Override
+    public String getType() {
+        return TYPE_TLS;
+    }
+
+
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
@@ -20,8 +20,6 @@ public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
 
     public static final String TYPE_TLS = "tls";
 
-
-
     @Description("Must be `" + TYPE_TLS + "`")
     @Override
     public String getType() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TlsClientAuthentication implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.test.Namespace;
+import io.strimzi.test.Resources;
+import io.strimzi.test.StrimziRunner;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The purpose of this test is to confirm that we can create a
+ * resource from the POJOs, serialize it and create the resource in K8S.
+ * I.e. that such instance resources obtained from POJOs are valid according to the schema
+ * validation done by K8S.
+ */
+@RunWith(StrimziRunner.class)
+@Namespace(KafkaUserCrdIT.NAMESPACE)
+@Resources(value = TestUtils.KAFKA_USER_CRD, asAdmin = true)
+public class KafkaUserCrdIT extends AbstractCrdIT {
+    public static final String NAMESPACE = "kafkausercrd-it";
+
+    @Test
+    public void testKafkaUser() {
+        createDelete(KafkaUser.class, "KafkaUser.yaml");
+    }
+
+    @Test
+    public void testKafkaUserMinimal() {
+        createDelete(KafkaUser.class, "KafkaUser-minimal.yaml");
+    }
+
+    @Test
+    public void testKafkaUserWithExtraProperty() {
+        createDelete(KafkaUser.class, "KafkaUser-with-extra-property.yaml");
+    }
+
+    @Test
+    public void testKafkaUserWithMissingRequired() {
+        try {
+            createDelete(KafkaUser.class, "KafkaUser-with-missing-required.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.authentication in body is required"));
+        }
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * The purpose of this test is to ensure:
+ *
+ * 1. we get a correct tree of POJOs when reading a JSON/YAML `Kafka` resource.
+ */
+public class KafkaUserTest extends AbstractCrdTest<KafkaUser, KafkaUserBuilder> {
+
+    public KafkaUserTest() {
+        super(KafkaUser.class, KafkaUserBuilder.class);
+    }
+
+}

--- a/api/src/test/java/io/strimzi/test/TestUtils.java
+++ b/api/src/test/java/io/strimzi/test/TestUtils.java
@@ -50,6 +50,8 @@ public final class TestUtils {
         // All static methods
     }
 
+    public static final String KAFKA_USER_CRD = "../examples/install/cluster-operator/04-Crd-kafkauser.yaml";
+
     /** Returns a Map of the given sequence of key, value pairs. */
     public static <T> Map<T, T> map(T... pairs) {
         if (pairs.length % 2 != 0) {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-minimal.yaml
@@ -1,0 +1,6 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaUser
+metadata:
+  name: minimal
+spec:
+  authentication: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-minimal.yaml
@@ -3,4 +3,5 @@ kind: KafkaUser
 metadata:
   name: minimal
 spec:
-  authentication: {}
+  authentication:
+    type: tls

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-extra-property.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaUser
+metadata:
+  name: extra-property
+spec:
+  thisPropertyIsNotInTheSchema: true
+  authentication:
+    thisPropertyIsAlsoNotInTheSchema: true
+    tls: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-extra-property.yaml
@@ -6,4 +6,4 @@ spec:
   thisPropertyIsNotInTheSchema: true
   authentication:
     thisPropertyIsAlsoNotInTheSchema: true
-    tls: {}
+    type: tls

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-missing-required.yaml
@@ -1,0 +1,6 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaUser
+metadata:
+  name: missing-required
+spec:
+  {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: "kafka.strimzi.io/v1alpha1"
+kind: "KafkaUser"
+metadata:
+  finalizers: []
+  name: "my-user"
+  ownerReferences: []
+spec:
+  authentication:
+    tls: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
@@ -7,4 +7,4 @@ metadata:
   ownerReferences: []
 spec:
   authentication:
-    tls: {}
+    type: "tls"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
@@ -1,0 +1,7 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaUser
+metadata:
+  name: my-user
+spec:
+  authentication:
+    tls: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
@@ -4,4 +4,4 @@ metadata:
   name: my-user
 spec:
   authentication:
-    tls: {}
+    type: tls

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -406,7 +406,6 @@ Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 [[type-KafkaTopic]]
 ### `KafkaTopic` kind v1alpha1 kafka.strimzi.io
 
-
 [options="header"]
 |====
 |Field        |Description
@@ -418,6 +417,47 @@ Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 ### `KafkaTopicSpec` type v1alpha1 kafka.strimzi.io
 
 Used in: <<type-KafkaTopic,`KafkaTopic`>>
+|Field                        |Description
+|spec                  1.2+<.<|The specification of the user.
+|<<type-KafkaUserSpec,`KafkaUserSpec`>>
+|additionalProperties  1.2+<.<|
+|map
+|====
+
+[[type-KafkaUserSpec]]
+### `KafkaUserSpec` type v1alpha1 kafka.strimzi.io
+
+Used in: <<kind-KafkaUser,`KafkaUser`>>
+
+
+[options="header"]
+|====
+|Field                        |Description
+|authentication        1.2+<.<|Authentication mechanisms enabled for this Kafka user
+|<<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
+|additionalProperties  1.2+<.<|
+|map
+|====
+
+[[type-KafkaUserAuthentication]]
+### `KafkaUserAuthentication` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaUserSpec,`KafkaUserSpec`>>
+
+
+[options="header"]
+|====
+|Field                        |Description
+|additionalProperties  1.2+<.<|
+|map
+|tls                   1.2+<.<|Enables TLS client authentication for given Kafka user
+|<<type-TlsClientAuthentication,`TlsClientAuthentication`>>
+|====
+
+[[type-TlsClientAuthentication]]
+### `TlsClientAuthentication` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
 
 
 [options="header"]

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -406,6 +406,7 @@ Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 [[type-KafkaTopic]]
 ### `KafkaTopic` kind v1alpha1 kafka.strimzi.io
 
+
 [options="header"]
 |====
 |Field        |Description
@@ -417,47 +418,6 @@ Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 ### `KafkaTopicSpec` type v1alpha1 kafka.strimzi.io
 
 Used in: <<type-KafkaTopic,`KafkaTopic`>>
-|Field                        |Description
-|spec                  1.2+<.<|The specification of the user.
-|<<type-KafkaUserSpec,`KafkaUserSpec`>>
-|additionalProperties  1.2+<.<|
-|map
-|====
-
-[[type-KafkaUserSpec]]
-### `KafkaUserSpec` type v1alpha1 kafka.strimzi.io
-
-Used in: <<kind-KafkaUser,`KafkaUser`>>
-
-
-[options="header"]
-|====
-|Field                        |Description
-|authentication        1.2+<.<|Authentication mechanisms enabled for this Kafka user
-|<<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
-|additionalProperties  1.2+<.<|
-|map
-|====
-
-[[type-KafkaUserAuthentication]]
-### `KafkaUserAuthentication` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-KafkaUserSpec,`KafkaUserSpec`>>
-
-
-[options="header"]
-|====
-|Field                        |Description
-|additionalProperties  1.2+<.<|
-|map
-|tls                   1.2+<.<|Enables TLS client authentication for given Kafka user
-|<<type-TlsClientAuthentication,`TlsClientAuthentication`>>
-|====
-
-[[type-TlsClientAuthentication]]
-### `TlsClientAuthentication` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
 
 
 [options="header"]
@@ -471,5 +431,53 @@ Used in: <<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
 |map
 |topicName   1.2+<.<|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
 |string
+|====
+
+[[type-KafkaUser]]
+### `KafkaUser` kind v1alpha1 kafka.strimzi.io
+
+
+[options="header"]
+|====
+|Field        |Description
+|spec  1.2+<.<|The specification of the user.
+|<<type-KafkaUserSpec,`KafkaUserSpec`>>
+|====
+
+[[type-KafkaUserSpec]]
+### `KafkaUserSpec` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaUser,`KafkaUser`>>
+
+
+[options="header"]
+|====
+|Field                  |Description
+|authentication  1.2+<.<|Authentication mechanisms enabled for this Kafka user
+|<<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
+|====
+
+[[type-KafkaUserAuthentication]]
+### `KafkaUserAuthentication` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaUserSpec,`KafkaUserSpec`>>
+
+
+[options="header"]
+|====
+|Field       |Description
+|tls  1.2+<.<|Enables TLS client authentication for given Kafka user
+|<<type-TlsClientAuthentication,`TlsClientAuthentication`>>
+|====
+
+[[type-TlsClientAuthentication]]
+### `TlsClientAuthentication` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
+
+
+[options="header"]
+|====
+|Field|Description
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -453,31 +453,22 @@ Used in: <<type-KafkaUser,`KafkaUser`>>
 [options="header"]
 |====
 |Field                  |Description
-|authentication  1.2+<.<|Authentication mechanisms enabled for this Kafka user
-|<<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
+|authentication  1.2+<.<|Authentication mechanism enabled for this Kafka user The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls]
+|<<type-KafkaUserTlsClientAuthentication,`KafkaUserTlsClientAuthentication`>>
 |====
 
-[[type-KafkaUserAuthentication]]
-### `KafkaUserAuthentication` type v1alpha1 kafka.strimzi.io
+[[type-KafkaUserTlsClientAuthentication]]
+### `KafkaUserTlsClientAuthentication` type v1alpha1 kafka.strimzi.io
 
 Used in: <<type-KafkaUserSpec,`KafkaUserSpec`>>
 
 
+The `type` property is a discriminator that distinguishes the use of the type `KafkaUserTlsClientAuthentication` from .
+It must have the value `tls` for the type `KafkaUserTlsClientAuthentication`.
 [options="header"]
 |====
-|Field       |Description
-|tls  1.2+<.<|Enables TLS client authentication for given Kafka user
-|<<type-TlsClientAuthentication,`TlsClientAuthentication`>>
-|====
-
-[[type-TlsClientAuthentication]]
-### `TlsClientAuthentication` type v1alpha1 kafka.strimzi.io
-
-Used in: <<type-KafkaUserAuthentication,`KafkaUserAuthentication`>>
-
-
-[options="header"]
-|====
-|Field|Description
+|Field        |Description
+|type  1.2+<.<|Must be `tls`
+|string
 |====
 

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkausers.kafka.strimzi.io
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaUser
+    listKind: KafkaUserList
+    singular: kafkauser
+    plural: kafkausers
+    shortNames:
+    - ku
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            authentication:
+              type: object
+              properties:
+                additionalProperties:
+                  type: object
+                tls:
+                  type: object
+                  properties:
+                    additionalProperties:
+                      type: object
+            additionalProperties:
+              type: object
+          required:
+          - authentication
+        additionalProperties:
+          type: object
+      required:
+      - spec

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -23,18 +23,10 @@ spec:
             authentication:
               type: object
               properties:
-                additionalProperties:
-                  type: object
                 tls:
                   type: object
-                  properties:
-                    additionalProperties:
-                      type: object
-            additionalProperties:
-              type: object
+                  properties: {}
           required:
           - authentication
-        additionalProperties:
-          type: object
       required:
       - spec

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -23,9 +23,8 @@ spec:
             authentication:
               type: object
               properties:
-                tls:
-                  type: object
-                  properties: {}
+                type:
+                  type: string
           required:
           - authentication
       required:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~
- ~~Documentation~~

### Description

This PR adds initial version of the `KafkaUser` CRD. It doesn't add any code using it - just the CRD and tests. The added version of the CR looks like this:

```
apiVersion: kafka.strimzi.io/v1alpha1
kind: KafkaUser
metadata:
  name: my-user
spec:
  authentication:
    tls: {}
```

This should help to make smaller PRs.
