### PR TITLE
Docs: Add attribute to hide/show security image

### DIFF
--- a/documentation/book/security.adoc
+++ b/documentation/book/security.adoc
@@ -6,8 +6,12 @@ For the Kafka and Strimzi components, TLS certificates are also used for authent
 
 The Cluster Operator sets up the SSL/TLS certificates to provide this encryption and authentication.
 
+ifdef::SecurityImg[]
+
 .Example Architecture diagram of the communication secured by TLS.
 image::secure_communication.png[Secure Communication]
+
+endif::SecurityImg[]
 
 === Certificates
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -60,3 +60,4 @@
 :InstallationAppendix:
 :MetricsAppendix:
 :Downloading:
+:SecurityImg:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Add ability to include/exclude security image in the book with an attribute
