### PR TITLE
Added missing label installation YAMLs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -657,7 +657,6 @@ public class KafkaCluster extends AbstractModel {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
                     .withName(initContainerServiceAccountName(cluster))
-                    .addToLabels("app", "strimzi")
                     .withNamespace(namespace)
                 .endMetadata()
             .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -372,7 +372,6 @@ public class TopicOperator extends AbstractModel {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
                     .withName(getServiceAccountName())
-                    .addToLabels("app", "strimzi")
                     .withNamespace(namespace)
                 .endMetadata()
             .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -372,6 +372,7 @@ public class TopicOperator extends AbstractModel {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
                     .withName(getServiceAccountName())
+                    .addToLabels("app", "strimzi")
                     .withNamespace(namespace)
                 .endMetadata()
             .build();

--- a/examples/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: strimzi-topic-operator
   labels:
-    app: strimzi-kafka-operator
+    app: strimzi
     chart: strimzi-kafka-operator-0.1.0
     component: kafka-service-account
     release: RELEASE-NAME

--- a/examples/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/examples/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: strimzi-topic-operator
+  labels:
+    app: strimzi
 spec:
   replicas: 1
   template:

--- a/examples/install/user-operator/01-ServiceAccount-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/01-ServiceAccount-strimzi-user-operator.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: strimzi-user-operator
+  labels:
+    app: strimzi

--- a/examples/install/user-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/user-operator/04-Crd-kafkauser.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kafkausers.kafka.strimzi.io
+  labels:
+    app: strimzi
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: strimzi-user-operator
+  labels:
+    app: strimzi
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This trivial PR adds the `app: strimzi` label to the installation YAMLs where it's missing and removing from the deployed (by CO) resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

