### PR TITLE
Smaller lock timeout

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -54,7 +54,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
     private static final Logger log = LogManager.getLogger(AbstractAssemblyOperator.class.getName());
 
-    protected static final int LOCK_TIMEOUT = 60000;
+    protected static final int LOCK_TIMEOUT_MS = 10;
     protected static final int CERTS_EXPIRATION_DAYS = 365;
 
     protected final Vertx vertx;
@@ -212,7 +212,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         String namespace = reconciliation.namespace();
         String assemblyName = reconciliation.assemblyName();
         final String lockName = getLockName(assemblyType, namespace, assemblyName);
-        vertx.sharedData().getLockWithTimeout(lockName, LOCK_TIMEOUT, res -> {
+        vertx.sharedData().getLockWithTimeout(lockName, LOCK_TIMEOUT_MS, res -> {
             if (res.succeeded()) {
                 log.debug("{}: Lock {} acquired", reconciliation, lockName);
                 Lock lock = res.result();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -273,7 +273,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                     handler.handle(Future.failedFuture(ex));
                 }
             } else {
-                log.warn("{}: Failed to acquire lock {}.", reconciliation, lockName);
+                log.debug("{}: Failed to acquire lock {}.", reconciliation, lockName);
             }
         });
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -54,7 +54,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
     private static final Logger log = LogManager.getLogger(AbstractAssemblyOperator.class.getName());
 
-    protected static final int LOCK_TIMEOUT_MS = 10;
+    protected static final int LOCK_TIMEOUT_MS = 10000;
     protected static final int CERTS_EXPIRATION_DAYS = 365;
 
     protected final Vertx vertx;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Very minor enhancement

### Description

Don't bother waiting upto 1 minute to acquire the lock when we're be reconciling again soon enough anyway. Consequently we should stop considering failure to acquire the lock as a warning log event.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

