### PR TITLE
Docs: Remove references to attributes

### DIFF
--- a/documentation/book/assembly-cluster-operator.adoc
+++ b/documentation/book/assembly-cluster-operator.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='cluster-operator-{context}']
 = Cluster Operator
 

--- a/documentation/book/assembly-dedicated-nodes.adoc
+++ b/documentation/book/assembly-dedicated-nodes.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='assembly-dedidcated-nodes-{context}']
 = Using dedicated nodes
 

--- a/documentation/book/assembly-deploying-the-topic-operator.adoc
+++ b/documentation/book/assembly-deploying-the-topic-operator.adoc
@@ -6,8 +6,6 @@
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
-//:context: deployment
-include::common/attributes.adoc[]
 
 [id='deploying-the-topic-operator-{context}']
 = Deploying the Topic Operator

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='kafka-cluster-{context}']
 = Kafka cluster
 

--- a/documentation/book/assembly-kafka-connect.adoc
+++ b/documentation/book/assembly-kafka-connect.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='kafka-connect-{context}']
 = Kafka Connect
 

--- a/documentation/book/assembly-node-scheduling.adoc
+++ b/documentation/book/assembly-node-scheduling.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='assembly-node-scheduling-{context}']
 = Scheduling pods to specific nodes
 

--- a/documentation/book/assembly-overview.adoc
+++ b/documentation/book/assembly-overview.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='overview-{context}']
 = Overview
 

--- a/documentation/book/assembly-scheduling-based-on-other-pods.adoc
+++ b/documentation/book/assembly-scheduling-based-on-other-pods.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='assembly-scheduling-pods-based-on-other-applications-{context}']
 = Scheduling pods based on other applications
 

--- a/documentation/book/assembly-scheduling.adoc
+++ b/documentation/book/assembly-scheduling.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='assembly-scheduling-{context}']
 = Configuring pod scheduling
 

--- a/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
+++ b/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='using-kafka-connect-with-plugins-{context}']
 = Using Kafka Connect with plugins
 

--- a/documentation/book/assembly-using-the-topic-operator.adoc
+++ b/documentation/book/assembly-using-the-topic-operator.adoc
@@ -6,8 +6,6 @@
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
-//:context: use
-include::common/attributes.adoc[]
 
 [id='using-the-topic-operator-{context}']
 = Using the Topic Operator

--- a/documentation/book/con-dedicated-nodes.adoc
+++ b/documentation/book/con-dedicated-nodes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-dedicated-nodes.adoc
 
-include::common/attributes.adoc[]
-
 [id='con-dedicated-nodes-{context}']
 = Dedicated nodes
 

--- a/documentation/book/con-how-the-topic-operator-works.adoc
+++ b/documentation/book/con-how-the-topic-operator-works.adoc
@@ -2,8 +2,6 @@
 //
 // topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='how-the-topic-operator-works-{context}']
 = How the Topic Operator works
 

--- a/documentation/book/con-product-downloads.adoc
+++ b/documentation/book/con-product-downloads.adoc
@@ -2,8 +2,6 @@
 //
 // getting-started.adoc
 
-include::common/attributes.adoc[]
-
 [id='downloads-{context}']
 = {ProductName} Downloads
 

--- a/documentation/book/con-scheduling-based-on-other-pods.adoc
+++ b/documentation/book/con-scheduling-based-on-other-pods.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-scheduling-based-on-other-pods.adoc
 
-include::common/attributes.adoc[]
-
 [id='con-scheduling-based-on-other-pods-{context}']
 = Avoid critical applications to share the node
 

--- a/documentation/book/con-scheduling-to-specific-nodes.adoc
+++ b/documentation/book/con-scheduling-to-specific-nodes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-node-scheduling.adoc
 
-include::common/attributes.adoc[]
-
 [id='con-scheduling-to-specific-nodes-{context}']
 = Node scheduling
 

--- a/documentation/book/con-scheduling.adoc
+++ b/documentation/book/con-scheduling.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-scheduling.adoc
 
-include::common/attributes.adoc[]
-
 [id='con-scheduling-{context}']
 
 IMPORTANT: When two application are scheduled to the same {ProductPlatformName} node, both applications might use the same resources like disk I/O and impact performance.

--- a/documentation/book/con-what-the-topic-operator-does.adoc
+++ b/documentation/book/con-what-the-topic-operator-does.adoc
@@ -2,8 +2,6 @@
 //
 // topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='what-the-topic-operator-does-{context}']
 = What the Topic Operator does
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -7,8 +7,6 @@
 // See also the complementary step on the last line of this file.
 :parent-context: {context}
 
-include::common/attributes.adoc[]
-
 [id='getting-started-{context}']
 = Getting started
 

--- a/documentation/book/proc-changing-a-topic.adoc
+++ b/documentation/book/proc-changing-a-topic.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-using-the-topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='changing-a-topic-{context}']
 = Changing a topic
 

--- a/documentation/book/proc-creating-a-topic.adoc
+++ b/documentation/book/proc-creating-a-topic.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-using-the-topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='creating-a-topic-{context}']
 = Creating a topic
 

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-using-kafka-connect-with-plugins.adoc
 
-include::common/attributes.adoc[]
-
 [id='creating-new-image-from-base-{context}']
 = Create a new image based on our base image
 

--- a/documentation/book/proc-dedicated-nodes.adoc
+++ b/documentation/book/proc-dedicated-nodes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-dedicated-nodes.adoc
 
-include::common/attributes.adoc[]
-
 [id='proc-dedicated-nodes-{context}']
 = Setting up dedicated nodes and scheduling pods on them
 

--- a/documentation/book/proc-deleting-a-topic.adoc
+++ b/documentation/book/proc-deleting-a-topic.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-using-the-topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='deleting-a-topic-{context}']
 = Deleting a topic
 

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-cluster-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-cluster-operator-kubernetes-{context}']
 = Deploying the Cluster Operator to {KubernetesName}
 

--- a/documentation/book/proc-deploying-cluster-operator-openshift.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-openshift.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-cluster-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-cluster-operator-openshift-{context}']
 = Deploying the Cluster Operator to {OpenShiftName}
 

--- a/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-kafka-cluster.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-kafka-cluster-kubernetes-{context}']
 = Deploying the Kafka cluster to {KubernetesName}
 

--- a/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-kafka-cluster.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-kafka-cluster-openshift-{context}']
 = Deploying the Kafka cluster to {OpenShiftName}
 

--- a/documentation/book/proc-deploying-kafka-connect-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-connect-kubernetes.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-kafka-connect.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-kafka-connect-kubernetes-{context}']
 = Deploying Kafka Connect to {KubernetesName}
 

--- a/documentation/book/proc-deploying-kafka-connect-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-connect-openshift.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-kafka-connect.adoc
 
-include::common/attributes.adoc[]
-
 [id='deploying-kafka-connect-openshift-{context}']
 = Deploying Kafka Connect to {OpenShiftName}
 

--- a/documentation/book/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/book/proc-scheduling-based-on-other-pods.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-scheduling-based-on-other-pods.adoc
 
-include::common/attributes.adoc[]
-
 [id='configuring-pod-anti-affinity-in-kafka-components-{context}']
 = Configuring pod anti-affinity in Kafka components
 

--- a/documentation/book/proc-scheduling-deplyoment-to-node-using-node-affinity.adoc
+++ b/documentation/book/proc-scheduling-deplyoment-to-node-using-node-affinity.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-node-scheduling.adoc
 
-include::common/attributes.adoc[]
-
 [id='proc-configuring-node-affinity-{context}']
 = Configuring node affinity in Kafka components
 

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-using-kafka-connect-with-plugins.adoc
 
-include::common/attributes.adoc[]
-
 [id='using-openshift-s2i-create-image-{context}']
 = Using {OpenShiftName} builds and S2I to create new images
 

--- a/documentation/book/ref-affinity.adoc
+++ b/documentation/book/ref-affinity.adoc
@@ -3,8 +3,6 @@
 // assembly-node-scheduling.adoc
 // assembly-dedicated-nodes.adoc
 
-include::common/attributes.adoc[]
-
 [id='affinity-{context}']
 = Affinity
 

--- a/documentation/book/ref-document-conventions.adoc
+++ b/documentation/book/ref-document-conventions.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-overview.adoc
 
-include::common/attributes.adoc[]
-
 [id='document-conventions-{context}']
 = Document Conventions
 

--- a/documentation/book/ref-tolerations.adoc
+++ b/documentation/book/ref-tolerations.adoc
@@ -2,8 +2,6 @@
 //
 // assembly-dedicated-nodes.adoc
 
-include::common/attributes.adoc[]
-
 [id='tolerations-{context}']
 = Tolerations
 

--- a/documentation/book/ref-topic-operator-environment.adoc
+++ b/documentation/book/ref-topic-operator-environment.adoc
@@ -2,8 +2,6 @@
 //
 // topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='topic-operator-environment-{context}']
 = Topic Operator environment
 

--- a/documentation/book/ref-topic-operator-usage-recommendation.adoc
+++ b/documentation/book/ref-topic-operator-usage-recommendation.adoc
@@ -2,8 +2,6 @@
 //
 // topic-operator.adoc
 
-include::common/attributes.adoc[]
-
 [id='topic-operator-usage-recommendations-{context}']
 = Topic Operator usage recommendations
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

@strimzi/developers & @strimzi/docs  Including attributes in every module is causing issues in the downstream, for now, we should **only include attributes in master.adoc**.


