### PR TITLE
Generate CRDs direct to examples

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -100,12 +100,38 @@
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--yaml</argument>
-                                <argument>--helm-metadata</argument>
+                                <argument>--label</argument><argument>app:{{ template "strimzi.name" . }}</argument>
+                                <argument>--label</argument><argument>chart:{{ template "strimzi.chart" . }}</argument>
+                                <argument>--label</argument><argument>component:%plural%.%group%-crd</argument>
+                                <argument>--label</argument><argument>release:{{ .Release.Name }}</argument>
+                                <argument>--label</argument><argument>heritage:{{ .Release.Service }}</argument>
                                 <argument>io.strimzi.api.kafka.model.Kafka=${pom.basedir}${file.separator}..${file.separator}helm-charts${file.separator}strimzi-kafka-operator${file.separator}templates${file.separator}04-Crd-kafka.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnect=${pom.basedir}${file.separator}..${file.separator}helm-charts${file.separator}strimzi-kafka-operator${file.separator}templates${file.separator}04-Crd-kafkaconnect.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnectS2I=${pom.basedir}${file.separator}..${file.separator}helm-charts${file.separator}strimzi-kafka-operator${file.separator}templates${file.separator}04-Crd-kafkaconnects2i.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaTopic=${pom.basedir}${file.separator}..${file.separator}helm-charts${file.separator}strimzi-kafka-operator${file.separator}templates${file.separator}04-Crd-kafkatopic.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaUser=${pom.basedir}${file.separator}..${file.separator}helm-charts${file.separator}strimzi-kafka-operator${file.separator}templates${file.separator}04-Crd-kafkauser.yaml</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-crd-examples</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
+                                <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
+                                <argument>--label</argument><argument>app:strimzi</argument>
+                                <argument>--yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.Kafka=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafka.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnect=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkaconnect.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnectS2I=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkaconnects2i.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaTopic=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkatopic.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaUser=${pom.basedir}${file.separator}..${file.separator}examples${file.separator}install${file.separator}cluster-operator${file.separator}04-Crd-kafkauser.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,7 +27,13 @@ public class CrdGeneratorTest {
 
     @Test
     public void generateHelmMetadataLabels() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(new YAMLMapper(), true);
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("app", "{{ template \"strimzi.name\" . }}");
+        labels.put("chart", "{{ template \"strimzi.chart\" . }}");
+        labels.put("component", "%plural%.%group%-crd");
+        labels.put("release", "{{ .Release.Name }}");
+        labels.put("heritage", "{{ .Release.Service }}");
+        CrdGenerator crdGenerator = new CrdGenerator(new YAMLMapper(), labels);
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -29,11 +29,11 @@ helm_examples: helm_template
 	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.heritage \;
 	# Copying rendered template files to: $(CHART_RENDERED_TEMPLATES_EXAMPLES)
 	mkdir -p $(CHART_RENDERED_TEMPLATES_EXAMPLES)
-	# Find rendered resources which are CustomResourceDefinition and move them
+	# Find rendered resources which are not CustomResourceDefinition and move them
 	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -printf "%p " -exec yq r {} kind \; \
-	| grep 'CustomResourceDefinition$$' \
-	| sed -E 's/([^ ]*) CustomResourceDefinition$$/\1/' \
-	| xargs -IFILE echo FILE $(CHART_RENDERED_TEMPLATES_EXAMPLES)
+	| grep -v 'CustomResourceDefinition$$' \
+	| sed -E 's/([^ ]*) ([a-zA-Z0-9]*)$$/\1/' \
+	| xargs -IFILE cp FILE $(CHART_RENDERED_TEMPLATES_EXAMPLES)
 
 helm_pkg: helm_lint helm_examples
 	# Copying unarchived Helm Chart to release directory

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -22,14 +22,18 @@ helm_template:
 	helm template --namespace myproject --output-dir $(CHART_RENDERED_TEMPLATES_TMP) --set imageTagOverride=$(RELEASE_VERSION) $(CHART_PATH)
 
 helm_examples: helm_template
+	# Remove Helm-related labels
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.chart \;
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.component \;
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.release \;
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.heritage \;
 	# Copying rendered template files to: $(CHART_RENDERED_TEMPLATES_EXAMPLES)
 	mkdir -p $(CHART_RENDERED_TEMPLATES_EXAMPLES)
-	cp $(CHART_RENDERED_TEMPLATES_TMP)/$(CHART_NAME)/templates/* $(CHART_RENDERED_TEMPLATES_EXAMPLES)
-	# Remove Helm-related labels
-	find $(CHART_RENDERED_TEMPLATES_EXAMPLES) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.chart \;
-	find $(CHART_RENDERED_TEMPLATES_EXAMPLES) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.component \;
-	find $(CHART_RENDERED_TEMPLATES_EXAMPLES) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.release \;
-	find $(CHART_RENDERED_TEMPLATES_EXAMPLES) -type f -name '*.yaml' -exec yq d -i {} metadata.labels.heritage \;
+	# Find rendered resources which are CustomResourceDefinition and move them
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -printf "%p " -exec yq r {} kind \; \
+	| grep 'CustomResourceDefinition$$' \
+	| sed -E 's/([^ ]*) CustomResourceDefinition$$/\1/' \
+	| xargs -IFILE echo FILE $(CHART_RENDERED_TEMPLATES_EXAMPLES)
 
 helm_pkg: helm_lint helm_examples
 	# Copying unarchived Helm Chart to release directory


### PR DESCRIPTION
### Type of change

- Build

### Description

@ppatierno wanted that `mvn verify` is sufficient to update the comitted CRDs, without needing to use a full `make` to do this. This PR generates CRDs directly to `examples` as well as `helm-charts`. When we copy the rendered helm templates to `examples` we don't copy the CRDs, just everything else.

I added support to the `CrdGenerator` to generate the CRDs with arbitrary labels, because it would be weird for the `helm-chart/Makefile` to mess with the labels in `examples` to add the `app: strimzi` label. In hindsight this might have better been done using the `api/Makefile`, but it's done now.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

