### PR TITLE
Add Route and Ingress Operators to operator-common

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.extensions.DoneableIngress;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.extensions.IngressList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+/**
+ * Operations for {@code Secret}s.
+ */
+public class IngressOperator extends AbstractResourceOperator<KubernetesClient, Ingress, IngressList, DoneableIngress, Resource<Ingress, DoneableIngress>> {
+
+    /**
+     * Constructor
+     * @param vertx The Vertx instance
+     * @param client The Kubernetes client
+     */
+    public IngressOperator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "Ingress");
+    }
+
+    @Override
+    protected MixedOperation<Ingress, IngressList, DoneableIngress, Resource<Ingress, DoneableIngress>> operation() {
+        return client.extensions().ingresses();
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
 
 /**
- * Operations for {@code Secret}s.
+ * Operations for {@code Ingress}es.
  */
 public class IngressOperator extends AbstractResourceOperator<KubernetesClient, Ingress, IngressList, DoneableIngress, Resource<Ingress, DoneableIngress>> {
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DoneableRoute;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.vertx.core.Vertx;
+
+/**
+ * Operations for {@code Route}s.
+ */
+public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> {
+    /**
+     * Constructor
+     * @param vertx The Vertx instance
+     * @param client The OpenShift client
+     */
+    public RouteOperator(Vertx vertx, OpenShiftClient client) {
+        super(vertx, client, "Route");
+    }
+
+    @Override
+    protected MixedOperation<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> operation() {
+        return client.routes();
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.extensions.DoneableIngress;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IngressOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Ingress, IngressList, DoneableIngress, Resource<Ingress, DoneableIngress>> {
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<? extends Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Ingress resource() {
+        return new IngressBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withNamespace(NAMESPACE)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .build();
+    }
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        ExtensionsAPIGroupDSL mockExt = mock(ExtensionsAPIGroupDSL.class);
+        when(mockExt.ingresses()).thenReturn(op);
+        when(mockClient.extensions()).thenReturn(mockExt);
+    }
+
+    @Override
+    protected AbstractResourceOperator<KubernetesClient, Ingress, IngressList, DoneableIngress, Resource<Ingress, DoneableIngress>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new IngressOperator(vertx, mockClient);
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DoneableRoute;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.vertx.core.Vertx;
+
+import static org.mockito.Mockito.when;
+
+public class RouteOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> {
+    @Override
+    protected Class<OpenShiftClient> clientType() {
+        return OpenShiftClient.class;
+    }
+
+    @Override
+    protected Class<Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Route resource() {
+        return new RouteBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(RESOURCE_NAME).endMetadata().build();
+    }
+
+    @Override
+    protected void mocker(OpenShiftClient mockClient, MixedOperation op) {
+        when(mockClient.routes()).thenReturn(op);
+    }
+
+    @Override
+    protected AbstractResourceOperator<OpenShiftClient, Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
+        return new RouteOperator(vertx, mockClient);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

For exposing Kafka on Kubernetes and OpenShift (#128) we will need to use among other Routes and Ingresses. This PR does some preparation work and adds `RouteOperator` and `IngressOperator` to `operator-common` so that.