### PR TITLE
Architecture: Changed JVM options' to labels

### DIFF
--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -15,7 +15,7 @@ JVM options can be configured using the `jvmOptions` property in following resou
 Only a selected subset of available JVM options can be configured.
 The following options are supported:
 
-== `-Xmx`
+.-Xmx
 
 `-Xmx` configures the maximum heap size.
 
@@ -60,7 +60,7 @@ jvmOptions:
 In the above example, the JVM will use 2 GiB (=2,147,483,648 bytes) for its heap.
 Its total memory usage will be approximately 8GiB.
 
-== `-Xms`
+.-Xms
 
 `-Xms` configures the initial heap size.
 
@@ -82,7 +82,7 @@ jvmOptions:
 # ...
 ----
 
-== `-server`
+.-server
 
 `-server` enables the server JVM. This option can be set to true or false.
 
@@ -97,7 +97,7 @@ jvmOptions:
 
 NOTE: When neither of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
 
-== `-XX`
+.-XX
 
 `-XX` object can be used for configuring advanced runtime options of a JVM.
 The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE_OPTS` option of Apache Kafka.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Changed JVM options' from headings to labels to avoid them in ToC