### PR TITLE
Docs: Fix context again

### DIFF
--- a/documentation/book/assembly-cluster-operator.adoc
+++ b/documentation/book/assembly-cluster-operator.adoc
@@ -25,11 +25,9 @@ The format of the `Kafka` resource is described in xref:kafka_assembly_details[F
 NOTE: {ProductName} contains example YAML files, which make deploying a Cluster Operator easier.
 
 ifdef::Kubernetes[]
-:context: str
 include::proc-deploying-cluster-operator-kubernetes.adoc[leveloffset=+1]
 endif::Kubernetes[]
 
-:context: str
 include::proc-deploying-cluster-operator-openshift.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -25,11 +25,9 @@ ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
 
 ifdef::Kubernetes[]
-:context: str
 include::proc-deploying-kafka-cluster-kubernetes.adoc[leveloffset=+1]
 endif::Kubernetes[]
 
-:context: str
 include::proc-deploying-kafka-cluster-openshift.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/book/assembly-overview.adoc
+++ b/documentation/book/assembly-overview.adoc
@@ -21,10 +21,8 @@ Topic Operator:: Responsible for managing Kafka topics within a Kafka cluster ru
 
 This guide describes how to install and use {ProductLongName}.
 
-:context: str
 include::ref-key-features.adoc[leveloffset=+1]
 
-:context: str
 include::ref-document-conventions.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -32,14 +32,11 @@ ifdef::Kubernetes[{KubernetesLongName} and]
 {OpenShiftLongName} user must have the rights to manage role-based access control (RBAC).
 
 ifdef::Downloading[]
-:context: str
 include::con-product-downloads.adoc[leveloffset=+1]
 endif::Downloading[]
 
-:context: str
 include::assembly-cluster-operator.adoc[leveloffset=+1]
 
-:context: str
 include::assembly-kafka-cluster.adoc[leveloffset=+1]
 
 === Deploying with Helm Charts
@@ -185,8 +182,8 @@ _The name of the build should be changed according to the cluster name of the de
 
 == Topic Operator
 
-{ProductName} uses a component called the Topic Operator to manage topics in the Kafka cluster. 
-The Topic Operator is deployed as a process running inside a {ProductPlatformName} cluster. 
+{ProductName} uses a component called the Topic Operator to manage topics in the Kafka cluster.
+The Topic Operator is deployed as a process running inside a {ProductPlatformName} cluster.
 To create a new Kafka topic, a `KafkaTopic` custom resource with the related configuration (name, partitions, replication factor, ...) has to be created.
 Based on the information in that `KafkaTopic`, the Topic Operator will create a corresponding Kafka topic in the cluster.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

_fix redefinitions of context & define context on master.adoc so it trickles down._
