### PR TITLE
Fail CI when derived resources differ from committed

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -11,9 +11,10 @@ export DOCKER_TAG=$COMMIT
 make docker_build
 
 CHANGED_DERIVED=$(git diff --name-status -- examples/ helm-charts/)
-if [ -n $CHANGED_DERIVED ] ; then
-  echo $CHANGED_DERIVED
-  echo "Uncommitted changes in derived resources: Run the following to add up-to-date resources:"
+if [ -n "$CHANGED_DERIVED" ] ; then
+  echo "Uncommitted changes in derived resources:"
+  echo "$CHANGED_DERIVED"
+  echo "Run the following to add up-to-date resources:"
   echo "  mvn clean verify -DskipTests -DskipITs \\"
   echo "    && git add examples/ helm-charts/"
   echo "    && git commit -m 'Update derived resources'"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -10,6 +10,16 @@ export DOCKER_TAG=$COMMIT
 
 make docker_build
 
+CHANGED_DERIVED=$(git diff --name-status -- examples/ helm-charts/)
+if [ -n $CHANGED_DERIVED ] ; then
+  echo $CHANGED_DERIVED
+  echo "Uncommitted changes in derived resources: Run the following to add up-to-date resources:"
+  echo "  mvn clean verify -DskipTests -DskipITs \\"
+  echo "    && git add examples/ helm-charts/"
+  echo "    && git commit -m 'Update derived resources'"
+  exit 1
+fi
+
 # Use local registry for system tests
 OLD_DOCKER_REGISTRY=$DOCKER_REGISTRY
 export DOCKER_REGISTRY="localhost:5000"


### PR DESCRIPTION
### Type of change

- CI change

### Description

Fail the CI build if the build generates CRs which differ from those in `git`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

