### PR TITLE
run SimpleAclAuthorizer methods as blocking

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -122,7 +122,7 @@ public class SimpleAclOperator {
 
     /**
      * Update all ACLs for given user.
-     * SimpleAclAuthorizer doesn't support modyfication of existing rules.
+     * SimpleAclAuthorizer doesn't support modification of existing rules.
      * This class is using Sets to decide which rules need to be added and which need to be deleted.
      * It delagates to {@link #internalCreate internalCreate} and {@link #internalDelete internalDelete} methods for the actual addition or deletion.
      */


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

Running `SimpleAclAuthorizer` methods as blocking by wrapping them into `executeBlocking`.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging 
- [ ] Update CHANGELOG.md

https://github.com/strimzi/strimzi-kafka-operator/issues/723