### PR TITLE
Fix issues with labels, selectors and their changes - Closes #699

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -223,6 +223,11 @@ public abstract class AbstractModel {
         return headlessServiceName;
     }
 
+
+    protected Map<String, String> getSelectorLabels() {
+        return labels.withName(name).strimziLabels().toMap();
+    }
+
     protected Map<String, String> getLabelsWithName() {
         return getLabelsWithName(name);
     }
@@ -705,7 +710,7 @@ public abstract class AbstractModel {
                 .endMetadata()
                 .withNewSpec()
                     .withType(type)
-                    .withSelector(getLabelsWithName())
+                    .withSelector(getSelectorLabels())
                     .withPorts(ports)
                 .endSpec()
                 .build();
@@ -728,7 +733,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withType("ClusterIP")
                     .withClusterIP("None")
-                    .withSelector(getLabelsWithName())
+                    .withSelector(getSelectorLabels())
                     .withPorts(ports)
                 .endSpec()
                 .build();
@@ -791,7 +796,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withPodManagementPolicy("Parallel")
                     .withUpdateStrategy(new StatefulSetUpdateStrategyBuilder().withType("OnDelete").build())
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getLabelsWithName()).build())
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels()).build())
                     .withServiceName(headlessServiceName)
                     .withReplicas(replicas)
                     .withNewTemplate()
@@ -835,6 +840,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withStrategy(updateStrategy)
                     .withReplicas(replicas)
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels()).build())
                     .withNewTemplate()
                         .withNewMetadata()
                             .withLabels(getLabelsWithName())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -112,6 +112,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(replicas)
+                    .withSelector(getSelectorLabels())
                     .withNewTemplate()
                         .withNewMetadata()
                             .withAnnotations(annotations)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -77,6 +77,10 @@ public class KafkaClusterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster, "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster), Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
     }
 
+    private Map<String, String> expectedSelectorLabels()    {
+        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+    }
+
     @Test
     public void testGenerateService() {
         Service headful = kc.generateService();
@@ -85,7 +89,7 @@ public class KafkaClusterTest {
 
     private void checkService(Service headful) {
         assertEquals("ClusterIP", headful.getSpec().getType());
-        assertEquals(expectedLabels(), headful.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), headful.getSpec().getSelector());
         assertEquals(4, headful.getSpec().getPorts().size());
         assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headful.getSpec().getPorts().get(0).getPort());
@@ -112,7 +116,7 @@ public class KafkaClusterTest {
         assertEquals(KafkaCluster.headlessServiceName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
-        assertEquals(expectedLabels(), headless.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), headless.getSpec().getSelector());
         assertEquals(3, headless.getSpec().getPorts().size());
         assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headless.getSpec().getPorts().get(0).getPort());
@@ -200,6 +204,7 @@ public class KafkaClusterTest {
         assertEquals(namespace, ss.getMetadata().getNamespace());
         // ... with these labels
         assertEquals(expectedLabels(), ss.getMetadata().getLabels());
+        assertEquals(expectedSelectorLabels(), ss.getSpec().getSelector().getMatchLabels());
 
         List<Container> containers = ss.getSpec().getTemplate().getSpec().getContainers();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -89,6 +89,10 @@ public class KafkaConnectClusterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, name, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
     }
 
+    private Map<String, String> expectedSelectorLabels()    {
+        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+    }
+
     private Map<String, String> expectedLabels()    {
         return expectedLabels(kc.kafkaConnectClusterName(cluster));
     }
@@ -139,7 +143,7 @@ public class KafkaConnectClusterTest {
 
         assertEquals("ClusterIP", svc.getSpec().getType());
         assertEquals(expectedLabels(kc.getServiceName()), svc.getMetadata().getLabels());
-        assertEquals(expectedLabels(), svc.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
@@ -155,6 +159,7 @@ public class KafkaConnectClusterTest {
         assertEquals(namespace, dep.getMetadata().getNamespace());
         Map<String, String> expectedLabels = expectedLabels();
         assertEquals(expectedLabels, dep.getMetadata().getLabels());
+        assertEquals(expectedSelectorLabels(), dep.getSpec().getSelector().getMatchLabels());
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
         assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -91,6 +91,14 @@ public class KafkaConnectS2IClusterTest {
         return TestUtils.map("my-user-label", "cromulent", Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_NAME_LABEL, name, Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND);
     }
 
+    private Map<String, String> expectedSelectorLabels()    {
+        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+    }
+
+    private Map<String, String> expectedLabels()    {
+        return expectedLabels(kc.kafkaConnectClusterName(cluster));
+    }
+
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
@@ -140,7 +148,7 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals("ClusterIP", svc.getSpec().getType());
         assertEquals(expectedLabels(kc.serviceName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(expectedLabels(kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), svc.getSpec().getSelector());
         assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
@@ -156,6 +164,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(namespace, dep.getMetadata().getNamespace());
         Map<String, String> expectedLabels = expectedLabels(kc.kafkaConnectClusterName(cluster));
         assertEquals(expectedLabels, dep.getMetadata().getLabels());
+        assertEquals(expectedSelectorLabels(), dep.getSpec().getSelector());
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
         assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -67,6 +67,10 @@ public class ZookeeperClusterTest {
         assertEquals(TestUtils.toJsonString(metricsCmJson), metricsCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS));
     }
 
+    private Map<String, String> expectedSelectorLabels()    {
+        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+    }
+
     private Map<String, String> expectedLabels()    {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster, "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster), Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
     }
@@ -79,7 +83,7 @@ public class ZookeeperClusterTest {
 
     private void checkService(Service headful) {
         assertEquals("ClusterIP", headful.getSpec().getType());
-        assertEquals(expectedLabels(), headful.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), headful.getSpec().getSelector());
         assertEquals(2, headful.getSpec().getPorts().size());
         assertEquals(ZookeeperCluster.METRICS_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(1).getName());
@@ -99,7 +103,7 @@ public class ZookeeperClusterTest {
         assertEquals(ZookeeperCluster.headlessServiceName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
-        assertEquals(expectedLabels(), headless.getSpec().getSelector());
+        assertEquals(expectedSelectorLabels(), headless.getSpec().getSelector());
         assertEquals(3, headless.getSpec().getPorts().size());
         assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
@@ -123,6 +127,7 @@ public class ZookeeperClusterTest {
         assertEquals(namespace, ss.getMetadata().getNamespace());
         // ... with these labels
         assertEquals(expectedLabels(), ss.getMetadata().getLabels());
+        assertEquals(expectedSelectorLabels(), ss.getSpec().getSelector().getMatchLabels());
 
         List<Container> containers = ss.getSpec().getTemplate().getSpec().getContainers();
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -243,7 +243,7 @@ public class Labels {
     }
 
     public Labels strimziLabels() {
-        Map<String, String> newLabels = new HashMap<>(labels.size() + 1);
+        Map<String, String> newLabels = new HashMap<>(3);
 
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             if (entry.getKey().startsWith(STRIMZI_DOMAIN)) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -242,6 +242,18 @@ public class Labels {
         return type != null ? ResourceType.fromName(type) : null;
     }
 
+    public Labels strimziLabels() {
+        Map<String, String> newLabels = new HashMap<>(labels.size() + 1);
+
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            if (entry.getKey().startsWith(STRIMZI_DOMAIN)) {
+                newLabels.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return new Labels(newLabels);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -57,4 +57,22 @@ public class LabelsTest {
 
         Labels.fromString(invalidLabels);
     }
+
+    @Test
+    public void testStrimziLabels()   {
+        Map sourceMap = new HashMap<String, String>(5);
+        sourceMap.put(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster");
+        sourceMap.put("key1", "value1");
+        sourceMap.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
+        sourceMap.put("key2", "value2");
+        sourceMap.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
+        Labels labels = Labels.fromMap(sourceMap);
+
+        Map expected = new HashMap<String, String>(2);
+        expected.put(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster");
+        expected.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
+        expected.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
+
+        assertEquals(expected, labels.strimziLabels().toMap());
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

Label changes do not work. Also, to allow label changes, we need to use only our own labels for selectors to make sure that label changes do not decouple the pods from the services or statefulsets.

This PR:
- Add new method `strimziLabels` to the Labels class which filters only Srtrmzi labels from the map with all labels
- It uses these labels for all selectors. In services, deployments, deployment configs and stateful sets.

This should close the issue #699. I expect that the problem there was that CO errored on the selectors and didn't managed to get through to change the labels on other objects. Thsi should also close #122 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

