### PR TITLE
Docs: Clean up modules for Authentication & Authorization

### DIFF
--- a/documentation/book/assembly-kafka-authentication-and-authorization.adoc
+++ b/documentation/book/assembly-kafka-authentication-and-authorization.adoc
@@ -8,17 +8,16 @@
 :parent-context: {context}
 
 [id='assembly-kafka-authentication-and-authorization-{context}']
-= Authentication and Authorization
+= Authentication and authorization in Kafka brokers
 
-{ProductName} supports authentication and authorization.
-Authentication can be configured independently for each xref:assembly-configuring-kafka-broker-listeners-{context}[listener].
+In {ProductName} authentication can be configured independently for each xref:assembly-configuring-kafka-broker-listeners-{context}[listener].
 Authorization is always configured for the whole Kafka cluster.
 
-include::ref-kafka-authentication.adoc[leveloffset=+1]
+//include::ref-kafka-authentication.adoc[leveloffset=+1]
 
 include::proc-kafka-authentication.adoc[leveloffset=+1]
 
-include::ref-kafka-authorization.adoc[leveloffset=+1]
+//include::ref-kafka-authorization.adoc[leveloffset=+1]
 
 include::proc-kafka-authorization.adoc[leveloffset=+1]
 

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -5,6 +5,12 @@
 [id='proc-kafka-authentication-{context}']
 = Configuring authentication in Kafka brokers
 
+Authentication is configured as part of the xref:assembly-configuring-kafka-broker-listeners-{context}[listener configuration] in the `authentication` property.
+When the `authentication` property is missing, no authentication will be enabled on a given listener.
+The authentication mechanism that will be used is defined by the `type` field.
+
+NOTE: Currently, the only supported authentication mechanism is the TLS client authentication.
+
 .Prerequisites
 
 * An {ProductPlatformName} cluster
@@ -14,7 +20,7 @@
 
 . Edit the `listeners` property in the `Kafka.spec.kafka` resource.
 Add the `authentication` field to the listeners where you want to enable authentication.
-For example:
+For example, to enable TLS client authentication on the `tls listener`:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -52,5 +52,5 @@ On {OpenShiftName} this can be done using `oc apply`:
 oc apply -f _<your-file>_
 
 .Additional resources
-* For more information about the supported authentication mechanisms, see xref:ref-kafka-authentication-{context}[authentication reference].
+//* For more information about the supported authentication mechanisms, see xref:ref-kafka-authentication-{context}[authentication reference].
 * For more information about the schema for `Kafka`, see xref:type-Kafka-reference[`Kafka` schema reference].

--- a/documentation/book/proc-kafka-authorization.adoc
+++ b/documentation/book/proc-kafka-authorization.adoc
@@ -5,6 +5,13 @@
 [id='proc-kafka-authorization-{context}']
 = Configuring authorization in Kafka brokers
 
+Authorization can be configured using the `authorization` property in the `Kafka.spec.kafka` resource.
+When the `authorization` property is missing, no authorization will be enabled.
+When authorization is enabled it will be applied for all enabled xref:assembly-configuring-kafka-broker-listeners-{context}[listeners].
+The authorization method is defined by the `type` field.
+
+NOTE: Currently, the only supported authorization method is the Simple authorization. Simple authorization is using the `SimpleAclAuthorizer` plugin, the default authorization plugin in Apache Kafka.
+
 .Prerequisites
 
 * An {ProductPlatformName} cluster

--- a/documentation/book/proc-kafka-authorization.adoc
+++ b/documentation/book/proc-kafka-authorization.adoc
@@ -50,5 +50,5 @@ On {OpenShiftName} this can be done using `oc apply`:
 oc apply -f _<your-file>_
 
 .Additional resources
-* For more information about the supported authorization methods, see xref:ref-kafka-authorization-{context}[authorization reference].
+//* For more information about the supported authorization methods, see xref:ref-kafka-authorization-{context}[authorization reference].
 * For more information about the schema for `Kafka`, see xref:type-Kafka-reference[`Kafka` schema reference].


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Remove unnecessary reference modules & clean up Authorization & Authentication sections.
