### PR TITLE
Moving Kafka Connect bootstrap servers as CR spec field

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
@@ -165,7 +165,7 @@ public class KafkaConnectAssemblySpec implements Serializable {
         this.tolerations = tolerations;
     }
 
-    @Description("Bootstrap servers to connect to")
+    @Description("Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:\u200D_<port>_ pairs.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public String getBootstrapServers() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAssemblySpec.java
@@ -36,7 +36,7 @@ public class KafkaConnectAssemblySpec implements Serializable {
     public static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE", "strimzi/kafka-connect:latest");
 
-    public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest.";
+    public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers";
 
     private Map<String, Object> config = new HashMap<>(0);
 
@@ -50,6 +50,7 @@ public class KafkaConnectAssemblySpec implements Serializable {
     private Map<String, Object> metrics = new HashMap<>(0);
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private String bootstrapServers;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The number of pods in the Kafka Connect group.")
@@ -59,7 +60,6 @@ public class KafkaConnectAssemblySpec implements Serializable {
     }
 
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
-    @JsonProperty(required = true)
     public Map<String, Object> getConfig() {
         return config;
     }
@@ -163,6 +163,17 @@ public class KafkaConnectAssemblySpec implements Serializable {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("Bootstrap servers to connect to")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
     }
 
     @JsonAnyGetter

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -46,7 +46,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
         try {
             createDelete(KafkaConnectAssembly.class, "KafkaConnectAssembly-with-missing-required-property.yaml");
         } catch (KubeClusterException.InvalidResource e) {
-            assertTrue(e.getMessage(), e.getMessage().contains("spec.config in body is required"));
+            assertTrue(e.getMessage(), e.getMessage().contains("spec.bootstrapServers in body is required"));
         }
     }
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-minimal.yaml
@@ -3,5 +3,4 @@ kind: KafkaConnect
 metadata:
   name: test-kafka-connect
 spec:
-  config:
-    name: bar
+  bootstrapServers: kafka:9092

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-extra-property.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   image: foo
   replicas: 6
+  bootstrapServers: kafka:9092
   config:
     name: bar
   extra: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-invalid-resource-memory.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-invalid-resource-memory.yaml
@@ -5,5 +5,6 @@ metadata:
 spec:
   image: foo
   replicas: oops, this is not an int
+  bootstrapServers: kafka:9092
   config:
     name: bar

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly-with-missing-required-property.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   image: foo
   replicas: 6
+  config:
+    name: bar

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.out.yaml
@@ -23,3 +23,4 @@ spec:
   metrics: {}
   config:
     name: "bar"
+  bootstrapServers: "kafka:9092"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnectAssembly.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   image: foo
   replicas: 6
+  bootstrapServers: kafka:9092
   config:
     name: bar
   tolerations:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/InvalidConfigParameterException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/InvalidConfigParameterException.java
@@ -5,10 +5,10 @@
 
 package io.strimzi.operator.cluster;
 
-public class InvalidConfigMapException extends RuntimeException {
+public class InvalidConfigParameterException extends RuntimeException {
 
     private String key;
-    public InvalidConfigMapException(String key, String message) {
+    public InvalidConfigParameterException(String key, String message) {
         super(key + message);
         this.key = key;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -5,7 +5,7 @@
 
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.operator.cluster.InvalidConfigMapException;
+import io.strimzi.operator.cluster.InvalidConfigParameterException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -81,10 +81,10 @@ public abstract class AbstractConfiguration {
                 map.put(key, String.valueOf(value));
             } else if (value == null) {
                 log.error("A null value for key {} is not allowed", key);
-                throw new InvalidConfigMapException(key, "A null value is not allowed for this key");
+                throw new InvalidConfigParameterException(key, "A null value is not allowed for this key");
             } else  {
                 log.error("Unsupported type {} in configuration for key {}", value.getClass(), key);
-                throw new InvalidConfigMapException(key, " - Unsupported type " + value.getClass() + " in configuration for this key");
+                throw new InvalidConfigParameterException(key, " - Unsupported type " + value.getClass() + " in configuration for this key");
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -77,8 +77,11 @@ public abstract class AbstractConfiguration {
 
             if (value instanceof String)    {
                 map.put(key, (String) value);
-            } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean || value instanceof Double || value instanceof Float)    {
+            } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean || value instanceof Double || value instanceof Float) {
                 map.put(key, String.valueOf(value));
+            } else if (value == null) {
+                log.error("A null value for key {} is not allowed", key);
+                throw new InvalidConfigMapException(key, "A null value is not allowed for this key");
             } else  {
                 log.error("Unsupported type {} in configuration for key {}", value.getClass(), key);
                 throw new InvalidConfigMapException(key, " - Unsupported type " + value.getClass() + " in configuration for this key");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -50,7 +50,9 @@ public class KafkaConnectCluster extends AbstractModel {
     // Kafka Connect configuration keys (EnvVariables)
     protected static final String ENV_VAR_KAFKA_CONNECT_CONFIGURATION = "KAFKA_CONNECT_CONFIGURATION";
     protected static final String ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED = "KAFKA_CONNECT_METRICS_ENABLED";
-    protected static final String ENV_VAR_KAFKA_CONNECT_LOGGING = "KAFKA_CONNECT_LOGGING";
+    protected static final String ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS = "KAFKA_CONNECT_BOOTSTRAP_SERVERS";
+
+    protected String bootstrapServers;
 
     /**
      * Constructor
@@ -130,6 +132,7 @@ public class KafkaConnectCluster extends AbstractModel {
             }
             kafkaConnect.setUserAffinity(spec.getAffinity());
             kafkaConnect.setTolerations(spec.getTolerations());
+            kafkaConnect.setBootstrapServers(spec.getBootstrapServers());
         }
         return kafkaConnect;
     }
@@ -213,6 +216,7 @@ public class KafkaConnectCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_CONFIGURATION, configuration.getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS, bootstrapServers));
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);
         return varList;
@@ -221,5 +225,13 @@ public class KafkaConnectCluster extends AbstractModel {
     @Override
     protected String getDefaultLogConfigFileName() {
         return "kafkaConnectDefaultLoggingProperties";
+    }
+
+    /**
+     * Set the bootstrap servers to connect to
+     * @param bootstrapServers bootstrap servers comma separated list
+     */
+    protected void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -17,7 +17,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.certs.Subject;
-import io.strimzi.operator.cluster.InvalidConfigMapException;
+import io.strimzi.operator.cluster.InvalidConfigParameterException;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -235,7 +235,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                     lock.release();
                                     log.debug("{}: Lock {} released", reconciliation, lockName);
                                     if (createResult.failed()) {
-                                        if (createResult.cause() instanceof InvalidConfigMapException) {
+                                        if (createResult.cause() instanceof InvalidConfigParameterException) {
                                             log.error(createResult.cause().getMessage());
                                         } else {
                                             log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());
@@ -380,7 +380,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
             log.info("{}: Assembly reconciled", reconciliation);
         } else {
             Throwable cause = result.cause();
-            if (cause instanceof InvalidConfigMapException) {
+            if (cause instanceof InvalidConfigParameterException) {
                 log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
             } else {
                 log.warn("{}: Failed to reconcile", reconciliation, cause);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -284,12 +284,13 @@ public class ResourceUtils {
      */
     public static KafkaConnectS2IAssembly createKafkaConnectS2ICluster(String clusterCmNamespace, String clusterCmName, int replicas,
                                                                        String image, int healthDelay, int healthTimeout, String metricsCmJson,
-                                                                       String connectConfig, boolean insecureSourceRepo) {
+                                                                       String connectConfig, boolean insecureSourceRepo, String bootstrapServers) {
 
         return new KafkaConnectS2IAssemblyBuilder(createEmptyKafkaConnectS2ICluster(clusterCmNamespace, clusterCmName))
                 .withNewSpec()
                     .withImage(image)
                     .withReplicas(replicas)
+                    .withBootstrapServers(bootstrapServers)
                     .withLivenessProbe(new Probe(healthDelay, healthTimeout))
                     .withReadinessProbe(new Probe(healthDelay, healthTimeout))
                     .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -7,7 +7,7 @@ package io.strimzi.operator.cluster.model;
 import java.util.List;
 import java.util.Properties;
 
-import io.strimzi.operator.cluster.InvalidConfigMapException;
+import io.strimzi.operator.cluster.InvalidConfigParameterException;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
@@ -194,7 +194,7 @@ public class AbstractConfigurationTest {
         try {
             AbstractConfiguration config = new TestConfiguration(configuration);
             fail("Expected it to throw an exception");
-        } catch (InvalidConfigMapException e) {
+        } catch (InvalidConfigParameterException e) {
             assertEquals("var3", e.getKey());
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -12,10 +12,8 @@ import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.strimzi.api.kafka.model.KafkaConnectAssembly;
 import io.strimzi.api.kafka.model.KafkaConnectAssemblyBuilder;
 import io.strimzi.api.kafka.model.Probe;
-import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,7 +59,6 @@ public class KafkaConnectClusterTest {
             "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
 
-    private CertManager certManager = new MockCertManager();
     private final KafkaConnectAssembly resource = new KafkaConnectAssemblyBuilder(ResourceUtils.createEmptyKafkaConnectCluster(namespace, cluster))
             .withNewSpec()
             .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))
@@ -120,7 +117,7 @@ public class KafkaConnectClusterTest {
     }
 
     @Test
-    public void testFromConfigMap() {
+    public void testFromCrd() {
         assertEquals(replicas, kc.replicas);
         assertEquals(image, kc.image);
         assertEquals(healthDelay, kc.readinessInitialDelay);
@@ -128,6 +125,7 @@ public class KafkaConnectClusterTest {
         assertEquals(healthDelay, kc.livenessInitialDelay);
         assertEquals(healthTimeout, kc.livenessTimeout);
         assertEquals(expectedConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(bootstrapServers, kc.bootstrapServers);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -38,6 +38,7 @@ public class KafkaConnectClusterTest {
     private final int healthTimeout = 10;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
+    private final String bootstrapServers = "foo-kafka:9092";
     private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
             "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
             "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
@@ -69,6 +70,7 @@ public class KafkaConnectClusterTest {
             .withReplicas(replicas)
             .withReadinessProbe(new Probe(healthDelay, healthTimeout))
             .withLivenessProbe(new Probe(healthDelay, healthTimeout))
+            .withBootstrapServers(bootstrapServers)
             .endSpec()
             .build();
     private final KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(resource);
@@ -96,9 +98,10 @@ public class KafkaConnectClusterTest {
 
     protected List<EnvVar> getExpectedEnvVars() {
 
-        List<EnvVar> expected = new ArrayList<EnvVar>();
+        List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
         expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -43,6 +43,7 @@ public class KafkaConnectS2IClusterTest {
     private final int healthTimeout = 10;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
+    private final String bootstrapServers = "foo-kafka:9092";
     private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
             "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
             "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
@@ -67,7 +68,7 @@ public class KafkaConnectS2IClusterTest {
     private final boolean insecureSourceRepo = false;
 
     private final KafkaConnectS2IAssembly cm = ResourceUtils.createKafkaConnectS2ICluster(namespace, cluster, replicas, image,
-            healthDelay, healthTimeout, metricsCmJson, configurationJson, insecureSourceRepo);
+            healthDelay, healthTimeout, metricsCmJson, configurationJson, insecureSourceRepo, bootstrapServers);
     private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(cm);
 
     @Rule
@@ -92,6 +93,7 @@ public class KafkaConnectS2IClusterTest {
         List<EnvVar> expected = new ArrayList<EnvVar>();
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
         expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
@@ -112,7 +114,7 @@ public class KafkaConnectS2IClusterTest {
     }
 
     @Test
-    public void testFromConfigMap() {
+    public void testFromCrd() {
         assertEquals(kc.kafkaConnectClusterName(cluster) + ":latest", kc.image);
         assertEquals(replicas, kc.replicas);
         assertEquals(image, kc.sourceImageBaseName + ":" + kc.sourceImageTag);
@@ -121,6 +123,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(healthDelay, kc.livenessInitialDelay);
         assertEquals(healthTimeout, kc.livenessTimeout);
         assertEquals(expectedConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(bootstrapServers, kc.bootstrapServers);
         assertFalse(kc.isInsecureSourceRepository());
     }
 
@@ -218,7 +221,7 @@ public class KafkaConnectS2IClusterTest {
     @Test
     public void testInsecureSourceRepo() {
         KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(ResourceUtils.createKafkaConnectS2ICluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout,  metricsCmJson, configurationJson, true));
+                healthDelay, healthTimeout,  metricsCmJson, configurationJson, true, bootstrapServers));
 
         assertTrue(kc.isInsecureSourceRepository());
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -2,6 +2,8 @@
 
 # Write the config file
 cat <<EOF
+# Bootstrap servers
+bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
 # REST Listeners
 rest.port=8083
 rest.advertised.host.name=$(hostname -I)

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -397,32 +397,34 @@ Used in: <<type-KafkaConnectAssembly,`KafkaConnectAssembly`>>
 
 [options="header"]
 |====
-|Field                  |Description
-|replicas        1.2+<.<|The number of pods in the Kafka Connect group.
+|Field                    |Description
+|replicas          1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
-|image           1.2+<.<|The docker image for the pods.
+|image             1.2+<.<|The docker image for the pods.
 |string
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|livenessProbe     1.2+<.<|Pod liveness checking.
 |<<type-Probe,`Probe`>>
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe    1.2+<.<|Pod readiness checking.
 |<<type-Probe,`Probe`>>
-|jvmOptions      1.2+<.<|JVM Options for pods
+|jvmOptions        1.2+<.<|JVM Options for pods
 |<<type-JvmOptions,`JvmOptions`>>
-|affinity        1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
+|affinity          1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
-|tolerations     1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
+|tolerations       1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
-|logging         1.2+<.<|Logging configuration for Kafka Connect The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
+|logging           1.2+<.<|Logging configuration for Kafka Connect The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
 |<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
-|metrics         1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
+|metrics           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|config          1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest.
+|bootstrapServers  1.2+<.<|Bootstrap servers to connect to
+|string
+|config            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers
 |map
-|resources       1.2+<.<|Resource constraints (limits and requests).
+|resources         1.2+<.<|Resource constraints (limits and requests).
 |<<type-Resources,`Resources`>>
 |====
 
@@ -462,7 +464,9 @@ Used in: <<type-KafkaConnectS2IAssembly,`KafkaConnectS2IAssembly`>>
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics                   1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest.
+|bootstrapServers          1.2+<.<|Bootstrap servers to connect to
+|string
+|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers
 |map
 |insecureSourceRepository  1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
 |boolean

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -259,6 +259,8 @@ spec:
                   type: string
             metrics:
               type: object
+            bootstrapServers:
+              type: string
             config:
               type: object
             resources:
@@ -283,4 +285,4 @@ spec:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
           required:
-          - config
+          - bootstrapServers

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -235,6 +235,8 @@ spec:
                             type: string
             metrics:
               type: object
+            bootstrapServers:
+              type: string
             config:
               type: object
             insecureSourceRepository:
@@ -285,4 +287,4 @@ spec:
                   value:
                     type: string
           required:
-          - config
+          - bootstrapServers

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -10,7 +10,6 @@ spec:
   livenessProbe:
     initialDelaySeconds: 60
     timeoutSeconds: 5
-  config:
-    bootstrap.servers: my-cluster-kafka-bootstrap:9092
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
   metrics:
     lowercaseOutputName: true

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -10,7 +10,6 @@ spec:
   livenessProbe:
     initialDelaySeconds: 60
     timeoutSeconds: 5
-  config:
-    bootstrap.servers: my-cluster-kafka-bootstrap:9092
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
   metrics:
     lowercaseOutputName: true

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -83,8 +83,8 @@ objects:
     readinessProbe:
       initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
       timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    bootstrapServers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
     config:
-      bootstrap.servers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
       group.id: "${KAFKA_CONNECT_GROUP_ID}"
       offset.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-offsets"
       config.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-configs"

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -82,8 +82,8 @@ objects:
     readinessProbe:
       initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
       timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    bootstrapServers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
     config:
-      bootstrap.servers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
       group.id: "${KAFKA_CONNECT_GROUP_ID}"
       offset.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-offsets"
       config.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-configs"

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
@@ -265,6 +265,8 @@ spec:
                   type: string
             metrics:
               type: object
+            bootstrapServers:
+              type: string
             config:
               type: object
             resources:
@@ -289,4 +291,4 @@ spec:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
           required:
-          - config
+          - bootstrapServers

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
@@ -241,6 +241,8 @@ spec:
                             type: string
             metrics:
               type: object
+            bootstrapServers:
+              type: string
             config:
               type: object
             insecureSourceRepository:
@@ -291,4 +293,4 @@ spec:
                   value:
                     type: string
           required:
-          - config
+          - bootstrapServers

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -54,12 +54,10 @@ public class ConnectST extends AbstractST {
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
     public static final String CONNECT_CLUSTER_NAME = "my-cluster";
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka-bootstrap:9092";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED = KAFKA_CLUSTER_NAME + "-kafka-bootstrap\\:9092";
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
             "internal.key.converter.schemas.enable=false\\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
-            "bootstrap.servers=" + KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED + "\\n" +
             "config.storage.topic=connect-cluster-configs\\n" +
             "status.storage.topic=connect-cluster-status\\n" +
             "offset.storage.topic=connect-cluster-offsets\\n" +
@@ -92,6 +90,8 @@ public class ConnectST extends AbstractST {
         String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("my-cluster-connect-")).findFirst().get();
         String kafkaPodJson = kubeClient.getResourceAsJson("pod", podName);
 
+        assertEquals(KAFKA_CONNECT_BOOTSTRAP_SERVERS.replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
+                globalVariableJsonPathBuilder("KAFKA_CONNECT_BOOTSTRAP_SERVERS")));
         assertEquals(EXPECTED_CONFIG.replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
                 globalVariableJsonPathBuilder("KAFKA_CONNECT_CONFIGURATION")));
         testDockerImagesForKafkaConnect();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -174,12 +174,12 @@ public class ConnectST extends AbstractST {
         List<String> connectPods = kubeClient.listResourcesByLabel("pod", "strimzi.io/kind=KafkaConnect");
 
         String connectConfig = "{\n" +
-                "      \"bootstrap.servers\": \"" + KAFKA_CONNECT_BOOTSTRAP_SERVERS + "\",\n" +
                 "      \"config.storage.replication.factor\": \"1\",\n" +
                 "      \"offset.storage.replication.factor\": \"1\",\n" +
                 "      \"status.storage.replication.factor\": \"1\"\n" +
                 "    }";
         replaceKafkaConnectResource(CONNECT_CLUSTER_NAME, c -> {
+            c.getSpec().setBootstrapServers(KAFKA_CONNECT_BOOTSTRAP_SERVERS);
             c.getSpec().setConfig(TestUtils.fromJson(connectConfig, Map.class));
             c.getSpec().getLivenessProbe().setInitialDelaySeconds(61);
             c.getSpec().getReadinessProbe().setInitialDelaySeconds(61);
@@ -202,6 +202,8 @@ public class ConnectST extends AbstractST {
             assertThat(connectPodJson, containsString("config.storage.replication.factor=1"));
             assertThat(connectPodJson, containsString("offset.storage.replication.factor=1"));
             assertThat(connectPodJson, containsString("status.storage.replication.factor=1"));
+            assertThat(connectPodJson, hasJsonPath("$.spec.containers[*].env[?(@.name=='KAFKA_CONNECT_BOOTSTRAP_SERVERS')].value",
+                    hasItem(KAFKA_CONNECT_BOOTSTRAP_SERVERS)));
         }
     }
 

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.testDeployS2IWithMongoDBPlugin.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.testDeployS2IWithMongoDBPlugin.yaml
@@ -6,7 +6,7 @@ metadata:
     type: kafka-connect-s2i
 spec:
   replicas: 1
+  bootstrapServers: connect-s2i-tests-kafka-bootstrap:9092
   config:
-    bootstrap.servers: connect-s2i-tests-kafka-bootstrap:9092
     key.converter.schemas.enable: false
     value.converter.schemas.enable: false

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testDeployUndeploy.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testDeployUndeploy.yaml
@@ -6,5 +6,4 @@ metadata:
     type: kafka-connect
 spec:
   replicas: 1
-  config:
-    bootstrap.servers: connect-tests-kafka-bootstrap:9092
+  bootstrapServers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testForUpdateValuesInConnectCM.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testForUpdateValuesInConnectCM.yaml
@@ -4,11 +4,10 @@ metadata:
   name: my-cluster
 spec:
   replicas: 1
+  bootstrapServers: connect-tests-kafka-bootstrap:9092
   readinessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  config:
-    bootstrap.servers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testJvmAndResources.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jvm-resource
 spec:
   replicas: 1
+  bootstrapServers: connect-tests-kafka-bootstrap:9092
   resources:
     limits:
       memory: 400M
@@ -18,5 +19,3 @@ spec:
     "-XX": {
       "UseG1GC": "true"
     }
-  config:
-    bootstrap.servers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testKafkaConnectScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testKafkaConnectScaleUpScaleDown.yaml
@@ -4,5 +4,4 @@ metadata:
   name: my-cluster
 spec:
   replicas: 1
-  config:
-    bootstrap.servers: connect-tests-kafka-bootstrap:9092
+  bootstrapServers: connect-tests-kafka-bootstrap:9092

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testKafkaConnectWithFileSinkPlugin.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.testKafkaConnectWithFileSinkPlugin.yaml
@@ -6,7 +6,7 @@ metadata:
     type: kafka-connect
 spec:
   replicas: 1
+  bootstrapServers: connect-tests-kafka-bootstrap:9092
   config:
-    bootstrap.servers: connect-tests-kafka-bootstrap:9092
     key.converter.schemas.enable: false
     value.converter.schemas.enable: false


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR is part of a larger work around Kafka Connect in order to enable TLS and authentication. The first step is moving the "bootstrap.servers" parameter from the `spec.config` field (making it forbidden) to a `spec.bootstrapServers` field which is required.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

