### PR TITLE
Git ignoring created plugins stuff for Kafka Connect S2I in ST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ documentation/html/**
 documentation/htmlnoheader/**
 
 helm-charts/strimzi-kafka-operator-*.*.*.tgz
+
+# Connect plugin (tests)
+systemtest/*.tar.gz
+systemtest/my-plugins/


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Running the `testDeployS2IWithMongoDBPlugin` ST ad MongoDB plugin is downloaded and then a `my-plugins` folder is created for the test with S2I; this PR avoid that someone could push this stuff to the repo.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

