### PR TITLE
Apparently people search for "error" when their builds fail

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -15,7 +15,7 @@ if [ ! -e  documentation/book/appendix_crds.adoc ] ; then
 fi
 CHANGED_DERIVED=$(git diff --name-status -- examples/ helm-charts/ documentation/book/appendix_crds.adoc)
 if [ -n "$CHANGED_DERIVED" ] ; then
-  echo "Uncommitted changes in derived resources:"
+  echo "ERROR: Uncommitted changes in derived resources:"
   echo "$CHANGED_DERIVED"
   echo "Run the following to add up-to-date resources:"
   echo "  mvn clean verify -DskipTests -DskipITs \\"

--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -31,6 +31,6 @@ grep_check '\<a {ProductPlatformName}' "The article should be 'an' {ProductPlatf
 grep_check '\<a {ProductPlatformLongName}' "The article should be 'an' {ProductPlatformLongName}"
 
 if [ $fatal -gt 0 ]; then
-  echo "${fatal} docs problems found."
+  echo "ERROR: ${fatal} docs problems found."
   exit 1
 fi


### PR DESCRIPTION
### Type of change

- Incrediable minor travis improvment

### Description

It seems people search for the word ERROR when their builds fail. So use this when we fail the build.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

