### PR TITLE
Added spcification for TLS and Authentication in the Kafka Connect CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
@@ -24,7 +24,6 @@ public class CertAndKeySecretSource extends CertSecretSource {
     protected String key;
 
     @Description("The name of the private key in the Secret.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public String getKey() {
         return key;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Represents a certificate and private key pair inside a Secret
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CertAndKeySecretSource extends CertSecretSource {
+    private static final long serialVersionUID = 1L;
+
+    protected String key;
+
+    @Description("The name of the private key in the Secret.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
@@ -33,7 +33,6 @@ public class CertSecretSource implements Serializable {
     protected Map<String, Object> additionalProperties;
 
     @Description("The name of the Secret containing the certificate.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public String getSecretName() {
         return secretName;
@@ -44,7 +43,6 @@ public class CertSecretSource implements Serializable {
     }
 
     @Description("The name of the file certificate in the Secret.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public String getCertificate() {
         return certificate;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a certificate inside a Secret
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CertSecretSource implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected String secretName;
+    protected String certificate;
+
+    protected Map<String, Object> additionalProperties;
+
+    @Description("The name of the Secret containing the certificate.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    public String getSecretName() {
+        return secretName;
+    }
+
+    public void setSecretName(String secretName) {
+        this.secretName = secretName;
+    }
+
+    @Description("The name of the file certificate in the Secret.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    public String getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -232,7 +232,6 @@ public class KafkaClusterSpec implements Serializable {
     }
 
     @Description("Configures listeners of Kafka brokers")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public KafkaListeners getListeners() {
         return listeners;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures the Kafka Connect authentication
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = KafkaConnectAuthenticationTls.TYPE_TLS, value = KafkaConnectAuthenticationTls.class),
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class KafkaConnectAuthentication implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @Description("Authentication type. " +
+            "Currently the only supported type is `tls`. " +
+            "`tls` type uses TLS Client Authentication. ")
+    @JsonIgnore
+    public abstract String getType();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Configures the Kafka Connect authentication
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaConnectAuthenticationTls extends KafkaConnectAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_TLS = "tls";
+
+    private CertAndKeySecretSource certificate;
+
+    @Description("Must be `" + TYPE_TLS + "`")
+    @Override
+    public String getType() {
+        return TYPE_TLS;
+    }
+
+    @Description("Certificate and private key pair for TLS authentication.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public CertAndKeySecretSource getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(CertAndKeySecretSource certificate) {
+        this.certificate = certificate;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -22,7 +23,7 @@ public class KafkaConnectAuthenticationTls extends KafkaConnectAuthentication {
 
     public static final String TYPE_TLS = "tls";
 
-    private CertAndKeySecretSource certificate;
+    private CertAndKeySecretSource certificateAndKey;
 
     @Description("Must be `" + TYPE_TLS + "`")
     @Override
@@ -31,12 +32,12 @@ public class KafkaConnectAuthenticationTls extends KafkaConnectAuthentication {
     }
 
     @Description("Certificate and private key pair for TLS authentication.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public CertAndKeySecretSource getCertificate() {
-        return certificate;
+    @JsonProperty(required = true)
+    public CertAndKeySecretSource getCertificateAndKey() {
+        return certificateAndKey;
     }
 
-    public void setCertificate(CertAndKeySecretSource certificate) {
-        this.certificate = certificate;
+    public void setCertificateAndKey(CertAndKeySecretSource certificateAndKey) {
+        this.certificateAndKey = certificateAndKey;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -168,7 +168,6 @@ public class KafkaConnectSpec implements Serializable {
     }
 
     @Description("Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:\u200D_<port>_ pairs.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(required = true)
     public String getBootstrapServers() {
         return bootstrapServers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -51,6 +51,8 @@ public class KafkaConnectSpec implements Serializable {
     private Affinity affinity;
     private List<Toleration> tolerations;
     private String bootstrapServers;
+    private KafkaConnectTls tls;
+    private KafkaConnectAuthentication authentication;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The number of pods in the Kafka Connect group.")
@@ -174,6 +176,26 @@ public class KafkaConnectSpec implements Serializable {
 
     public void setBootstrapServers(String bootstrapServers) {
         this.bootstrapServers = bootstrapServers;
+    }
+
+    @Description("TLS configuration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaConnectTls getTls() {
+        return tls;
+    }
+
+    public void setTls(KafkaConnectTls tls) {
+        this.tls = tls;
+    }
+
+    @Description("Authentication configuration for Kafka Connect")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaConnectAuthentication getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(KafkaConnectAuthentication authentication) {
+        this.authentication = authentication;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -33,7 +34,7 @@ public class KafkaConnectTls implements Serializable {
     private Map<String, Object> additionalProperties;
 
     @Description("Trusted certificates for TLS connection")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
     public List<CertSecretSource> getTrustedCertificates() {
         return trustedCertificates;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Represent the TLS configuration for Kafka Connect
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaConnectTls implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<CertSecretSource> trustedCertificates;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Trusted certificates for TLS connection")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<CertSecretSource> getTrustedCertificates() {
+        return trustedCertificates;
+    }
+
+    public void setTrustedCertificates(List<CertSecretSource> trustedCertificates) {
+        this.trustedCertificates = trustedCertificates;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -59,4 +59,23 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
         }
     }
 
+    @Test
+    public void testKafkaWithTls() {
+        createDelete(KafkaConnect.class, "KafkaConnect-with-tls.yaml");
+    }
+
+    @Test
+    public void testKafkaWithTlsAuth() {
+        createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth.yaml");
+    }
+
+    @Test
+    public void testKafkaWithTlsAuthWithMissingRequired() {
+        try {
+            createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.authentication.certificateAndKey.certificate in body is required"));
+            assertTrue(e.getMessage().contains("spec.authentication.certificateAndKey.key in body is required"));
+        }
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth-with-missing-required.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: test-kafka-connect
+spec:
+  image: foo
+  replicas: 6
+  bootstrapServers: kafka:9092
+  config:
+    name: bar
+  tolerations:
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
+    - key: "key2"
+      operator: "Equal"
+      value: "value2"
+      effect: "NoSchedule"
+  tls:
+    trustedCertificates:
+      - secretName: my-secret
+        certificate: ca.crt
+  authentication:
+    type: tls
+    certificateAndKey:
+      secretName: my-user-secret

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth.yaml
@@ -1,0 +1,29 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: test-kafka-connect
+spec:
+  image: foo
+  replicas: 6
+  bootstrapServers: kafka:9092
+  config:
+    name: bar
+  tolerations:
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
+    - key: "key2"
+      operator: "Equal"
+      value: "value2"
+      effect: "NoSchedule"
+  tls:
+    trustedCertificates:
+      - secretName: my-secret
+        certificate: ca.crt
+  authentication:
+    type: tls
+    certificateAndKey:
+      secretName: my-user-secret
+      key: user.key
+      certificate: user.crt

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: test-kafka-connect
+spec:
+  image: foo
+  replicas: 6
+  bootstrapServers: kafka:9092
+  config:
+    name: bar
+  tolerations:
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
+    - key: "key2"
+      operator: "Equal"
+      value: "value2"
+      effect: "NoSchedule"
+  tls:
+    trustedCertificates:
+      - secretName: my-secret
+        certificate: ca.crt
+      - secretName: my-another-secret
+        certificate: another-ca.crt

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -425,12 +425,78 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |metrics           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
+|authentication    1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
+|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`]
 |bootstrapServers  1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
 |config            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers.
 |map
 |resources         1.2+<.<|Resource constraints (limits and requests).
 |xref:type-Resources-{context}[`Resources`]
+|tls               1.2+<.<|TLS configuration.
+|xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
+|====
+
+[id='type-KafkaConnectAuthenticationTls-{context}']
+### `KafkaConnectAuthenticationTls` schema reference
+
+Used in: xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaConnectAuthenticationTls` from other subtypes which may be added in the future.
+It must have the value `tls` for the type `KafkaConnectAuthenticationTls`.
+[options="header"]
+|====
+|Field               |Description
+|certificate  1.2+<.<|Certificate and private key pair for TLS authentication.
+|xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
+|type         1.2+<.<|Must be `tls`.
+|string
+|====
+
+[id='type-CertAndKeySecretSource-{context}']
+### `CertAndKeySecretSource` schema reference
+
+Used in: xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`]
+
+
+[options="header"]
+|====
+|Field               |Description
+|certificate  1.2+<.<|The name of the file certificate in the Secret.
+|string
+|key          1.2+<.<|The name of the private key in the Secret.
+|string
+|secretName   1.2+<.<|The name of the Secret containing the certificate.
+|string
+|====
+
+[id='type-KafkaConnectTls-{context}']
+### `KafkaConnectTls` schema reference
+
+Used in: xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+
+
+[options="header"]
+|====
+|Field                       |Description
+|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|====
+
+[id='type-CertSecretSource-{context}']
+### `CertSecretSource` schema reference
+
+Used in: xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
+
+
+[options="header"]
+|====
+|Field               |Description
+|certificate  1.2+<.<|The name of the file certificate in the Secret.
+|string
+|secretName   1.2+<.<|The name of the Secret containing the certificate.
+|string
 |====
 
 [id='type-KafkaConnectS2I-{context}']
@@ -469,6 +535,8 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics                   1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
+|authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
+|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`]
 |bootstrapServers          1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
 |config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers.
@@ -479,6 +547,8 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |resources                 1.2+<.<|Resource constraints (limits and requests).
 |xref:type-Resources-{context}[`Resources`]
+|tls                       1.2+<.<|TLS configuration.
+|xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
 |tolerations               1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations].
 
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -447,10 +447,10 @@ The `type` property is a discriminator that distinguishes the use of the type `K
 It must have the value `tls` for the type `KafkaConnectAuthenticationTls`.
 [options="header"]
 |====
-|Field               |Description
-|certificate  1.2+<.<|Certificate and private key pair for TLS authentication.
+|Field                     |Description
+|certificateAndKey  1.2+<.<|Certificate and private key pair for TLS authentication.
 |xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
-|type         1.2+<.<|Must be `tls`.
+|type               1.2+<.<|Must be `tls`.
 |string
 |====
 

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -264,7 +264,7 @@ spec:
             authentication:
               type: object
               properties:
-                certificate:
+                certificateAndKey:
                   type: object
                   properties:
                     certificate:
@@ -279,6 +279,8 @@ spec:
                   - secretName
                 type:
                   type: string
+              required:
+              - certificateAndKey
             bootstrapServers:
               type: string
             config:
@@ -316,5 +318,7 @@ spec:
                         type: string
                       secretName:
                         type: string
+              required:
+              - trustedCertificates
           required:
           - bootstrapServers

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -261,6 +261,24 @@ spec:
                   type: string
             metrics:
               type: object
+            authentication:
+              type: object
+              properties:
+                certificate:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
             bootstrapServers:
               type: string
             config:
@@ -286,5 +304,17 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
           required:
           - bootstrapServers

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -237,6 +237,24 @@ spec:
                             type: string
             metrics:
               type: object
+            authentication:
+              type: object
+              properties:
+                certificate:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
             bootstrapServers:
               type: string
             config:
@@ -273,6 +291,18 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
             tolerations:
               type: array
               items:

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -240,7 +240,7 @@ spec:
             authentication:
               type: object
               properties:
-                certificate:
+                certificateAndKey:
                   type: object
                   properties:
                     certificate:
@@ -255,6 +255,8 @@ spec:
                   - secretName
                 type:
                   type: string
+              required:
+              - certificateAndKey
             bootstrapServers:
               type: string
             config:
@@ -303,6 +305,8 @@ spec:
                         type: string
                       secretName:
                         type: string
+              required:
+              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
@@ -268,7 +268,7 @@ spec:
             authentication:
               type: object
               properties:
-                certificate:
+                certificateAndKey:
                   type: object
                   properties:
                     certificate:
@@ -283,6 +283,8 @@ spec:
                   - secretName
                 type:
                   type: string
+              required:
+              - certificateAndKey
             bootstrapServers:
               type: string
             config:
@@ -320,5 +322,7 @@ spec:
                         type: string
                       secretName:
                         type: string
+              required:
+              - trustedCertificates
           required:
           - bootstrapServers

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
@@ -265,6 +265,24 @@ spec:
                   type: string
             metrics:
               type: object
+            authentication:
+              type: object
+              properties:
+                certificate:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
             bootstrapServers:
               type: string
             config:
@@ -290,5 +308,17 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
           required:
           - bootstrapServers

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
@@ -244,7 +244,7 @@ spec:
             authentication:
               type: object
               properties:
-                certificate:
+                certificateAndKey:
                   type: object
                   properties:
                     certificate:
@@ -259,6 +259,8 @@ spec:
                   - secretName
                 type:
                   type: string
+              required:
+              - certificateAndKey
             bootstrapServers:
               type: string
             config:
@@ -307,6 +309,8 @@ spec:
                         type: string
                       secretName:
                         type: string
+              required:
+              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
@@ -241,6 +241,24 @@ spec:
                             type: string
             metrics:
               type: object
+            authentication:
+              type: object
+              properties:
+                certificate:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
             bootstrapServers:
               type: string
             config:
@@ -277,6 +295,18 @@ spec:
                     memory:
                       type: string
                       pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
             tolerations:
               type: array
               items:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is a WIP PR for adding the TLS and Authentication to the Kafka Connect CRD for reflecting the following.

```yaml
tls:
     trustedCertificates:
       - secretName: my-secret
         certificate: ca.crt
       - secretName: my-secret
         certificate: ca2.crt
       - secretName: my-secret
         certificate: ca3.crt

authentication:
      type: tls
      certificateAndKey:
        secretName: my-secret
        key: user.key
        certificate: user.crt
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

