### PR TITLE
Organization should not be in the subject when it is not set

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -41,8 +41,16 @@ public class Subject {
 
     @Override
     public String toString() {
-        return String.format("/O=%s/CN=%s",
-                organizationName,
-                commonName);
+        StringBuilder bldr = new StringBuilder();
+
+        if (organizationName != null)   {
+            bldr.append(String.format("/O=%s", organizationName));
+        }
+
+        if (commonName != null)   {
+            bldr.append(String.format("/CN=%s", commonName));
+        }
+
+        return bldr.toString();
     }
 }

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.certs;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubjectTests {
+    @Test
+    public void testSubjectToString()   {
+        Subject sbj = new Subject();
+        sbj.setCommonName("joe");
+        assertEquals("/CN=joe", sbj.toString());
+
+        sbj = new Subject();
+        sbj.setOrganizationName("MyOrg");
+        assertEquals("/O=MyOrg", sbj.toString());
+
+        sbj = new Subject();
+        sbj.setCommonName("joe");
+        sbj.setOrganizationName("MyOrg");
+        assertEquals("/O=MyOrg/CN=joe", sbj.toString());
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

Currently, when the Organization is not set in a certificate subject, it is still added to the certificate as `O=null`. This PR makes sure that the subject of the certificate contains only the fields which were set.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

