### PR TITLE
Support enum-typed properties in CRDs

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -343,6 +343,10 @@ public class CrdGenerator {
             result.put("pattern", pattern.value());
         }
 
+        if (property.getType().isEnum()) {
+            result.set("enum", enumCaseArray(property.getType().getEnumElements()));
+        }
+
         if (property.getDeclaringClass().isAnnotationPresent(JsonTypeInfo.class)
             && property.getName().equals(property.getDeclaringClass().getAnnotation(JsonTypeInfo.class).property())) {
             result.set("enum", stringArray(Property.subtypeNames(property.getDeclaringClass())));
@@ -357,6 +361,12 @@ public class CrdGenerator {
         }
 
         return result;
+    }
+
+    private <E extends Enum<E>> ArrayNode enumCaseArray(E[] values) {
+        ArrayNode arrayNode = nf.arrayNode();
+        arrayNode.addAll(Schema.enumCases(values));
+        return arrayNode;
     }
 
     private void addDescription(ObjectNode result, AnnotatedElement element) {
@@ -387,6 +397,8 @@ public class CrdGenerator {
         } else if (List.class.equals(type)
                 || type.isArray()) {
             return "array";
+        } else if (type.isEnum()) {
+            return "string";
         } else {
             throw new RuntimeException(type.getName());
         }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.crdgenerator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -199,6 +200,17 @@ public class DocGenerator {
         // Now the type link
         if (externalUrl != null) {
             out.append(externalUrl).append("[").append(propertyClass.getSimpleName()).append("]");
+        } else if (propertyType.isEnum()) {
+            Set<String> strings = new HashSet<>();
+            for (JsonNode n : Schema.enumCases(propertyType.getEnumElements())) {
+                if (n.isTextual()) {
+                    strings.add(n.asText());
+                } else {
+                    throw new RuntimeException("Enum case is not a string");
+                }
+            }
+            out.append("string (one of " + strings + ")");
+
         } else {
             typeLink(crd, out, propertyClass);
         }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -60,10 +60,15 @@ class Property implements AnnotatedElement {
         String name = method.getName();
         return name.startsWith("get")
                 && name.length() > 3
-                && !"getClass".equals(name)
+                && isReallyGetterName(method, name)
                 || name.startsWith("is")
                 && name.length() > 2
                 && method.getReturnType().equals(boolean.class);
+    }
+
+    private static boolean isReallyGetterName(Method method, String name) {
+        return !"getClass".equals(name)
+                && !("getDeclaringClass".equals(name) && Enum.class.equals(method.getDeclaringClass()));
     }
 
     private static String propertyName(Method getterMethod) {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
@@ -5,6 +5,7 @@
 package io.strimzi.crdgenerator;
 
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -134,5 +135,22 @@ public class PropertyType {
             }
         }
         return result;
+    }
+
+    public boolean isEnum() {
+        return this.type.isEnum();
+    }
+
+    public Enum[] getEnumElements() {
+        if (isEnum()) {
+            try {
+                Method valuesMethod = this.getType().getMethod("values");
+                return (Enum[]) valuesMethod.invoke(null);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return new Enum[0];
+        }
     }
 }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Schema.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Schema.java
@@ -4,6 +4,13 @@
  */
 package io.strimzi.crdgenerator;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 class Schema {
     private Schema() { }
 
@@ -21,6 +28,20 @@ class Schema {
     static boolean isJsonScalarType(Class<?> cls) {
         return cls.isPrimitive()
                 || isBoxedPrimitive(cls)
-                || cls.equals(String.class);
+                || cls.equals(String.class)
+                || cls.isEnum();
+    }
+
+    static List<JsonNode> enumCases(Enum<?>[] values) {
+        try {
+            List<JsonNode> result = new ArrayList<>();
+            ObjectMapper objectMapper = new ObjectMapper();
+            for (Object o : values) {
+                result.add(objectMapper.readTree(objectMapper.writeValueAsString(o)));
+            }
+            return result;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CustomisedEnum.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CustomisedEnum.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum CustomisedEnum {
+    ONE,
+    TWO;
+
+    @JsonCreator
+    public static CustomisedEnum forValue(String value) {
+        switch (value) {
+            case "one":
+                return ONE;
+            case "two":
+                return TWO;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case ONE:
+                return "one";
+            case TWO:
+                return "two";
+            default:
+                return null;
+        }
+    }
+
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -41,6 +41,10 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
 
     private boolean booleanProperty;
 
+    public NormalEnum normalEnum;
+
+    public CustomisedEnum customisedEnum;
+
     private ObjectProperty objectProperty;
 
     private Affinity affinity;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/NormalEnum.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/NormalEnum.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+public enum NormalEnum {
+    FOO,
+    BAR;
+}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -25,6 +25,8 @@
 |string array of dimension 2
 |booleanProperty         1.2+<.<|
 |boolean
+|customisedEnum          1.2+<.<|
+|string (one of [one, two])
 |fieldProperty           1.2+<.<|Example of field property.
 |string
 |intProperty             1.2+<.<|An example int property
@@ -59,6 +61,8 @@
 |integer
 |mapProperty             1.2+<.<|
 |map
+|normalEnum              1.2+<.<|
+|string (one of [BAR, FOO])
 |objectProperty          1.2+<.<|
 |<<type-ObjectProperty,`ObjectProperty`>>
 |polymorphicProperty     1.2+<.<| The type depends on the value of the `polymorphicProperty.discrim` property within the given object, which must be one of [left, right]

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -285,6 +285,11 @@ spec:
               type: "string"
         booleanProperty:
           type: "boolean"
+        customisedEnum:
+          type: "string"
+          enum:
+          - "one"
+          - "two"
         fieldProperty:
           type: "string"
         intProperty:
@@ -382,6 +387,11 @@ spec:
           minimum: 42
         mapProperty:
           type: "object"
+        normalEnum:
+          type: "string"
+          enum:
+          - "FOO"
+          - "BAR"
         objectProperty:
           type: "object"
           properties:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Support enum-typed properties in CRD POJOs by adding `enum` constraint to the schema and documenting the constrained values in the DocGenerator.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

