### PR TITLE
Fix some issues with example YAML files

### DIFF
--- a/examples/install/cluster-operator/01-ServiceAccount-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/01-ServiceAccount-strimzi-cluster-operator.yaml
@@ -1,12 +1,4 @@
-##---
-# Source: strimzi-kafka-operator/templates/01-ServiceAccount-strimzi-cluster-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: strimzi-cluster-operator
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: service-account
-    release: RELEASE-NAME
-    heritage: Tiller

--- a/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,15 +1,7 @@
-##---
-# Source: strimzi-kafka-operator/templates/02-ClusterRole-strimzi-cluster-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: role
-    release: RELEASE-NAME
-    heritage: Tiller
 rules:
 - apiGroups:
   - ""

--- a/examples/install/cluster-operator/02-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/02-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -1,19 +1,11 @@
-##---
-# Source: strimzi-kafka-operator/templates/02-ClusterRoleBinding-strimzi-cluster-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: role-binding
-    release: RELEASE-NAME
-    heritage: Tiller
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: default
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator

--- a/examples/install/cluster-operator/03-ClusterRole-strimzi-kafka-broker.yaml
+++ b/examples/install/cluster-operator/03-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,15 +1,7 @@
-##---
-# Source: strimzi-kafka-operator/templates/03-ClusterRole-strimzi-kafka-broker.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: strimzi-kafka-broker
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: broker-role
-    release: RELEASE-NAME
-    heritage: Tiller
 rules:
 - apiGroups:
   - ""

--- a/examples/install/cluster-operator/03-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/examples/install/cluster-operator/03-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -1,19 +1,11 @@
-##---
-# Source: strimzi-kafka-operator/templates/03-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator-kafka-broker-delegation
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: broker-role-binding
-    release: RELEASE-NAME
-    heritage: Tiller
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: default
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-kafka-broker

--- a/examples/install/cluster-operator/04-ClusterRole-strimzi-topic-operator.yaml
+++ b/examples/install/cluster-operator/04-ClusterRole-strimzi-topic-operator.yaml
@@ -1,15 +1,7 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-ClusterRole-strimzi-topic-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: strimzi-topic-operator
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: topic-operator-role
-    release: RELEASE-NAME
-    heritage: Tiller
 rules:
 - apiGroups:
   - "kafka.strimzi.io"

--- a/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,19 +1,11 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-ClusterRoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator-topic-operator-delegation
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: topic-operator-role-binding
-    release: RELEASE-NAME
-    heritage: Tiller
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: default
+    namespace: myproject
 roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -1,16 +1,8 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-Crd-kafka.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkas.kafka.strimzi.io
-  labels:
-    app: 'strimzi-kafka-operator'
-    chart: 'strimzi-kafka-operator-0.1.0'
-    component: kafkas.kafka.strimzi.io-crd
-    release: 'RELEASE-NAME'
-    heritage: 'Tiller'
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -1,16 +1,8 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkaconnects.kafka.strimzi.io
-  labels:
-    app: 'strimzi-kafka-operator'
-    chart: 'strimzi-kafka-operator-0.1.0'
-    component: kafkaconnects.kafka.strimzi.io-crd
-    release: 'RELEASE-NAME'
-    heritage: 'Tiller'
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -1,16 +1,8 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkaconnects2is.kafka.strimzi.io
-  labels:
-    app: 'strimzi-kafka-operator'
-    chart: 'strimzi-kafka-operator-0.1.0'
-    component: kafkaconnects2is.kafka.strimzi.io-crd
-    release: 'RELEASE-NAME'
-    heritage: 'Tiller'
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
@@ -1,16 +1,7 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-Crd-kafkatopic.yaml
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkatopics.kafka.strimzi.io
-  labels:
-    app: 'strimzi-kafka-operator'
-    chart: 'strimzi-kafka-operator-0.1.0'
-    component: kafkatopics.kafka.strimzi.io-crd
-    release: 'RELEASE-NAME'
-    heritage: 'Tiller'
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -1,16 +1,8 @@
-##---
-# Source: strimzi-kafka-operator/templates/04-Crd-kafkauser.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkausers.kafka.strimzi.io
-  labels:
-    app: 'strimzi-kafka-operator'
-    chart: 'strimzi-kafka-operator-0.1.0'
-    component: kafkausers.kafka.strimzi.io-crd
-    release: 'RELEASE-NAME'
-    heritage: 'Tiller'
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
@@ -1,15 +1,7 @@
-##---
-# Source: strimzi-kafka-operator/templates/05-Deployment-strimzi-cluster-operator.yaml
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: strimzi-cluster-operator
-  labels:
-    app: strimzi-kafka-operator
-    chart: strimzi-kafka-operator-0.1.0
-    component: deployment
-    release: RELEASE-NAME
-    heritage: Tiller
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

The Helm Charts PR introduced some changes to the example files for installing the Cluster operator. Mainly it changed the namespace it is using from `myproject` to `default`. This PR reverts these changes.
