### PR TITLE
Use 'standalone' consistently in docs - issue #772

### DIFF
--- a/documentation/book/proc-creating-a-topic.adoc
+++ b/documentation/book/proc-creating-a-topic.adoc
@@ -52,4 +52,4 @@ oc apply -f _<your-file>_
 * For more information about the schema for `KafkaTopics`, see xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].
 * For more information about deploying a Kafka cluster using the Cluster Operator, see xref:cluster-operator-str[].
 * For more information about deploying the Topic Operator using the Cluster Operator, see xref:deploying-the-topic-operator-using-the-cluster-operator-str[].
-* For more information about deploying the Topic Operator standalone, see xref:deploying-the-topic-operator-standalone-deploying[].
+* For more information about deploying the standalone Topic Operator, see xref:deploying-the-topic-operator-standalone-deploying[].

--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -4,7 +4,7 @@
 // assembly-deploying-the-topic-operator.adoc
 
 [id='deploying-the-topic-operator-standalone-{context}']
-= Deploying the Topic Operator standalone
+= Deploying the standalone Topic Operator 
 
 Deploying the Topic Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
 For instance is can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Used 'standalone' consistently in docs
