### PR TITLE
Docs: Address issue with commondir

### DIFF
--- a/documentation/book/assembly-cluster-operator.adoc
+++ b/documentation/book/assembly-cluster-operator.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='cluster-operator-{context}']
 = Cluster Operator

--- a/documentation/book/assembly-deploying-the-topic-operator.adoc
+++ b/documentation/book/assembly-deploying-the-topic-operator.adoc
@@ -6,8 +6,10 @@
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
-//:context: deployment
-include::common/attributes.adoc[]
+
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='deploying-the-topic-operator-{context}']
 = Deploying the Topic Operator

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='kafka-cluster-{context}']
 = Kafka cluster

--- a/documentation/book/assembly-kafka-connect.adoc
+++ b/documentation/book/assembly-kafka-connect.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='kafka-connect-{context}']
 = Kafka Connect

--- a/documentation/book/assembly-overview.adoc
+++ b/documentation/book/assembly-overview.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='overview-{context}']
 = Overview

--- a/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
+++ b/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='using-kafka-connect-with-plugins-{context}']
 = Using Kafka Connect with plugins

--- a/documentation/book/assembly-using-the-topic-operator.adoc
+++ b/documentation/book/assembly-using-the-topic-operator.adoc
@@ -6,8 +6,10 @@
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
-//:context: use
-include::common/attributes.adoc[]
+
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='using-the-topic-operator-{context}']
 = Using the Topic Operator

--- a/documentation/book/commondir.adoc
+++ b/documentation/book/commondir.adoc
@@ -1,0 +1,1 @@
+:CommonDir:  common

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -7,7 +7,9 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
+//include commondir and attributes on every file
+include::commondir.adoc[]
+include::{CommonDir}/attributes.adoc[]
 
 [id='getting-started-{context}']
 = Getting started


### PR DESCRIPTION
### Type of change

- Documentation

### Description

When putting the docs in a downstream repository the common directory can't always be found, this patch will resolve that issue.
