### PR TITLE
ST: Fixed recovery and helm ST tests

### DIFF
--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -666,7 +666,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 LOGGER.info("Creating cluster operator with Helm Chart {} before test per @ClusterOperator annotation on {}", cc, name(element));
                 Path pathToChart = new File(HELM_CHART).toPath();
                 String oldNamespace = kubeClient().namespace("kube-system");
-                String pathToHelmServiceAccount = Thread.currentThread().getContextClassLoader().getResource("helm/helm-service-account.yaml").getPath();
+                String pathToHelmServiceAccount = getClass().getClassLoader().getResource("helm/helm-service-account.yaml").getPath();
                 String helmServiceAccount = TestUtils.getFileAsString(pathToHelmServiceAccount);
                 kubeClient().applyContent(helmServiceAccount);
                 helmClient().init();

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -132,8 +132,8 @@ public class AbstractST {
         return "data-" + zookeeperClusterName(clusterName) + "-" + podId;
     }
 
-    static String topicOperatorDeploymentName(String clusterName) {
-        return clusterName + "-topic-operator";
+    static String entityOperatorDeploymentName(String clusterName) {
+        return clusterName + "-entity-operator";
     }
 
     private <T extends CustomResource, L extends CustomResourceList<T>, D extends CustomResourceDoneable<T>>

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -33,16 +33,16 @@ public class RecoveryST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RecoveryST.class);
 
     @Test
-    public void testRecoveryFromTopicOperatorDeletion() {
+    public void testRecoveryFromEntityOperatorDeletion() {
         // kafka cluster already deployed via annotation
-        String topicOperatorDeploymentName = topicOperatorDeploymentName(CLUSTER_NAME);
-        LOGGER.info("Running deleteTopicOperatorDeployment with cluster {}", CLUSTER_NAME);
+        String entityOperatorDeploymentName = entityOperatorDeploymentName(CLUSTER_NAME);
+        LOGGER.info("Running testRecoveryFromEntityOperatorDeletion with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(DEPLOYMENT, topicOperatorDeploymentName);
-        kubeClient.waitForResourceDeletion(DEPLOYMENT, topicOperatorDeploymentName);
+        kubeClient.deleteByName(DEPLOYMENT, entityOperatorDeploymentName);
+        kubeClient.waitForResourceDeletion(DEPLOYMENT, entityOperatorDeploymentName);
 
-        LOGGER.info("Waiting for recovery {}", topicOperatorDeploymentName);
-        kubeClient.waitForDeployment(topicOperatorDeploymentName, 1);
+        LOGGER.info("Waiting for recovery {}", entityOperatorDeploymentName);
+        kubeClient.waitForDeployment(entityOperatorDeploymentName, 1);
 
         //Test that CO doesn't have any exceptions in log
         assertNoCoErrorsLogged(stopwatch.runtime(SECONDS));


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Updated test for recovering. After implementing `Entity Operator` we don't have `Topic Operator` as deployment and it means that we need to remove `Topic Operator` from `RecoveryST` and add `Entity Operator`
2. Removed using `Thread.currentThread()` in `StrimziRunner` to get the path to the helm .yaml because of the current thread for system test lives in the module `systemtest`

### Checklist
- [ ] Make sure all tests pass
