### PR TITLE
Allowing "authorizer." in Kafka config

### DIFF
--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -274,7 +274,6 @@ Specifically, all configuration options with keys starting with one of the follo
 * `log.dir`
 * `zookeeper.connect`
 * `zookeeper.set.acl`
-* `authorizer.`
 * `super.user`
 
 All other options will be passed to Kafka.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR is about fixing "authorizer." which is now allowed to set in the Kafka config.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

