### PR TITLE
Docs: Add User Operator docs

### DIFF
--- a/documentation/book/assembly-getting-started-user-operator.adoc
+++ b/documentation/book/assembly-getting-started-user-operator.adoc
@@ -1,0 +1,13 @@
+// This assembly is included in the following assemblies:
+//
+// getting-started.adoc
+
+[id='assembly-getting-started-user-operator-{context}']
+= User Operator
+
+User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+
+include::con-what-the-user-operator-does.adoc[leveloffset=+1]
+
+include::proc-deploying-the-user-operator-using-the-cluster-operator.adoc[leveloffset=+1]
+

--- a/documentation/book/assembly-getting-started-user-operator.adoc
+++ b/documentation/book/assembly-getting-started-user-operator.adoc
@@ -5,7 +5,7 @@
 [id='assembly-getting-started-user-operator-{context}']
 = User Operator
 
-User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+The User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
 
 include::con-what-the-user-operator-does.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-user-operator.adoc
+++ b/documentation/book/assembly-user-operator.adoc
@@ -1,0 +1,20 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-operators.adoc
+
+:parent-context-deploying-uo: {context}
+
+[id='assembly-user-operator-{context}']
+= User Operator
+
+:context: deploying-uo
+
+User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+
+include::con-what-the-user-operator-does.adoc[leveloffset=+1]
+
+include::proc-deploying-the-user-operator-using-the-cluster-operator.adoc[leveloffset=+1]
+
+include::proc-deploying-the-user-operator-standalone.adoc[leveloffset=+1]
+
+:context: {parent-context-deploying-uo}

--- a/documentation/book/assembly-user-operator.adoc
+++ b/documentation/book/assembly-user-operator.adoc
@@ -9,7 +9,7 @@
 
 :context: deploying-uo
 
-User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+The User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
 
 include::con-what-the-user-operator-does.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-using-the-user-operator.adoc
+++ b/documentation/book/assembly-using-the-user-operator.adoc
@@ -9,7 +9,7 @@
 
 :context: using-uo
 
-User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+The User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
 
 include::con-what-the-user-operator-does.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-using-the-user-operator.adoc
+++ b/documentation/book/assembly-using-the-user-operator.adoc
@@ -1,0 +1,24 @@
+// This assembly is included in the following assemblies:
+//
+// getting-started.adoc
+
+:parent-context-using-uo: {context}
+
+[id='assembly-using-the-user-operator-{context}']
+= Using the User Operator
+
+:context: using-uo
+
+User Operator provides a way of managing Kafka users via {ProductPlatformName} resources.
+
+include::con-what-the-user-operator-does.adoc[leveloffset=+1]
+
+include::proc-creating-kafka-user.adoc[leveloffset=+1]
+
+include::proc-changing-kafka-user.adoc[leveloffset=+1]
+
+include::proc-deleting-kafka-user.adoc[leveloffset=+1]
+
+include::ref-kafka-user.adoc[leveloffset=+1]
+
+:context: {parent-context-using-uo}

--- a/documentation/book/con-what-the-user-operator-does.adoc
+++ b/documentation/book/con-what-the-user-operator-does.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// assembly-getting-started-user-operator.adoc
+
+[id='con-what-the-user-operator-does-{context}']
+= What the User Operator does
+
+The User Operator provides a way of managing Kafka users for a Kafka cluster via {ProductPlatformName} resources.
+
+The role of the User Operator is to watch for `KafkaUser` {ProductPlatformName} resources describing Kafka users and make sure they are configured inside the Kafka cluster as declared in the `KafkaUser` resource.
+
+Specifically:
+
+* if a `KafkaUser` is created, the operator will create the user it describes
+* if a `KafkaUser` is deleted, the operator will delete the user it describes
+* if a `KafkaUser` is changed, the operator will update the user it describes
+
+Unlike the xref:what-the-topic-operator-does-str[Topic Operator], the User Operator does not sync any changes back from the Kafka cluster into the {ProductPlatformName} resources.
+Unlike the Kafka topics which might be created by applications directly in Kafka, it is not expected that the users will be managed directly in the Kafka cluster in parallel with the User Operator, so this should not be needed.
+
+User Operator allows you to declare a `KafkaUser` as part of your application's deployment and the User Operator will take care of creating the user for you.
+When the user is created, the credentials will be created in a secret.
+Your application just needs to use the user and its credentials for authentication and produce or consume messages.
+
+The User Operator does not manage only credentials for authentication.
+It can also manage authorization rules.
+The `KafkaUser` declaration can contain a description of the rights which should be granted to this user and these rules will be created, updated or deleted together with the user.
+
+
+

--- a/documentation/book/con-what-the-user-operator-does.adoc
+++ b/documentation/book/con-what-the-user-operator-does.adoc
@@ -5,26 +5,18 @@
 [id='con-what-the-user-operator-does-{context}']
 = What the User Operator does
 
-The User Operator provides a way of managing Kafka users for a Kafka cluster via {ProductPlatformName} resources.
+The User Operator manages Kafka users for a Kafka cluster by watching for `KafkaUser` {ProductPlatformName} resources that describe Kafka users and ensuring that they are configured properly in the Kafka cluster.
+For example:
 
-The role of the User Operator is to watch for `KafkaUser` {ProductPlatformName} resources describing Kafka users and make sure they are configured inside the Kafka cluster as declared in the `KafkaUser` resource.
+* if a `KafkaUser` is created, the User Operator will create the user it describes
+* if a `KafkaUser` is deleted, the User Operator will delete the user it describes
+* if a `KafkaUser` is changed, the User Operator will update the user it describes
 
-Specifically:
-
-* if a `KafkaUser` is created, the operator will create the user it describes
-* if a `KafkaUser` is deleted, the operator will delete the user it describes
-* if a `KafkaUser` is changed, the operator will update the user it describes
-
-Unlike the xref:what-the-topic-operator-does-str[Topic Operator], the User Operator does not sync any changes back from the Kafka cluster into the {ProductPlatformName} resources.
+Unlike the xref:what-the-topic-operator-does-str[Topic Operator], the User Operator does not sync any changes from the Kafka cluster with the {ProductPlatformName} resources.
 Unlike the Kafka topics which might be created by applications directly in Kafka, it is not expected that the users will be managed directly in the Kafka cluster in parallel with the User Operator, so this should not be needed.
 
-User Operator allows you to declare a `KafkaUser` as part of your application's deployment and the User Operator will take care of creating the user for you.
-When the user is created, the credentials will be created in a secret.
-Your application just needs to use the user and its credentials for authentication and produce or consume messages.
+The User Operator allows you to declare a `KafkaUser` as part of your application's deployment.
+When the user is created, the credentials will be created in a `Secret`.
+Your application needs to use the user and its credentials for authentication and to produce or consume messages.
 
-The User Operator does not manage only credentials for authentication.
-It can also manage authorization rules.
-The `KafkaUser` declaration can contain a description of the rights which should be granted to this user and these rules will be created, updated or deleted together with the user.
-
-
-
+In addition to managing credentials for authentication, the User Operator also manages authorization rules by including a description of the user's rights in the `KafkaUser` declaration.

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -40,6 +40,7 @@ include::assembly-kafka-cluster.adoc[leveloffset=+1]
 include::assembly-kafka-connect.adoc[leveloffset=+1]
 
 include::assembly-hello-world.adoc[leveloffset=+1]
+
 //Modularized above here
 
 == Topic Operator
@@ -66,6 +67,8 @@ rootLogger.level
 For information on the logging options and examples of how to set logging, see <<logging_examples, logging examples>> for Kafka.
 
 When using external ConfigMap remember to place your custom ConfigMap under `log4j2.properties` key.
+
+include::assembly-getting-started-user-operator.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.
 :context: {parent-context}

--- a/documentation/book/master.adoc
+++ b/documentation/book/master.adoc
@@ -14,6 +14,10 @@ include::assembly-deploying-the-topic-operator.adoc[leveloffset=+1]
 
 include::assembly-using-the-topic-operator.adoc[leveloffset=+1]
 
+include::assembly-user-operator.adoc[leveloffset=+1]
+
+include::assembly-using-the-user-operator.adoc[leveloffset=+1]
+
 include::security.adoc[]
 
 include::faq.adoc[]

--- a/documentation/book/proc-changing-kafka-user.adoc
+++ b/documentation/book/proc-changing-kafka-user.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-user-operator.adoc
 
 [id='proc-changing-kafka-user-{context}']
-= Changing a user
+= Editing a Kafka user
 
 This procedure describes how to change the configuration of an existing Kafka user by using a `KafkaUser` {ProductPlatformName} resource.
 
@@ -15,7 +15,7 @@ This procedure describes how to change the configuration of an existing Kafka us
 
 .Procedure
 
-. Prepare a file containing the desired `KafkaUser`.
+. Prepare a YAML file containing the desired `KafkaUser`.
 +
 .An example `KafkaUser`
 [source,yaml,subs="attributes+"]
@@ -65,6 +65,7 @@ oc edit kafkauser _<your-user-name>_
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
++
 [source,shell,subs=+quotes]
 kubectl apply -f _<your-file>_
 +

--- a/documentation/book/proc-changing-kafka-user.adoc
+++ b/documentation/book/proc-changing-kafka-user.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-user-operator.adoc
+
+[id='proc-changing-kafka-user-{context}']
+= Changing a user
+
+This procedure describes how to change the configuration of an existing Kafka user by using a `KafkaUser` {ProductPlatformName} resource.
+
+.Prerequisites
+
+* A running Kafka cluster.
+* A running User Operator.
+* An existing `KafkaUser` to be changed
+
+.Procedure
+
+. Prepare a file containing the desired `KafkaUser`.
++
+.An example `KafkaUser`
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+----
++
+Or edit the `KafkaUser` resource using {ProductPlatformName} tools.
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl edit`:
+[source,shell,subs=+quotes]
+kubectl edit kafkauser _<your-user-name>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc edit`:
++
+[source,shell,subs=+quotes]
+oc edit kafkauser _<your-user-name>_
+
+. Update the `KafkaUser` resource in {ProductPlatformName}.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _<your-file>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+. Use the updated credentials from the secret `my-user` in your application
+
+.Additional resources
+
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
+// TODO: Uncomment link after merging with the other PR
+//* For more information about deploying the Entity Operator, see xref:assembly-kafka-entity-operator-deployment-configuration-kafka[].
+* For more information about the `KafkaUser` object, see xref:type-KafkaUser-reference[`KafkaUser` schema reference].

--- a/documentation/book/proc-creating-kafka-user.adoc
+++ b/documentation/book/proc-creating-kafka-user.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-user-operator.adoc
+
+[id='proc-creating-kafka-user-{context}']
+= Creating a user
+
+.Prerequisites
+
+* A running Kafka cluster.
+* A running User Operator.
+
+.Procedure
+
+. Prepare a file containing the `KafkaUserq to be created.
++
+.An example `KafkaUser`
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+----
+
+. Create the `KafkaUser` resource in {ProductPlatformName}.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _<your-file>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+. Use the credentials from the secret `my-user` in your application
+
+.Additional resources
+
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
+// TODO: Uncomment link after merging with the other PR
+//* For more information about deploying the Entity Operator, see xref:assembly-kafka-entity-operator-deployment-configuration-kafka[].
+* For more information about the `KafkaUser` object, see xref:type-KafkaUser-reference[`KafkaUser` schema reference].

--- a/documentation/book/proc-creating-kafka-user.adoc
+++ b/documentation/book/proc-creating-kafka-user.adoc
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Prepare a file containing the `KafkaUserq to be created.
+. Prepare a file containing the `KafkaUser` to be created.
 +
 .An example `KafkaUser`
 [source,yaml,subs="attributes+"]

--- a/documentation/book/proc-creating-kafka-user.adoc
+++ b/documentation/book/proc-creating-kafka-user.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-user-operator.adoc
 
 [id='proc-creating-kafka-user-{context}']
-= Creating a user
+= Creating a Kafka user
 
 .Prerequisites
 
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Prepare a file containing the `KafkaUser` to be created.
+. Prepare a YAML file containing the `KafkaUser` to be created.
 +
 .An example `KafkaUser`
 [source,yaml,subs="attributes+"]
@@ -50,6 +50,7 @@ spec:
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
++
 [source,shell,subs=+quotes]
 kubectl apply -f _<your-file>_
 +

--- a/documentation/book/proc-deleting-kafka-user.adoc
+++ b/documentation/book/proc-deleting-kafka-user.adoc
@@ -3,9 +3,9 @@
 // assembly-using-the-user-operator.adoc
 
 [id='deleting-kafka-user-{context}']
-= Deleting a user
+= Deleting a Kafka user
 
-This procedure describes how to delete a Kafka user using a `KafkaUser` {ProductPlatformName} resource.
+This procedure describes how to delete a Kafka user created with `KafkaUser` {ProductPlatformName} resource.
 
 .Prerequisites
 

--- a/documentation/book/proc-deleting-kafka-user.adoc
+++ b/documentation/book/proc-deleting-kafka-user.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-user-operator.adoc
+
+[id='deleting-kafka-user-{context}']
+= Deleting a user
+
+This procedure describes how to delete a Kafka user using a `KafkaUser` {ProductPlatformName} resource.
+
+.Prerequisites
+
+* A running Kafka cluster.
+* A running User Operator.
+* An existing `KafkaUser` to be deleted.
+
+.Procedure
+
+. Delete the `KafkaUser` resource in {ProductPlatformName}.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl`:
++
+[source,shell,subs=+quotes]
+kubectl delete kafkauser _<your-user-name>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc`:
++
+[source,shell,subs=+quotes]
+oc delete kafkauser _<your-user-name>_
++
+
+.Additional resources
+
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
+// TODO: Uncomment link after merging with the other PR
+//* For more information about deploying the Entity Operator, see xref:assembly-kafka-entity-operator-deployment-configuration-kafka[].
+* For more information about the `KafkaUser` object, see xref:type-KafkaUser-reference[`KafkaUser` schema reference].

--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -15,7 +15,7 @@ For instance is can operate _with_ any Kafka cluster, not necessarily one deploy
 
 .Procedure
 
-. Edit the `examples/install/cluster-operator/05-Deployment-strimzi-topic-operator.yaml` resource. You will need to change the following
+. Edit the `examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml` resource. You will need to change the following
 +
 .. The `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of bootstrap brokers in your Kafka cluster, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs.
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
@@ -27,13 +27,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell]
-kubectl apply -f examples/install/cluster-operator
+kubectl apply -f examples/install/user-operator
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell]
-oc apply -f examples/install/cluster-operator
+oc apply -f examples/install/user-operator
 
 . Verify that the Topic Operator has been deployed successfully. 
 ifdef::Kubernetes[]

--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -27,13 +27,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell]
-kubectl apply -f examples/install/user-operator
+kubectl apply -f examples/install/topic-operator
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell]
-oc apply -f examples/install/user-operator
+oc apply -f examples/install/topic-operator
 
 . Verify that the Topic Operator has been deployed successfully. 
 ifdef::Kubernetes[]

--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -17,7 +17,7 @@ For instance is can operate _with_ any Kafka cluster, not necessarily one deploy
 . Edit the `examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml` resource. You will need to change the following
 +
 .. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} Secret which should contain the Cetificate Authority for signing new user certificates for TLS Client Authentication.
-The secret should contain the public key of the certificate authority under the key `clients-ca.crt and the pribate key under `clients-ca.key`.
+The secret should contain the public key of the certificate authority under the key `clients-ca.crt` and the private key under `clients-ca.key`.
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
 

--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// assembly-user-operator.adoc
+
+[id='proc-deploying-the-user-operator-standalone-{context}']
+= Deploying the User Operator standalone
+
+Deploying the User Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
+For instance is can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+
+.Prerequisites
+
+* An existing Kafka cluster for the User Operator to connect to.
+
+.Procedure
+
+. Edit the `examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml` resource. You will need to change the following
++
+.. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} Secret which should contain the Cetificate Authority for signing new user certificates for TLS Client Authentication.
+The secret should contain the public key of the certificate authority under the key `clients-ca.crt and the pribate key under `clients-ca.key`.
+.. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
+.. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
+
+. Deploy the Cluster Operator.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
++
+[source,shell]
+kubectl apply -f examples/install/user-operator
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell]
+oc apply -f examples/install/user-operator
+
+. Verify that the User Operator has been deployed successfully.
+ifdef::Kubernetes[]
++
+On {KubernetesName} this can be done using `kubectl describe`:
++
+[source,shell]
+kubectl describe deployment strimzi-user-operator
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc describe`:
++
+[source,shell]
+oc describe deployment strimzi-user-operator
++ 
+The User Operator is deployed once the `Replicas:` entry shows `1 available`.
++
+NOTE: This could take some time if you have a slow connection to the {ProductPlatformName} and the images have not been downloaded before.
+
+.Additional resources
+
+* For more information about getting the Cluster Operator to deploy the User Operator for you, see xref:proc-deploying-the-user-operator-using-the-cluster-operator-str[].

--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -3,10 +3,10 @@
 // assembly-user-operator.adoc
 
 [id='proc-deploying-the-user-operator-standalone-{context}']
-= Deploying the User Operator standalone
+= Deploying the standalone User Operator
 
 Deploying the User Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
-For instance is can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+For instance it can operate _with_ any Kafka cluster, not only the one deployed by the Cluster Operator.
 
 .Prerequisites
 
@@ -16,8 +16,8 @@ For instance is can operate _with_ any Kafka cluster, not necessarily one deploy
 
 . Edit the `examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml` resource. You will need to change the following
 +
-.. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} Secret which should contain the Cetificate Authority for signing new user certificates for TLS Client Authentication.
-The secret should contain the public key of the certificate authority under the key `clients-ca.crt` and the private key under `clients-ca.key`.
+.. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} `Secret` which should contain the Certificate Authority for signing new user certificates for TLS Client Authentication.
+The `Secret` should contain the public key of the Certificate Authority under the key `clients-ca.crt` and the private key under `clients-ca.key`.
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
 

--- a/documentation/book/proc-deploying-the-user-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-using-the-cluster-operator.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// assembly-getting-started-user-operator.adoc
+
+[id='proc-deploying-the-user-operator-using-the-cluster-operator-{context}']
+= Deploying the User Operator using the Cluster Operator
+
+.Prerequisites
+
+* A running Cluster Operator.
+* A `Kafka` resource to be created or updated.
+
+.Procedure
+
+. Edit the `Kafka` resource ensuring it has a `Kafka.spec.entityOperator.userOperator` object that configures the User Operator how you want.
+
+. Create or update the Kafka resource in {ProductPlatformName}.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _<your-file>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+.Additional resources
+
+* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
+// TODO: Uncomment link after merging with the other PR
+// * For more information about deploying the Entity Operator, see xref:assembly-kafka-entity-operator-deployment-configuration-kafka[].
+* For more information about the `Kafka.spec.entityOperator` object used to configure the User Operator when deployed by the Cluster Operator, see xref:type-EntityOperatorSpec-reference[`EntityOperatorSpec` schema reference].

--- a/documentation/book/ref-kafka-user.adoc
+++ b/documentation/book/ref-kafka-user.adoc
@@ -1,0 +1,160 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-user-operator.adoc
+
+[id='ref-kafka-user-{context}']
+= Kafka User resource
+
+The Kafka User resource is used to declare a user with its authentication mechanism, authorization mechanism and access rights.
+
+== Authentication
+
+Authentication is configured using the `authentication` property in `KafkaUser.spec`.
+The authentication mechanism enabled for this user will be specified using the `type` field.
+Currently, the only support authentication mechanism is the TLS Client Authentication mechanism.
+
+When no authentication mechanism is specified, User Operator will not create the user and its credentials.
+
+=== TLS Client Authentication
+
+To use TLS client authentication, set the `type` field to `tls`.
+
+.An example of `KafkaUser` with enabled TLS Client Authentication
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  # ...
+----
+
+When the user is created by the User Operator, it will create a new secret with the same name as the `KafkaUser` resource.
+The secret will contain a public and private key which should be used for the TLS Client Authentication.
+Together with them it will also bundle the public key of the client certification authority which was used to sign the user certificate.
+All keys will be in X509 format.
+
+.An example of the `Secret` with user credentials
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/kind: KafkaUser
+    strimzi.io/cluster: my-cluster
+type: Opaque
+data:
+  ca.crt: # Public key of the Clients CA
+  user.crt: # Public key of the user
+  user.key: # Private key of the user
+----
+
+== Authorization
+
+Authorization is configured using the `authorization` property in `KafkaUser.spec`.
+The authorization type enabled for this user will be specified using the `type` field.
+Currently, the only supported authorization type is the Simple authorization.
+
+When no authorization is specified, User Operator will not provision any access rights for the user.
+
+=== Simple Authorization
+
+To use Simple Authorization, set the `type` property to `simple`.
+Simple authorization is using the `SimpleAclAuthorizer` plugin.
+`SimpleAclAuthorizer` is the default authorization plugin which is part of Apache Kafka.
+Simple Authorization allows you to specify list of ACL rules in the `acls` property.
+
+The `acls` property should contain a list of `AclRule` objects.
+`AclRule` specifies the access rights whcih will be granted to the user.
+The `AclRule` object contains following properties:
+
+`type`::
+Specifies the type of the ACL rule.
+The type can be either `allow` or `deny.
+The `type` field is optional and when not specified, the ACL rule will be treated as `allow` rule.
+
+`operation`:: Specifies the operation which will be allowed or denied.
+Following operations are supported:
++
+* Read
+* Write
+* Delete
+* Alter
+* Describe
+* All
+* IdempotentWrite
+* ClusterAction
+* Create
+* AlterConfigs
+* DescribeConfigs
++
+NOTE: Not every operation can be combined with every resource.
+
+`host`:: Specifies a remote host from which is the rule allowed or denied.
+Use `\*` to allow or deny the operation from all hosts.
+The `host` field is optional and when not specified, the value `*` will be used as default.
+
+`resource`:: Specifies the resource for which does the rule apply.
+Simple Authorization supports 3 different resource types:
++
+* Topics
+* Consumer Groups
+* Clusters
++
+The resource type can be specified in the `type` property.
+Use `topic` for Topics, `group` for Consumer Groups and `cluster` for clusters.
++
+Topic and Group resources additionally allow to specify the name of the resource for which the rule applies.
+The name can be specified in the `name` property.
+The name can be either specified as literal or as a prefix.
+To specify the name as literal, set the `patternType` property to the value `literal`.
+Literal names will be taken exactly as they are specified in the `name` field.
+To specify the name as a prefix, set the `patternType` property to the value `prefix`.
+Prefix type names will use the value from the `name` only a prefix and will apply the rule to all resources with names starting with the value.
+The cluster type resources have no name.
+
+For more details about `SimpleAclAuthorizer`, its ACL rules and the allowed combinations of resources and operations, visit link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
+
+For more information about the `AclRule` object, see xref:type-AclRule-reference[`AclRule` schema reference].
+
+.An example `KafkaUser`
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  # ...
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+      - resource:
+          type: group
+          name: my-group
+          patternType: prefix
+        operation: Read
+----
+
+== Additional resources
+
+* For more information about the `KafkaUser` object, see xref:type-KafkaUser-reference[`KafkaUser` schema reference].

--- a/documentation/book/ref-kafka-user.adoc
+++ b/documentation/book/ref-kafka-user.adoc
@@ -5,15 +5,15 @@
 [id='ref-kafka-user-{context}']
 = Kafka User resource
 
-The Kafka User resource is used to declare a user with its authentication mechanism, authorization mechanism and access rights.
+The `KafkaUser` resource is used to declare a user with its authentication mechanism, authorization mechanism, and access rights.
 
 == Authentication
 
 Authentication is configured using the `authentication` property in `KafkaUser.spec`.
 The authentication mechanism enabled for this user will be specified using the `type` field.
-Currently, the only support authentication mechanism is the TLS Client Authentication mechanism.
+Currently, the only supported authentication mechanism is the TLS Client Authentication mechanism.
 
-When no authentication mechanism is specified, User Operator will not create the user and its credentials.
+When no authentication mechanism is specified, User Operator will not create the user or its credentials.
 
 === TLS Client Authentication
 
@@ -36,7 +36,7 @@ spec:
 
 When the user is created by the User Operator, it will create a new secret with the same name as the `KafkaUser` resource.
 The secret will contain a public and private key which should be used for the TLS Client Authentication.
-Together with them it will also bundle the public key of the client certification authority which was used to sign the user certificate.
+Bundled with them will be the public key of the client certification authority which was used to sign the user certificate.
 All keys will be in X509 format.
 
 .An example of the `Secret` with user credentials
@@ -62,7 +62,7 @@ Authorization is configured using the `authorization` property in `KafkaUser.spe
 The authorization type enabled for this user will be specified using the `type` field.
 Currently, the only supported authorization type is the Simple authorization.
 
-When no authorization is specified, User Operator will not provision any access rights for the user.
+When no authorization is specified, the User Operator will not provision any access rights for the user.
 
 === Simple Authorization
 
@@ -120,7 +120,7 @@ To specify the name as a prefix, set the `patternType` property to the value `pr
 Prefix type names will use the value from the `name` only a prefix and will apply the rule to all resources with names starting with the value.
 The cluster type resources have no name.
 
-For more details about `SimpleAclAuthorizer`, its ACL rules and the allowed combinations of resources and operations, visit link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
+For more details about `SimpleAclAuthorizer`, its ACL rules and the allowed combinations of resources and operations, see link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
 
 For more information about the `AclRule` object, see xref:type-AclRule-reference[`AclRule` schema reference].
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -57,6 +57,7 @@
 :KafkaConnectApiVersion: kafka.strimzi.io/v1alpha1
 :KafkaConnectS2IApiVersion: kafka.strimzi.io/v1alpha1
 :KafkaTopicApiVersion: kafka.strimzi.io/v1alpha1
+:KafkaUserApiVersion: kafka.strimzi.io/v1alpha1
 
 // Section enablers
 :Kubernetes:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds documentation related to the User Operator. After #742 is merged, it might need to change into whcih sections are the assemblies included. But it should be ready for review as the test is final.

### Checklist

- [x] Update documentation