### PR TITLE
ST: Fix for bootstrap config

### DIFF
--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -932,7 +932,7 @@ metadata:
   name: my-connect-cluster
 spec:
   config:
-    bootstrap.servers: my-cluster-kafka:9092
+    bootstrap.servers: my-cluster-kafka-bootstrap:9092
     group.id: my-connect-cluster
     offset.storage.topic: my-connect-cluster-offsets
     config.storage.topic: my-connect-cluster-configs
@@ -1004,7 +1004,7 @@ spec:
     initialDelaySeconds: 60
     timeoutSeconds: 5
   config: 
-    bootstrap.servers: my-cluster-kafka:9092
+    bootstrap.servers: my-cluster-kafka-bootstrap:9092
 ----
 
 The S2I deployment is very similar to the regular Kafka Connect deployment (as represented by the `KafkaConnect` resource).

--- a/examples/install/topic-operator/04-deployment.yaml
+++ b/examples/install/topic-operator/04-deployment.yaml
@@ -17,9 +17,9 @@ spec:
             - name: STRIMZI_CONFIGMAP_LABELS
               value: "strimzi.io/kind=topic"
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
-              value: my-cluster-kafka:9092
+              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_ZOOKEEPER_CONNECT
-              value: my-cluster-zookeeper:2181
+              value: my-cluster-zookeeper-client:2181
             - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS
               value: "20000"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -104,7 +104,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
     public void testKafkaConnectWithFileSinkPlugin() {
 
         String connectorConfig = getFileAsString("../systemtest/src/test/resources/file/sink/connector.json");
-        String kafkaConnectPodName = kubeClient.listResourcesByLabel("pod", "strimzi.io/type=kafka-connect").get(0);
+        String kafkaConnectPodName = kubeClient.listResourcesByLabel("pod", "type=kafka-connect").get(0);
         kubeClient.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testKafkaConnectWithFileSinkPlugin.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.testKafkaConnectWithFileSinkPlugin.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   replicas: 1
   config:
-    bootstrap.servers: connect-tests-kafka:9092
+    bootstrap.servers: connect-tests-kafka-bootstrap:9092
     key.converter.schemas.enable: false
     value.converter.schemas.enable: false

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IClusterIT.testDeployS2IWithMongoDBPlugin.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IClusterIT.testDeployS2IWithMongoDBPlugin.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   replicas: 1
   config:
-    bootstrap.servers: connect-s2i-tests-kafka:9092
+    bootstrap.servers: connect-s2i-tests-kafka-bootstrap:9092
     key.converter.schemas.enable: false
     value.converter.schemas.enable: false


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Added 'bootstrap' in the value for bootstrap.servers

It was a fix for:
`2018-07-25 15:25:29,769 WARN Removing server connect-s2i-tests-kafka:9092 from bootstrap.servers as DNS resolution failed for connect-s2i-tests-kafka (org.apache.kafka.clients.ClientUtils) [main]
2018-07-25 15:25:29,779 ERROR Stopping due to error (org.apache.kafka.connect.cli.ConnectDistributed) [main]`

### Checklist
- [ ] Make sure all tests pass
- [ ] Update documentation