### PR TITLE
Check doc

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,6 +8,8 @@ export DOCKER_ORG=${DOCKER_ORG:-strimzici}
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io}
 export DOCKER_TAG=$COMMIT
 
+./.travis/check_docs.sh
+
 make docker_build
 
 if [ ! -e  documentation/book/appendix_crds.adoc ] ; then
@@ -38,7 +40,7 @@ make docker_push
 OLD_DOCKER_ORG=$DOCKER_ORG
 export DOCKER_ORG="localhost:5000/strimzici"
 
-./.travis/check_docs.sh
+
 
 echo "Running systemtests"
 ./systemtest/scripts/run_tests.sh ${SYSTEMTEST_ARGS}

--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -5,8 +5,9 @@ fatal=0
 function grep_check {
   local pattern=$1
   local description=$2
-  local fatalness=${3:-1}
-  x=$(grep -i -E -r -Hn "$pattern" documentation/book/)
+  local opts=${3:--i -E -r -n}
+  local fatalness=${4:-1}
+  x=$(grep $opts "$pattern" documentation/book/)
   if [ -n "$x" ]; then
     echo "$description:"
     echo "$x"
@@ -29,6 +30,10 @@ grep_check '[^[:alpha:]]it'"'"'s[^[:alpha:]]' "Avoid it's contraction"
 grep_check '[^[:alpha:]]can not[^[:alpha:]]' "Use 'cannot' not 'can not'"
 grep_check '\<a {ProductPlatformName}' "The article should be 'an' {ProductPlatformName}"
 grep_check '\<a {ProductPlatformLongName}' "The article should be 'an' {ProductPlatformLongName}"
+
+# Asciidoc standards
+#grep_check '[<][<][[:alnum:]_-]+,' "Internal links should be xrefs"
+grep_check '[[]id=(["'"'"'])[[:alnum:]_-]+(?!-[{]context[}])\1' "[id=...] should end with -{context}" "-i -P -r -n"
 
 if [ $fatal -gt 0 ]; then
   echo "ERROR: ${fatal} docs problems found."

--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -32,7 +32,7 @@ grep_check '\<a {ProductPlatformName}' "The article should be 'an' {ProductPlatf
 grep_check '\<a {ProductPlatformLongName}' "The article should be 'an' {ProductPlatformLongName}"
 
 # Asciidoc standards
-#grep_check '[<][<][[:alnum:]_-]+,' "Internal links should be xrefs"
+grep_check '[<][<][[:alnum:]_-]+,' "Internal links should be xref:doc_id[Section title], not <<doc_id,link text>>"
 grep_check '[[]id=(["'"'"'])[[:alnum:]_-]+(?!-[{]context[}])\1' "[id=...] should end with -{context}" "-i -P -r -n"
 
 if [ $fatal -gt 0 ]; then

--- a/documentation/book/master.adoc
+++ b/documentation/book/master.adoc
@@ -25,7 +25,7 @@ include::appendix_deploying_kubernetes_openshift_cluster.adoc[]
 endif::InstallationAppendix[]
 
 [appendix]
-[id='api_reference']
+[id='api_reference-{context}']
 :parent-context: {context}
 :context: reference
 ## Custom Resource API Reference


### PR DESCRIPTION
### Type of change

- Documentation

### Description

* Enforce `xref:` style linking rather that `<<,>>` style. 
* Fail travis build sooner in presence of doc errors
* Enforce id with context `[id=...-{context}]`

Currently the build will fail with this PR, but should hopefully pass once #659 is merged and this branch rebased.

@ncbaratta I suppose the CRD API reference docs should use `[id=...-{context}]` ids too? If so let me know and I will fix it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

