### PR TITLE
Migrate System Tests to use the Entity Operator

### DIFF
--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -562,7 +562,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 Kafka kafkaAssembly = TestUtils.fromYamlString(yaml, Kafka.class);
                 final String kafkaStatefulSetName = kafkaAssembly.getMetadata().getName() + "-kafka";
                 final String zookeeperStatefulSetName = kafkaAssembly.getMetadata().getName() + "-zookeeper";
-                final String tcDeploymentName = kafkaAssembly.getMetadata().getName() + "-topic-operator";
+                final String eoDeploymentName = kafkaAssembly.getMetadata().getName() + "-entity-operator";
                 last = new Bracket(last, new ResourceAction()
                     .getPo(CO_DEPLOYMENT_NAME + ".*")
                     .logs(CO_DEPLOYMENT_NAME + ".*", "strimzi-cluster-operator")
@@ -574,8 +574,8 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     .getSs(zookeeperStatefulSetName)
                     .getPo(zookeeperStatefulSetName)
                     .logs(zookeeperStatefulSetName + ".*", "zookeeper")
-                    .getDep(tcDeploymentName)
-                    .logs(tcDeploymentName + ".*", "topic-operator")) {
+                    .getDep(eoDeploymentName)
+                    .logs(eoDeploymentName + ".*", "entity-operator")) {
 
                     @Override
                     protected void before() {
@@ -588,9 +588,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                         // wait for ss
                         LOGGER.info("Waiting for Kafka SS");
                         kubeClient().waitForStatefulSet(kafkaStatefulSetName, kafkaAssembly.getSpec().getKafka().getReplicas());
-                        // wait for TOs
-                        LOGGER.info("Waiting for TC Deployment");
-                        kubeClient().waitForDeployment(tcDeploymentName, 1);
+                        // wait for EO
+                        LOGGER.info("Waiting for Entity Operator Deployment");
+                        kubeClient().waitForDeployment(eoDeploymentName, 1);
                     }
 
                     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -66,11 +66,12 @@ public class AbstractST {
     protected static final String CONNECT_IMAGE = "STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE";
     protected static final String S2I_IMAGE = "STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE";
     protected static final String TO_IMAGE = "STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE";
+    protected static final String UO_IMAGE = "STRIMZI_DEFAULT_USER_OPERATOR_IMAGE";
     protected static final String TEST_TOPIC_NAME = "test-topic";
     protected static final String KAFKA_INIT_IMAGE = "STRIMZI_DEFAULT_KAFKA_INIT_IMAGE";
     protected static final String TLS_SIDECAR_ZOOKEEPER_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE";
     protected static final String TLS_SIDECAR_KAFKA_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE";
-    protected static final String TLS_SIDECAR_TO_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
+    protected static final String TLS_SIDECAR_EO_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
 
     @Rule
     public Stopwatch stopwatch = new Stopwatch() {
@@ -337,10 +338,11 @@ public class AbstractST {
         images.put(CONNECT_IMAGE, getImageNameFromJSON(configJson, CONNECT_IMAGE));
         images.put(S2I_IMAGE, getImageNameFromJSON(configJson, S2I_IMAGE));
         images.put(TO_IMAGE, getImageNameFromJSON(configJson, TO_IMAGE));
+        images.put(UO_IMAGE, getImageNameFromJSON(configJson, UO_IMAGE));
         images.put(KAFKA_INIT_IMAGE, getImageNameFromJSON(configJson, KAFKA_INIT_IMAGE));
         images.put(TLS_SIDECAR_ZOOKEEPER_IMAGE, getImageNameFromJSON(configJson, TLS_SIDECAR_ZOOKEEPER_IMAGE));
         images.put(TLS_SIDECAR_KAFKA_IMAGE, getImageNameFromJSON(configJson, TLS_SIDECAR_KAFKA_IMAGE));
-        images.put(TLS_SIDECAR_TO_IMAGE, getImageNameFromJSON(configJson, TLS_SIDECAR_TO_IMAGE));
+        images.put(TLS_SIDECAR_EO_IMAGE, getImageNameFromJSON(configJson, TLS_SIDECAR_EO_IMAGE));
         return images;
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -391,8 +391,6 @@ public class KafkaST extends AbstractST {
                 "strimzi.io/name=" + clusterName + "-entity-operator").get(0);
         String imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-topic-operator");
         assertEquals(imgFromDeplConf.get(TO_IMAGE), imgFromPod);
-        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-user-operator");
-        assertEquals(imgFromDeplConf.get(UO_IMAGE), imgFromPod);
         imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "tls-sidecar");
         assertEquals(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE), imgFromPod);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -391,6 +391,8 @@ public class KafkaST extends AbstractST {
                 "strimzi.io/name=" + clusterName + "-entity-operator").get(0);
         String imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-topic-operator");
         assertEquals(imgFromDeplConf.get(TO_IMAGE), imgFromPod);
+        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-user-operator");
+        assertEquals(imgFromDeplConf.get(UO_IMAGE), imgFromPod);
         imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "tls-sidecar");
         assertEquals(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE), imgFromPod);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -309,7 +309,7 @@ public class KafkaST extends AbstractST {
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
                 "-Xmx600m", "-Xms300m", "-server", "-XX:+UseG1GC");
 
-        String podName = client.pods().inNamespace(kubeClient.namespace()).list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-operator-")).findFirst().get().getMetadata().getName();
+        String podName = client.pods().inNamespace(kubeClient.namespace()).list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-entity-operator-")).findFirst().get().getMetadata().getName();
 
         assertResources(kubeClient.namespace(), podName,
                 "500M", "300m", "500M", "300m");

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -386,13 +386,15 @@ public class KafkaST extends AbstractST {
             }
         }
 
-        //Verifying docker image for topic-operator
-        String topicOperatorPodName = kubeClient.listResourcesByLabel("pod",
-                "strimzi.io/name=" + clusterName + "-topic-operator").get(0);
-        String imgFromPod = getContainerImageNameFromPod(topicOperatorPodName, "topic-operator");
+        //Verifying docker image for entity-operator
+        String entityOperatorPodName = kubeClient.listResourcesByLabel("pod",
+                "strimzi.io/name=" + clusterName + "-entity-operator").get(0);
+        String imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-topic-operator");
         assertEquals(imgFromDeplConf.get(TO_IMAGE), imgFromPod);
-        imgFromPod = getContainerImageNameFromPod(topicOperatorPodName, "tls-sidecar");
-        assertEquals(imgFromDeplConf.get(TLS_SIDECAR_TO_IMAGE), imgFromPod);
+        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-user-operator");
+        assertEquals(imgFromDeplConf.get(UO_IMAGE), imgFromPod);
+        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "tls-sidecar");
+        assertEquals(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE), imgFromPod);
 
         LOGGER.info("Docker images verified");
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -309,7 +309,9 @@ public class KafkaST extends AbstractST {
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
                 "-Xmx600m", "-Xms300m", "-server", "-XX:+UseG1GC");
 
-        String podName = client.pods().inNamespace(kubeClient.namespace()).list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-entity-operator-")).findFirst().get().getMetadata().getName();
+        String podName = client.pods().inNamespace(kubeClient.namespace()).list().getItems()
+                .stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-entity-operator-"))
+                .findFirst().get().getMetadata().getName();
 
         assertResources(kubeClient.namespace(), podName,
                 "500M", "300m", "500M", "300m");

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectS2IST.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/ConnectST.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/HelmChartST.testDeployKafkaClusterViaHelmChart.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/HelmChartST.testDeployKafkaClusterViaHelmChart.yaml
@@ -34,3 +34,4 @@ spec:
       lowercaseOutputName: true
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/HelmChartST.testDeployKafkaClusterViaHelmChart.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/HelmChartST.testDeployKafkaClusterViaHelmChart.yaml
@@ -32,4 +32,5 @@ spec:
       type: ephemeral
     metrics:
       lowercaseOutputName: true
-  topicOperator: { }
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testCustomAndUpdatedValues.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testCustomAndUpdatedValues.yaml
@@ -34,5 +34,5 @@ spec:
       timeTick: 2000
       initLimit: 5
       syncLimit: 2
-  topicOperator: {}
-
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testCustomAndUpdatedValues.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testCustomAndUpdatedValues.yaml
@@ -36,3 +36,4 @@ spec:
       syncLimit: 2
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testForTopicOperator.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testForTopicOperator.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testForTopicOperator.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testForTopicOperator.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testJvmAndResources.yaml
@@ -52,11 +52,12 @@ spec:
       "-server": true
       "-XX":
         UseG1GC: "true"
-  topicOperator:
-    resources:
-      limits:
-        memory: 500M
-        cpu: 300m
-      requests:
-        memory: 500M
-        cpu: 300m
+  entityOperator:
+    topicOperator:
+      resources:
+        limits:
+          memory: 500M
+          cpu: 300m
+        requests:
+          memory: 500M
+          cpu: 300m

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testJvmAndResources.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testJvmAndResources.yaml
@@ -61,3 +61,4 @@ spec:
         requests:
           memory: 500M
           cpu: 300m
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testKafkaAndZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testKafkaAndZookeeperScaleUpScaleDown.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testKafkaAndZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testKafkaAndZookeeperScaleUpScaleDown.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testRackAware.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testRackAware.yaml
@@ -30,3 +30,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testRackAware.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testRackAware.yaml
@@ -28,4 +28,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testSendMessages.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testSendMessages.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testSendMessages.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testSendMessages.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testWatchingOtherNamespace.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testWatchingOtherNamespace.yaml
@@ -26,5 +26,6 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator:
-    watchedNamespace: topic-operator-namespace
+  entityOperator:
+    topicOperator:
+      watchedNamespace: topic-operator-namespace

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testWatchingOtherNamespace.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testWatchingOtherNamespace.yaml
@@ -29,3 +29,4 @@ spec:
   entityOperator:
     topicOperator:
       watchedNamespace: topic-operator-namespace
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testZookeeperScaleUpScaleDown.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testZookeeperScaleUpScaleDown.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/KafkaST.testZookeeperScaleUpScaleDown.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryST.yaml
@@ -26,4 +26,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryST.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/RecoveryST.yaml
@@ -28,3 +28,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/SecurityST.testCertificates.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/SecurityST.testCertificates.yaml
@@ -32,3 +32,4 @@ spec:
       type: ephemeral
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/systemtest/src/test/resources/io/strimzi/systemtest/SecurityST.testCertificates.yaml
+++ b/systemtest/src/test/resources/io/strimzi/systemtest/SecurityST.testCertificates.yaml
@@ -30,4 +30,5 @@ spec:
       timeoutSeconds: 5
     storage:
       type: ephemeral
-  topicOperator: {}
+  entityOperator:
+    topicOperator: {}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR updates the YAMLs file used by System Tests in order to use the new Entity Operator for deploying the Topic Operator instead of the old way. Other than YAMLs file it adds other needed fixes on source code.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

