### PR TITLE
TO watchedNamespace test

### DIFF
--- a/api/src/test/java/io/strimzi/test/Namespace.java
+++ b/api/src/test/java/io/strimzi/test/Namespace.java
@@ -23,6 +23,11 @@ public @interface Namespace {
     /** The name of the namespace to create/delete. */
     String value();
 
+    /**
+     * Whether the KubeClient should be switched to the new namespace
+     */
+    boolean use() default true;
+
     @Target({ElementType.METHOD, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
     @interface Container {

--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -799,7 +799,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 protected void before() {
                     LOGGER.info("Creating namespace '{}' before test per @Namespace annotation on {}", namespace.value(), name(element));
                     kubeClient().createNamespace(namespace.value());
-                    previousNamespace = kubeClient().namespace(namespace.value());
+                    previousNamespace = namespace.use() ? kubeClient().namespace(namespace.value()) : kubeClient().namespace();
                 }
 
                 @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -521,7 +521,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         TopicOperator.topicOperatorServiceAccountName(name),
                         desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateServiceAccount() : null)))
                 .compose(desc -> {
-                    String watchedNamespace = desc.topicOperator().getWatchedNamespace();
+                    String watchedNamespace = desc.topicOperator() != null ? desc.topicOperator().getWatchedNamespace() : null;
                     return desc.withVoid(roleBindingOperator.reconcile(
                             watchedNamespace != null && !watchedNamespace.isEmpty() ?
                                     watchedNamespace : namespace,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -520,9 +520,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(desc -> desc.withVoid(serviceAccountOperator.reconcile(namespace,
                         TopicOperator.topicOperatorServiceAccountName(name),
                         desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateServiceAccount() : null)))
-                .compose(desc -> desc.withVoid(roleBindingOperator.reconcile(namespace,
-                        TopicOperator.TO_ROLE_BINDING_NAME,
-                        desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateRoleBinding(namespace) : null)))
+                .compose(desc -> {
+                    String watchedNamespace = desc.topicOperator().getWatchedNamespace();
+                    return desc.withVoid(roleBindingOperator.reconcile(
+                            watchedNamespace != null && !watchedNamespace.isEmpty() ?
+                                    watchedNamespace : namespace,
+                            TopicOperator.TO_ROLE_BINDING_NAME,
+                            desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateRoleBinding(namespace) : null));
+                })
                 .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace,
                         desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().getAncillaryConfigName() : TopicOperator.metricAndLogConfigsName(name),
                         desc.metricsAndLogsConfigMap())))

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartClusterIT.java
@@ -26,11 +26,6 @@ public class HelmChartClusterIT extends KafkaClusterIT {
     private static final String CLUSTER_NAME = "my-cluster";
     private static final String TOPIC_NAME = "test-topic";
 
-    @Override
-    protected String testNamespace() {
-        return NAMESPACE;
-    }
-
     @Test
     @JUnitGroup(name = "regression")
     @KafkaFromClasspathYaml()

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartClusterIT.java
@@ -26,6 +26,11 @@ public class HelmChartClusterIT extends KafkaClusterIT {
     private static final String CLUSTER_NAME = "my-cluster";
     private static final String TOPIC_NAME = "test-topic";
 
+    @Override
+    protected String testNamespace() {
+        return NAMESPACE;
+    }
+
     @Test
     @JUnitGroup(name = "regression")
     @KafkaFromClasspathYaml()

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -430,6 +430,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         kubeClient.namespace("topic-operator-namespace");
         kubeClient.create(new File("../examples/topic/kafka-topic.yaml"));
         Thread.sleep(10_000);
+        kubeClient.namespace(NAMESPACE);
         topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, hasItems("my-topic"));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -67,6 +67,10 @@ public class KafkaClusterIT extends AbstractClusterIT {
     public static final String NAMESPACE = "kafka-cluster-test";
     private static final String TOPIC_NAME = "test-topic";
 
+    protected String testNamespace() {
+        return NAMESPACE;
+    }
+
     @Test
     @JUnitGroup(name = "regression")
     @OpenShiftOnly
@@ -430,7 +434,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         kubeClient.namespace("topic-operator-namespace");
         kubeClient.create(new File("../examples/topic/kafka-topic.yaml"));
         Thread.sleep(10_000);
-        kubeClient.namespace(NAMESPACE);
+        kubeClient.namespace(testNamespace());
         topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, hasItems("my-topic"));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -67,10 +67,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     public static final String NAMESPACE = "kafka-cluster-test";
     private static final String TOPIC_NAME = "test-topic";
 
-    protected String testNamespace() {
-        return NAMESPACE;
-    }
-
     @Test
     @JUnitGroup(name = "regression")
     @OpenShiftOnly
@@ -431,10 +427,10 @@ public class KafkaClusterIT extends AbstractClusterIT {
     public void testWatchingOtherNamespace() throws InterruptedException {
         List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, not(hasItems("my-topic")));
-        kubeClient.namespace("topic-operator-namespace");
+        String origNamespace = kubeClient.namespace("topic-operator-namespace");
         kubeClient.create(new File("../examples/topic/kafka-topic.yaml"));
         Thread.sleep(10_000);
-        kubeClient.namespace(testNamespace());
+        kubeClient.namespace(origNamespace);
         topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, hasItems("my-topic"));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -423,12 +423,13 @@ public class KafkaClusterIT extends AbstractClusterIT {
     @Test
     //@JUnitGroup(name = "regression")
     @KafkaFromClasspathYaml
-    @Namespace(value = "topicOperatorNamespace", use = false)
-    public void testWatchingOtherNamespace() {
+    @Namespace(value = "topic-operator-namespace", use = false)
+    public void testWatchingOtherNamespace() throws InterruptedException {
         List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, not(hasItems("my-topic")));
-        kubeClient.namespace("topicOperatorNamespace");
+        kubeClient.namespace("topic-operator-namespace");
         kubeClient.create(new File("../examples/topic/kafka-topic.yaml"));
+        Thread.sleep(10_000);
         topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, hasItems("my-topic"));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -414,5 +415,21 @@ public class KafkaClusterIT extends AbstractClusterIT {
         List<Event> events = getEvents("Pod", kafkaPodName);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
+    }
+
+    /**
+     * Test the case where the TO is configured to watch a different namespace that it is deployed in
+     */
+    @Test
+    //@JUnitGroup(name = "regression")
+    @KafkaFromClasspathYaml
+    @Namespace(value = "topicOperatorNamespace", use = false)
+    public void testWatchingOtherNamespace() {
+        List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
+        assertThat(topics, not(hasItems("my-topic")));
+        kubeClient.namespace("topicOperatorNamespace");
+        kubeClient.create(new File("../examples/topic/kafka-topic.yaml"));
+        topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
+        assertThat(topics, hasItems("my-topic"));
     }
 }

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
@@ -13,6 +13,9 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
+    listeners:
+      plain: {}
+      tls: {}
   zookeeper:
     replicas: 1
     readinessProbe:

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
@@ -24,4 +24,4 @@ spec:
     storage:
       type: ephemeral
   topicOperator:
-    watchedNamespace: topicOperatorNamespace
+    watchedNamespace: topic-operator-namespace

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaClusterIT.testWatchingOtherNamespace.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 1
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    storage:
+      type: ephemeral
+  topicOperator:
+    watchedNamespace: topicOperatorNamespace


### PR DESCRIPTION
### Type of change

- Test

### Description

This PR adds a test that when the CO deploys a TO configured with a non-default `watchedNamespace` the TO thus deployed really is watching that namespace.

It also fixes the CO because this wasn't working before due to RBAC issue.

Fixes #414

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

