### PR TITLE
Added new EntityOperator to the model

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -38,6 +38,7 @@ public class EntityOperatorSpec implements Serializable {
     public static final String DEFAULT_TLS_SIDECAR_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE", "strimzi/entity-operator-stunnel:latest");
     public static final int DEFAULT_REPLICAS = 1;
+    public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
 
     private EntityTopicOperatorSpec topicOperator;
     private EntityUserOperatorSpec userOperator;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -34,6 +34,9 @@ public class EntityUserOperatorSpec implements Serializable {
 
     public static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_USER_OPERATOR_IMAGE", "strimzi/user-operator:latest");
+    public static final int DEFAULT_HEALTHCHECK_DELAY = 10;
+    public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
     public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 6;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
+import io.strimzi.api.kafka.model.EntityOperatorSpec;
+import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.Resources;
+import io.strimzi.api.kafka.model.Sidecar;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
+import io.strimzi.certs.Subject;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Represents the Entity Operator deployment
+ */
+public class EntityOperator extends AbstractModel {
+
+    private static final String NAME_SUFFIX = "-entity-operator";
+    private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
+    protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
+    protected static final String TLS_SIDECAR_VOLUME_NAME = "tls-sidecar-certs";
+    protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
+
+    // Entity Operator configuration keys
+    public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    public static final String EO_CLUSTER_ROLE_NAME = "strimzi-entity-operator";
+    public static final String EO_ROLE_BINDING_NAME = "strimzi-entity-operator-role-binding";
+
+    private String zookeeperConnect;
+    private EntityTopicOperator topicOperator;
+    private EntityUserOperator userOperator;
+    private Sidecar tlsSidecar;
+
+    /**
+     * Private key and certificate for encrypting communication with Zookeeper and Kafka
+     */
+    private CertAndKey cert;
+
+    /**
+     * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
+     * @param cluster overall cluster name
+     * @param labels
+     */
+    protected EntityOperator(String namespace, String cluster, Labels labels) {
+        super(namespace, cluster, labels);
+        this.name = entityOperatorName(cluster);
+        this.replicas = EntityOperatorSpec.DEFAULT_REPLICAS;
+        this.zookeeperConnect = defaultZookeeperConnect(cluster);
+    }
+
+    protected void setTlsSidecar(Sidecar tlsSidecar) {
+        this.tlsSidecar = tlsSidecar;
+    }
+
+    public void setTopicOperator(EntityTopicOperator topicOperator) {
+        this.topicOperator = topicOperator;
+    }
+
+    public void setUserOperator(EntityUserOperator userOperator) {
+        this.userOperator = userOperator;
+    }
+
+    public static String entityOperatorName(String cluster) {
+        return cluster + NAME_SUFFIX;
+    }
+
+    protected static String defaultZookeeperConnect(String cluster) {
+        return ZookeeperCluster.serviceName(cluster) + ":" + EntityOperatorSpec.DEFAULT_ZOOKEEPER_PORT;
+    }
+
+    public static String secretName(String cluster) {
+        return cluster + CERTS_SUFFIX;
+    }
+
+    /**
+     * Create a Entity Operator from given desired resource
+     *
+     * @param certManager Certificate manager for certificates generation
+     * @param kafkaAssembly desired resource with cluster configuration containing the entity operator one
+     * @param secrets Secrets containing already generated certificates
+     * @return Entity Operator instance, null if not configured in the ConfigMap
+     */
+    public static EntityOperator fromCrd(CertManager certManager, Kafka kafkaAssembly, List<Secret> secrets) {
+        EntityOperator result = null;
+        EntityOperatorSpec entityOperatorSpec = kafkaAssembly.getSpec().getEntityOperator();
+        if (entityOperatorSpec != null) {
+
+            String namespace = kafkaAssembly.getMetadata().getNamespace();
+            result = new EntityOperator(
+                    namespace,
+                    kafkaAssembly.getMetadata().getName(),
+                    Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
+
+            result.setUserAffinity(entityOperatorSpec.getAffinity());
+            result.setTolerations(entityOperatorSpec.getTolerations());
+            result.setTlsSidecar(entityOperatorSpec.getTlsSidecar());
+
+            EntityTopicOperatorSpec topicOperatorSpec = entityOperatorSpec.getTopicOperator();
+            if (topicOperatorSpec != null) {
+
+                EntityTopicOperator topicOperator = new EntityTopicOperator(
+                        namespace,
+                        kafkaAssembly.getMetadata().getName(),
+                        Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
+
+                topicOperator.setImage(topicOperatorSpec.getImage());
+                topicOperator.setWatchedNamespace(topicOperatorSpec.getWatchedNamespace() != null ? topicOperatorSpec.getWatchedNamespace() : namespace);
+                topicOperator.setReconciliationIntervalMs(topicOperatorSpec.getReconciliationIntervalSeconds() * 1_000);
+                topicOperator.setZookeeperSessionTimeoutMs(topicOperatorSpec.getZookeeperSessionTimeoutSeconds() * 1_000);
+                topicOperator.setTopicMetadataMaxAttempts(topicOperatorSpec.getTopicMetadataMaxAttempts());
+                topicOperator.setLogging(topicOperatorSpec.getLogging());
+                topicOperator.setResources(topicOperatorSpec.getResources());
+
+                result.setTopicOperator(topicOperator);
+            }
+
+            EntityUserOperatorSpec userOperatorSpec = entityOperatorSpec.getUserOperator();
+            if (userOperatorSpec != null) {
+
+                EntityUserOperator userOperator = new EntityUserOperator(
+                        namespace,
+                        kafkaAssembly.getMetadata().getName(),
+                        Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
+
+                userOperator.setImage(userOperatorSpec.getImage());
+                userOperator.setWatchedNamespace(userOperatorSpec.getWatchedNamespace());
+                userOperator.setReconciliationIntervalMs(userOperatorSpec.getReconciliationIntervalSeconds() * 1_000);
+                userOperator.setZookeeperSessionTimeoutMs(userOperatorSpec.getZookeeperSessionTimeoutSeconds() * 1_000);
+                userOperator.setLogging(userOperatorSpec.getLogging());
+                userOperator.setResources(userOperatorSpec.getResources());
+
+                result.setUserOperator(userOperator);
+            }
+
+            result.generateCertificates(certManager, secrets);
+        }
+        return result;
+    }
+
+    /**
+     * Manage certificates generation based on those already present in the Secrets
+     *
+     * @param certManager CertManager instance for handling certificates creation
+     * @param secrets The Secrets storing certificates
+     */
+    public void generateCertificates(CertManager certManager, List<Secret> secrets) {
+        log.debug("Generating certificates");
+
+        try {
+            Optional<Secret> clusterCAsecret = secrets.stream().filter(s -> s.getMetadata().getName().equals(getClusterCaName(cluster)))
+                    .findFirst();
+            if (clusterCAsecret.isPresent()) {
+                // get the generated CA private key + self-signed certificate for each broker
+                clusterCA = new CertAndKey(
+                        decodeFromSecret(clusterCAsecret.get(), "cluster-ca.key"),
+                        decodeFromSecret(clusterCAsecret.get(), "cluster-ca.crt"));
+
+                Optional<Secret> entityOperatorSecret = secrets.stream().filter(s -> s.getMetadata().getName().equals(EntityOperator.secretName(cluster))).findFirst();
+                if (!entityOperatorSecret.isPresent()) {
+                    log.debug("Entity Operator certificate to generate");
+
+                    File csrFile = File.createTempFile("tls", "csr");
+                    File keyFile = File.createTempFile("tls", "key");
+                    File certFile = File.createTempFile("tls", "cert");
+
+                    Subject sbj = new Subject();
+                    sbj.setOrganizationName("io.strimzi");
+                    sbj.setCommonName(EntityOperator.entityOperatorName(cluster));
+
+                    certManager.generateCsr(keyFile, csrFile, sbj);
+                    certManager.generateCert(csrFile, clusterCA.key(), clusterCA.cert(), certFile, CERTS_EXPIRATION_DAYS);
+
+                    cert = new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
+                } else {
+                    log.debug("Entity Operator certificate already exists");
+                    cert = new CertAndKey(
+                            decodeFromSecret(entityOperatorSecret.get(), "entity-operator.key"),
+                            decodeFromSecret(entityOperatorSecret.get(), "entity-operator.crt"));
+                }
+            } else {
+                throw new NoCertificateSecretException("The cluster CA certificate Secret is missing");
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        log.debug("End generating certificates");
+    }
+
+    @Override
+    protected String getDefaultLogConfigFileName() {
+        return null;
+    }
+
+    public Deployment generateDeployment() {
+        DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
+                .withType("Recreate")
+                .build();
+
+        return createDeployment(
+                updateStrategy,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                getMergedAffinity(),
+                getInitContainers(),
+                getContainers(),
+                getVolumes()
+        );
+    }
+
+    @Override
+    protected List<Container> getContainers() {
+        List<Container> containers = new ArrayList<>();
+
+        if (topicOperator != null) {
+            containers.addAll(topicOperator.getContainers());
+        }
+        if (userOperator != null) {
+            containers.addAll(userOperator.getContainers());
+        }
+
+        String tlsSidecarImage = (tlsSidecar != null && tlsSidecar.getImage() != null) ?
+                tlsSidecar.getImage() : EntityOperatorSpec.DEFAULT_TLS_SIDECAR_IMAGE;
+
+        Resources tlsSidecarResources = (tlsSidecar != null) ? tlsSidecar.getResources() : null;
+
+        Container tlsSidecarContainer = new ContainerBuilder()
+                .withName(TLS_SIDECAR_NAME)
+                .withImage(tlsSidecarImage)
+                .withResources(resources(tlsSidecarResources))
+                .withEnv(singletonList(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect)))
+                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT))
+                .build();
+
+        containers.add(tlsSidecarContainer);
+
+        return containers;
+    }
+
+    private List<Volume> getVolumes() {
+        List<Volume> volumeList = new ArrayList<>();
+        if (topicOperator != null) {
+            volumeList.addAll(topicOperator.getVolumes());
+        }
+        if (userOperator != null) {
+            volumeList.addAll(userOperator.getVolumes());
+        }
+        volumeList.add(createSecretVolume(TLS_SIDECAR_VOLUME_NAME, EntityOperator.secretName(cluster)));
+        return volumeList;
+    }
+
+    /**
+     * Generate the Secret containing CA self-signed certificates for internal communication
+     * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
+     * @return The generated Secret
+     */
+    public Secret generateSecret() {
+        Map<String, String> data = new HashMap<>();
+        data.put("cluster-ca.crt", Base64.getEncoder().encodeToString(clusterCA.cert()));
+        data.put("entity-operator.key", Base64.getEncoder().encodeToString(cert.key()));
+        data.put("entity-operator.crt", Base64.getEncoder().encodeToString(cert.cert()));
+        return createSecret(EntityOperator.secretName(cluster), data);
+    }
+
+    /**
+     * Get the name of the Entity Operator service account given the name of the {@code cluster}.
+     */
+    public static String entityOperatorServiceAccountName(String cluster) {
+        return entityOperatorName(cluster);
+    }
+
+    @Override
+    protected String getServiceAccountName() {
+        return entityOperatorServiceAccountName(cluster);
+    }
+
+    public ServiceAccount generateServiceAccount() {
+        return new ServiceAccountBuilder()
+                .withNewMetadata()
+                    .withName(getServiceAccountName())
+                    .withNamespace(namespace)
+                .endMetadata()
+                .build();
+    }
+
+    public RoleBindingOperator.RoleBinding generateRoleBinding(String namespace) {
+        return new RoleBindingOperator.RoleBinding(EO_ROLE_BINDING_NAME, EO_CLUSTER_ROLE_NAME, namespace, getServiceAccountName());
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -82,8 +82,16 @@ public class EntityOperator extends AbstractModel {
         this.topicOperator = topicOperator;
     }
 
+    public EntityTopicOperator getTopicOperator() {
+        return topicOperator;
+    }
+
     public void setUserOperator(EntityUserOperator userOperator) {
         this.userOperator = userOperator;
+    }
+
+    public EntityUserOperator getUserOperator() {
+        return userOperator;
     }
 
     public static String entityOperatorName(String cluster) {
@@ -92,6 +100,14 @@ public class EntityOperator extends AbstractModel {
 
     protected static String defaultZookeeperConnect(String cluster) {
         return ZookeeperCluster.serviceName(cluster) + ":" + EntityOperatorSpec.DEFAULT_ZOOKEEPER_PORT;
+    }
+
+    public void setZookeeperConnect(String zookeeperConnect) {
+        this.zookeeperConnect = zookeeperConnect;
+    }
+
+    public String getZookeeperConnect() {
+        return zookeeperConnect;
     }
 
     public static String secretName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -116,6 +116,14 @@ public class EntityTopicOperator extends AbstractModel {
         return zookeeperSessionTimeoutMs;
     }
 
+    public void setKafkaBootstrapServers(String kafkaBootstrapServers) {
+        this.kafkaBootstrapServers = kafkaBootstrapServers;
+    }
+
+    public String getKafkaBootstrapServers() {
+        return kafkaBootstrapServers;
+    }
+
     public void setTopicMetadataMaxAttempts(int topicMetadataMaxAttempts) {
         this.topicMetadataMaxAttempts = topicMetadataMaxAttempts;
     }
@@ -126,6 +134,14 @@ public class EntityTopicOperator extends AbstractModel {
 
     protected static String defaultZookeeperConnect(String cluster) {
         return String.format("%s:%d", "localhost", EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_PORT);
+    }
+
+    public void setZookeeperConnect(String zookeeperConnect) {
+        this.zookeeperConnect = zookeeperConnect;
+    }
+
+    public String getZookeeperConnect() {
+        return zookeeperConnect;
     }
 
     protected static String defaultBootstrapServers(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Represents the User Operator deployment
+ */
+public class EntityUserOperator extends AbstractModel {
+
+    protected static final String USER_OPERATOR_NAME = "user-operator";
+    private static final String NAME_SUFFIX = "-user-operator";
+    protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
+
+    // Port configuration
+    protected static final int HEALTHCHECK_PORT = 8080;
+    protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
+
+    // User Operator configuration keys
+    public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
+    public static final String ENV_VAR_CLIENTS_CA_NAME = "STRIMZI_CA_NAME";
+
+    private String zookeeperConnect;
+    private String watchedNamespace;
+    private long reconciliationIntervalMs;
+    private long zookeeperSessionTimeoutMs;
+
+    /**
+     * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
+     * @param cluster overall cluster name
+     * @param labels
+     */
+    protected EntityUserOperator(String namespace, String cluster, Labels labels) {
+        super(namespace, cluster, labels);
+        this.name = userOperatorName(cluster);
+        this.image = EntityUserOperatorSpec.DEFAULT_IMAGE;
+        this.readinessPath = "/";
+        this.readinessTimeout = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
+        this.readinessInitialDelay = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
+        this.livenessPath = "/";
+        this.livenessTimeout = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
+        this.livenessInitialDelay = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
+
+        // create a default configuration
+        this.zookeeperConnect = defaultZookeeperConnect(cluster);
+        this.watchedNamespace = namespace;
+        this.reconciliationIntervalMs = EntityUserOperatorSpec.DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS * 1_000;
+        this.zookeeperSessionTimeoutMs = EntityUserOperatorSpec.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS * 1_000;
+
+        this.ancillaryConfigName = metricAndLogConfigsName(cluster);
+        this.logAndMetricsConfigVolumeName = "user-operator-metrics-and-logging";
+        this.logAndMetricsConfigMountPath = "/opt/user-operator/custom-config/";
+        this.validLoggerFields = getDefaultLogConfig();
+    }
+
+    public void setWatchedNamespace(String watchedNamespace) {
+        this.watchedNamespace = watchedNamespace;
+    }
+
+    public String getWatchedNamespace() {
+        return watchedNamespace;
+    }
+
+    public void setReconciliationIntervalMs(long reconciliationIntervalMs) {
+        this.reconciliationIntervalMs = reconciliationIntervalMs;
+    }
+
+    public long getReconciliationIntervalMs() {
+        return reconciliationIntervalMs;
+    }
+
+    public void setZookeeperSessionTimeoutMs(long zookeeperSessionTimeoutMs) {
+        this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
+    }
+
+    public long getZookeeperSessionTimeoutMs() {
+        return zookeeperSessionTimeoutMs;
+    }
+
+    protected static String defaultZookeeperConnect(String cluster) {
+        return String.format("%s:%d", "localhost", EntityUserOperatorSpec.DEFAULT_ZOOKEEPER_PORT);
+    }
+
+    public static String userOperatorName(String cluster) {
+        return cluster + NAME_SUFFIX;
+    }
+
+    public static String metricAndLogConfigsName(String cluster) {
+        return cluster + METRICS_AND_LOG_CONFIG_SUFFIX;
+    }
+
+    @Override
+    protected String getDefaultLogConfigFileName() {
+        return "userOperatorDefaultLoggingProperties";
+    }
+
+    @Override
+    String getAncillaryConfigMapKeyLogConfig() {
+        return "log4j2.properties";
+    }
+
+    @Override
+    protected List<Container> getContainers() {
+
+        return Collections.singletonList(new ContainerBuilder()
+                .withName(USER_OPERATOR_NAME)
+                .withImage(getImage())
+                .withEnv(getEnvVars())
+                .withPorts(singletonList(createContainerPort(HEALTHCHECK_PORT_NAME, HEALTHCHECK_PORT, "TCP")))
+                .withLivenessProbe(createHttpProbe(livenessPath + "healthy", HEALTHCHECK_PORT_NAME, livenessInitialDelay, livenessTimeout))
+                .withReadinessProbe(createHttpProbe(readinessPath + "ready", HEALTHCHECK_PORT_NAME, readinessInitialDelay, readinessTimeout))
+                .withResources(resources(getResources()))
+                .withVolumeMounts(getVolumeMounts())
+                .build());
+    }
+
+    @Override
+    protected List<EnvVar> getEnvVars() {
+        List<EnvVar> varList = new ArrayList<>();
+        varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
+        varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_NAME, KafkaCluster.clientsCASecretName(cluster)));
+        return varList;
+    }
+
+    public List<Volume> getVolumes() {
+        return Collections.singletonList(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
+    }
+
+    private List<VolumeMount> getVolumeMounts() {
+        return Collections.singletonList(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -35,6 +35,7 @@ public class EntityUserOperator extends AbstractModel {
 
     // User Operator configuration keys
     public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    public static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_CLIENTS_CA_NAME = "STRIMZI_CA_NAME";
@@ -147,7 +148,7 @@ public class EntityUserOperator extends AbstractModel {
                         Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
 
                 result.setImage(userOperatorSpec.getImage());
-                result.setWatchedNamespace(userOperatorSpec.getWatchedNamespace());
+                result.setWatchedNamespace(userOperatorSpec.getWatchedNamespace() != null ? userOperatorSpec.getWatchedNamespace() : namespace);
                 result.setReconciliationIntervalMs(userOperatorSpec.getReconciliationIntervalSeconds() * 1_000);
                 result.setZookeeperSessionTimeoutMs(userOperatorSpec.getZookeeperSessionTimeoutSeconds() * 1_000);
                 result.setLogging(userOperatorSpec.getLogging());
@@ -176,6 +177,7 @@ public class EntityUserOperator extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(ENV_VAR_WATCHED_NAMESPACE, watchedNamespace));
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_NAME, KafkaCluster.clientsCASecretName(cluster)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -28,7 +28,7 @@ public class EntityUserOperator extends AbstractModel {
     protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
     // Port configuration
-    protected static final int HEALTHCHECK_PORT = 8080;
+    protected static final int HEALTHCHECK_PORT = 8081;
     protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
 
     // User Operator configuration keys

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -100,6 +100,14 @@ public class EntityUserOperator extends AbstractModel {
         return String.format("%s:%d", "localhost", EntityUserOperatorSpec.DEFAULT_ZOOKEEPER_PORT);
     }
 
+    public void setZookeeperConnect(String zookeeperConnect) {
+        this.zookeeperConnect = zookeeperConnect;
+    }
+
+    public String getZookeeperConnect() {
+        return zookeeperConnect;
+    }
+
     public static String userOperatorName(String cluster) {
         return cluster + NAME_SUFFIX;
     }

--- a/cluster-operator/src/main/resources/userOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/userOperatorDefaultLoggingProperties
@@ -1,0 +1,13 @@
+name = UOConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+
+property.user-operator.root.logger=${env:STRIMZI_LOG_LEVEL:-INFO}
+
+rootLogger.level = ${user-operator.root.logger}
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.strimzi.api.kafka.model.EntityOperatorSpec;
+import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
+import io.strimzi.api.kafka.model.EntityTopicOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.certs.CertManager;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.common.operator.MockCertManager;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EntityOperatorTest {
+
+    private final String namespace = "test";
+    private final String cluster = "foo";
+    private final int replicas = 3;
+    private final String image = "my-image:latest";
+    private final int healthDelay = 120;
+    private final int healthTimeout = 30;
+
+    private final EntityUserOperatorSpec entityUserOperatorSpec = new EntityUserOperatorSpecBuilder()
+            .build();
+    private final EntityTopicOperatorSpec entityTopicOperatorSpec = new EntityTopicOperatorSpecBuilder()
+            .build();
+
+    private final EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
+            .withTopicOperator(entityTopicOperatorSpec)
+            .withUserOperator(entityUserOperatorSpec)
+            .build();
+
+    private final Kafka resource =
+            new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                    .editSpec()
+                    .withEntityOperator(entityOperatorSpec)
+                    .endSpec()
+                    .build();
+
+    private final CertManager certManager = new MockCertManager();
+    private final EntityOperator entityOperator = EntityOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
+
+    @Test
+    public void testGenerateDeployment() {
+
+        Deployment dep = entityOperator.generateDeployment();
+
+        List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
+
+        assertEquals(entityOperator.entityOperatorName(cluster), dep.getMetadata().getName());
+        assertEquals(namespace, dep.getMetadata().getNamespace());
+        assertEquals(new Integer(EntityOperatorSpec.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
+
+        assertEquals(3, containers.size());
+        // just check names of topic and user operators (their containers are tested in the related unit test classes)
+        assertEquals(EntityTopicOperator.TOPIC_OPERATOR_NAME, containers.get(0).getName());
+        assertEquals(EntityUserOperator.USER_OPERATOR_NAME, containers.get(1).getName());
+        // checks on the TLS sidecar container
+        assertEquals(EntityOperatorSpec.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(2).getImage());
+        assertEquals(EntityOperator.defaultZookeeperConnect(cluster), AbstractModel.containerEnvVars(containers.get(2)).get(EntityOperator.ENV_VAR_ZOOKEEPER_CONNECT));
+        assertEquals(EntityOperator.TLS_SIDECAR_VOLUME_NAME, containers.get(2).getVolumeMounts().get(0).getName());
+        assertEquals(EntityOperator.TLS_SIDECAR_VOLUME_MOUNT, containers.get(2).getVolumeMounts().get(0).getMountPath());
+    }
+
+    @Test
+    public void testFromCrd() {
+        assertEquals(namespace, entityOperator.namespace);
+        assertEquals(cluster, entityOperator.cluster);
+        assertEquals(EntityOperator.defaultZookeeperConnect(cluster), entityOperator.getZookeeperConnect());
+    }
+
+    @Test
+    public void testFromCrdNoTopicAndUserOperatorInEntityOperator() {
+        EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
+        Kafka resource =
+                new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                        .editSpec()
+                        .withEntityOperator(entityOperatorSpec)
+                        .endSpec()
+                        .build();
+        EntityOperator entityOperator = EntityOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
+
+        assertNull(entityOperator.getTopicOperator());
+        assertNull(entityOperator.getUserOperator());
+    }
+
+    @Rule
+    public ResourceTester<Kafka, EntityOperator> helper = new ResourceTester<>(Kafka.class, EntityOperator::fromCrd);
+
+    @Test
+    public void withAffinity() throws IOException {
+        helper.assertDesiredResource("-Deployment.yaml", zc -> zc.generateDeployment().getSpec().getTemplate().getSpec().getAffinity());
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.strimzi.api.kafka.model.EntityOperatorSpec;
+import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
+import io.strimzi.api.kafka.model.EntityTopicOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EntityTopicOperatorTest {
+
+    private final String namespace = "test";
+    private final String cluster = "foo";
+    private final int replicas = 3;
+    private final String image = "my-image:latest";
+    private final int healthDelay = 120;
+    private final int healthTimeout = 30;
+    private final InlineLogging topicOperatorLogging = new InlineLogging();
+    {
+        topicOperatorLogging.setLoggers(Collections.singletonMap("topic-operator.root.logger", "OFF"));
+    }
+
+    private final String toWatchedNamespace = "my-topic-namespace";
+    private final String toImage = "my-topic-operator-image";
+    private final int toReconciliationInterval = 90;
+    private final int toZookeeperSessionTimeout = 20;
+    private final int toTopicMetadataMaxAttempts = 3;
+
+    private final EntityTopicOperatorSpec entityTopicOperatorSpec = new EntityTopicOperatorSpecBuilder()
+            .withWatchedNamespace(toWatchedNamespace)
+            .withImage(toImage)
+            .withReconciliationIntervalSeconds(toReconciliationInterval)
+            .withZookeeperSessionTimeoutSeconds(toZookeeperSessionTimeout)
+            .withTopicMetadataMaxAttempts(toTopicMetadataMaxAttempts)
+            .withLogging(topicOperatorLogging)
+            .build();
+
+    private final EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
+            .withTopicOperator(entityTopicOperatorSpec)
+            .build();
+
+    private final Kafka resource =
+            new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                    .editSpec()
+                    .withEntityOperator(entityOperatorSpec)
+                    .endSpec()
+                    .build();
+
+    private final EntityTopicOperator entityTopicOperator = EntityTopicOperator.fromCrd(resource);
+
+    private List<EnvVar> getExpectedEnvVars() {
+        List<EnvVar> expected = new ArrayList<>();
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_RESOURCE_LABELS).withValue(EntityTopicOperator.defaultTopicConfigMapLabels(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_KAFKA_BOOTSTRAP_SERVERS).withValue(EntityTopicOperator.defaultBootstrapServers(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(String.format("%s:%d", "localhost", EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_PORT)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(toWatchedNamespace).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(toReconciliationInterval * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(toZookeeperSessionTimeout * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(toTopicMetadataMaxAttempts)).build());
+        expected.add(new EnvVarBuilder().withName(TopicOperator.ENV_VAR_TLS_ENABLED).withValue(Boolean.toString(true)).build());
+        return expected;
+    }
+
+    @Test
+    public void testEnvVars()   {
+        Assert.assertEquals(getExpectedEnvVars(), entityTopicOperator.getEnvVars());
+    }
+
+    @Test
+    public void testFromCrd() {
+        assertEquals(namespace, entityTopicOperator.namespace);
+        assertEquals(cluster, entityTopicOperator.cluster);
+        assertEquals(toImage, entityTopicOperator.image);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.readinessInitialDelay);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.readinessTimeout);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.livenessInitialDelay);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.livenessTimeout);
+        assertEquals(toWatchedNamespace, entityTopicOperator.getWatchedNamespace());
+        assertEquals(toReconciliationInterval * 1000, entityTopicOperator.getReconciliationIntervalMs());
+        assertEquals(toZookeeperSessionTimeout * 1000, entityTopicOperator.getZookeeperSessionTimeoutMs());
+        assertEquals(EntityTopicOperator.defaultZookeeperConnect(cluster), entityTopicOperator.getZookeeperConnect());
+        assertEquals(EntityTopicOperator.defaultBootstrapServers(cluster), entityTopicOperator.getKafkaBootstrapServers());
+        assertEquals(EntityTopicOperator.defaultTopicConfigMapLabels(cluster), entityTopicOperator.getTopicConfigMapLabels());
+        assertEquals(toTopicMetadataMaxAttempts, entityTopicOperator.getTopicMetadataMaxAttempts());
+        assertEquals(topicOperatorLogging.getType(), entityTopicOperator.getLogging().getType());
+        assertEquals(topicOperatorLogging.getLoggers(), ((InlineLogging) entityTopicOperator.getLogging()).getLoggers());
+    }
+
+    @Test
+    public void testFromCrdDefault() {
+        EntityTopicOperatorSpec entityTopicOperatorSpec = new EntityTopicOperatorSpecBuilder()
+                .build();
+        EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
+                .withTopicOperator(entityTopicOperatorSpec)
+                .build();
+        Kafka resource =
+                new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                        .editSpec()
+                        .withEntityOperator(entityOperatorSpec)
+                        .endSpec()
+                        .build();
+        EntityTopicOperator entityTopicOperator = EntityTopicOperator.fromCrd(resource);
+
+        assertEquals(namespace, entityTopicOperator.getWatchedNamespace());
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_IMAGE, entityTopicOperator.getImage());
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS * 1000, entityTopicOperator.getReconciliationIntervalMs());
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS * 1000, entityTopicOperator.getZookeeperSessionTimeoutMs());
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS, entityTopicOperator.getTopicMetadataMaxAttempts());
+        assertEquals(EntityTopicOperator.defaultZookeeperConnect(cluster), entityTopicOperator.getZookeeperConnect());
+        assertEquals(EntityTopicOperator.defaultBootstrapServers(cluster), entityTopicOperator.getKafkaBootstrapServers());
+        assertEquals(EntityTopicOperator.defaultTopicConfigMapLabels(cluster), entityTopicOperator.getTopicConfigMapLabels());
+        assertNull(entityTopicOperator.getLogging());
+    }
+
+    @Test
+    public void testFromCrdNoEntityOperator() {
+        Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout);
+        EntityTopicOperator entityTopicOperator = EntityTopicOperator.fromCrd(resource);
+        assertNull(entityTopicOperator);
+    }
+
+    @Test
+    public void testFromCrdNoTopicOperatorInEntityOperator() {
+        EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
+        Kafka resource =
+                new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                        .editSpec()
+                        .withEntityOperator(entityOperatorSpec)
+                        .endSpec()
+                        .build();
+        EntityTopicOperator entityTopicOperator = EntityTopicOperator.fromCrd(resource);
+        assertNull(entityTopicOperator);
+    }
+
+    @Test
+    public void testGetContainers() {
+        List<Container> containers = entityTopicOperator.getContainers();
+        assertEquals(1, containers.size());
+
+        Container container = containers.get(0);
+        assertEquals(EntityTopicOperator.TOPIC_OPERATOR_NAME, container.getName());
+        assertEquals(entityTopicOperator.getImage(), container.getImage());
+        assertEquals(getExpectedEnvVars(), container.getEnv());
+        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY), container.getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT), container.getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY), container.getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT), container.getReadinessProbe().getTimeoutSeconds());
+        assertEquals(1, container.getPorts().size());
+        assertEquals(new Integer(EntityTopicOperator.HEALTHCHECK_PORT), container.getPorts().get(0).getContainerPort());
+        assertEquals(EntityTopicOperator.HEALTHCHECK_PORT_NAME, container.getPorts().get(0).getName());
+        assertEquals("TCP", container.getPorts().get(0).getProtocol());
+        assertEquals("/opt/topic-operator/custom-config/", container.getVolumeMounts().get(0).getMountPath());
+        assertEquals("topic-operator-metrics-and-logging", container.getVolumeMounts().get(0).getName());
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.strimzi.api.kafka.model.EntityOperatorSpec;
+import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
+import io.strimzi.api.kafka.model.EntityUserOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EntityUserOperatorTest {
+
+    private final String namespace = "test";
+    private final String cluster = "foo";
+    private final int replicas = 3;
+    private final String image = "my-image:latest";
+    private final int healthDelay = 120;
+    private final int healthTimeout = 30;
+    private final InlineLogging userOperatorLogging = new InlineLogging();
+    {
+        userOperatorLogging.setLoggers(Collections.singletonMap("user-operator.root.logger", "OFF"));
+    }
+
+    private final String uoWatchedNamespace = "my-user-namespace";
+    private final String uoImage = "my-user-operator-image";
+    private final int uoReconciliationInterval = 90;
+    private final int uoZookeeperSessionTimeout = 20;
+
+    private final EntityUserOperatorSpec entityUserOperatorSpec = new EntityUserOperatorSpecBuilder()
+            .withWatchedNamespace(uoWatchedNamespace)
+            .withImage(uoImage)
+            .withReconciliationIntervalSeconds(uoReconciliationInterval)
+            .withZookeeperSessionTimeoutSeconds(uoZookeeperSessionTimeout)
+            .withLogging(userOperatorLogging)
+            .build();
+
+    private final EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
+            .withUserOperator(entityUserOperatorSpec)
+            .build();
+
+    private final Kafka resource =
+            new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                    .editSpec()
+                    .withEntityOperator(entityOperatorSpec)
+                    .endSpec()
+                    .build();
+
+    private final EntityUserOperator entityUserOperator = EntityUserOperator.fromCrd(resource);
+
+    private List<EnvVar> getExpectedEnvVars() {
+        List<EnvVar> expected = new ArrayList<>();
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(String.format("%s:%d", "localhost", EntityUserOperatorSpec.DEFAULT_ZOOKEEPER_PORT)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAME).withValue(KafkaCluster.clientsCASecretName(cluster)).build());
+        return expected;
+    }
+
+    @Test
+    public void testFromCrd() {
+        assertEquals(namespace, entityUserOperator.namespace);
+        assertEquals(cluster, entityUserOperator.cluster);
+        assertEquals(uoImage, entityUserOperator.image);
+        assertEquals(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityUserOperator.readinessInitialDelay);
+        assertEquals(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityUserOperator.readinessTimeout);
+        assertEquals(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityUserOperator.livenessInitialDelay);
+        assertEquals(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityUserOperator.livenessTimeout);
+        assertEquals(uoWatchedNamespace, entityUserOperator.getWatchedNamespace());
+        assertEquals(uoReconciliationInterval * 1000, entityUserOperator.getReconciliationIntervalMs());
+        assertEquals(uoZookeeperSessionTimeout * 1000, entityUserOperator.getZookeeperSessionTimeoutMs());
+        assertEquals(EntityUserOperator.defaultZookeeperConnect(cluster), entityUserOperator.getZookeeperConnect());
+        assertEquals(userOperatorLogging.getType(), entityUserOperator.getLogging().getType());
+        assertEquals(userOperatorLogging.getLoggers(), ((InlineLogging) entityUserOperator.getLogging()).getLoggers());
+    }
+
+    @Test
+    public void testEnvVars()   {
+        Assert.assertEquals(getExpectedEnvVars(), entityUserOperator.getEnvVars());
+    }
+
+    @Test
+    public void testFromCrdNoEntityOperator() {
+        Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout);
+        EntityUserOperator entityUserOperator = EntityUserOperator.fromCrd(resource);
+        assertNull(entityUserOperator);
+    }
+
+    @Test
+    public void testFromCrdNoUserOperatorInEntityOperator() {
+        EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder().build();
+        Kafka resource =
+                new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+                        .editSpec()
+                        .withEntityOperator(entityOperatorSpec)
+                        .endSpec()
+                        .build();
+        EntityUserOperator entityUserOperator = EntityUserOperator.fromCrd(resource);
+        assertNull(entityUserOperator);
+    }
+}

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/EntityOperatorTest.withAffinity-Deployment.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/EntityOperatorTest.withAffinity-Deployment.yaml
@@ -1,0 +1,18 @@
+---
+nodeAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - preference:
+      matchExpressions:
+      - key: "another-node-label-key"
+        operator: "In"
+        values:
+        - "another-node-label-value"
+    weight: 1
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: "kubernetes.io/e2e-az-name"
+        operator: "In"
+        values:
+        - "e2e-az1"
+        - "e2e-az2"

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/EntityOperatorTest.withAffinity-Kafka.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/EntityOperatorTest.withAffinity-Kafka.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/e2e-az-name
+              operator: In
+              values:
+              - e2e-az1
+              - e2e-az2
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: another-node-label-key
+              operator: In
+              values:
+              - another-node-label-value
+  kafka:
+    replicas: 2

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS=java-base kafka-base zookeeper kafka kafka-connect kafka-connect/s2i stunnel-base zookeeper-stunnel kafka-stunnel topic-operator-stunnel
+SUBDIRS=java-base kafka-base zookeeper kafka kafka-connect kafka-connect/s2i stunnel-base zookeeper-stunnel kafka-stunnel topic-operator-stunnel entity-operator-stunnel
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/docker-images/entity-operator-stunnel/Dockerfile
+++ b/docker-images/entity-operator-stunnel/Dockerfile
@@ -1,0 +1,8 @@
+FROM strimzi/stunnel-base:latest
+
+# copy scripts for starting Stunnel
+COPY ./scripts/ $STUNNEL_HOME
+
+USER stunnel:stunnel
+
+CMD ["/opt/stunnel/stunnel_run.sh"]

--- a/docker-images/entity-operator-stunnel/Makefile
+++ b/docker-images/entity-operator-stunnel/Makefile
@@ -1,0 +1,5 @@
+PROJECT_NAME=entity-operator-stunnel
+
+include ../../Makefile.docker
+
+.PHONY: build clean release

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# path were the Secret with certificates is mounted
+CERTS=/etc/tls-sidecar/certs
+
+echo "pid = /usr/local/var/run/stunnel.pid"
+echo "foreground = yes"
+echo "debug = info"
+
+cat <<-EOF
+[zookeeper-2181]
+client = yes
+CAfile = ${CERTS}/cluster-ca.crt
+cert = ${CERTS}/entity-operator.crt
+key = ${CERTS}/entity-operator.key
+accept = 127.0.0.1:2181
+connect = ${STRIMZI_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+verify = 2
+
+EOF

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Generate and print the config file
+echo "Starting Stunnel with configuration:"
+./stunnel_config_generator.sh | tee /tmp/stunnel.conf
+echo ""
+
+# starting Stunnel with final configuration
+exec /usr/bin/stunnel /tmp/stunnel.conf

--- a/examples/install/cluster-operator/04-ClusterRole-strimzi-entity-operator.yaml
+++ b/examples/install/cluster-operator/04-ClusterRole-strimzi-entity-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete

--- a/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-entity-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR added a new `EntityOperator` model for deploying the Pod having Topic and User Operators containers and the related TLS sidecar for connecting to Zookeeper.
It also adds new `EntityUserOperator` and `EntityTopicOperator` related to the above containers.
(notice that the current `TopicOperator` model is left for compatibility).
Finally, this PR provides the `entity-operator-stunnel` Docker image for the TLS sidecar and the YAML files for the `ClusterRole` and `ClusterRoleBinding` related to the Entity Operator.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

