### PR TITLE
Docs: Update titles

### DIFF
--- a/documentation/book/con-how-the-topic-operator-works.adoc
+++ b/documentation/book/con-how-the-topic-operator-works.adoc
@@ -3,7 +3,7 @@
 // topic-operator.adoc
 
 [id='how-the-topic-operator-works-{context}']
-= How the Topic Operator works
+= Understanding the Topic Operator
 
 A fundamental problem that the operator has to solve is that there is no single source of truth:
 Both the `KafkaTopic` resource and the topic within Kafka can be modified independently of the operator.

--- a/documentation/book/con-what-the-cluster-operator-does.adoc
+++ b/documentation/book/con-what-the-cluster-operator-does.adoc
@@ -4,7 +4,7 @@
 // assembnly-cluster-operator.adoc
 
 [id='con-what-the-cluster-operator-does-{context}']
-= What the Cluster Operator does
+= Overview of the Cluster Operator component
 
 The Cluster Operator is in charge of deploying a Kafka cluster alongside a Zookeeper ensemble.
 As part of the Kafka cluster, it can also deploy the topic operator which provides operator-style topic management via `KafkaTopic` custom resources.

--- a/documentation/book/con-what-the-topic-operator-does.adoc
+++ b/documentation/book/con-what-the-topic-operator-does.adoc
@@ -3,7 +3,7 @@
 // topic-operator.adoc
 
 [id='what-the-topic-operator-does-{context}']
-= What the Topic Operator does
+= Overview of the Topic Operator component
 
 The Topic Operator provides a way of managing topics in a Kafka cluster via {ProductPlatformName} resources.
 

--- a/documentation/book/con-what-the-user-operator-does.adoc
+++ b/documentation/book/con-what-the-user-operator-does.adoc
@@ -3,7 +3,7 @@
 // assembly-getting-started-user-operator.adoc
 
 [id='con-what-the-user-operator-does-{context}']
-= What the User Operator does
+= Overview of the User Operator component
 
 The User Operator manages Kafka users for a Kafka cluster by watching for `KafkaUser` {ProductPlatformName} resources that describe Kafka users and ensuring that they are configured properly in the Kafka cluster.
 For example:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Retitle sections that start with 'what' and 'how'

