### PR TITLE
fix for leaking test files

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
@@ -191,6 +192,9 @@ public class OpenSslCertManager implements CertManager {
                 log.warn("{} cannot be deleted", openSslConf.getName());
             }
         }
+
+        // We need to remove CA serial file
+        Files.deleteIfExists(Paths.get(caCert.getPath().replace(".crt", ".srl")));
     }
 
     @Override

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -10,6 +10,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -115,6 +118,8 @@ public class OpenSslCertManagerTest {
     @Test
     public void testGenerateSignedCert() throws Exception {
 
+        Path path = Paths.get("/tmp");
+        long fileCount = Files.list(path).count();
         File caKey = File.createTempFile("ca-key-", ".key");
         File caCert = File.createTempFile("ca-crt-", ".crt");
 
@@ -127,7 +132,6 @@ public class OpenSslCertManagerTest {
         Subject sbj = new Subject();
         sbj.setCommonName("MyCommonName");
         sbj.setOrganizationName("MyOrganization");
-
         File cert = File.createTempFile("crt-", ".crt");
 
         testGenerateSignedCert(caKey, caCert, caSbj, key, csr, cert, sbj);
@@ -137,6 +141,8 @@ public class OpenSslCertManagerTest {
         key.delete();
         csr.delete();
         cert.delete();
+
+        assertEquals(Files.list(path).count(), fileCount);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -32,6 +32,9 @@ import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -328,4 +331,16 @@ public class ResourceUtils {
                 .build();
     }
 
+    public static void cleanUpTemporaryTLSFiles() {
+        String tmpString = "/tmp";
+        try {
+            Files.list(Paths.get(tmpString)).filter(path -> path.toString().startsWith(tmpString + "/tls")).forEach(delPath -> {
+                try {
+                    Files.deleteIfExists(delPath);
+                } catch (IOException e) {
+                }
+            });
+        } catch (IOException e) {
+        }
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.operator.MockCertManager;
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -105,5 +106,10 @@ public class EntityOperatorTest {
     @Test
     public void withAffinity() throws IOException {
         helper.assertDesiredResource("-Deployment.yaml", zc -> zc.generateDeployment().getSpec().getTemplate().getSpec().getAffinity());
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        ResourceUtils.cleanUpTemporaryTLSFiles();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -20,6 +20,7 @@ import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.operator.MockCertManager;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -195,5 +196,10 @@ public class TopicOperatorTest {
         assertEquals("topic-operator-metrics-and-logging", volumeMount.getName());
         assertEquals("topic-operator-metrics-and-logging", volume.getName());
         assertEquals("foo-topic-operator-config", volume.getConfigMap().getName());
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        ResourceUtils.cleanUpTemporaryTLSFiles();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -24,6 +24,7 @@ import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.ResourcesBuilder;
 import io.strimzi.api.kafka.model.Storage;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.TopicOperator;
@@ -42,6 +43,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -206,6 +208,11 @@ public class KafkaAssemblyOperatorMockTest {
     @After
     public void after() {
         this.vertx.close();
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        ResourceUtils.cleanUpTemporaryTLSFiles();
     }
 
     private ResourceOperatorSupplier supplierWithMocks() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1008,4 +1008,9 @@ public class KafkaAssemblyOperatorTest {
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());
         return supplier;
     }
+
+    @AfterClass
+    public static void cleanUp() {
+        ResourceUtils.cleanUpTemporaryTLSFiles();
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.DoneableKafkaAssembly;
 import io.strimzi.api.kafka.KafkaAssemblyList;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -27,6 +28,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -196,4 +198,8 @@ public class PartialRollingUpdateTest {
         });
     }
 
+    @AfterClass
+    public static void cleanUp() {
+        ResourceUtils.cleanUpTemporaryTLSFiles();
+    }
 }


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Some test was leaking serial CA files. Fixing.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging https://github.com/strimzi/strimzi-kafka-operator/issues/714
- [ ] Update CHANGELOG.md

