### PR TITLE
Fix some Makefiles issues with seding Helm Chart files during release…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ release_pkg: helm_pkg
 release_helm_version:
 	echo "Updating default image tags in Helm Chart to $(RELEASE_VERSION)"
 	# Update default image tag in chart values.yaml to RELEASE_VERSION
-	sed -i 's/\(tag: \)latest/\1$(RELEASE_VERSION)/g' $(CHART_PATH)values.yaml
+	sed -i 's/\(tag: \).*/\1$(RELEASE_VERSION)/g' $(CHART_PATH)values.yaml
 	# Update default image tag in chart README.md config grid with RELEASE_VERSION
-	sed -i 's/\(image\.tag[^\n]*\| \)`latest`/\1`$(RELEASE_VERSION)`/g' $(CHART_PATH)README.md
+	sed -i 's/\(image\.tag[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $(CHART_PATH)README.md
 
 helm_pkg:
 	# Copying unarchived Helm Chart to release directory


### PR DESCRIPTION
… process - between RCs etc.

### Type of change

- Bugfix

### Description

This is a minor fix to the Makefile for releasing. The problem was that the replacement rules worked only for `latest` -> `0.6.0-rc1`. But they failed for `0.6.0-rc1` to `0.6.0-rc2`. This fix should work if the 0.6.0 release where it was used passes the test of time :-D.