### PR TITLE
Use InvalidConfigurationException in ClusterOperatorConfig

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.strimzi.operator.common.InvalidConfigurationException;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -51,7 +53,7 @@ public class ClusterOperatorConfig {
         String namespacesList = map.get(ClusterOperatorConfig.STRIMZI_NAMESPACE);
         Set<String> namespaces;
         if (namespacesList == null || namespacesList.isEmpty()) {
-            throw new IllegalArgumentException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " cannot be null");
+            throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " cannot be null");
         } else {
             namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.model.Labels;
 
 import org.junit.Test;
@@ -89,7 +90,7 @@ public class ClusterOperatorConfigTest {
         assertEquals(30_000, config.getOperationTimeoutMs());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidConfigurationException.class)
     public void testNoNamespace() {
 
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
@@ -98,7 +99,7 @@ public class ClusterOperatorConfigTest {
         ClusterOperatorConfig.fromMap(envVars);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidConfigurationException.class)
     public void testEmptyEnvVars() {
 
         ClusterOperatorConfig.fromMap(Collections.emptyMap());


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- ~~Enhancement / new feature~~
- Refactoring
- ~~Documentation~~

### Description

This is a minor PR which replaces the `IllegalArgumentException` exception with the new shared `InvalidConfigurationException` class.