### PR TITLE
Fix NPE when topic contains no config

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -42,31 +42,35 @@ public class TopicSerialization {
 
     @SuppressWarnings("unchecked")
     private static Map<String, String> topicConfigFromTopicConfig(KafkaTopic kafkaTopic) {
-        Map<String, String> result = new HashMap<>(kafkaTopic.getSpec().getConfig().size());
-        for (Map.Entry<String, Object> entry : kafkaTopic.getSpec().getConfig().entrySet()) {
-            String key = entry.getKey();
-            Object v = entry.getValue();
-            boolean isNumberType = v instanceof Long
-                    || v instanceof Integer
-                    || v instanceof Short
-                    || v instanceof Double
-                    || v instanceof Float;
-            if (v instanceof String
-                    || isNumberType
-                    || v instanceof Boolean) {
-                result.put(key, v.toString());
-            } else {
-                String msg = "The value corresponding to the key must have a string, number or boolean value";
-                if (v == null) {
-                    msg += " but the value was null";
+        if (kafkaTopic.getSpec().getConfig() != null) {
+            Map<String, String> result = new HashMap<>(kafkaTopic.getSpec().getConfig().size());
+            for (Map.Entry<String, Object> entry : kafkaTopic.getSpec().getConfig().entrySet()) {
+                String key = entry.getKey();
+                Object v = entry.getValue();
+                boolean isNumberType = v instanceof Long
+                        || v instanceof Integer
+                        || v instanceof Short
+                        || v instanceof Double
+                        || v instanceof Float;
+                if (v instanceof String
+                        || isNumberType
+                        || v instanceof Boolean) {
+                    result.put(key, v.toString());
                 } else {
-                    msg += " but was of type " + v.getClass().getName();
+                    String msg = "The value corresponding to the key must have a string, number or boolean value";
+                    if (v == null) {
+                        msg += " but the value was null";
+                    } else {
+                        msg += " but was of type " + v.getClass().getName();
+                    }
+                    throw new InvalidTopicException(kafkaTopic, "KafkaTopic's spec.config has invalid entry: " +
+                            "The key '" + key + "' of the topic config is invalid: " + msg);
                 }
-                throw new InvalidTopicException(kafkaTopic, "KafkaTopic's spec.config has invalid entry: " +
-                        "The key '" + key + "' of the topic config is invalid: " + msg);
             }
+            return result;
+        } else {
+            return Collections.EMPTY_MAP;
         }
-        return result;
     }
 
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
@@ -7,6 +7,8 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.KafkaTopicSpec;
+
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -257,5 +259,16 @@ public class TopicSerializationTest {
         }
     }
 
+    @Test
+    public void testNoConfig() {
+        KafkaTopicSpec spec = new KafkaTopicSpec();
+        spec.setPartitions(3);
+        spec.setReplicas(3);
+        KafkaTopic kafkaTopic = new KafkaTopic();
+        kafkaTopic.setMetadata(new ObjectMetaBuilder().withName("my-topic").build());
+        kafkaTopic.setSpec(spec);
+
+        TopicSerialization.fromTopicResource(kafkaTopic);
+    }
 }
 


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

When the KafkaTopic resource doesn't contain any config field, the Topic Operator will NPE and not create it. Using a default topic config is valid situation and the TO should be able to handle this. Tis PR fixes the NPE and adds test for this situation.

This should fix issue #706 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

