### PR TITLE
Render templates with Helm's default version

### DIFF
--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -19,7 +19,7 @@ helm_lint:
 helm_template:
 	# Generating rendered template files to: $(CHART_RENDERED_TEMPLATES_TMP)
 	mkdir -p $(CHART_RENDERED_TEMPLATES_TMP)
-	helm template --namespace myproject --output-dir $(CHART_RENDERED_TEMPLATES_TMP) --set imageTagOverride=$(RELEASE_VERSION) $(CHART_PATH)
+	helm template --namespace myproject --output-dir $(CHART_RENDERED_TEMPLATES_TMP) $(CHART_PATH)
 
 helm_examples: helm_template
 	# Remove Helm-related labels


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When rendering the Helm templates into examples, Make is currently enforcing a new version. That seems to be unnecessary for master and makes the build fail for releases. This PR changes the behaviour to simply use the version which is in Helm charts.