### PR TITLE
Add Helm Chart repository index.yaml generation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -134,7 +134,7 @@ The chart is also available in the release artifact as a tarball.
 version. The `release` target will:
 * Update all tags of Docker images to `RELEASE_VERSION`
 * Update documentation version to `RELEASE_VERSION`
-* Set version of the main Maven projects (`topic-operator` and `clutser-operator`) to `RELEASE_VERSION` 
+* Set version of the main Maven projects (`topic-operator` and `cluster-operator`) to `RELEASE_VERSION` 
 * Create TAR.GZ and ZIP archives with the Kubernetes and OpenShift YAML files which can be used for deployment
 and documentation in HTML format.
  
@@ -152,8 +152,15 @@ The release process should normally look like this:
 tag name has to be the same as the `RELEASE_VERSION`,
 7. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. 
 Attach the TAR.GZ/ZIP archives and the Helm Chart to the release
-8. On the `master` git branch, update the versions to the next SNAPSHOT version using the `next_version` `make` target. 
-For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
+8. On the `master` git branch
+  * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. 
+  For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
+  * Copy the `helm-charts/index.yaml` from the `release` branch to `master`.
+9. Update the website
+  * Add release documentation to `strimzi.github.io/docs/`.  Update references to docs in 
+  `strimzi.github.io/documentation/index.md`.
+  * Update the Helm Chart repository file by copying `strimzi-kafka-operator/helm-charts/index.yaml` to 
+  `strimzi.github.io/charts/index.yaml`. 
 
 ## Running system tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 RELEASE_VERSION ?= latest
 CHART_PATH ?= ./helm-charts/strimzi-kafka-operator/
-CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | sed 's/\([0-9.]*\).*/\1/')
+CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
 
 SUBDIRS=docker-images crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init helm-charts examples
 DOCKER_TARGETS=docker_build docker_push docker_tag

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_TARGETS=docker_build docker_push docker_tag
 all: $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): $(SUBDIRS)
-release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_pkg docu_clean
+release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_pkg release_helm_repo docu_clean
 
 next_version:
 	echo $(shell echo $(NEXT_VERSION) | tr a-z A-Z) > release.version
@@ -45,6 +45,11 @@ release_helm_version:
 	sed -i 's/\(tag: \).*/\1$(RELEASE_VERSION)/g' $(CHART_PATH)values.yaml
 	# Update default image tag in chart README.md config grid with RELEASE_VERSION
 	sed -i 's/\(image\.tag[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $(CHART_PATH)README.md
+
+release_helm_repo:
+	echo "Updating Helm Repository index.yaml"
+	helm repo index ./ --url https://github.com/strimzi/strimzi-kafka-operator/releases/download/$(RELEASE_VERSION)/ --merge ./helm-charts/index.yaml
+	mv ./index.yaml ./helm-charts/index.yaml
 
 helm_pkg:
 	# Copying unarchived Helm Chart to release directory

--- a/documentation/book/proc-deploying-cluster-operator-helm-chart.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-helm-chart.adoc
@@ -12,17 +12,20 @@
 
 .Procedure
 
+. Add the Strimzi Helm Chart repository:
++
+[source,shell,subs=attributes+]
+helm repo add strimzi {ChartRepositoryUrl}
+
 . Deploy the Cluster Operator using the Helm command line tool:
 +
 [source,shell,subs=attributes+]
-helm install {ChartReleaseDownload}
+helm install {ChartReleaseCoordinate}
 
 . Verify whether the Cluster Operator has been deployed successfully using the Helm command line tool:
 +
-[source]
-----
+[source,shell]
 helm ls
-----
 
 .Additional resources
 * For more information about Helm, see the https://helm.sh/[Helm website^].

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -31,7 +31,8 @@
 
 // Helm Chart
 :ChartName: strimzi-kafka-operator
-:ChartReleaseDownload: {ChartName}-{ProductVersion}.tgz
+:ChartReleaseCoordinate: strimzi/strimzi-kafka-operator
+:ChartRepositoryUrl: http://strimzi.io/charts/
 
 // External links
 :KafkaRacks: link:https://kafka.apache.org/documentation/#basic_ops_racks[Kafka racks documentation^]

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME=helm-charts
 
 RELEASE_VERSION ?= latest
-CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ../release.version | sed 's/\([0-9.]*\).*/\1/')
+CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ../release.version | tr A-Z a-z)
 CHART_NAME=strimzi-kafka-operator
 CHART_PATH=./$(CHART_NAME)/
 CHART_RENDERED_TEMPLATES_TMP=../target/charts

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+entries:
+  strimzi-kafka-operator:
+  - apiVersion: v1
+    appVersion: 0.6.0
+    created: 2018-08-23T14:25:34.526805221-04:00
+    description: 'Strimzi: Kafka as a Service'
+    digest: 684868a46604411a151d90579f15e065320ba636c2afd25702b508fe11b30c64
+    home: http://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: ppatierno
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v1
+    appVersion: 0.6.0-rc3
+    created: 2018-08-23T14:22:34.723706021-04:00
+    description: 'Strimzi: Kafka as a Service'
+    digest: f21f51f0611da940d987911f760ed4ed8bf3d6aaa6de0ba2207630cee7d97b19
+    home: http://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: ppatierno
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0-rc3/strimzi-kafka-operator-0.6.0-rc3.tgz
+    version: 0.6.0-rc3
+generated: 2018-08-23T14:25:34.526112491-04:00

--- a/helm-charts/strimzi-kafka-operator/README.md
+++ b/helm-charts/strimzi-kafka-operator/README.md
@@ -17,10 +17,16 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Installing the Chart
 
+Add the Strimzi Helm Chart repository:
+
+```bash
+$ helm repo add strimzi http://strimzi.io/charts/
+```
+
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release incubator/strimzi-kafka-operator
+$ helm install --name my-release strimzi/strimzi-kafka-operator
 ```
 
 The command deploys the Strimzi Cluster Operator on the Kubernetes cluster with the default configuration. 
@@ -91,5 +97,5 @@ the documentation for more details.
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release --set logLevel=DEBUG,fullReconciliationIntervalMs=240000 incubator/strimzi-kafka-operator
+$ helm install --name my-release --set logLevel=DEBUG,fullReconciliationIntervalMs=240000 strimzi/strimzi-kafka-operator
 ```


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add Helm Chart repository index.yaml with valid previous chart releases (#686).  I updated documentation and chart README to reference using the repository.  I added notes to the `HACKING.md` file's release section on how to manually copy the cumulative `index.yaml` to the strimzi website as part of the release process.

Bonus: [@scholzj's fix](https://github.com/strimzi/strimzi-kafka-operator/commit/11b19f11ac87a9f5a85998560d4ee5b148ea0ee4) for obtaining valid semantic version for chart release process.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

