### PR TITLE
Add Kafka Connect TLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Configure Kafka _super users_ (`super.users` field in Kafka configuration) 
 * User operator
 * Kafka 2.0.0
+* Kafka Connect:
+  * Added TLS support for connecting to the Kafka cluster
 
 ## 0.5.0
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+if [ -n "$KAFKA_CONNECT_TRUSTED_CERTS" ]; then
+
+    TLS_CONFIGURATION=$(cat <<EOF
+# TLS / SSL
+security.protocol=SSL
+ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
+ssl.truststore.password=${CERTS_STORE_PASSWORD}
+ssl.truststore.type=PKCS12
+
+producer.security.protocol=SSL
+producer.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
+producer.ssl.truststore.password=${CERTS_STORE_PASSWORD}
+
+consumer.security.protocol=SSL
+consumer.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
+consumer.ssl.truststore.password=${CERTS_STORE_PASSWORD}
+EOF
+)
+fi
+
 # Write the config file
 cat <<EOF
 # Bootstrap servers
@@ -12,4 +32,6 @@ rest.advertised.port=8083
 plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
 # Provided configuration
 ${KAFKA_CONNECT_CONFIGURATION}
+
+${TLS_CONFIGURATION}
 EOF

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -4,6 +4,16 @@ if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
 export KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
 fi
 
+if [ -n "$KAFKA_CONNECT_TRUSTED_CERTS" ]; then
+    # Generate temporary keystore password
+    export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
+
+    mkdir -p /tmp/kafka
+
+    # Import certificates into truststore
+    ./kafka_connect_tls_prepare_certificates.sh
+fi
+
 # Generate and print the config file
 echo "Starting Kafka Connect with configuration:"
 ./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties

--- a/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Parameters:
+# $1: Path to the new truststore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Alias of the certificate
+function create_truststore {
+   keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
+}
+
+echo "Preparing truststore"
+
+IFS=';' read -ra CERTS <<< ${KAFKA_CONNECT_TRUSTED_CERTS}
+for cert in "${CERTS[@]}"
+do
+    create_truststore /tmp/kafka/cluster.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/trusted-certs/$cert $cert
+done
+echo "Preparing truststore is complete"

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -10,6 +10,10 @@ spec:
   livenessProbe:
     initialDelaySeconds: 60
     timeoutSeconds: 5
-  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
   metrics:
     lowercaseOutputName: true
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -10,6 +10,10 @@ spec:
   livenessProbe:
     initialDelaySeconds: 60
     timeoutSeconds: 5
-  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
   metrics:
     lowercaseOutputName: true
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is a follow up for the already merged #710.
It handles the `tls` part adding the specified certificates to a truststore and configuring all the `ssl.*` parameter for Kafka Connect (the generic ones related to worker nodes coordination and the more specific ones related to producers and consumers). With this PR, the Kafka Connect is able to connect to a Kafka Cluster using port `9093`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

