### PR TITLE
Make it possible to configure super users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Make it possible to enabled and disable:
   * Listeners
   * Authorization
-  * Authentication 
+  * Authentication
+* Configure Kafka _super users_ (`super.users` field in Kafka configuration) 
 * User operator
 * Kafka 2.0.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -5,6 +5,9 @@
 package io.strimzi.api.kafka.model;
 
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Example;
+
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
@@ -23,9 +26,23 @@ public class KafkaAuthorizationSimple extends KafkaAuthorization {
 
     public static final String TYPE_SIMPLE = "simple";
 
+    private List<String> superUsers;
+
     @Description("Must be `" + TYPE_SIMPLE + "`")
     @Override
     public String getType() {
         return TYPE_SIMPLE;
+    }
+
+    @Description("List of super users. Should contain list of user principals which should get unlimited access rights.")
+    @Example("- CN=my-user\n" +
+             "- CN=my-other-user")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<String> getSuperUsers() {
+        return superUsers;
+    }
+
+    public void setSuperUsers(List<String> superUsers) {
+        this.superUsers = superUsers;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -49,19 +49,9 @@ public class KafkaClusterSpec implements Serializable {
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE", "strimzi/kafka-stunnel:latest");
 
-    /*
-    // Forbidden prefixes were temporarily modified to allow configuration of Authentication and Authorization before we
-    // have UserOperator implemented.
-
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, authorizer., super.user";
-    */
-
-    public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener.name.replication., "
-            + "listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, "
-            + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
-            + "zookeeper.connect, zookeeper.set.acl, super.user";
 
     protected Storage storage;
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -20,6 +20,14 @@ spec:
           type: "tls"
     authorization:
       type: "simple"
+      superUsers:
+      - "CN=jakub"
+      - "CN=paolo"
+      - "CN=tom"
+      - "CN=stanislav"
+      - "CN=kyle"
+      - "CN=sergey"
+      - "CN=andryi"
     config:
       min.insync.replicas: 3
     brokerRackInitImage: "strimzi/kafka-init:latest"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
@@ -43,6 +43,14 @@ spec:
           type: tls
     authorization:
       type: simple
+      superUsers:
+        - CN=jakub
+        - CN=paolo
+        - CN=tom
+        - CN=stanislav
+        - CN=kyle
+        - CN=sergey
+        - CN=andryi
     metrics: {
         "lowercaseOutputName": true,
         "rules": [

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 
@@ -64,6 +65,7 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_CLIENTTLS_ENABLED = "KAFKA_CLIENTTLS_ENABLED";
     private static final String ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION = "KAFKA_CLIENTTLS_AUTHENTICATION";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_TYPE = "KAFKA_AUTHORIZATION_TYPE";
+    private static final String ENV_VAR_KAFKA_AUTHORIZATION_SUPER_USERS = "KAFKA_AUTHORIZATION_SUPER_USERS";
 
     protected static final int CLIENT_PORT = 9092;
     protected static final String CLIENT_PORT_NAME = "clients";
@@ -619,6 +621,12 @@ public class KafkaCluster extends AbstractModel {
 
         if (authorization != null && KafkaAuthorizationSimple.TYPE_SIMPLE.equals(authorization.getType()))  {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_AUTHORIZATION_TYPE, KafkaAuthorizationSimple.TYPE_SIMPLE));
+
+            KafkaAuthorizationSimple simpleAuthz = (KafkaAuthorizationSimple) authorization;
+            if (simpleAuthz.getSuperUsers() != null && simpleAuthz.getSuperUsers().size() > 0)  {
+                String superUsers = simpleAuthz.getSuperUsers().stream().map(e -> String.format("User:%s", e)).collect(Collectors.joining(";"));
+                varList.add(buildEnvVar(ENV_VAR_KAFKA_AUTHORIZATION_SUPER_USERS, superUsers));
+            }
         }
 
         return varList;

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Prepare super.users field
-KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
-ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
-SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;User:CN=${KAFKA_NAME},O=io.strimzi"
-
 #####
 # Configuring listeners
 #####
@@ -44,6 +39,15 @@ fi
 #####
 if [ "$KAFKA_AUTHORIZATION_TYPE" = "simple" ]; then
   AUTHORIZER_CLASS_NAME="kafka.security.auth.SimpleAclAuthorizer"
+
+  # Prepare super.users field
+  KAFKA_NAME=$(hostname | rev | cut -d "-" -f2- | rev)
+  ASSEMBLY_NAME=$(echo "${KAFKA_NAME}" | rev | cut -d "-" -f2- | rev)
+  SUPER_USERS="super.users=User:CN=${ASSEMBLY_NAME}-topic-operator,O=io.strimzi;User:CN=${KAFKA_NAME},O=io.strimzi"
+
+  if [ "$KAFKA_AUTHORIZATION_SUPER_USERS" ]; then
+    SUPER_USERS="${SUPER_USERS};${KAFKA_AUTHORIZATION_SUPER_USERS}"
+  fi
 else
   AUTHORIZER_CLASS_NAME=""
 fi

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -44,8 +44,13 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |listeners            1.2+<.<|Configures listeners of Kafka brokers
 |xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |authorization        1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple]
+<<<<<<< HEAD
 |xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`]
 |config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener.name.replication., listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, super.user
+=======
+|<<type-KafkaAuthorizationSimple,`KafkaAuthorizationSimple`>>
+|config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user
+>>>>>>> Make it possible to configure super users
 |map
 |rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
 |xref:type-Rack-{context}[`Rack`]
@@ -177,8 +182,10 @@ The `type` property is a discriminator that distinguishes the use of the type `K
 It must have the value `simple` for the type `KafkaAuthorizationSimple`.
 [options="header"]
 |====
-|Field        |Description
-|type  1.2+<.<|Must be `simple`
+|Field              |Description
+|superUsers  1.2+<.<|List of super users. Should contain list of user principals which should get unlimited access rights.
+|string array
+|type        1.2+<.<|Must be `simple`
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1,35 +1,35 @@
-[id='type-Kafka-{context}']
-### `Kafka` schema reference
+[[type-Kafka]]
+### `Kafka` kind v1alpha1 kafka.strimzi.io
 
 
 [options="header"]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the Kafka and Zookeeper clusters, and Topic Operator.
-|xref:type-KafkaSpec-{context}[`KafkaSpec`]
+|<<type-KafkaSpec,`KafkaSpec`>>
 |====
 
-[id='type-KafkaSpec-{context}']
-### `KafkaSpec` schema reference
+[[type-KafkaSpec]]
+### `KafkaSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-Kafka-{context}[`Kafka`]
+Used in: <<type-Kafka,`Kafka`>>
 
 
 [options="header"]
 |====
 |Field                 |Description
 |kafka          1.2+<.<|Configuration of the Kafka cluster
-|xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+|<<type-KafkaClusterSpec,`KafkaClusterSpec`>>
 |zookeeper      1.2+<.<|Configuration of the Zookeeper cluster
-|xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+|<<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 |topicOperator  1.2+<.<|Configuration of the Topic Operator
-|xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
+|<<type-TopicOperatorSpec,`TopicOperatorSpec`>>
 |====
 
-[id='type-KafkaClusterSpec-{context}']
-### `KafkaClusterSpec` schema reference
+[[type-KafkaClusterSpec]]
+### `KafkaClusterSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+Used in: <<type-KafkaSpec,`KafkaSpec`>>
 
 
 [options="header"]
@@ -40,20 +40,15 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |image                1.2+<.<|The docker image for the pods.
 |string
 |storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim]
-|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
+|<<type-EphemeralStorage,`EphemeralStorage`>>, <<type-PersistentClaimStorage,`PersistentClaimStorage`>>
 |listeners            1.2+<.<|Configures listeners of Kafka brokers
-|xref:type-KafkaListeners-{context}[`KafkaListeners`]
+|<<type-KafkaListeners,`KafkaListeners`>>
 |authorization        1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple]
-<<<<<<< HEAD
-|xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`]
-|config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener.name.replication., listener.name.clienttls.ssl.truststore, listener.name.clienttls.ssl.keystore, host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, super.user
-=======
 |<<type-KafkaAuthorizationSimple,`KafkaAuthorizationSimple`>>
 |config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user
->>>>>>> Make it possible to configure super users
 |map
 |rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
-|xref:type-Rack-{context}[`Rack`]
+|<<type-Rack,`Rack`>>
 |brokerRackInitImage  1.2+<.<|The image of the init container used for initializing the `broker.rack`.
 |string
 |affinity             1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
@@ -65,28 +60,28 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |livenessProbe        1.2+<.<|Pod liveness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |readinessProbe       1.2+<.<|Pod readiness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |jvmOptions           1.2+<.<|JVM Options for pods
-|xref:type-JvmOptions-{context}[`JvmOptions`]
+|<<type-JvmOptions,`JvmOptions`>>
 |resources            1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |metrics              1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
 |logging              1.2+<.<|Logging configuration for Kafka The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |tlsSidecar           1.2+<.<|TLS sidecar configuration
-|xref:type-Sidecar-{context}[`Sidecar`]
+|<<type-Sidecar,`Sidecar`>>
 |====
 
-[id='type-EphemeralStorage-{context}']
-### `EphemeralStorage` schema reference
+[[type-EphemeralStorage]]
+### `EphemeralStorage` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
-The `type` property is a discriminator that distinguishes the use of the type `EphemeralStorage` from xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`].
+The `type` property is a discriminator that distinguishes the use of the type `EphemeralStorage` from <<type-PersistentClaimStorage,`PersistentClaimStorage`>>.
 It must have the value `ephemeral` for the type `EphemeralStorage`.
 [options="header"]
 |====
@@ -95,13 +90,13 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 |string
 |====
 
-[id='type-PersistentClaimStorage-{context}']
-### `PersistentClaimStorage` schema reference
+[[type-PersistentClaimStorage]]
+### `PersistentClaimStorage` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
-The `type` property is a discriminator that distinguishes the use of the type `PersistentClaimStorage` from xref:type-EphemeralStorage-{context}[`EphemeralStorage`].
+The `type` property is a discriminator that distinguishes the use of the type `PersistentClaimStorage` from <<type-EphemeralStorage,`EphemeralStorage`>>.
 It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 [options="header"]
 |====
@@ -118,25 +113,25 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |string
 |====
 
-[id='type-KafkaListeners-{context}']
-### `KafkaListeners` schema reference
+[[type-KafkaListeners]]
+### `KafkaListeners` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>
 
 
 [options="header"]
 |====
 |Field         |Description
 |plain  1.2+<.<|Configures plain listener on port 9092.
-|xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`]
+|<<type-KafkaListenerPlain,`KafkaListenerPlain`>>
 |tls    1.2+<.<|Configures TLS listener on port 9093.
-|xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+|<<type-KafkaListenerTls,`KafkaListenerTls`>>
 |====
 
-[id='type-KafkaListenerPlain-{context}']
-### `KafkaListenerPlain` schema reference
+[[type-KafkaListenerPlain]]
+### `KafkaListenerPlain` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
+Used in: <<type-KafkaListeners,`KafkaListeners`>>
 
 
 [options="header"]
@@ -144,23 +139,23 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |Field|Description
 |====
 
-[id='type-KafkaListenerTls-{context}']
-### `KafkaListenerTls` schema reference
+[[type-KafkaListenerTls]]
+### `KafkaListenerTls` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
+Used in: <<type-KafkaListeners,`KafkaListeners`>>
 
 
 [options="header"]
 |====
 |Field                  |Description
 |authentication  1.2+<.<|Authorization configuration for Kafka brokers The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls]
-|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`]
+|<<type-KafkaListenerAuthenticationTls,`KafkaListenerAuthenticationTls`>>
 |====
 
-[id='type-KafkaListenerAuthenticationTls-{context}']
-### `KafkaListenerAuthenticationTls` schema reference
+[[type-KafkaListenerAuthenticationTls]]
+### `KafkaListenerAuthenticationTls` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+Used in: <<type-KafkaListenerTls,`KafkaListenerTls`>>
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationTls` from .
@@ -172,10 +167,10 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 |string
 |====
 
-[id='type-KafkaAuthorizationSimple-{context}']
-### `KafkaAuthorizationSimple` schema reference
+[[type-KafkaAuthorizationSimple]]
+### `KafkaAuthorizationSimple` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaAuthorizationSimple` from .
@@ -189,10 +184,10 @@ It must have the value `simple` for the type `KafkaAuthorizationSimple`.
 |string
 |====
 
-[id='type-Rack-{context}']
-### `Rack` schema reference
+[[type-Rack]]
+### `Rack` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>
 
 
 [options="header"]
@@ -202,10 +197,10 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |string
 |====
 
-[id='type-Probe-{context}']
-### `Probe` schema reference
+[[type-Probe]]
+### `Probe` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-KafkaConnectSpec,`KafkaConnectSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
 [options="header"]
@@ -217,10 +212,10 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 |integer
 |====
 
-[id='type-JvmOptions-{context}']
-### `JvmOptions` schema reference
+[[type-JvmOptions]]
+### `JvmOptions` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-KafkaConnectSpec,`KafkaConnectSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
 [options="header"]
@@ -234,25 +229,25 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 |string
 |====
 
-[id='type-Resources-{context}']
-### `Resources` schema reference
+[[type-Resources]]
+### `Resources` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-KafkaConnectSpec,`KafkaConnectSpec`>>, <<type-Sidecar,`Sidecar`>>, <<type-TopicOperatorSpec,`TopicOperatorSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
 [options="header"]
 |====
 |Field            |Description
 |limits    1.2+<.<|Resource limits applied at runtime.
-|xref:type-CpuMemory-{context}[`CpuMemory`]
+|<<type-CpuMemory,`CpuMemory`>>
 |requests  1.2+<.<|Resource requests applied during pod scheduling.
-|xref:type-CpuMemory-{context}[`CpuMemory`]
+|<<type-CpuMemory,`CpuMemory`>>
 |====
 
-[id='type-CpuMemory-{context}']
-### `CpuMemory` schema reference
+[[type-CpuMemory]]
+### `CpuMemory` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-Resources-{context}[`Resources`]
+Used in: <<type-Resources,`Resources`>>
 
 
 [options="header"]
@@ -264,13 +259,13 @@ Used in: xref:type-Resources-{context}[`Resources`]
 |string
 |====
 
-[id='type-InlineLogging-{context}']
-### `InlineLogging` schema reference
+[[type-InlineLogging]]
+### `InlineLogging` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-KafkaConnectSpec,`KafkaConnectSpec`>>, <<type-TopicOperatorSpec,`TopicOperatorSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
-The `type` property is a discriminator that distinguishes the use of the type `InlineLogging` from xref:type-ExternalLogging-{context}[`ExternalLogging`].
+The `type` property is a discriminator that distinguishes the use of the type `InlineLogging` from <<type-ExternalLogging,`ExternalLogging`>>.
 It must have the value `inline` for the type `InlineLogging`.
 [options="header"]
 |====
@@ -281,13 +276,13 @@ It must have the value `inline` for the type `InlineLogging`.
 |string
 |====
 
-[id='type-ExternalLogging-{context}']
-### `ExternalLogging` schema reference
+[[type-ExternalLogging]]
+### `ExternalLogging` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>, <<type-KafkaConnectSpec,`KafkaConnectSpec`>>, <<type-TopicOperatorSpec,`TopicOperatorSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
-The `type` property is a discriminator that distinguishes the use of the type `ExternalLogging` from xref:type-InlineLogging-{context}[`InlineLogging`].
+The `type` property is a discriminator that distinguishes the use of the type `ExternalLogging` from <<type-InlineLogging,`InlineLogging`>>.
 It must have the value `external` for the type `ExternalLogging`.
 [options="header"]
 |====
@@ -298,10 +293,10 @@ It must have the value `external` for the type `ExternalLogging`.
 |string
 |====
 
-[id='type-Sidecar-{context}']
-### `Sidecar` schema reference
+[[type-Sidecar]]
+### `Sidecar` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: <<type-KafkaClusterSpec,`KafkaClusterSpec`>>, <<type-TopicOperatorSpec,`TopicOperatorSpec`>>, <<type-ZookeeperClusterSpec,`ZookeeperClusterSpec`>>
 
 
 [options="header"]
@@ -310,13 +305,13 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Top
 |image      1.2+<.<|The docker image for the container
 |string
 |resources  1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |====
 
-[id='type-ZookeeperClusterSpec-{context}']
-### `ZookeeperClusterSpec` schema reference
+[[type-ZookeeperClusterSpec]]
+### `ZookeeperClusterSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+Used in: <<type-KafkaSpec,`KafkaSpec`>>
 
 
 [options="header"]
@@ -327,7 +322,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |image           1.2+<.<|The docker image for the pods.
 |string
 |storage         1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim]
-|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
+|<<type-EphemeralStorage,`EphemeralStorage`>>, <<type-PersistentClaimStorage,`PersistentClaimStorage`>>
 |config          1.2+<.<|The zookeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme
 |map
 |affinity        1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
@@ -339,25 +334,25 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |livenessProbe   1.2+<.<|Pod liveness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |readinessProbe  1.2+<.<|Pod readiness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |jvmOptions      1.2+<.<|JVM Options for pods
-|xref:type-JvmOptions-{context}[`JvmOptions`]
+|<<type-JvmOptions,`JvmOptions`>>
 |resources       1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |metrics         1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
 |logging         1.2+<.<|Logging configuration for Zookeeper The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |tlsSidecar      1.2+<.<|TLS sidecar configuration
-|xref:type-Sidecar-{context}[`Sidecar`]
+|<<type-Sidecar,`Sidecar`>>
 |====
 
-[id='type-TopicOperatorSpec-{context}']
-### `TopicOperatorSpec` schema reference
+[[type-TopicOperatorSpec]]
+### `TopicOperatorSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+Used in: <<type-KafkaSpec,`KafkaSpec`>>
 
 
 [options="header"]
@@ -376,30 +371,30 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |resources                       1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata
 |integer
 |tlsSidecar                      1.2+<.<|TLS sidecar configuration
-|xref:type-Sidecar-{context}[`Sidecar`]
+|<<type-Sidecar,`Sidecar`>>
 |logging                         1.2+<.<|Logging configuration The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |====
 
-[id='type-KafkaConnect-{context}']
-### `KafkaConnect` schema reference
+[[type-KafkaConnect]]
+### `KafkaConnect` kind v1alpha1 kafka.strimzi.io
 
 
 [options="header"]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the Kafka Connect deployment.
-|xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+|<<type-KafkaConnectSpec,`KafkaConnectSpec`>>
 |====
 
-[id='type-KafkaConnectSpec-{context}']
-### `KafkaConnectSpec` schema reference
+[[type-KafkaConnectSpec]]
+### `KafkaConnectSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
+Used in: <<type-KafkaConnect,`KafkaConnect`>>
 
 
 [options="header"]
@@ -410,11 +405,11 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |image             1.2+<.<|The docker image for the pods.
 |string
 |livenessProbe     1.2+<.<|Pod liveness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |readinessProbe    1.2+<.<|Pod readiness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |jvmOptions        1.2+<.<|JVM Options for pods
-|xref:type-JvmOptions-{context}[`JvmOptions`]
+|<<type-JvmOptions,`JvmOptions`>>
 |affinity          1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
 
 
@@ -424,7 +419,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |logging           1.2+<.<|Logging configuration for Kafka Connect The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |metrics           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
 |bootstrapServers  1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
@@ -432,24 +427,24 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |config            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers
 |map
 |resources         1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |====
 
-[id='type-KafkaConnectS2I-{context}']
-### `KafkaConnectS2I` schema reference
+[[type-KafkaConnectS2I]]
+### `KafkaConnectS2I` kind v1alpha1 kafka.strimzi.io
 
 
 [options="header"]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the Kafka Connect deployment.
-|xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`]
+|<<type-KafkaConnectS2IAssemblySpec,`KafkaConnectS2IAssemblySpec`>>
 |====
 
-[id='type-KafkaConnectS2IAssemblySpec-{context}']
-### `KafkaConnectS2IAssemblySpec` schema reference
+[[type-KafkaConnectS2IAssemblySpec]]
+### `KafkaConnectS2IAssemblySpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
+Used in: <<type-KafkaConnectS2I,`KafkaConnectS2I`>>
 
 
 [options="header"]
@@ -460,11 +455,11 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |image                     1.2+<.<|The docker image for the pods.
 |string
 |livenessProbe             1.2+<.<|Pod liveness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |readinessProbe            1.2+<.<|Pod readiness checking.
-|xref:type-Probe-{context}[`Probe`]
+|<<type-Probe,`Probe`>>
 |jvmOptions                1.2+<.<|JVM Options for pods
-|xref:type-JvmOptions-{context}[`JvmOptions`]
+|<<type-JvmOptions,`JvmOptions`>>
 |affinity                  1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity]
 
 
@@ -478,30 +473,30 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |insecureSourceRepository  1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
 |boolean
 |logging                   1.2+<.<|Logging configuration for Kafka Connect The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external]
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|<<type-InlineLogging,`InlineLogging`>>, <<type-ExternalLogging,`ExternalLogging`>>
 |resources                 1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
+|<<type-Resources,`Resources`>>
 |tolerations               1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations]
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |====
 
-[id='type-KafkaTopic-{context}']
-### `KafkaTopic` schema reference
+[[type-KafkaTopic]]
+### `KafkaTopic` kind v1alpha1 kafka.strimzi.io
 
 
 [options="header"]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the topic.
-|xref:type-KafkaTopicSpec-{context}[`KafkaTopicSpec`]
+|<<type-KafkaTopicSpec,`KafkaTopicSpec`>>
 |====
 
-[id='type-KafkaTopicSpec-{context}']
-### `KafkaTopicSpec` schema reference
+[[type-KafkaTopicSpec]]
+### `KafkaTopicSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
+Used in: <<type-KafkaTopic,`KafkaTopic`>>
 
 
 [options="header"]
@@ -517,34 +512,34 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |string
 |====
 
-[id='type-KafkaUser-{context}']
-### `KafkaUser` schema reference
+[[type-KafkaUser]]
+### `KafkaUser` kind v1alpha1 kafka.strimzi.io
 
 
 [options="header"]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the user.
-|xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
+|<<type-KafkaUserSpec,`KafkaUserSpec`>>
 |====
 
-[id='type-KafkaUserSpec-{context}']
-### `KafkaUserSpec` schema reference
+[[type-KafkaUserSpec]]
+### `KafkaUserSpec` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
+Used in: <<type-KafkaUser,`KafkaUser`>>
 
 
 [options="header"]
 |====
 |Field                  |Description
 |authentication  1.2+<.<|Authentication mechanism enabled for this Kafka user The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls]
-|xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`]
+|<<type-KafkaUserTlsClientAuthentication,`KafkaUserTlsClientAuthentication`>>
 |====
 
-[id='type-KafkaUserTlsClientAuthentication-{context}']
-### `KafkaUserTlsClientAuthentication` schema reference
+[[type-KafkaUserTlsClientAuthentication]]
+### `KafkaUserTlsClientAuthentication` type v1alpha1 kafka.strimzi.io
 
-Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
+Used in: <<type-KafkaUserSpec,`KafkaUserSpec`>>
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaUserTlsClientAuthentication` from .

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -57,6 +57,10 @@ spec:
                 authorization:
                   type: object
                   properties:
+                    superUsers:
+                      type: array
+                      items:
+                        type: string
                     type:
                       type: string
                 config:

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
@@ -62,6 +62,10 @@ spec:
                 authorization:
                   type: object
                   properties:
+                    superUsers:
+                      type: array
+                      items:
+                        type: string
                     type:
                       type: string
                 config:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~
- ~~Documentation~~

### Description

This PR adds possibility to configure some users as super users in Kafka configuration. It can be done using following YAML snippet:
```yaml
    authorization:
      type: "simple"
      superUsers:
      - "CN=jakub"
      - "CN=paolo"
      - "CN=tom"
      - "CN=stanislav"
      - "CN=kyle"
      - "CN=sergey"
      - "CN=andryi"
```

They will be passed as environment variable to the Docker images and added to the `super.users` list.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

