### PR TITLE
Broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 
 # Velocity.log
 velocity.log
+
+# Generated docs
+documentation/html/**
+documentation/htmlnoheader/**

--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,14 @@ release_pkg:
 
 docu_html: docu_htmlclean
 	mkdir -p documentation/html
-	asciidoctor --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/book/master.adoc -o documentation/html/index.html
-	asciidoctor --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/book/master.adoc -o documentation/html/index.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
 	cp -vrL documentation/book/images documentation/html/images
 
 docu_htmlnoheader: docu_htmlnoheaderclean
 	mkdir -p documentation/htmlnoheader
-	asciidoctor --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/book/master.adoc -o documentation/htmlnoheader/master.html
-	asciidoctor --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/book/master.adoc -o documentation/htmlnoheader/master.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing.html
 	cp -vrL documentation/book/images documentation/htmlnoheader/images
 
 docu_pushtowebsite: docu_htmlnoheader docu_html

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -57,14 +57,6 @@ public class DocGenerator {
         }
     }
 
-    private void appendAnchor(Crd crd) throws IOException {
-        out.append("[[").append(anchor(crd)).append("]]").append(NL);
-    }
-
-    private String anchor(Crd crd) {
-        return "kind-" + crd.spec().names().kind();
-    }
-
     private void appendAnchor(Crd crd, Class<?> anchor) throws IOException {
         out.append("[[").append(anchor(anchor)).append("]]").append(NL);
     }
@@ -113,7 +105,6 @@ public class DocGenerator {
 
     public void generate(Class<? extends CustomResource> crdClass) throws IOException {
         Crd crd = crdClass.getAnnotation(Crd.class);
-        appendAnchor(crd);
         appendAnchor(crd, crdClass);
         appendHeading(crd, "`" + crd.spec().names().kind() + "` kind");
         appendCommonTypeDoc(crd, crdClass);
@@ -294,9 +285,6 @@ public class DocGenerator {
                     throw new RuntimeException(e);
                 }
             }).collect(Collectors.joining(", ")));
-        } else if (cls.isAnnotationPresent(Crd.class)) {
-            // <<KafkaType,`KafkaType`>>
-            out.append("<<").append(anchor(crd)).append(",`").append(cls.getSimpleName()).append("`>>");
         } else {
             out.append("<<").append(anchor(cls)).append(",`").append(cls.getSimpleName()).append("`>>");
         }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -1,4 +1,3 @@
-[[kind-Example]]
 [[type-ExampleCrd]]
 # `Example` kind v1alpha1 crdgenerator.strimzi.io
 
@@ -73,7 +72,7 @@
 [[type-Number]]
 # `Number` type v1alpha1 crdgenerator.strimzi.io
 
-Used in: <<kind-Example,`ExampleCrd`>>
+Used in: <<type-ExampleCrd,`ExampleCrd`>>
 
 
 [options="header"]
@@ -84,7 +83,7 @@ Used in: <<kind-Example,`ExampleCrd`>>
 [[type-ObjectProperty]]
 # `ObjectProperty` type v1alpha1 crdgenerator.strimzi.io
 
-Used in: <<kind-Example,`ExampleCrd`>>
+Used in: <<type-ExampleCrd,`ExampleCrd`>>
 
 Example of complex type.
 
@@ -100,7 +99,7 @@ Example of complex type.
 [[type-PolymorphicLeft]]
 # `PolymorphicLeft` type v1alpha1 crdgenerator.strimzi.io
 
-Used in: <<kind-Example,`ExampleCrd`>>
+Used in: <<type-ExampleCrd,`ExampleCrd`>>
 
 
 The `discrim` property is a discriminator that distinguishes the use of the type `PolymorphicLeft` from <<type-PolymorphicRight,`PolymorphicRight`>>.
@@ -119,7 +118,7 @@ It must have the value `left` for the type `PolymorphicLeft`.
 [[type-PolymorphicRight]]
 # `PolymorphicRight` type v1alpha1 crdgenerator.strimzi.io
 
-Used in: <<kind-Example,`ExampleCrd`>>
+Used in: <<type-ExampleCrd,`ExampleCrd`>>
 
 
 The `discrim` property is a discriminator that distinguishes the use of the type `PolymorphicRight` from <<type-PolymorphicLeft,`PolymorphicLeft`>>.

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1,4 +1,3 @@
-[[kind-Kafka]]
 [[type-KafkaAssembly]]
 ### `Kafka` kind v1alpha1 kafka.strimzi.io
 
@@ -15,7 +14,7 @@
 [[type-KafkaAssemblySpec]]
 ### `KafkaAssemblySpec` type v1alpha1 kafka.strimzi.io
 
-Used in: <<kind-Kafka,`KafkaAssembly`>>
+Used in: <<type-KafkaAssembly,`KafkaAssembly`>>
 
 
 [options="header"]
@@ -330,7 +329,6 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |====
 
-[[kind-KafkaConnect]]
 [[type-KafkaConnectAssembly]]
 ### `KafkaConnect` kind v1alpha1 kafka.strimzi.io
 
@@ -347,7 +345,7 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 [[type-KafkaConnectAssemblySpec]]
 ### `KafkaConnectAssemblySpec` type v1alpha1 kafka.strimzi.io
 
-Used in: <<kind-KafkaConnect,`KafkaConnectAssembly`>>
+Used in: <<type-KafkaConnectAssembly,`KafkaConnectAssembly`>>
 
 
 [options="header"]
@@ -383,7 +381,6 @@ Used in: <<kind-KafkaConnect,`KafkaConnectAssembly`>>
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 
-[[kind-KafkaConnectS2I]]
 [[type-KafkaConnectS2IAssembly]]
 ### `KafkaConnectS2I` kind v1alpha1 kafka.strimzi.io
 
@@ -400,7 +397,7 @@ Used in: <<kind-KafkaConnect,`KafkaConnectAssembly`>>
 [[type-KafkaConnectS2IAssemblySpec]]
 ### `KafkaConnectS2IAssemblySpec` type v1alpha1 kafka.strimzi.io
 
-Used in: <<kind-KafkaConnectS2I,`KafkaConnectS2IAssembly`>>
+Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 
 
 [options="header"]

--- a/documentation/book/appendix_metrics.adoc
+++ b/documentation/book/appendix_metrics.adoc
@@ -1,4 +1,5 @@
 [appendix]
+[id="metrics-{context}"]
 == Metrics
 
 This section describes how to deploy a Prometheus server for scraping metrics from the Kafka cluster and showing them using a Grafana dashboard. The resources provided are examples to show how Kafka metrics can be stored in Prometheus: They are not a recommended configuration, and further support should be available from the Prometheus and Grafana communities.

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -29,7 +29,7 @@ In order to handle failovers properly, a periodic reconciliation process is exec
 [[kafka_assembly_details]]
 === Format of the `Kafka` resource
 
-The full API is described in <<kafka_resource_reference>>.
+The full API is described in <<type-KafkaAssembly>>.
 
 Whatever other labels are applied to the desired Kafka resource will also be applied to the {ProductPlatformName} resources making up the Kafka cluster.
 This provides a convenient mechanism for those resources to be labelled in whatever way the user requires.
@@ -157,8 +157,8 @@ For information about the accepted JSON format, see <<resources_json_config>>.
 `spec.topicOperator`::
 An object representing the topic operator configuration. 
 See the <<topic_operator_json_config>> documentation for further details.
-More info about the topic operator in the related <<Topic operator>> documentation page.
- 
+More info about the topic operator in the related xref:topic-operator-{context}[Topic Operator] documentation page.
+
 The following is an example of a Kafka resource.
 
 .Example `Kafka` resource
@@ -491,7 +491,7 @@ Persistent Volume Claim for the volume used for storing data for the Kafka broke
 `data-[cluster-name]-zookeeper-[idx]`:: 
 Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `[idx]`.
 
-See <<kafka.strimzi.io-v1alpha1-type-EphemeralStorage>> and <<kafka.strimzi.io-v1alpha1-type-PersistentClaimStorage>> for further details.
+See <<type-EphemeralStorage>> and <<type-PersistentClaimStorage>> for further details.
 
 ===== Metrics
 
@@ -500,9 +500,11 @@ It is possible to configure a `metrics` object in the `kafka` and `zookeeper` ob
 In all cases the `metrics` object should be the configuration for the JMX exporter. 
 You can find more information on how to use it in the corresponding GitHub repo.
 
-For more information about using the metrics with Prometheus and Grafana, see <<_metrics>>
+For more information about using the metrics with Prometheus and Grafana, see xref:metrics[Metrics]
 
-===== [[logging_examples]]Logging
+
+[[logging_examples]]
+===== Logging
 The `logging` field allows the configuration of loggers. These loggers for Zookeeper and Kafka are available in the <<spec.zookeeper.logging,`spec.zookeeper.logging`>> and <<spec.kafka.logging,`spec.kafka.logging`>> sections respectively.
 
 The setting can be done in one of two ways. Either by specifying the loggers and their levels directly or by using a custom config map.
@@ -780,7 +782,7 @@ The configurable fields are the following :
 
 `image`::
 The Docker image to be used by the Topic Operator.
-The default value is determined by the value specified in the `<<STRIMZI_DEFAULT_TOPIC_operator_IMAGE,STRIMZI_DEFAULT_TOPIC_operator_IMAGE>>` environment variable of the Cluster Operator.
+The default value is determined by the value specified in the `<<STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE,STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE>>` environment variable of the Cluster Operator.
 `watchedNamespace`::
 The {ProductPlatformName} namespace in which the topic operator watches for topic ConfigMaps. Default is the namespace
 where the topic operator is running.
@@ -811,7 +813,7 @@ For information about the accepted JSON format, see <<resources_json_config>>.
 { "reconciliationIntervalMs": "900000", "zookeeperSessionTimeoutMs": "20000" }
 ----
 
-More information about these configuration parameters in the related <<Topic Operator>> documentation page.
+More information about these configuration parameters in the related xref:topic-operator-{context}[Topic Operator] documentation page.
 
 [[kafka_connect_config_map_details]]
 ==== Kafka Connect

--- a/documentation/book/topic-operator.adoc
+++ b/documentation/book/topic-operator.adoc
@@ -1,3 +1,4 @@
+[id='topic-operator-{context}']
 == Topic Operator
 
 The Topic Operator is in charge of managing topics in a Kafka cluster. The Topic Operator is deployed as a process


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixes #636 and makes CI fail if the documentation has broken xrefs (internal links). This doesn't check external links. This might cause some conflicts with the current docs modularisation, but it will also help with that by detecting broken links.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

