### PR TITLE
Docs: Fix topology key alignment

### DIFF
--- a/documentation/book/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/book/proc-scheduling-based-on-other-pods.adoc
@@ -34,7 +34,7 @@ spec:
                   values:
                     - postgresql
                     - mongodb
-          topologyKey: "kubernetes.io/hostname"
+            topologyKey: "kubernetes.io/hostname"
     # ...
   zookeeper:
     # ...


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes a bug in the alignment of the `topologyKey` field in the pod affinity example.