### PR TITLE
Configuration of listeners, authorization and authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # CHANGELOG
 
-## 0.6.0
+## 0.6.0 (Work in Progress)
 
 * Topic Operator moving to Custom Resources instead of Config Maps
+* Make it possible to enabled and disable:
+  * Listeners
+  * Authorization
+  * Authentication 
 
-## 0.5.0 (Work in Progress)
+## 0.5.0
 
 * The Cluster Operator now manages RBAC resource for managed resources:
     * `ServiceAccount` and `ClusterRoleBindings` for Kafka pods

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -31,7 +31,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "replicas", "image", "storage", "config",
+        "replicas", "image", "storage",
+        "authorization", "config",
         "rack", "brokerRackInitImage",
         "affinity", "tolerations",
         "livenessProbe", "readinessProbe",
@@ -82,6 +83,7 @@ public class Kafka implements Serializable {
     private Map<String, Object> metrics = new HashMap<>(0);
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private KafkaAuthorization authorization;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The kafka broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
@@ -236,6 +238,16 @@ public class Kafka implements Serializable {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("Authorization configuration for Kafka brokers")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaAuthorization getAuthorization() {
+        return authorization;
+    }
+
+    public void setAuthorization(KafkaAuthorization authorization) {
+        this.authorization = authorization;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -32,7 +32,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "replicas", "image", "storage",
-        "authorization", "config",
+        "listeners", "authorization", "config",
         "rack", "brokerRackInitImage",
         "affinity", "tolerations",
         "livenessProbe", "readinessProbe",
@@ -83,6 +83,7 @@ public class Kafka implements Serializable {
     private Map<String, Object> metrics = new HashMap<>(0);
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private KafkaListeners listeners;
     private KafkaAuthorization authorization;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -238,6 +239,17 @@ public class Kafka implements Serializable {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("Configures listeners of Kafka brokers")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    public KafkaListeners getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(KafkaListeners listeners) {
+        this.listeners = listeners;
     }
 
     @Description("Authorization configuration for Kafka brokers")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Configures the broker authorization
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = KafkaAuthorizationSimple.TYPE_SIMPLE, value = KafkaAuthorizationSimple.class),
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class KafkaAuthorization implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @Description("Authorization type. " +
+            "Currently the only supported type is `simple`. " +
+            "`simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization.")
+    @JsonIgnore
+    public abstract String getType();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Configures the broker authorization
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaAuthorizationSimple extends KafkaAuthorization {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_SIMPLE = "simple";
+
+    @Description("Must be `" + TYPE_SIMPLE + "`")
+    @Override
+    public String getType() {
+        return TYPE_SIMPLE;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
@@ -12,39 +12,34 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.sundr.builder.annotations.Buildable;
-
-import static java.util.Collections.emptyMap;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * Configures the TLS listener of Kafka broker
+ * Configures the broker authorization
  */
-@Buildable(
-        editableEnabled = false,
-        generateBuilderPackage = true,
-        builderPackage = "io.strimzi.api.kafka.model"
-)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = KafkaListenerAuthenticationTls.TYPE_TLS, value = KafkaListenerAuthenticationTls.class),
+})
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class KafkaListenerTls implements Serializable {
+public abstract class KafkaListenerAuthentication implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private KafkaListenerAuthentication authentication;
     private Map<String, Object> additionalProperties;
 
-    @Description("Authorization configuration for Kafka brokers")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public KafkaListenerAuthentication getAuthentication() {
-        return authentication;
-    }
-
-    public void setAuthentication(KafkaListenerAuthentication authentication) {
-        this.authentication = authentication;
-    }
+    @Description("Authentication type. " +
+            "Currently the only supported type is `tls`. " +
+            "`tls` type uses TLS Client Authentication. " +
+            "`tls` type is supported only on TLS listeners.")
+    @JsonIgnore
+    public abstract String getType();
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+        return this.additionalProperties;
     }
 
     @JsonAnySetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthenticationTls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Configures the broker authorization
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_TLS = "tls";
+
+    @Description("Must be `" + TYPE_TLS + "`")
+    @Override
+    public String getType() {
+        return TYPE_TLS;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Configures the TCP listener of Kafka broker
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaListenerPlain implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -29,17 +29,17 @@ import static java.util.Collections.emptyMap;
 public class KafkaListenerTls implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private KafkaListenerAuthentication authentication;
+    private KafkaListenerAuthentication serverAuthentication;
     private Map<String, Object> additionalProperties;
 
     @Description("Authorization configuration for Kafka brokers")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public KafkaListenerAuthentication getAuthentication() {
-        return authentication;
+        return serverAuthentication;
     }
 
-    public void setAuthentication(KafkaListenerAuthentication authentication) {
-        this.authentication = authentication;
+    public void setAuthentication(KafkaListenerAuthentication serverAuthentication) {
+        this.serverAuthentication = serverAuthentication;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Configures the TLS listener of Kafka broker
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaListenerTls implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListeners.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListeners.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.sundr.builder.annotations.Buildable;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Configures the broker authorization
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"plain", "tls"})
+public class KafkaListeners implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private KafkaListenerTls tls;
+    private KafkaListenerPlain plain;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Configures TLS listener on port 9093.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaListenerTls getTls() {
+        return tls;
+    }
+
+    public void setTls(KafkaListenerTls tls) {
+        this.tls = tls;
+    }
+
+    @Description("Configures plain listener on port 9092.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaListenerPlain getPlain() {
+        return plain;
+    }
+
+    public void setPlain(KafkaListenerPlain plain) {
+        this.plain = plain;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
@@ -26,7 +26,7 @@ public abstract class Logging implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    @Description("Storage type, must be either 'inline' or 'external'.")
+    @Description("Logging type, must be either 'inline' or 'external'.")
     @JsonIgnore
     public abstract String getType();
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -123,7 +123,8 @@ public class ExamplesTest {
             if (isGetter(method)) {
                 Object result = method.invoke(resource);
                 if (result != null
-                    && !result.getClass().isPrimitive()) {
+                    && !result.getClass().isPrimitive()
+                    && !result.getClass().isEnum()) {
                     path.push(method.getName());
                     recurseForAdditionalProperties(path, result);
                     path.pop();

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-minimal.yaml
@@ -8,6 +8,9 @@ spec:
     storage:
       type: persistent-claim
       size: 500Gi
+    listeners:
+      plain: {}
+      tls: {}
   zookeeper:
     replicas: 3
     storage:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-with-extra-property.yaml
@@ -10,6 +10,9 @@ spec:
     resources:
       limits:
         memory: "5Gi"
+    listeners:
+      plain: {}
+      tls: {}
     livenessProbe:
       initialDelaySeconds: 5
       timeoutSeconds: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-with-invalid-resource-memory.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly-with-invalid-resource-memory.yaml
@@ -9,6 +9,9 @@ spec:
     resources:
       limits:
         memory: "5GiFooBar"
+    listeners:
+      plain: {}
+      tls: {}
     livenessProbe:
       initialDelaySeconds: 5
       timeoutSeconds: 1

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
@@ -13,6 +13,9 @@ spec:
       type: "persistent-claim"
       size: "500Gi"
       deleteClaim: false
+    listeners:
+      plain: {}
+      tls: {}
     authorization:
       type: "simple"
     config:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
@@ -15,7 +15,9 @@ spec:
       deleteClaim: false
     listeners:
       plain: {}
-      tls: {}
+      tls:
+        authentication:
+          type: "tls"
     authorization:
       type: "simple"
     config:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.out.yaml
@@ -13,6 +13,8 @@ spec:
       type: "persistent-claim"
       size: "500Gi"
       deleteClaim: false
+    authorization:
+      type: "simple"
     config:
       min.insync.replicas: 3
     brokerRackInitImage: "strimzi/kafka-init:latest"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
@@ -36,6 +36,9 @@ spec:
       size: 500Gi
     config:
       min.insync.replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     authorization:
       type: simple
     metrics: {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
@@ -36,6 +36,8 @@ spec:
       size: 500Gi
     config:
       min.insync.replicas: 3
+    authorization:
+      type: simple
     metrics: {
         "lowercaseOutputName": true,
         "rules": [

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaAssembly.yaml
@@ -38,7 +38,9 @@ spec:
       min.insync.replicas: 3
     listeners:
       plain: {}
-      tls: {}
+      tls:
+        authentication:
+          type: tls
     authorization:
       type: simple
     metrics: {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -131,8 +131,8 @@ public abstract class AbstractModel {
     protected String headlessServiceName;
     protected String name;
 
-    protected final int metricsPort = 9404;
-    protected final String metricsPortName = "kafkametrics";
+    protected static final int METRICS_PORT = 9404;
+    protected static final String METRICS_PORT_NAME = "metrics";
     protected boolean isMetricsEnabled;
 
     protected Iterable<Map.Entry<String, Object>> metricsConfig;
@@ -1095,7 +1095,7 @@ public abstract class AbstractModel {
      */
     protected Map<String, String> getPrometheusAnnotations()    {
         Map<String, String> annotations = new HashMap<String, String>(3);
-        annotations.put("prometheus.io/port", String.valueOf(metricsPort));
+        annotations.put("prometheus.io/port", String.valueOf(METRICS_PORT));
         annotations.put("prometheus.io/scrape", "true");
         annotations.put("prometheus.io/path", "/metrics");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -25,6 +25,8 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAssembly;
+import io.strimzi.api.kafka.model.KafkaAuthorization;
+import io.strimzi.api.kafka.model.KafkaAuthorizationSimple;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.Resources;
@@ -55,6 +57,7 @@ public class KafkaCluster extends AbstractModel {
     protected static final String RACK_VOLUME_MOUNT = "/opt/kafka/rack";
     private static final String ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
     private static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
+    private static final String ENV_VAR_KAFKA_AUTHORIZATION_TYPE = "KAFKA_AUTHORIZATION_TYPE";
 
     protected static final int CLIENT_PORT = 9092;
     protected static final String CLIENT_PORT_NAME = "clients";
@@ -90,6 +93,7 @@ public class KafkaCluster extends AbstractModel {
     private Rack rack;
     private String initImage;
     private Sidecar tlsSidecar;
+    private KafkaAuthorization authorization;
 
     // Configuration defaults
     private static final int DEFAULT_REPLICAS = 3;
@@ -218,6 +222,8 @@ public class KafkaCluster extends AbstractModel {
 
         result.generateCertificates(certManager, secrets);
         result.setTlsSidecar(kafka.getTlsSidecar());
+
+        result.setAuthorization(kafka.getAuthorization());
 
         return result;
     }
@@ -572,6 +578,10 @@ public class KafkaCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_LOG_CONFIGURATION, getLogging().getCm().toString()));
         }
 
+        if (authorization != null && KafkaAuthorizationSimple.TYPE_SIMPLE.equals(authorization.getType()))  {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_AUTHORIZATION_TYPE, KafkaAuthorizationSimple.TYPE_SIMPLE));
+        }
+
         return varList;
     }
 
@@ -636,5 +646,12 @@ public class KafkaCluster extends AbstractModel {
         }
     }
 
-
+    /**
+     * Sets the object with Kafka authorization configuration
+     *
+     * @param authorization
+     */
+    public void setAuthorization(KafkaAuthorization authorization) {
+        this.authorization = authorization;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -27,6 +27,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAssembly;
 import io.strimzi.api.kafka.model.KafkaAuthorization;
 import io.strimzi.api.kafka.model.KafkaAuthorizationSimple;
+import io.strimzi.api.kafka.model.KafkaListenerAuthenticationTls;
 import io.strimzi.api.kafka.model.KafkaListeners;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Rack;
@@ -60,6 +61,7 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
     private static final String ENV_VAR_KAFKA_CLIENT_ENABLED = "KAFKA_CLIENT_ENABLED";
     private static final String ENV_VAR_KAFKA_CLIENTTLS_ENABLED = "KAFKA_CLIENTTLS_ENABLED";
+    private static final String ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION = "KAFKA_CLIENTTLS_AUTHENTICATION";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_TYPE = "KAFKA_AUTHORIZATION_TYPE";
 
     protected static final int CLIENT_PORT = 9092;
@@ -611,6 +613,10 @@ public class KafkaCluster extends AbstractModel {
 
             if (listeners.getTls() != null) {
                 varList.add(buildEnvVar(ENV_VAR_KAFKA_CLIENTTLS_ENABLED, "TRUE"));
+
+                if (listeners.getTls().getAuthentication() != null && KafkaListenerAuthenticationTls.TYPE_TLS.equals(listeners.getTls().getAuthentication().getType())) {
+                    varList.add(buildEnvVar(ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS));
+                }
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -32,8 +32,6 @@ public class KafkaConnectCluster extends AbstractModel {
     // Port configuration
     protected static final int REST_API_PORT = 8083;
     protected static final String REST_API_PORT_NAME = "rest-api";
-    protected static final int METRICS_PORT = 9404;
-    protected static final String METRICS_PORT_NAME = "metrics";
 
     private static final String NAME_SUFFIX = "-connect";
     private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-api";
@@ -149,7 +147,7 @@ public class KafkaConnectCluster extends AbstractModel {
         List<ContainerPort> portList = new ArrayList<>(2);
         portList.add(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP"));
         if (isMetricsEnabled) {
-            portList.add(createContainerPort(metricsPortName, metricsPort, "TCP"));
+            portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }
 
         return portList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -44,8 +44,6 @@ public class ZookeeperCluster extends AbstractModel {
     protected static final String CLUSTERING_PORT_NAME = "clustering";
     protected static final int LEADER_ELECTION_PORT = 3888;
     protected static final String LEADER_ELECTION_PORT_NAME = "leader-election";
-    protected static final int METRICS_PORT = 9404;
-    protected static final String METRICS_PORT_NAME = "metrics";
 
     protected static final String ZOOKEEPER_NAME = "zookeeper";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
@@ -327,7 +325,7 @@ public class ZookeeperCluster extends AbstractModel {
     private List<ContainerPort> getContainerPortList() {
         List<ContainerPort> portList = new ArrayList<>();
         if (isMetricsEnabled) {
-            portList.add(createContainerPort(metricsPortName, metricsPort, "TCP"));
+            portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }
 
         return portList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -18,6 +18,8 @@ import io.strimzi.api.kafka.model.KafkaConnectAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectAssemblyBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2IAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectS2IAssemblyBuilder;
+import io.strimzi.api.kafka.model.KafkaListenerPlain;
+import io.strimzi.api.kafka.model.KafkaListenerTls;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
@@ -203,6 +205,10 @@ public class ResourceUtils {
                 .editSpec()
                 .editKafka()
                     .withLogging(kafkaLogging)
+                    .withNewListeners()
+                        .withPlain(new KafkaListenerPlain())
+                        .withTls(new KafkaListenerTls())
+                    .endListeners()
                 .endKafka()
                 .editZookeeper()
                     .withLogging(zkLogging)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -86,9 +86,18 @@ public class KafkaClusterTest {
         assertEquals("ClusterIP", headful.getSpec().getType());
         assertEquals(expectedLabels(), headful.getSpec().getSelector());
         assertEquals(4, headful.getSpec().getPorts().size());
-        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(1).getPort());
+        assertEquals("TCP", headful.getSpec().getPorts().get(1).getProtocol());
+        assertEquals(KafkaCluster.CLIENT_TLS_PORT_NAME, headful.getSpec().getPorts().get(2).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_TLS_PORT), headful.getSpec().getPorts().get(2).getPort());
+        assertEquals("TCP", headful.getSpec().getPorts().get(2).getProtocol());
+        assertEquals(AbstractModel.METRICS_PORT_NAME, headful.getSpec().getPorts().get(3).getName());
+        assertEquals(new Integer(KafkaCluster.METRICS_PORT), headful.getSpec().getPorts().get(3).getPort());
+        assertEquals("TCP", headful.getSpec().getPorts().get(2).getProtocol());
         assertEquals(kc.getPrometheusAnnotations(), headful.getMetadata().getAnnotations());
     }
 
@@ -104,12 +113,15 @@ public class KafkaClusterTest {
         assertEquals("None", headless.getSpec().getClusterIP());
         assertEquals(expectedLabels(), headless.getSpec().getSelector());
         assertEquals(3, headless.getSpec().getPorts().size());
-        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headless.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headless.getSpec().getPorts().get(0).getProtocol());
-        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headless.getSpec().getPorts().get(1).getName());
-        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headless.getSpec().getPorts().get(1).getPort());
+        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(1).getPort());
         assertEquals("TCP", headless.getSpec().getPorts().get(1).getProtocol());
+        assertEquals(KafkaCluster.CLIENT_TLS_PORT_NAME, headless.getSpec().getPorts().get(2).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_TLS_PORT), headless.getSpec().getPorts().get(2).getPort());
+        assertEquals("TCP", headless.getSpec().getPorts().get(2).getProtocol());
     }
 
     @Test

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -23,11 +23,18 @@ if [ "$KAFKA_CLIENTTLS_ENABLED" = "TRUE" ]; then
   ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},CLIENTTLS://$(hostname -f):9093"
   LISTENER_SECURITY_PROTOCOL_MAP="${LISTENER_SECURITY_PROTOCOL_MAP},CLIENTTLS:SSL"
 
+  # Configuring TLS client authentication for clienttls interface
+  if [ "$KAFKA_CLIENTTLS_AUTHENTICATION" = "tls" ]; then
+    LISTENER_NAME_CLIENTTLS_SSL_CLIENT_AUTH="required"
+  else
+    LISTENER_NAME_CLIENTTLS_SSL_CLIENT_AUTH="none"
+  fi
+
   CLIENTTLS_LISTENER=$(cat <<EOF
 # TLS interface configuration
 listener.name.clienttls.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.p12
-listener.name.clienttls.ssl.client.auth=none
+listener.name.clienttls.ssl.client.auth=${LISTENER_NAME_CLIENTTLS_SSL_CLIENT_AUTH}
 EOF
 )
 fi
@@ -70,8 +77,7 @@ listener.name.replication.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.replication.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
 listener.name.replication.ssl.client.auth=required
 
-listener.name.clienttls.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
-listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.p12
+${CLIENTTLS_LISTENER}
 
 # Authorization configuration
 authorizer.class.name=${AUTHORIZER_CLASS_NAME}

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -5,6 +5,15 @@ KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
 ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
 SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;User:CN=${KAFKA_NAME},O=io.strimzi"
 
+#####
+# Configuring authorization
+#####
+if [ "$KAFKA_AUTHORIZATION_TYPE" = "simple" ]; then
+  AUTHORIZER_CLASS_NAME="kafka.security.auth.SimpleAclAuthorizer"
+else
+  AUTHORIZER_CLASS_NAME=""
+fi
+
 # Write the config file
 cat <<EOF
 broker.id=${KAFKA_BROKER_ID}
@@ -37,7 +46,8 @@ listener.name.replication.ssl.client.auth=required
 listener.name.clienttls.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.clienttls.ssl.truststore.location=/tmp/kafka/clients.truststore.p12
 
-# ACL Super users (all nodes for replication)
+# Authorization configuration
+authorizer.class.name=${AUTHORIZER_CLASS_NAME}
 ${SUPER_USERS}
 
 # Provided configuration

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -41,6 +41,8 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |string
 |storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim]
 |<<type-EphemeralStorage,`EphemeralStorage`>>, <<type-PersistentClaimStorage,`PersistentClaimStorage`>>
+|authorization        1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple]
+|<<type-KafkaAuthorizationSimple,`KafkaAuthorizationSimple`>>
 |config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener.name.replication., listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, super.user
 |map
 |rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
@@ -106,6 +108,21 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |size         1.2+<.<|When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
 |string
 |type         1.2+<.<|Must be `persistent-claim`
+|string
+|====
+
+[[type-KafkaAuthorizationSimple]]
+### `KafkaAuthorizationSimple` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Kafka,`Kafka`>>
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaAuthorizationSimple` from .
+It must have the value `simple` for the type `KafkaAuthorizationSimple`.
+[options="header"]
+|====
+|Field        |Description
+|type  1.2+<.<|Must be `simple`
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -147,7 +147,24 @@ Used in: <<type-KafkaListeners,`KafkaListeners`>>
 
 [options="header"]
 |====
-|Field|Description
+|Field                  |Description
+|authentication  1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls]
+|<<type-KafkaListenerAuthenticationTls,`KafkaListenerAuthenticationTls`>>
+|====
+
+[[type-KafkaListenerAuthenticationTls]]
+### `KafkaListenerAuthenticationTls` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaListenerTls,`KafkaListenerTls`>>
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationTls` from .
+It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
+[options="header"]
+|====
+|Field        |Description
+|type  1.2+<.<|Must be `tls`
+|string
 |====
 
 [[type-KafkaAuthorizationSimple]]

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -41,6 +41,8 @@ Used in: <<type-KafkaAssemblySpec,`KafkaAssemblySpec`>>
 |string
 |storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim]
 |<<type-EphemeralStorage,`EphemeralStorage`>>, <<type-PersistentClaimStorage,`PersistentClaimStorage`>>
+|listeners            1.2+<.<|Configures listeners of Kafka brokers
+|<<type-KafkaListeners,`KafkaListeners`>>
 |authorization        1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple]
 |<<type-KafkaAuthorizationSimple,`KafkaAuthorizationSimple`>>
 |config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener.name.replication., listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, super.user
@@ -109,6 +111,43 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |string
 |type         1.2+<.<|Must be `persistent-claim`
 |string
+|====
+
+[[type-KafkaListeners]]
+### `KafkaListeners` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-Kafka,`Kafka`>>
+
+
+[options="header"]
+|====
+|Field         |Description
+|plain  1.2+<.<|Configures plain listener on port 9092.
+|<<type-KafkaListenerPlain,`KafkaListenerPlain`>>
+|tls    1.2+<.<|Configures TLS listener on port 9093.
+|<<type-KafkaListenerTls,`KafkaListenerTls`>>
+|====
+
+[[type-KafkaListenerPlain]]
+### `KafkaListenerPlain` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaListeners,`KafkaListeners`>>
+
+
+[options="header"]
+|====
+|Field|Description
+|====
+
+[[type-KafkaListenerTls]]
+### `KafkaListenerTls` type v1alpha1 kafka.strimzi.io
+
+Used in: <<type-KafkaListeners,`KafkaListeners`>>
+
+
+[options="header"]
+|====
+|Field|Description
 |====
 
 [[type-KafkaAuthorizationSimple]]

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -39,6 +39,11 @@ spec:
                       type: string
                     type:
                       type: string
+                authorization:
+                  type: object
+                  properties:
+                    type:
+                      type: string
                 config:
                   type: object
                 rack:

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -39,6 +39,15 @@ spec:
                       type: string
                     type:
                       type: string
+                listeners:
+                  type: object
+                  properties:
+                    plain:
+                      type: object
+                      properties: {}
+                    tls:
+                      type: object
+                      properties: {}
                 authorization:
                   type: object
                   properties:
@@ -343,6 +352,7 @@ spec:
               required:
               - replicas
               - storage
+              - listeners
             zookeeper:
               type: object
               properties:

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -47,7 +47,12 @@ spec:
                       properties: {}
                     tls:
                       type: object
-                      properties: {}
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
                 authorization:
                   type: object
                   properties:

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -5,6 +5,18 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
+    authorization:
+      type: simple
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: 500m
+      limits:
+        memory: 2Gi
+        cpu: 1000m
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
@@ -28,6 +40,13 @@ spec:
             topic: "$3"
   zookeeper:
     replicas: 3
+    resources:
+      requests:
+        memory: 512Mi
+        cpu: 300m
+      limits:
+        memory: 1Gi
+        cpu: 2000m
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
@@ -38,4 +57,11 @@ spec:
       type: ephemeral
     metrics:
       lowercaseOutputName: true
-  topicOperator: { }
+  topicOperator:
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 200m
+      limits:
+        memory: 256Mi
+        cpu: 1000m

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -66,6 +66,9 @@ objects:
   spec:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
+      listeners:
+        plain: {}
+        tls: {}
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -72,6 +72,9 @@ objects:
   spec:
     kafka:
       replicas: ${{KAFKA_NODE_COUNT}}
+      listeners:
+        plain: {}
+        tls: {}
       livenessProbe:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectClusterIT.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IClusterIT.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IClusterIT.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testCustomAndUpdatedValues.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 30
       timeoutSeconds: 10

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testForTopicOperator.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testForTopicOperator.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testJvmAndResources.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 1
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testKafkaAndZookeeperScaleUpScaleDown.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testRackAware.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testRackAware.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 1
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testSendMessages.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testSendMessages.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testZookeeperScaleUpScaleDown.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5

--- a/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryClusterIT.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryClusterIT.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   kafka:
     replicas: 1
+    listeners:
+      plain: {}
+      tls: {}
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~
- ~~Documentation~~

### Description

This PR Adds support for several features:
* Configuring Authorization mechanism (cirrently only SimpleASLAuthorizer supported)
* Configuring listeners
* Configuring authentication for listeners (currenlty only TLS supported)

The new full CR looks like this:
```
apiVersion: kafka.strimzi.io/v1alpha1
kind: Kafka
metadata:
  name: my-cluster
spec:
  kafka:
    ...
    listeners:
      plain: {}
      tls:
        authentication:
          type: tls
    authorization:
      type: simple
    ...
  zookeeper:
    ...
```

The minimal one looks like this:

```
apiVersion: kafka.strimzi.io/v1alpha1
kind: Kafka
metadata:
  name: my-cluster
spec:
  kafka:
    ...
    listeners:
      plain: {}
      tls: {}
    ...
  zookeeper:
    ...
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

