### PR TITLE
Docs: Fix ID Context

### DIFF
--- a/documentation/book/assembly-cluster-operator.adoc
+++ b/documentation/book/assembly-cluster-operator.adoc
@@ -25,12 +25,12 @@ The format of the `Kafka` resource is described in xref:kafka_assembly_details[F
 NOTE: {ProductName} contains example YAML files, which make deploying a Cluster Operator easier.
 
 ifdef::Kubernetes[]
-:context: {ContextProduct}
+:context: str
 include::proc-deploying-cluster-operator-kubernetes.adoc[leveloffset=+1]
 endif::Kubernetes[]
 
+:context: str
 include::proc-deploying-cluster-operator-openshift.adoc[leveloffset=+1]
-
 
 // Restore the context to what it was before this assembly.
 :context: {parent-context}

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -25,9 +25,11 @@ ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
 
 ifdef::Kubernetes[]
+:context: str
 include::proc-deploying-kafka-cluster-kubernetes.adoc[leveloffset=+1]
 endif::Kubernetes[]
 
+:context: str
 include::proc-deploying-kafka-cluster-openshift.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/book/assembly-overview.adoc
+++ b/documentation/book/assembly-overview.adoc
@@ -21,8 +21,10 @@ Topic Operator:: Responsible for managing Kafka topics within a Kafka cluster ru
 
 This guide describes how to install and use {ProductLongName}.
 
+:context: str
 include::ref-key-features.adoc[leveloffset=+1]
 
+:context: str
 include::ref-document-conventions.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -32,14 +32,14 @@ ifdef::Kubernetes[{KubernetesLongName} and]
 {OpenShiftLongName} user must have the rights to manage role-based access control (RBAC).
 
 ifdef::Downloading[]
-:context: {ContextProduct}
+:context: str
 include::con-product-downloads.adoc[leveloffset=+1]
 endif::Downloading[]
 
-:context: {ContextProduct}
+:context: str
 include::assembly-cluster-operator.adoc[leveloffset=+1]
 
-:context: {ContextProduct}
+:context: str
 include::assembly-kafka-cluster.adoc[leveloffset=+1]
 
 == Kafka Connect

--- a/documentation/book/master.adoc
+++ b/documentation/book/master.adoc
@@ -1,11 +1,11 @@
 include::common/attributes.adoc[]
 
+:context: str
+
 = Using {ProductLongName}
 
-:context: {ContextProduct}
 include::assembly-overview.adoc[leveloffset=+1]
 
-:context: {ContextProduct}
 include::getting-started.adoc[leveloffset=+1]
 
 include::cluster-operator.adoc[]

--- a/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
@@ -26,5 +26,5 @@ kubectl apply -f examples/kafka/kafka-persistent.yaml
 ----
 
 .Additional resources
-* For more information about deploying the Cluster Operator, see xref:assembly-cluster-operator.adoc[]
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[]
 * Example resources and details about the `Kafka` resource format are in xref:kafka_assembly_details[].

--- a/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
@@ -28,5 +28,5 @@ oc apply -f examples/kafka/kafka-persistent.yaml
 ----
 
 .Additional resources
-* For more information about deploying the Cluster Operator, see xref:assembly-cluster-operator.adoc[]
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[]
 * Example resources and details about the `Kafka` resource format are in xref:kafka_assembly_details[].


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The way we were handling the context attribute would not work for those who fork the documentation.  This new way should work.
