### PR TITLE
add network policies to protect selected ports

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -101,7 +101,7 @@
 
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
-            <property name="max" value="41"/>
+            <property name="max" value="43"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -101,7 +101,7 @@
 
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
-            <property name="max" value="40"/>
+            <property name="max" value="41"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -18,7 +18,7 @@
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]AbstractModel.java"/>
 
-    <suppress checks="ClassFanOutComplexity"
+    <suppress checks="ClassFanOutComplexity|JavaNCSS"
               files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]assembly[/\\]KafkaAssemblyOperatorTest.java"/>
 
     <!-- topic operator -->

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 
@@ -84,11 +85,12 @@ public class Main {
         DeploymentOperator deploymentOperations = new DeploymentOperator(vertx, client);
         SecretOperator secretOperations = new SecretOperator(vertx, client);
         CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectAssemblyList, DoneableKafkaConnect> kco = new CrdOperator<>(vertx, client, KafkaConnect.class, KafkaConnectAssemblyList.class, DoneableKafkaConnect.class);
+        NetworkPolicyOperator networkPolicyOperator = new NetworkPolicyOperator(vertx, client);
 
         OpenSslCertManager certManager = new OpenSslCertManager();
         KafkaAssemblyOperator kafkaClusterOperations = new KafkaAssemblyOperator(vertx, isOpenShift,
                 config.getOperationTimeoutMs(), certManager, new ResourceOperatorSupplier(vertx, client, config.getOperationTimeoutMs()));
-        KafkaConnectAssemblyOperator kafkaConnectClusterOperations = new KafkaConnectAssemblyOperator(vertx, isOpenShift, certManager, kco, configMapOperations, deploymentOperations, serviceOperations, secretOperations);
+        KafkaConnectAssemblyOperator kafkaConnectClusterOperations = new KafkaConnectAssemblyOperator(vertx, isOpenShift, certManager, kco, configMapOperations, deploymentOperations, serviceOperations, secretOperations, networkPolicyOperator);
 
         KafkaConnectS2IAssemblyOperator kafkaConnectS2IClusterOperations = null;
         CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IAssemblyList, DoneableKafkaConnectS2I> kafkaConnectS2iCrdOperator = null;
@@ -140,17 +142,19 @@ public class Main {
         BuildConfigOperator buildConfigOperations;
         DeploymentConfigOperator deploymentConfigOperations;
         CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IAssemblyList, DoneableKafkaConnectS2I> kafkaConnectS2iCrdOperator;
+        NetworkPolicyOperator networkPolicyOperator;
         KafkaConnectS2IAssemblyOperator kafkaConnectS2IClusterOperations;
         OpenShiftClient osClient = client.adapt(OpenShiftClient.class);
         imagesStreamOperations = new ImageStreamOperator(vertx, osClient);
         buildConfigOperations = new BuildConfigOperator(vertx, osClient);
         deploymentConfigOperations = new DeploymentConfigOperator(vertx, osClient);
         kafkaConnectS2iCrdOperator = new CrdOperator<>(vertx, osClient, KafkaConnectS2I.class, KafkaConnectS2IAssemblyList.class, DoneableKafkaConnectS2I.class);
+        networkPolicyOperator = new NetworkPolicyOperator(vertx, client);
         kafkaConnectS2IClusterOperations = new KafkaConnectS2IAssemblyOperator(vertx, isOpenShift,
                 certManager,
                 kafkaConnectS2iCrdOperator,
                  configMapOperations, deploymentConfigOperations,
-                serviceOperations, imagesStreamOperations, buildConfigOperations, secretOperations);
+                serviceOperations, imagesStreamOperations, buildConfigOperations, secretOperations, networkPolicyOperator);
         return kafkaConnectS2IClusterOperations;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -109,7 +109,7 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
     public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
-    private static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
+    public static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
 
     private static final String DELETE_CLAIM_ANNOTATION =
             ClusterOperator.STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/delete-claim";
@@ -539,10 +539,6 @@ public abstract class AbstractModel {
      * @return a list of containers to add to the StatefulSet/Deployment
      */
     protected abstract List<Container> getContainers();
-
-    public static String policyName(String cluster) {
-        return cluster + NETWORK_POLICY_KEY_SUFFIX;
-    }
 
     protected VolumeMount createVolumeMount(String name, String path) {
         VolumeMount volumeMount = new VolumeMountBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -109,6 +109,7 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
     public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
+    private static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
 
     private static final String DELETE_CLAIM_ANNOTATION =
             ClusterOperator.STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/delete-claim";
@@ -538,6 +539,10 @@ public abstract class AbstractModel {
      * @return a list of containers to add to the StatefulSet/Deployment
      */
     protected abstract List<Container> getContainers();
+
+    public static String policyName(String cluster) {
+        return cluster + NETWORK_POLICY_KEY_SUFFIX;
+    }
 
     protected VolumeMount createVolumeMount(String name, String path) {
         VolumeMount volumeMount = new VolumeMountBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -21,6 +22,11 @@ import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyBuilder;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyIngressRule;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyIngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPort;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
@@ -695,6 +701,28 @@ public class KafkaCluster extends AbstractModel {
         }
     }
 
+    public NetworkPolicy generateNetworkPolicy() {
+        NetworkPolicyPort p1 = new NetworkPolicyPort();
+        p1.setPort(new IntOrString(REPLICATION_PORT));
+
+        NetworkPolicyIngressRule networkPolicyIngressRule = new NetworkPolicyIngressRuleBuilder()
+                .withPorts(p1)
+                .build();
+
+        NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
+                .withNewMetadata()
+                .withName(policyName(cluster))
+                .withNamespace(namespace)
+                .withLabels(labels.toMap())
+                .endMetadata()
+                .withNewSpec()
+                .withIngress(networkPolicyIngressRule)
+                .endSpec()
+                .build();
+
+        log.trace("Created network policy {}", networkPolicy);
+        return networkPolicy;
+    }
     /**
      * Sets the object with Kafka listeners configuration
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 
 import io.vertx.core.AsyncResult;
@@ -63,6 +64,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     protected final AbstractWatchableResourceOperator<C, T, L, D, R> resourceOperator;
     protected final SecretOperator secretOperations;
     protected final CertManager certManager;
+    protected final NetworkPolicyOperator networkPolicyOperator;
     private final String kind;
 
     /**
@@ -74,7 +76,8 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     protected AbstractAssemblyOperator(Vertx vertx, boolean isOpenShift, ResourceType assemblyType,
                                        CertManager certManager,
                                        AbstractWatchableResourceOperator<C, T, L, D, R> resourceOperator,
-                                       SecretOperator secretOperations) {
+                                       SecretOperator secretOperations,
+                                       NetworkPolicyOperator networkPolicyOperator) {
         this.vertx = vertx;
         this.isOpenShift = isOpenShift;
         this.assemblyType = assemblyType;
@@ -82,6 +85,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         this.resourceOperator = resourceOperator;
         this.certManager = certManager;
         this.secretOperations = secretOperations;
+        this.networkPolicyOperator = networkPolicyOperator;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 
@@ -64,8 +65,9 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                                         ConfigMapOperator configMapOperations,
                                         DeploymentOperator deploymentOperations,
                                         ServiceOperator serviceOperations,
-                                        SecretOperator secretOperations) {
-        super(vertx, isOpenShift, ResourceType.CONNECT, certManager, connectOperator, secretOperations);
+                                        SecretOperator secretOperations,
+                                        NetworkPolicyOperator networkPolicyOperator) {
+        super(vertx, isOpenShift, ResourceType.CONNECT, certManager, connectOperator, secretOperations, networkPolicyOperator);
         this.configMapOperations = configMapOperations;
         this.serviceOperations = serviceOperations;
         this.deploymentOperations = deploymentOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 
@@ -73,8 +74,9 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                                            ServiceOperator serviceOperations,
                                            ImageStreamOperator imagesStreamOperations,
                                            BuildConfigOperator buildConfigOperations,
-                                           SecretOperator secretOperations) {
-        super(vertx, isOpenShift, ResourceType.CONNECT_S2I, certManager, connectOperator, secretOperations);
+                                           SecretOperator secretOperations,
+                                           NetworkPolicyOperator networkPolicyOperator) {
+        super(vertx, isOpenShift, ResourceType.CONNECT_S2I, certManager, connectOperator, secretOperations, networkPolicyOperator);
         this.configMapOperations = configMapOperations;
         this.serviceOperations = serviceOperations;
         this.deploymentConfigOperations = deploymentConfigOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -14,6 +14,7 @@ import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
@@ -45,6 +46,7 @@ public class ResourceOperatorSupplier {
     public final RoleBindingOperator roleBindingOperator;
     public final ClusterRoleBindingOperator clusterRoleBindingOperator;
     public final CrdOperator<KubernetesClient, Kafka, KafkaAssemblyList, DoneableKafka> kafkaOperator;
+    public final NetworkPolicyOperator networkPolicyOperator;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
@@ -57,6 +59,7 @@ public class ResourceOperatorSupplier {
             new ServiceAccountOperator(vertx, client),
             new RoleBindingOperator(vertx, client),
             new ClusterRoleBindingOperator(vertx, client),
+            new NetworkPolicyOperator(vertx, client),
             new CrdOperator<>(vertx, client, Kafka.class, KafkaAssemblyList .class, DoneableKafka.class));
     }
 
@@ -70,6 +73,7 @@ public class ResourceOperatorSupplier {
                                     ServiceAccountOperator serviceAccountOperator,
                                     RoleBindingOperator roleBindingOperator,
                                     ClusterRoleBindingOperator clusterRoleBindingOperator,
+                                    NetworkPolicyOperator networkPolicyOperator,
                                     CrdOperator<KubernetesClient, Kafka, KafkaAssemblyList, DoneableKafka> kafkaOperator) {
         this.serviceOperations = serviceOperations;
         this.zkSetOperations = zkSetOperations;
@@ -81,6 +85,7 @@ public class ResourceOperatorSupplier {
         this.serviceAccountOperator = serviceAccountOperator;
         this.roleBindingOperator = roleBindingOperator;
         this.clusterRoleBindingOperator = clusterRoleBindingOperator;
+        this.networkPolicyOperator = networkPolicyOperator;
         this.kafkaOperator = kafkaOperator;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
@@ -83,10 +84,11 @@ public class KafkaConnectAssemblyOperatorMockTest {
         ServiceOperator svcops = new ServiceOperator(vertx, mockClient);
         DeploymentOperator depops = new DeploymentOperator(vertx, mockClient);
         SecretOperator secretops = new SecretOperator(vertx, mockClient);
+        NetworkPolicyOperator policyops = new NetworkPolicyOperator(vertx, mockClient);
         KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 connectOperator,
-                cmops, depops, svcops, secretops);
+                cmops, depops, svcops, secretops, policyops);
 
         LOGGER.info("Reconciling initially -> create");
         Async createAsync = context.async();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -20,6 +20,7 @@ import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
@@ -91,6 +92,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -110,7 +112,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(clusterCm);
 
@@ -151,6 +153,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -182,7 +185,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -211,6 +214,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -270,7 +274,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -311,6 +315,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -349,7 +354,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -368,6 +373,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -396,7 +402,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -417,6 +423,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -445,7 +452,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -464,6 +471,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -485,7 +493,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
         ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), createResult -> {
@@ -512,6 +520,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ServiceOperator mockServiceOps = mock(ServiceOperator.class);
         DeploymentOperator mockDcOps = mock(DeploymentOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator mockPolicyOps = mock(NetworkPolicyOperator.class);
 
 
         String clusterCmNamespace = "test";
@@ -550,7 +559,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps) {
+                mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps) {
 
             @Override
             public void createOrUpdate(Reconciliation reconciliation, KafkaConnect kafkaConnectAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -24,6 +24,7 @@ import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentConfigOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
@@ -96,6 +97,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -122,7 +124,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm);
 
@@ -180,6 +182,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -229,7 +232,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -268,6 +271,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -335,7 +339,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -393,6 +397,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -444,7 +449,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
 
         Async async = context.async();
@@ -466,6 +471,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -501,7 +507,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -524,6 +530,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -559,7 +566,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
         ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
@@ -581,6 +588,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
@@ -611,7 +619,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps);
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
         ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), createResult -> {
@@ -655,6 +663,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         BuildConfigOperator mockBcOps = mock(BuildConfigOperator.class);
         ImageStreamOperator mockIsOps = mock(ImageStreamOperator.class);
         SecretOperator mockSecretOps = mock(SecretOperator.class);
+        NetworkPolicyOperator networkPolicyOperator = mock(NetworkPolicyOperator.class);
 
 
         String clusterCmNamespace = "test";
@@ -693,7 +702,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
                 new MockCertManager(),
                 mockConnectOps,
-                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps) {
+                mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator) {
 
             @Override
             public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2I kafkaConnectS2IAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {

--- a/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -192,3 +192,15 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/helm-charts/strimzi-kafka-operator/templates/02-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/02-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -197,3 +197,15 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.extensions.DoneableNetworkPolicy;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+public class NetworkPolicyOperator extends AbstractResourceOperator<KubernetesClient, NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> {
+
+    public NetworkPolicyOperator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "NetworkPolicy");
+
+    }
+    @Override
+    protected MixedOperation<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> operation() {
+        return client.extensions().networkPolicies();
+    }
+}


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

Add Network Policies to protect selected ports (such as Zookeeper or Kafka cross-cluster listeners).
Work in progress.

### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

