### PR TITLE
Add Kafka Connect TLS authentication

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -113,7 +113,7 @@
         </module>
         <module name="NPathComplexity">
             <!-- default is 200 -->
-            <property name="max" value="900"/>
+            <property name="max" value="1158"/>
         </module>
 
         <module name="IllegalToken">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Kafka 2.0.0
 * Kafka Connect:
   * Added TLS support for connecting to the Kafka cluster
+  * Added TLS client authentication when connecting to the Kafka cluster 
 
 ## 0.5.0
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -18,6 +18,23 @@ consumer.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
 consumer.ssl.truststore.password=${CERTS_STORE_PASSWORD}
 EOF
 )
+
+    if [ -n "$KAFKA_CONNECT_TLS_AUTH_CERT" ] && [ -n "$KAFKA_CONNECT_TLS_AUTH_KEY" ]; then
+        TLS_AUTH_CONFIGURATION=$(cat <<EOF
+ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
+ssl.keystore.password=${CERTS_STORE_PASSWORD}
+ssl.keystore.type=PKCS12
+
+producer.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
+producer.ssl.keystore.password=${CERTS_STORE_PASSWORD}
+producer.ssl.keystore.type=PKCS12
+
+consumer.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
+consumer.ssl.keystore.password=${CERTS_STORE_PASSWORD}
+consumer.ssl.keystore.type=PKCS12
+EOF
+)
+    fi
 fi
 
 # Write the config file
@@ -34,4 +51,5 @@ plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
 ${KAFKA_CONNECT_CONFIGURATION}
 
 ${TLS_CONFIGURATION}
+${TLS_AUTH_CONFIGURATION}
 EOF

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -10,7 +10,7 @@ if [ -n "$KAFKA_CONNECT_TRUSTED_CERTS" ]; then
 
     mkdir -p /tmp/kafka
 
-    # Import certificates into truststore
+    # Import certificates into keystore and truststore
     ./kafka_connect_tls_prepare_certificates.sh
 fi
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
@@ -9,11 +9,27 @@ function create_truststore {
    keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
 }
 
-echo "Preparing truststore"
+# Parameters:
+# $1: Path to the new keystore
+# $2: Truststore password
+# $3: Public key to be imported
+# $4: Private key to be imported
+# $5: Alias of the certificate
+function create_keystore {
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $5 -password pass:$2 -out $1
+}
 
+echo "Preparing truststore"
 IFS=';' read -ra CERTS <<< ${KAFKA_CONNECT_TRUSTED_CERTS}
 for cert in "${CERTS[@]}"
 do
-    create_truststore /tmp/kafka/cluster.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/trusted-certs/$cert $cert
+    create_truststore /tmp/kafka/cluster.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/connect-certs/$cert $cert
 done
 echo "Preparing truststore is complete"
+
+
+if [ -n "$KAFKA_CONNECT_TLS_AUTH_CERT" ] && [ -n "$KAFKA_CONNECT_TLS_AUTH_KEY" ]; then
+    echo "Preparing keystore"
+    create_keystore /tmp/kafka/cluster.keystore.p12 $CERTS_STORE_PASSWORD /opt/kafka/connect-certs/${KAFKA_CONNECT_TLS_AUTH_CERT} /opt/kafka/connect-certs/${KAFKA_CONNECT_TLS_AUTH_KEY} ${KAFKA_CONNECT_TLS_AUTH_CERT}
+    echo "Preparing keystore is complete"
+fi


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is a follow up for the already merged #710 and #725.
It handles the `authentication` part just for TLS authentication support adding the specified certificate and private key to a keystore and configuring all the ssl.* parameter for Kafka Connect (the generic ones related to worker nodes coordination and the more specific ones related to producers and consumers). With this PR, the Kafka Connect is able to connect to a Kafka Cluster using port `9093` where the listener has TLS client authentication enabled.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

