### PR TITLE
Added CRD for Entity Operator in the Kafka spec

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Entity Operator deployment.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EntityOperatorSpec implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String DEFAULT_TLS_SIDECAR_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE", "strimzi/entity-operator-stunnel:latest");
+
+    private TopicOperatorSpec topicOperator;
+    private UserOperatorSpec userOperator;
+    private Affinity affinity;
+    private Sidecar tlsSidecar;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Configuration of the Topic Operator")
+    public TopicOperatorSpec getTopicOperator() {
+        return topicOperator;
+    }
+
+    public void setTopicOperator(TopicOperatorSpec topicOperator) {
+        this.topicOperator = topicOperator;
+    }
+
+    @Description("Configuration of the User Operator")
+    public UserOperatorSpec getUserOperator() {
+        return userOperator;
+    }
+
+    public void setUserOperator(UserOperatorSpec userOperator) {
+        this.userOperator = userOperator;
+    }
+
+    @Description("Pod affinity rules.")
+    @KubeLink(group = "core", version = "v1", kind = "affinity")
+    public Affinity getAffinity() {
+        return affinity;
+    }
+
+    public void setAffinity(Affinity affinity) {
+        this.affinity = affinity;
+    }
+
+    @Description("TLS sidecar configuration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Sidecar getTlsSidecar() {
+        return tlsSidecar;
+    }
+
+    public void setTlsSidecar(Sidecar tlsSidecar) {
+        this.tlsSidecar = tlsSidecar;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -7,13 +7,16 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -25,6 +28,9 @@ import java.util.Map;
         builderPackage = "io.strimzi.api.kafka.model"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "topicOperator", "userOperator", "affinity",
+        "tolerations", "tlsSidecar"})
 public class EntityOperatorSpec implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -33,38 +39,53 @@ public class EntityOperatorSpec implements Serializable {
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE", "strimzi/entity-operator-stunnel:latest");
     public static final int DEFAULT_REPLICAS = 1;
 
-    private TopicOperatorSpec topicOperator;
-    private UserOperatorSpec userOperator;
+    private EntityTopicOperatorSpec topicOperator;
+    private EntityUserOperatorSpec userOperator;
     private Affinity affinity;
+    private List<Toleration> tolerations;
     private Sidecar tlsSidecar;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Configuration of the Topic Operator")
-    public TopicOperatorSpec getTopicOperator() {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public EntityTopicOperatorSpec getTopicOperator() {
         return topicOperator;
     }
 
-    public void setTopicOperator(TopicOperatorSpec topicOperator) {
+    public void setTopicOperator(EntityTopicOperatorSpec topicOperator) {
         this.topicOperator = topicOperator;
     }
 
     @Description("Configuration of the User Operator")
-    public UserOperatorSpec getUserOperator() {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public EntityUserOperatorSpec getUserOperator() {
         return userOperator;
     }
 
-    public void setUserOperator(UserOperatorSpec userOperator) {
+    public void setUserOperator(EntityUserOperatorSpec userOperator) {
         this.userOperator = userOperator;
     }
 
     @Description("Pod affinity rules.")
     @KubeLink(group = "core", version = "v1", kind = "affinity")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Affinity getAffinity() {
         return affinity;
     }
 
     public void setAffinity(Affinity affinity) {
         this.affinity = affinity;
+    }
+
+    @Description("Pod's tolerations.")
+    @KubeLink(group = "core", version = "v1", kind = "tolerations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<Toleration> getTolerations() {
+        return tolerations;
+    }
+
+    public void setTolerations(List<Toleration> tolerations) {
+        this.tolerations = tolerations;
     }
 
     @Description("TLS sidecar configuration")

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -31,6 +31,7 @@ public class EntityOperatorSpec implements Serializable {
 
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE", "strimzi/entity-operator-stunnel:latest");
+    public static final int DEFAULT_REPLICAS = 1;
 
     private TopicOperatorSpec topicOperator;
     private UserOperatorSpec userOperator;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of a Strimzi-managed Topic Operator deployment.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"watchedNamespace", "image",
+        "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
+        "resources", "topicMetadataMaxAttempts", "logging"})
+public class EntityTopicOperatorSpec implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String DEFAULT_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator:latest");
+    public static final int DEFAULT_REPLICAS = 1;
+    public static final int DEFAULT_HEALTHCHECK_DELAY = 10;
+    public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
+    public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
+    public static final int DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 90;
+    public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 20;
+    public static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 6;
+
+    protected String watchedNamespace;
+    protected String image = DEFAULT_IMAGE;
+    protected int reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
+    protected int zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
+    protected int topicMetadataMaxAttempts = DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
+    protected Resources resources;
+    protected Logging logging;
+    protected Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("The namespace the Topic Operator should watch.")
+    public String getWatchedNamespace() {
+        return watchedNamespace;
+    }
+
+    public void setWatchedNamespace(String watchedNamespace) {
+        this.watchedNamespace = watchedNamespace;
+    }
+
+    @Description("The image to use for the Topic Operator")
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    @Description("Interval between periodic reconciliations.")
+    @Minimum(0)
+    public int getReconciliationIntervalSeconds() {
+        return reconciliationIntervalSeconds;
+    }
+
+    public void setReconciliationIntervalSeconds(int reconciliationIntervalSeconds) {
+        this.reconciliationIntervalSeconds = reconciliationIntervalSeconds;
+    }
+
+    @Description("Timeout for the Zookeeper session")
+    @Minimum(0)
+    public int getZookeeperSessionTimeoutSeconds() {
+        return zookeeperSessionTimeoutSeconds;
+    }
+
+    public void setZookeeperSessionTimeoutSeconds(int zookeeperSessionTimeoutSeconds) {
+        this.zookeeperSessionTimeoutSeconds = zookeeperSessionTimeoutSeconds;
+    }
+
+    @Description("The number of attempts at getting topic metadata")
+    @Minimum(0)
+    public int getTopicMetadataMaxAttempts() {
+        return topicMetadataMaxAttempts;
+    }
+
+    public void setTopicMetadataMaxAttempts(int topicMetadataMaxAttempts) {
+        this.topicMetadataMaxAttempts = topicMetadataMaxAttempts;
+    }
+
+    @Description("Resource constraints (limits and requests).")
+    public Resources getResources() {
+        return resources;
+    }
+
+    @Description("Resource constraints (limits and requests).")
+    public void setResources(Resources resources) {
+        this.resources = resources;
+    }
+
+    @Description("Logging configuration")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(Logging logging) {
+        this.logging = logging;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
@@ -24,19 +25,22 @@ import java.util.Map;
         builderPackage = "io.strimzi.api.kafka.model"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class UserOperatorSpec implements Serializable {
+@JsonPropertyOrder({"watchedNamespace", "image",
+        "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
+        "resources", "logging"})
+public class EntityUserOperatorSpec implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     public static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_USER_OPERATOR_IMAGE", "strimzi/user-operator:latest");
-    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
-    public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = 6_000;
+    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
+    public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 6;
 
     private String watchedNamespace;
     private String image = DEFAULT_IMAGE;
-    private long reconciliationIntervalMilliseconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
-    private long zookeeperSessionTimeoutMilliseconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS;
+    private long reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
+    private long zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
     private Resources resources;
     private Logging logging;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
@@ -61,22 +65,22 @@ public class UserOperatorSpec implements Serializable {
 
     @Description("Interval between periodic reconciliations.")
     @Minimum(0)
-    public long getReconciliationIntervalMilliseconds() {
-        return reconciliationIntervalMilliseconds;
+    public long getReconciliationIntervalSeconds() {
+        return reconciliationIntervalSeconds;
     }
 
-    public void setReconciliationIntervalMilliseconds(long reconciliationIntervalMilliseconds) {
-        this.reconciliationIntervalMilliseconds = reconciliationIntervalMilliseconds;
+    public void setReconciliationIntervalSeconds(long reconciliationIntervalSeconds) {
+        this.reconciliationIntervalSeconds = reconciliationIntervalSeconds;
     }
 
     @Description("Timeout for the Zookeeper session")
     @Minimum(0)
-    public long getZookeeperSessionTimeoutMilliseconds() {
-        return zookeeperSessionTimeoutMilliseconds;
+    public long getZookeeperSessionTimeoutSeconds() {
+        return zookeeperSessionTimeoutSeconds;
     }
 
-    public void setZookeeperSessionTimeoutMilliseconds(long zookeeperSessionTimeoutMilliseconds) {
-        this.zookeeperSessionTimeoutMilliseconds = zookeeperSessionTimeoutMilliseconds;
+    public void setZookeeperSessionTimeoutSeconds(long zookeeperSessionTimeoutSeconds) {
+        this.zookeeperSessionTimeoutSeconds = zookeeperSessionTimeoutSeconds;
     }
 
     @Description("Resource constraints (limits and requests).")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -35,6 +35,7 @@ public class KafkaSpec implements Serializable {
     private KafkaClusterSpec kafka;
     private ZookeeperClusterSpec zookeeper;
     private TopicOperatorSpec topicOperator;
+    private EntityOperatorSpec entityOperator;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Configuration of the Kafka cluster")
@@ -64,6 +65,15 @@ public class KafkaSpec implements Serializable {
 
     public void setTopicOperator(TopicOperatorSpec topicOperator) {
         this.topicOperator = topicOperator;
+    }
+
+    @Description("Configuration of the Entity Operator")
+    public EntityOperatorSpec getEntityOperator() {
+        return entityOperator;
+    }
+
+    public void setEntityOperator(EntityOperatorSpec entityOperator) {
+        this.entityOperator = entityOperator;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -34,9 +34,8 @@ public class TopicOperatorSpec implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String DEFAULT_IMAGE = System.getenv().getOrDefault(
-            "STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE",
-            "strimzi/topic-operator:latest");
+    public static final String DEFAULT_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator:latest");
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator-stunnel:latest");
     public static final int DEFAULT_REPLICAS = 1;
@@ -68,7 +67,7 @@ public class TopicOperatorSpec implements Serializable {
         this.watchedNamespace = watchedNamespace;
     }
 
-    @Description("The image to use for the topic operator")
+    @Description("The image to use for the Topic Operator")
     public String getImage() {
         return image;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -4,22 +4,15 @@
  */
 package io.strimzi.api.kafka.model;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
-import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * Representation of a Strimzi-managed topic operator deployment..
+ * Representation of a Strimzi-managed Topic Operator deployment.
  */
 @Buildable(
         editableEnabled = false,
@@ -29,92 +22,16 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"watchedNamespace", "image",
         "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
-        "affinity", "resources", "topicMetadataMaxAttempts", "tlsSidecar"})
-public class TopicOperatorSpec implements Serializable {
+        "affinity", "resources", "topicMetadataMaxAttempts", "tlsSidecar", "logging"})
+public class TopicOperatorSpec extends EntityTopicOperatorSpec {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String DEFAULT_IMAGE =
-            System.getenv().getOrDefault("STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator:latest");
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_TOPIC_OPERATOR_IMAGE", "strimzi/topic-operator-stunnel:latest");
-    public static final int DEFAULT_REPLICAS = 1;
-    public static final int DEFAULT_HEALTHCHECK_DELAY = 10;
-    public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
-    public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
-    public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
-    public static final int DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 90;
-    public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 20;
-    public static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 6;
 
-    private String watchedNamespace;
-    private String image = DEFAULT_IMAGE;
-    private int reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
-    private int zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
-    private int topicMetadataMaxAttempts = DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
-    private Resources resources;
     private Affinity affinity;
-    private Logging logging;
     private Sidecar tlsSidecar;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
-
-    @Description("The namespace the Topic Operator should watch.")
-    public String getWatchedNamespace() {
-        return watchedNamespace;
-    }
-
-    public void setWatchedNamespace(String watchedNamespace) {
-        this.watchedNamespace = watchedNamespace;
-    }
-
-    @Description("The image to use for the Topic Operator")
-    public String getImage() {
-        return image;
-    }
-
-    public void setImage(String image) {
-        this.image = image;
-    }
-
-    @Description("Interval between periodic reconciliations.")
-    @Minimum(0)
-    public int getReconciliationIntervalSeconds() {
-        return reconciliationIntervalSeconds;
-    }
-
-    public void setReconciliationIntervalSeconds(int reconciliationIntervalSeconds) {
-        this.reconciliationIntervalSeconds = reconciliationIntervalSeconds;
-    }
-
-    @Description("Timeout for the Zookeeper session")
-    @Minimum(0)
-    public int getZookeeperSessionTimeoutSeconds() {
-        return zookeeperSessionTimeoutSeconds;
-    }
-
-    public void setZookeeperSessionTimeoutSeconds(int zookeeperSessionTimeoutSeconds) {
-        this.zookeeperSessionTimeoutSeconds = zookeeperSessionTimeoutSeconds;
-    }
-
-    @Description("The number of attempts at getting topic metadata")
-    @Minimum(0)
-    public int getTopicMetadataMaxAttempts() {
-        return topicMetadataMaxAttempts;
-    }
-
-    public void setTopicMetadataMaxAttempts(int topicMetadataMaxAttempts) {
-        this.topicMetadataMaxAttempts = topicMetadataMaxAttempts;
-    }
-
-    @Description("Resource constraints (limits and requests).")
-    public Resources getResources() {
-        return resources;
-    }
-
-    @Description("Resource constraints (limits and requests).")
-    public void setResources(Resources resources) {
-        this.resources = resources;
-    }
 
     @Description("Pod affinity rules.")
     @KubeLink(group = "core", version = "v1", kind = "affinity")
@@ -126,16 +43,6 @@ public class TopicOperatorSpec implements Serializable {
         this.affinity = affinity;
     }
 
-    @Description("Logging configuration")
-    @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public Logging getLogging() {
-        return logging;
-    }
-
-    public void setLogging(Logging logging) {
-        this.logging = logging;
-    }
-
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Sidecar getTlsSidecar() {
@@ -145,15 +52,4 @@ public class TopicOperatorSpec implements Serializable {
     public void setTlsSidecar(Sidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
-
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
-
-    @JsonAnySetter
-    public void setAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
-    }
-
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/UserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/UserOperatorSpec.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the User Operator.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.strimzi.api.kafka.model"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserOperatorSpec implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String DEFAULT_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_USER_OPERATOR_IMAGE", "strimzi/user-operator:latest");
+    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+    public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = 6_000;
+
+    private String watchedNamespace;
+    private String image = DEFAULT_IMAGE;
+    private long reconciliationIntervalMilliseconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
+    private long zookeeperSessionTimeoutMilliseconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS;
+    private Resources resources;
+    private Logging logging;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("The namespace the User Operator should watch.")
+    public String getWatchedNamespace() {
+        return watchedNamespace;
+    }
+
+    public void setWatchedNamespace(String watchedNamespace) {
+        this.watchedNamespace = watchedNamespace;
+    }
+
+    @Description("The image to use for the User Operator")
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    @Description("Interval between periodic reconciliations.")
+    @Minimum(0)
+    public long getReconciliationIntervalMilliseconds() {
+        return reconciliationIntervalMilliseconds;
+    }
+
+    public void setReconciliationIntervalMilliseconds(long reconciliationIntervalMilliseconds) {
+        this.reconciliationIntervalMilliseconds = reconciliationIntervalMilliseconds;
+    }
+
+    @Description("Timeout for the Zookeeper session")
+    @Minimum(0)
+    public long getZookeeperSessionTimeoutMilliseconds() {
+        return zookeeperSessionTimeoutMilliseconds;
+    }
+
+    public void setZookeeperSessionTimeoutMilliseconds(long zookeeperSessionTimeoutMilliseconds) {
+        this.zookeeperSessionTimeoutMilliseconds = zookeeperSessionTimeoutMilliseconds;
+    }
+
+    @Description("Resource constraints (limits and requests).")
+    public Resources getResources() {
+        return resources;
+    }
+
+    @Description("Resource constraints (limits and requests).")
+    public void setResources(Resources resources) {
+        this.resources = resources;
+    }
+
+    @Description("Logging configuration")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(Logging logging) {
+        this.logging = logging;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -60,4 +60,10 @@ public class KafkaCrdIT extends AbstractCrdIT {
         }
     }
 
+    @Test
+
+    public void testKafkaWithEntityOperator() {
+        createDelete(Kafka.class, "Kafka-with-entity-operator.yaml");
+    }
+
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-entity-operator.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-entity-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 500Gi
+    listeners:
+      plain: {}
+      tls: {}
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator:
+      watchedNamespaces: my-ns
+      reconciliationIntervalSeconds: 60
+    userOperator:
+      watchedNamespaces: my-other-ns
+      reconciliationIntervalMilliseconds: 20000
+

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-entity-operator.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-entity-operator.yaml
@@ -21,5 +21,5 @@ spec:
       reconciliationIntervalSeconds: 60
     userOperator:
       watchedNamespaces: my-other-ns
-      reconciliationIntervalMilliseconds: 20000
+      reconciliationIntervalSeconds: 60
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -20,13 +20,15 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Field                 |Description
-|kafka          1.2+<.<|Configuration of the Kafka cluster.
+|Field                  |Description
+|kafka           1.2+<.<|Configuration of the Kafka cluster.
 |xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
-|zookeeper      1.2+<.<|Configuration of the Zookeeper cluster.
+|zookeeper       1.2+<.<|Configuration of the Zookeeper cluster.
 |xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
-|topicOperator  1.2+<.<|Configuration of the Topic Operator.
+|topicOperator   1.2+<.<|Configuration of the Topic Operator.
 |xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
+|entityOperator  1.2+<.<|Configuration of the Entity Operator.
+|xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |====
 
 [id='type-KafkaClusterSpec-{context}']
@@ -235,7 +237,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [id='type-Resources-{context}']
 ### `Resources` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -265,7 +267,7 @@ Used in: xref:type-Resources-{context}[`Resources`]
 [id='type-InlineLogging-{context}']
 ### `InlineLogging` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `InlineLogging` from xref:type-ExternalLogging-{context}[`ExternalLogging`].
@@ -282,7 +284,7 @@ It must have the value `inline` for the type `InlineLogging`.
 [id='type-ExternalLogging-{context}']
 ### `ExternalLogging` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `ExternalLogging` from xref:type-InlineLogging-{context}[`InlineLogging`].
@@ -299,7 +301,7 @@ It must have the value `external` for the type `ExternalLogging`.
 [id='type-Sidecar-{context}']
 ### `Sidecar` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -355,7 +357,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [id='type-TopicOperatorSpec-{context}']
 ### `TopicOperatorSpec` schema reference
 
-Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 
 [options="header"]
@@ -363,7 +365,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |Field                                  |Description
 |watchedNamespace                1.2+<.<|The namespace the Topic Operator should watch.
 |string
-|image                           1.2+<.<|The image to use for the topic operator.
+|image                           1.2+<.<|The image to use for the Topic Operator.
 |string
 |reconciliationIntervalSeconds   1.2+<.<|Interval between periodic reconciliations.
 |integer
@@ -381,6 +383,50 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-Sidecar-{context}[`Sidecar`]
 |logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|====
+
+[id='type-EntityOperatorSpec-{context}']
+### `EntityOperatorSpec` schema reference
+
+Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+
+
+[options="header"]
+|====
+|Field                 |Description
+|affinity       1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
+|tlsSidecar     1.2+<.<|TLS sidecar configuration.
+|xref:type-Sidecar-{context}[`Sidecar`]
+|topicOperator  1.2+<.<|Configuration of the Topic Operator.
+|xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
+|userOperator   1.2+<.<|Configuration of the User Operator.
+|xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`]
+|====
+
+[id='type-UserOperatorSpec-{context}']
+### `UserOperatorSpec` schema reference
+
+Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
+
+
+[options="header"]
+|====
+|Field                                       |Description
+|image                                1.2+<.<|The image to use for the User Operator.
+|string
+|logging                              1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|reconciliationIntervalMilliseconds   1.2+<.<|Interval between periodic reconciliations.
+|integer
+|resources                            1.2+<.<|Resource constraints (limits and requests).
+|xref:type-Resources-{context}[`Resources`]
+|watchedNamespace                     1.2+<.<|The namespace the User Operator should watch.
+|string
+|zookeeperSessionTimeoutMilliseconds  1.2+<.<|Timeout for the Zookeeper session.
+|integer
 |====
 
 [id='type-KafkaConnect-{context}']

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -237,7 +237,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [id='type-Resources-{context}']
 ### `Resources` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -267,7 +267,7 @@ Used in: xref:type-Resources-{context}[`Resources`]
 [id='type-InlineLogging-{context}']
 ### `InlineLogging` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `InlineLogging` from xref:type-ExternalLogging-{context}[`ExternalLogging`].
@@ -284,7 +284,7 @@ It must have the value `inline` for the type `InlineLogging`.
 [id='type-ExternalLogging-{context}']
 ### `ExternalLogging` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `ExternalLogging` from xref:type-InlineLogging-{context}[`InlineLogging`].
@@ -357,7 +357,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [id='type-TopicOperatorSpec-{context}']
 ### `TopicOperatorSpec` schema reference
 
-Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type-KafkaSpec-{context}[`KafkaSpec`]
+Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 
 [options="header"]
@@ -394,39 +394,68 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [options="header"]
 |====
 |Field                 |Description
+|topicOperator  1.2+<.<|Configuration of the Topic Operator.
+|xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`]
+|userOperator   1.2+<.<|Configuration of the User Operator.
+|xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`]
 |affinity       1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
+|tolerations    1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |tlsSidecar     1.2+<.<|TLS sidecar configuration.
 |xref:type-Sidecar-{context}[`Sidecar`]
-|topicOperator  1.2+<.<|Configuration of the Topic Operator.
-|xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
-|userOperator   1.2+<.<|Configuration of the User Operator.
-|xref:type-UserOperatorSpec-{context}[`UserOperatorSpec`]
 |====
 
-[id='type-UserOperatorSpec-{context}']
-### `UserOperatorSpec` schema reference
+[id='type-EntityTopicOperatorSpec-{context}']
+### `EntityTopicOperatorSpec` schema reference
 
 Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 
 
 [options="header"]
 |====
-|Field                                       |Description
-|image                                1.2+<.<|The image to use for the User Operator.
+|Field                                  |Description
+|watchedNamespace                1.2+<.<|The namespace the Topic Operator should watch.
 |string
-|logging                              1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|reconciliationIntervalMilliseconds   1.2+<.<|Interval between periodic reconciliations.
+|image                           1.2+<.<|The image to use for the Topic Operator.
+|string
+|reconciliationIntervalSeconds   1.2+<.<|Interval between periodic reconciliations.
 |integer
-|resources                            1.2+<.<|Resource constraints (limits and requests).
+|zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the Zookeeper session.
+|integer
+|resources                       1.2+<.<|Resource constraints (limits and requests).
 |xref:type-Resources-{context}[`Resources`]
-|watchedNamespace                     1.2+<.<|The namespace the User Operator should watch.
-|string
-|zookeeperSessionTimeoutMilliseconds  1.2+<.<|Timeout for the Zookeeper session.
+|topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata.
 |integer
+|logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|====
+
+[id='type-EntityUserOperatorSpec-{context}']
+### `EntityUserOperatorSpec` schema reference
+
+Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
+
+
+[options="header"]
+|====
+|Field                                  |Description
+|watchedNamespace                1.2+<.<|The namespace the User Operator should watch.
+|string
+|image                           1.2+<.<|The image to use for the User Operator.
+|string
+|reconciliationIntervalSeconds   1.2+<.<|Interval between periodic reconciliations.
+|integer
+|zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the Zookeeper session.
+|integer
+|resources                       1.2+<.<|Resource constraints (limits and requests).
+|xref:type-Resources-{context}[`Resources`]
+|logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |====
 
 [id='type-KafkaConnect-{context}']

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -931,6 +931,95 @@ spec:
             entityOperator:
               type: object
               properties:
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                userOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
                 affinity:
                   type: object
                   properties:
@@ -1113,6 +1202,21 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
                 tlsSidecar:
                   type: object
                   properties:
@@ -1139,303 +1243,6 @@ spec:
                             memory:
                               type: string
                               pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                topicOperator:
-                  type: object
-                  properties:
-                    watchedNamespace:
-                      type: string
-                    image:
-                      type: string
-                    reconciliationIntervalSeconds:
-                      type: integer
-                      minimum: 0
-                    zookeeperSessionTimeoutSeconds:
-                      type: integer
-                      minimum: 0
-                    affinity:
-                      type: object
-                      properties:
-                        nodeAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  preference:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: object
-                              properties:
-                                nodeSelectorTerms:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                        podAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  podAffinityTerm:
-                                    type: object
-                                    properties:
-                                      labelSelector:
-                                        type: object
-                                        properties:
-                                          matchExpressions:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  type: array
-                                                  items:
-                                                    type: string
-                                          matchLabels:
-                                            type: object
-                                      namespaces:
-                                        type: array
-                                        items:
-                                          type: string
-                                      topologyKey:
-                                        type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  labelSelector:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        type: object
-                                  namespaces:
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    type: string
-                        podAntiAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  podAffinityTerm:
-                                    type: object
-                                    properties:
-                                      labelSelector:
-                                        type: object
-                                        properties:
-                                          matchExpressions:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  type: array
-                                                  items:
-                                                    type: string
-                                          matchLabels:
-                                            type: object
-                                      namespaces:
-                                        type: array
-                                        items:
-                                          type: string
-                                      topologyKey:
-                                        type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  labelSelector:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        type: object
-                                  namespaces:
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    type: string
-                    resources:
-                      type: object
-                      properties:
-                        limits:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                        requests:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    topicMetadataMaxAttempts:
-                      type: integer
-                      minimum: 0
-                    tlsSidecar:
-                      type: object
-                      properties:
-                        image:
-                          type: string
-                        resources:
-                          type: object
-                          properties:
-                            limits:
-                              type: object
-                              properties:
-                                cpu:
-                                  type: string
-                                  pattern: '[0-9]+m?$'
-                                memory:
-                                  type: string
-                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                            requests:
-                              type: object
-                              properties:
-                                cpu:
-                                  type: string
-                                  pattern: '[0-9]+m?$'
-                                memory:
-                                  type: string
-                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    logging:
-                      type: object
-                      properties:
-                        loggers:
-                          type: object
-                        name:
-                          type: string
-                        type:
-                          type: string
-                userOperator:
-                  type: object
-                  properties:
-                    image:
-                      type: string
-                    logging:
-                      type: object
-                      properties:
-                        loggers:
-                          type: object
-                        name:
-                          type: string
-                        type:
-                          type: string
-                    reconciliationIntervalMilliseconds:
-                      type: integer
-                      minimum: 0
-                    resources:
-                      type: object
-                      properties:
-                        limits:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                        requests:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    watchedNamespace:
-                      type: string
-                    zookeeperSessionTimeoutMilliseconds:
-                      type: integer
-                      minimum: 0
           required:
           - kafka
           - zookeeper

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -928,6 +928,514 @@ spec:
                       type: string
                     type:
                       type: string
+            entityOperator:
+              type: object
+              properties:
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    tlsSidecar:
+                      type: object
+                      properties:
+                        image:
+                          type: string
+                        resources:
+                          type: object
+                          properties:
+                            limits:
+                              type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                  pattern: '[0-9]+m?$'
+                                memory:
+                                  type: string
+                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                            requests:
+                              type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                  pattern: '[0-9]+m?$'
+                                memory:
+                                  type: string
+                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                userOperator:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                    reconciliationIntervalMilliseconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    watchedNamespace:
+                      type: string
+                    zookeeperSessionTimeoutMilliseconds:
+                      type: integer
+                      minimum: 0
           required:
           - kafka
           - zookeeper

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
@@ -932,6 +932,514 @@ spec:
                       type: string
                     type:
                       type: string
+            entityOperator:
+              type: object
+              properties:
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    tlsSidecar:
+                      type: object
+                      properties:
+                        image:
+                          type: string
+                        resources:
+                          type: object
+                          properties:
+                            limits:
+                              type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                  pattern: '[0-9]+m?$'
+                                memory:
+                                  type: string
+                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                            requests:
+                              type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                  pattern: '[0-9]+m?$'
+                                memory:
+                                  type: string
+                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                userOperator:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                    reconciliationIntervalMilliseconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    watchedNamespace:
+                      type: string
+                    zookeeperSessionTimeoutMilliseconds:
+                      type: integer
+                      minimum: 0
           required:
           - kafka
           - zookeeper

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafka.yaml
@@ -935,6 +935,95 @@ spec:
             entityOperator:
               type: object
               properties:
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                userOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
                 affinity:
                   type: object
                   properties:
@@ -1117,6 +1206,21 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
                 tlsSidecar:
                   type: object
                   properties:
@@ -1143,303 +1247,6 @@ spec:
                             memory:
                               type: string
                               pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                topicOperator:
-                  type: object
-                  properties:
-                    watchedNamespace:
-                      type: string
-                    image:
-                      type: string
-                    reconciliationIntervalSeconds:
-                      type: integer
-                      minimum: 0
-                    zookeeperSessionTimeoutSeconds:
-                      type: integer
-                      minimum: 0
-                    affinity:
-                      type: object
-                      properties:
-                        nodeAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  preference:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: object
-                              properties:
-                                nodeSelectorTerms:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                        podAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  podAffinityTerm:
-                                    type: object
-                                    properties:
-                                      labelSelector:
-                                        type: object
-                                        properties:
-                                          matchExpressions:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  type: array
-                                                  items:
-                                                    type: string
-                                          matchLabels:
-                                            type: object
-                                      namespaces:
-                                        type: array
-                                        items:
-                                          type: string
-                                      topologyKey:
-                                        type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  labelSelector:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        type: object
-                                  namespaces:
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    type: string
-                        podAntiAffinity:
-                          type: object
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  podAffinityTerm:
-                                    type: object
-                                    properties:
-                                      labelSelector:
-                                        type: object
-                                        properties:
-                                          matchExpressions:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  type: array
-                                                  items:
-                                                    type: string
-                                          matchLabels:
-                                            type: object
-                                      namespaces:
-                                        type: array
-                                        items:
-                                          type: string
-                                      topologyKey:
-                                        type: string
-                                  weight:
-                                    type: integer
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  labelSelector:
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        type: object
-                                  namespaces:
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    type: string
-                    resources:
-                      type: object
-                      properties:
-                        limits:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                        requests:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    topicMetadataMaxAttempts:
-                      type: integer
-                      minimum: 0
-                    tlsSidecar:
-                      type: object
-                      properties:
-                        image:
-                          type: string
-                        resources:
-                          type: object
-                          properties:
-                            limits:
-                              type: object
-                              properties:
-                                cpu:
-                                  type: string
-                                  pattern: '[0-9]+m?$'
-                                memory:
-                                  type: string
-                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                            requests:
-                              type: object
-                              properties:
-                                cpu:
-                                  type: string
-                                  pattern: '[0-9]+m?$'
-                                memory:
-                                  type: string
-                                  pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    logging:
-                      type: object
-                      properties:
-                        loggers:
-                          type: object
-                        name:
-                          type: string
-                        type:
-                          type: string
-                userOperator:
-                  type: object
-                  properties:
-                    image:
-                      type: string
-                    logging:
-                      type: object
-                      properties:
-                        loggers:
-                          type: object
-                        name:
-                          type: string
-                        type:
-                          type: string
-                    reconciliationIntervalMilliseconds:
-                      type: integer
-                      minimum: 0
-                    resources:
-                      type: object
-                      properties:
-                        limits:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                        requests:
-                          type: object
-                          properties:
-                            cpu:
-                              type: string
-                              pattern: '[0-9]+m?$'
-                            memory:
-                              type: string
-                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                    watchedNamespace:
-                      type: string
-                    zookeeperSessionTimeoutMilliseconds:
-                      type: integer
-                      minimum: 0
           required:
           - kafka
           - zookeeper

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -41,7 +41,7 @@ public class UserOperatorConfig {
      * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
      * @param zookeperConnect Connecton URL for Zookeeper
      * @param zookeeperSessionTimeoutMs Session timeout for Zookeeper connections
-     * @param labels    Map with labels which should be used to find the KAfkaUser resources
+     * @param labels    Map with labels which should be used to find the KafkaUser resources
      * @param caName    Name of the secret containing the Certification Authority
      * @param caNamespace   Namespace with the CA secret
      */


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

This PR is about adding the `entityOperator` declaration inside the `Kafka` CRD.
It will contain the `topicOperator` and `userOperator'.
This PR doesn't remove the `topicOperator` declaration at root level in the `Kafka` CRD but we should consider that as deprecated.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

