### PR TITLE
Add support for Subject Alternative Names and full DNS names

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -28,6 +28,7 @@ ssl.keystore.password=${CERTS_STORE_PASSWORD}
 ssl.truststore.password=${CERTS_STORE_PASSWORD}
 ssl.keystore.type=PKCS12
 ssl.truststore.type=PKCS12
+ssl.endpoint.identification.algorithm=HTTPS
 
 listener.name.replication.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.replication.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -116,11 +116,12 @@ public class Session extends AbstractVerticle {
         adminClientProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(Config.KAFKA_BOOTSTRAP_SERVERS));
 
         if (Boolean.valueOf(config.get(Config.TLS_ENABLED))) {
-            adminClientProps.setProperty("security.protocol", "SSL");
+            adminClientProps.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
             adminClientProps.setProperty("ssl.truststore.location", config.get(Config.TLS_TRUSTSTORE_LOCATION));
             adminClientProps.setProperty("ssl.truststore.password", config.get(Config.TLS_TRUSTSTORE_PASSWORD));
             adminClientProps.setProperty("ssl.keystore.location", config.get(Config.TLS_KEYSTORE_LOCATION));
             adminClientProps.setProperty("ssl.keystore.password", config.get(Config.TLS_KEYSTORE_PASSWORD));
+            adminClientProps.setProperty("ssl.endpoint.identification.algorithm", "HTTPS");
         }
 
         this.adminClient = AdminClient.create(adminClientProps);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is adding SANs to the brokers certificates and enable hostname verification between Kafka brokers (each other communication) and Topic Operator (connecting to Kafka brokers).
It doesn't enable hostname verification for Zookeeper because in that case TLS is enabled using stunnel which in the current used version 4.65 doesn't allow hostname verification (added since 5.15 version).
This PR is related to #526 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

