### PR TITLE
Add `helm_examples` target to main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ docu_htmlnoheaderclean:
 systemtests:
 	./systemtest/scripts/run_tests.sh $(SYSTEMTEST_ARGS)
 
+helm_examples: helm-charts
+
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `helm_examples` target is currently hidden inside the `helm-charts` `Makefile`. That is not practical when you want to run in manually because you need to use the right `Makefile`. It is not possible to just call `make helm_examples` in the top directory. This PR adds a new target `helm_examples` to the main `Makefile` which makes this possible. It delegates to the subdirectory, so it doesn't duplicate functionality.