### PR TITLE
Kafka connect s2i rename and default image

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -60,7 +60,7 @@ public class KafkaConnectS2I extends CustomResource {
 
     private String apiVersion;
     private ObjectMeta metadata;
-    private KafkaConnectS2IAssemblySpec spec;
+    private KafkaConnectS2ISpec spec;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Override
@@ -91,11 +91,11 @@ public class KafkaConnectS2I extends CustomResource {
     }
 
     @Description("The specification of the Kafka Connect deployment.")
-    public KafkaConnectS2IAssemblySpec getSpec() {
+    public KafkaConnectS2ISpec getSpec() {
         return spec;
     }
 
-    public void setSpec(KafkaConnectS2IAssemblySpec spec) {
+    public void setSpec(KafkaConnectS2ISpec spec) {
         this.spec = spec;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
@@ -17,9 +17,12 @@ import io.sundr.builder.annotations.Buildable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "replicas", "image",
         "livenessProbe", "readinessProbe", "jvmOptions", "affinity", "metrics"})
-public class KafkaConnectS2IAssemblySpec extends KafkaConnectSpec {
+public class KafkaConnectS2ISpec extends KafkaConnectSpec {
 
     private static final long serialVersionUID = 1L;
+
+    public static final String DEFAULT_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
 
     private boolean insecureSourceRepository = false;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -44,8 +44,6 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/connect-certs/";
 
     // Configuration defaults
-    protected static final String DEFAULT_IMAGE =
-            System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE", "strimzi/kafka-connect:latest");
     protected static final int DEFAULT_REPLICAS = 3;
     protected static final int DEFAULT_HEALTHCHECK_DELAY = 60;
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
@@ -76,7 +74,7 @@ public class KafkaConnectCluster extends AbstractModel {
         this.serviceName = serviceName(cluster);
         this.validLoggerFields = getDefaultLogConfig();
         this.ancillaryConfigName = logAndMetricsConfigName(cluster);
-        this.image = DEFAULT_IMAGE;
+        this.image = KafkaConnectSpec.DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
         this.readinessPath = "/";
         this.readinessTimeout = DEFAULT_HEALTHCHECK_TIMEOUT;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -26,7 +26,7 @@ import io.fabric8.openshift.api.model.TagImportPolicyBuilder;
 import io.fabric8.openshift.api.model.TagReference;
 import io.fabric8.openshift.api.model.TagReferencePolicyBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
-import io.strimzi.api.kafka.model.KafkaConnectS2IAssemblySpec;
+import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
 import io.strimzi.operator.common.model.Labels;
 
 import java.util.Map;
@@ -34,13 +34,10 @@ import java.util.Map;
 public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
     // Kafka Connect S2I configuration
-    protected String sourceImageBaseName = DEFAULT_IMAGE.substring(0, DEFAULT_IMAGE.lastIndexOf(":"));
-    protected String sourceImageTag = DEFAULT_IMAGE.substring(DEFAULT_IMAGE.lastIndexOf(":") + 1);
+    protected String sourceImageBaseName = KafkaConnectS2ISpec.DEFAULT_IMAGE.substring(0, KafkaConnectS2ISpec.DEFAULT_IMAGE.lastIndexOf(":"));
+    protected String sourceImageTag = KafkaConnectS2ISpec.DEFAULT_IMAGE.substring(KafkaConnectS2ISpec.DEFAULT_IMAGE.lastIndexOf(":") + 1);
     protected String tag = "latest";
     protected boolean insecureSourceRepository = false;
-
-    // Configuration defaults
-    protected static final String DEFAULT_IMAGE = System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
 
     /**
      * Constructor
@@ -50,12 +47,12 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
      */
     private KafkaConnectS2ICluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
-        setImage(DEFAULT_IMAGE);
+        setImage(KafkaConnectS2ISpec.DEFAULT_IMAGE);
         this.validLoggerFields = getDefaultLogConfig();
     }
 
     public static KafkaConnectS2ICluster fromCrd(KafkaConnectS2I kafkaConnectS2I) {
-        KafkaConnectS2IAssemblySpec spec = kafkaConnectS2I.getSpec();
+        KafkaConnectS2ISpec spec = kafkaConnectS2I.getSpec();
         KafkaConnectS2ICluster cluster = fromSpec(spec, new KafkaConnectS2ICluster(kafkaConnectS2I.getMetadata().getNamespace(),
                 kafkaConnectS2I.getMetadata().getName(),
                 Labels.fromResource(kafkaConnectS2I).withKind(kafkaConnectS2I.getKind())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
@@ -118,7 +119,7 @@ public class KafkaConnectClusterTest {
     public void testDefaultValues() {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(ResourceUtils.createEmptyKafkaConnectCluster(namespace, cluster));
 
-        assertEquals(KafkaConnectCluster.DEFAULT_IMAGE, kc.image);
+        assertEquals(KafkaConnectSpec.DEFAULT_IMAGE, kc.image);
         assertEquals(KafkaConnectCluster.DEFAULT_REPLICAS, kc.replicas);
         assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY, kc.readinessInitialDelay);
         assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.readinessTimeout);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -120,7 +121,7 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster) + ":latest", kc.image);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_REPLICAS, kc.replicas);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_IMAGE, kc.sourceImageBaseName + ":" + kc.sourceImageTag);
+        assertEquals(KafkaConnectS2ISpec.DEFAULT_IMAGE, kc.sourceImageBaseName + ":" + kc.sourceImageTag);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_DELAY, kc.readinessInitialDelay);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.readinessTimeout);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_DELAY, kc.livenessInitialDelay);

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -205,7 +205,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 [id='type-Probe-{context}']
 ### `Probe` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -220,7 +220,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [id='type-JvmOptions-{context}']
 ### `JvmOptions` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -237,7 +237,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [id='type-Resources-{context}']
 ### `Resources` schema reference
 
-Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -267,7 +267,7 @@ Used in: xref:type-Resources-{context}[`Resources`]
 [id='type-InlineLogging-{context}']
 ### `InlineLogging` schema reference
 
-Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `InlineLogging` from xref:type-ExternalLogging-{context}[`ExternalLogging`].
@@ -284,7 +284,7 @@ It must have the value `inline` for the type `InlineLogging`.
 [id='type-ExternalLogging-{context}']
 ### `ExternalLogging` schema reference
 
-Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `ExternalLogging` from xref:type-InlineLogging-{context}[`InlineLogging`].
@@ -515,7 +515,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 [id='type-KafkaConnectAuthenticationTls-{context}']
 ### `KafkaConnectAuthenticationTls` schema reference
 
-Used in: xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaConnectAuthenticationTls` from other subtypes which may be added in the future.
@@ -549,7 +549,7 @@ Used in: xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenti
 [id='type-KafkaConnectTls-{context}']
 ### `KafkaConnectTls` schema reference
 
-Used in: xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
 
 [options="header"]
@@ -582,11 +582,11 @@ Used in: xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
 |====
 |Field        |Description
 |spec  1.2+<.<|The specification of the Kafka Connect deployment.
-|xref:type-KafkaConnectS2IAssemblySpec-{context}[`KafkaConnectS2IAssemblySpec`]
+|xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`]
 |====
 
-[id='type-KafkaConnectS2IAssemblySpec-{context}']
-### `KafkaConnectS2IAssemblySpec` schema reference
+[id='type-KafkaConnectS2ISpec-{context}']
+### `KafkaConnectS2ISpec` schema reference
 
 Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR fix some left overs from past PRs.

* Renames `KafkaConnectS2IAssemblySpec` to `KafkaConnectS2ISpec` to match the latest naming schema. It seems this class was left over during the big renaming.
* Moves the configuration of the default Docker image from the cluster operator model to the API for Kafka Connect and Connect S2I. This was already done for Kafka brokers and Zoo in the past. This PR brings it on the same level.