### PR TITLE
Cluster CA should be properly labeled

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -80,11 +80,25 @@ public class SecretCertProvider {
         data.put(keyKey, encoder.encodeToString(key));
         data.put(certKey, encoder.encodeToString(cert));
 
+        return createSecret(namespace, name, data, labels);
+    }
+
+    /**
+     * Create a Kubernetes secret containing the provided secret data section
+     *
+     * @param namespace Namespace
+     * @param name Secret name
+     * @param data Map with secret data / files
+     * @param labels Labels to add to the Secret
+     * @return the Secret
+     * @throws IOException
+     */
+    public Secret createSecret(String namespace, String name, Map<String, String> data, Map<String, String> labels) {
         Secret secret = new SecretBuilder()
                 .withNewMetadata()
-                    .withName(name)
-                    .withNamespace(namespace)
-                    .withLabels(labels)
+                .withName(name)
+                .withNamespace(namespace)
+                .withLabels(labels)
                 .endMetadata()
                 .withData(data)
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -151,9 +151,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                         secret = secretCertProvider.createSecret(reconciliation.namespace(), clusterCaName,
                                 "cluster-ca.key", "cluster-ca.crt",
                                 clusterCAkeyFile, clusterCAcertFile, labels.toMap());
-
-                        secretOperations.reconcile(reconciliation.namespace(), clusterCaName, secret)
-                                .compose(future::complete, future);
                     } catch (Throwable e) {
                         future.fail(e);
                     } finally {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -851,6 +851,7 @@ public class KafkaAssemblyOperatorTest {
         );
 
         when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName())))).thenReturn(fooSecrets.get(0));
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
@@ -863,6 +864,7 @@ public class KafkaAssemblyOperatorTest {
                         barCluster.generateBrokersSecret(), barCluster.generateClusterPublicKeySecret()))
         );
         when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         Labels bazLabels = Labels.forCluster("baz");
         KafkaCluster bazCluster = KafkaCluster.fromCrd(certManager, baz, bazSecrets);

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -77,14 +77,18 @@ public class Labels {
     }
 
     public static Labels userLabels(Map<String, String> userLabels) {
-        for (String key : userLabels.keySet()) {
-            if (key.startsWith(STRIMZI_DOMAIN)
-                    && !key.equals(STRIMZI_KIND_LABEL)) {
-                throw new IllegalArgumentException("User labels includes a Strimzi label that is not "
-                        + STRIMZI_KIND_LABEL + ": " + key);
+        if (userLabels != null) {
+            for (String key : userLabels.keySet()) {
+                if (key.startsWith(STRIMZI_DOMAIN)
+                        && !key.equals(STRIMZI_KIND_LABEL)) {
+                    throw new IllegalArgumentException("User labels includes a Strimzi label that is not "
+                            + STRIMZI_KIND_LABEL + ": " + key);
+                }
             }
+            return new Labels(userLabels);
         }
-        return new Labels(userLabels);
+
+        return EMPTY;
     }
 
     /**
@@ -98,7 +102,11 @@ public class Labels {
      * Returns the labels from Map.
      */
     public static Labels fromMap(Map<String, String> labels) {
-        return new Labels(labels);
+        if (labels != null) {
+            return new Labels(labels);
+        }
+
+        return EMPTY;
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -32,6 +32,16 @@ public class LabelsTest {
     }
 
     @Test
+    public void testParseNullLabelsInFromMap()   {
+        assertEquals(Labels.EMPTY, Labels.fromMap(null));
+    }
+
+    @Test
+    public void testParseNullLabelsInUserLabels()   {
+        assertEquals(Labels.EMPTY, Labels.userLabels(null));
+    }
+
+    @Test
     public void testParseEmptyLabels()   {
         String validLabels = "";
         assertEquals(Labels.EMPTY, Labels.fromString(validLabels));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Cluster CA secret is currently created without any labels. It should be properly labeled and the labels should be updated when the change on the original resource. This PR makes sure that happens.

Additionally, it brings some minor improvements to the `Labels` class and allows to call `fromMap` and `userLabels` with maps which are potentially null.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally