### PR TITLE
Use dynamic names for bindings created for TO and UO so that they do not conflict across clusters

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -163,10 +163,10 @@ public class EntityTopicOperator extends AbstractModel {
     }
 
     /**
-     * Get the name of the TO role binding given the name of the {@code kafkaResourceName}.
+     * Get the name of the TO role binding given the name of the {@code cluster}.
      */
-    public static String roleBindingName(String kafkaResourceName) {
-        return "strimzi-" + kafkaResourceName + "-topic-operator";
+    public static String roleBindingName(String cluster) {
+        return "strimzi-" + cluster + "-topic-operator";
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -43,7 +43,6 @@ public class EntityTopicOperator extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
-    public static final String TO_ROLE_BINDING_NAME = "strimzi-entity-topic-operator-role-binding";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON
     private String kafkaBootstrapServers;
@@ -163,6 +162,13 @@ public class EntityTopicOperator extends AbstractModel {
         return cluster + METRICS_AND_LOG_CONFIG_SUFFIX;
     }
 
+    /**
+     * Get the name of the TO role binding given the name of the {@code kafkaResourceName}.
+     */
+    public static String roleBindingName(String kafkaResourceName) {
+        return "strimzi-" + kafkaResourceName + "-topic-operator";
+    }
+
     @Override
     protected String getDefaultLogConfigFileName() {
         return "entityTopicOperatorDefaultLoggingProperties";
@@ -246,7 +252,7 @@ public class EntityTopicOperator extends AbstractModel {
     }
 
     public RoleBindingOperator.RoleBinding generateRoleBinding(String namespace) {
-        return new RoleBindingOperator.RoleBinding(TO_ROLE_BINDING_NAME, EntityOperator.EO_CLUSTER_ROLE_NAME,
+        return new RoleBindingOperator.RoleBinding(roleBindingName(cluster), EntityOperator.EO_CLUSTER_ROLE_NAME,
                 namespace, EntityOperator.entityOperatorServiceAccountName(cluster));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -40,7 +40,6 @@ public class EntityUserOperator extends AbstractModel {
     public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_CLIENTS_CA_NAME = "STRIMZI_CA_NAME";
-    public static final String UO_ROLE_BINDING_NAME = "strimzi-entity-user-operator-role-binding";
 
     private String zookeeperConnect;
     private String watchedNamespace;
@@ -119,6 +118,13 @@ public class EntityUserOperator extends AbstractModel {
         return cluster + METRICS_AND_LOG_CONFIG_SUFFIX;
     }
 
+    /**
+     * Get the name of the UO role binding given the name of the {@code kafkaResourceName}.
+     */
+    public static String roleBindingName(String kafkaResourceName) {
+        return "strimzi-" + kafkaResourceName + "-user-operator";
+    }
+
     @Override
     protected String getDefaultLogConfigFileName() {
         return "entityUserOperatorDefaultLoggingProperties";
@@ -195,7 +201,7 @@ public class EntityUserOperator extends AbstractModel {
     }
 
     public RoleBindingOperator.RoleBinding generateRoleBinding(String namespace) {
-        return new RoleBindingOperator.RoleBinding(UO_ROLE_BINDING_NAME, EntityOperator.EO_CLUSTER_ROLE_NAME,
+        return new RoleBindingOperator.RoleBinding(roleBindingName(cluster), EntityOperator.EO_CLUSTER_ROLE_NAME,
                 namespace, EntityOperator.entityOperatorServiceAccountName(cluster));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -119,10 +119,10 @@ public class EntityUserOperator extends AbstractModel {
     }
 
     /**
-     * Get the name of the UO role binding given the name of the {@code kafkaResourceName}.
+     * Get the name of the UO role binding given the name of the {@code cluster}.
      */
-    public static String roleBindingName(String kafkaResourceName) {
-        return "strimzi-" + kafkaResourceName + "-user-operator";
+    public static String roleBindingName(String cluster) {
+        return "strimzi-" + cluster + "-user-operator";
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -674,10 +674,10 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Get the name of the kafka kafkaResourceName role binding given the name of the {@code kafkaResourceName}.
+     * Get the name of the kafka kafkaResourceName role binding given the name of the {@code namespace} and {@code cluster}.
      */
-    public static String initContainerClusterRoleBindingName(String namespace, String kafkaResourceName) {
-        return "strimzi-" + namespace + "-" + kafkaResourceName + "-kafka-init";
+    public static String initContainerClusterRoleBindingName(String namespace, String cluster) {
+        return "strimzi-" + namespace + "-" + cluster + "-kafka-init";
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -676,8 +676,8 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Get the name of the kafka kafkaResourceName role binding given the name of the {@code kafkaResourceName}.
      */
-    public static String initContainerClusterRoleBindingName(String kafkaResourceName) {
-        return "strimzi-" + kafkaResourceName + "-kafka-init";
+    public static String initContainerClusterRoleBindingName(String namespace, String kafkaResourceName) {
+        return "strimzi-" + namespace + "-" + kafkaResourceName + "-kafka-init";
     }
 
     /**
@@ -687,7 +687,7 @@ public class KafkaCluster extends AbstractModel {
     public ClusterRoleBindingOperator.ClusterRoleBinding generateClusterRoleBinding(String assemblyNamespace) {
         if (rack != null) {
             return new ClusterRoleBindingOperator.ClusterRoleBinding(
-                    initContainerClusterRoleBindingName(cluster),
+                    initContainerClusterRoleBindingName(namespace, cluster),
                     "strimzi-kafka-broker",
                     assemblyNamespace, initContainerServiceAccountName(cluster));
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -674,7 +674,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Get the name of the kafka kafkaResourceName role binding given the name of the {@code namespace} and {@code cluster}.
+     * Get the name of the kafka init container role binding given the name of the {@code namespace} and {@code cluster}.
      */
     public static String initContainerClusterRoleBindingName(String namespace, String cluster) {
         return "strimzi-" + namespace + "-" + cluster + "-kafka-init";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -192,10 +192,10 @@ public class TopicOperator extends AbstractModel {
     }
 
     /**
-     * Get the name of the TO role binding given the name of the {@code kafkaResourceName}.
+     * Get the name of the TO role binding given the name of the {@code cluster}.
      */
-    public static String roleBindingName(String kafkaResourceName) {
-        return "strimzi-" + kafkaResourceName + "-topic-operator";
+    public static String roleBindingName(String cluster) {
+        return "strimzi-" + cluster + "-topic-operator";
     }
 
     protected static String defaultZookeeperConnect(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -76,7 +76,6 @@ public class TopicOperator extends AbstractModel {
     public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
     public static final String TO_CLUSTER_ROLE_NAME = "strimzi-topic-operator";
-    public static final String TO_ROLE_BINDING_NAME = "strimzi-topic-operator-role-binding";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON
     private String kafkaBootstrapServers;
@@ -190,6 +189,13 @@ public class TopicOperator extends AbstractModel {
 
     public static String metricAndLogConfigsName(String cluster) {
         return cluster + METRICS_AND_LOG_CONFIG_SUFFIX;
+    }
+
+    /**
+     * Get the name of the TO role binding given the name of the {@code kafkaResourceName}.
+     */
+    public static String roleBindingName(String kafkaResourceName) {
+        return "strimzi-" + kafkaResourceName + "-topic-operator";
     }
 
     protected static String defaultZookeeperConnect(String cluster) {
@@ -379,7 +385,7 @@ public class TopicOperator extends AbstractModel {
     }
 
     public RoleBindingOperator.RoleBinding generateRoleBinding(String namespace) {
-        return new RoleBindingOperator.RoleBinding(TO_ROLE_BINDING_NAME, TO_CLUSTER_ROLE_NAME, namespace, getServiceAccountName());
+        return new RoleBindingOperator.RoleBinding(roleBindingName(cluster), TO_CLUSTER_ROLE_NAME, namespace, getServiceAccountName());
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -609,7 +609,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     return desc.withVoid(roleBindingOperator.reconcile(
                             watchedNamespace != null && !watchedNamespace.isEmpty() ?
                                     watchedNamespace : namespace,
-                            TopicOperator.TO_ROLE_BINDING_NAME,
+                            TopicOperator.roleBindingName(name),
                             desc != TopicOperatorDescription.EMPTY ? desc.topicOperator().generateRoleBinding(namespace) : null));
                 })
                 .compose(desc -> desc.withVoid(configMapOperations.reconcile(namespace,
@@ -631,7 +631,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         result.add(configMapOperations.reconcile(namespace, TopicOperator.metricAndLogConfigsName(name), null));
         result.add(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), null));
         result.add(secretOperations.reconcile(namespace, TopicOperator.secretName(name), null));
-        result.add(roleBindingOperator.reconcile(namespace, TopicOperator.TO_ROLE_BINDING_NAME, null));
+        result.add(roleBindingOperator.reconcile(namespace, TopicOperator.roleBindingName(name), null));
         result.add(serviceAccountOperator.reconcile(namespace, TopicOperator.topicOperatorServiceAccountName(name), null));
         return CompositeFuture.join(result);
     }
@@ -697,7 +697,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     return desc.withVoid(roleBindingOperator.reconcile(
                             watchedNamespace != null && !watchedNamespace.isEmpty() ?
                                     watchedNamespace : namespace,
-                            EntityTopicOperator.TO_ROLE_BINDING_NAME,
+                            EntityTopicOperator.roleBindingName(name),
                             desc != EntityOperatorDescription.EMPTY && desc.entityOperator().getTopicOperator() != null ?
                                     desc.entityOperator().getTopicOperator().generateRoleBinding(namespace) : null));
                 })
@@ -707,7 +707,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     return desc.withVoid(roleBindingOperator.reconcile(
                             watchedNamespace != null && !watchedNamespace.isEmpty() ?
                                     watchedNamespace : namespace,
-                            EntityUserOperator.UO_ROLE_BINDING_NAME,
+                            EntityUserOperator.roleBindingName(name),
                             desc != EntityOperatorDescription.EMPTY && desc.entityOperator().getUserOperator() != null ?
                                     desc.entityOperator().getUserOperator().generateRoleBinding(namespace) : null));
                 })
@@ -736,8 +736,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         result.add(configMapOperations.reconcile(namespace, EntityUserOperator.metricAndLogConfigsName(name), null));
         result.add(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), null));
         result.add(secretOperations.reconcile(namespace, EntityOperator.secretName(name), null));
-        result.add(roleBindingOperator.reconcile(namespace, EntityTopicOperator.TO_ROLE_BINDING_NAME, null));
-        result.add(roleBindingOperator.reconcile(namespace, EntityUserOperator.UO_ROLE_BINDING_NAME, null));
+        result.add(roleBindingOperator.reconcile(namespace, EntityTopicOperator.roleBindingName(name), null));
+        result.add(roleBindingOperator.reconcile(namespace, EntityUserOperator.roleBindingName(name), null));
         result.add(serviceAccountOperator.reconcile(namespace, EntityOperator.entityOperatorServiceAccountName(name), null));
         return CompositeFuture.join(result);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -427,7 +427,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         KafkaCluster.initContainerServiceAccountName(desc.kafka().getCluster()),
                         desc.kafka.generateInitContainerServiceAccount())))
                 .compose(desc -> desc.withVoid(clusterRoleBindingOperator.reconcile(
-                        KafkaCluster.initContainerClusterRoleBindingName(desc.kafka().getCluster()),
+                        KafkaCluster.initContainerClusterRoleBindingName(namespace, name),
                         desc.kafka.generateClusterRoleBinding(namespace))))
                 .compose(desc -> desc.withVoid(kafkaSetOperations.scaleDown(namespace, desc.kafka().getName(), desc.kafka().getReplicas())))
                 .compose(desc -> desc.withVoid(serviceOperations.reconcile(namespace, desc.kafka().getServiceName(), desc.service())))
@@ -473,7 +473,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         KafkaCluster.getPersistentVolumeClaimName(kafkaSsName, i), null));
             }
         }
-        result.add(clusterRoleBindingOperator.reconcile(KafkaCluster.initContainerClusterRoleBindingName(name), null));
+        result.add(clusterRoleBindingOperator.reconcile(KafkaCluster.initContainerClusterRoleBindingName(namespace, name), null));
         result.add(serviceAccountOperator.reconcile(namespace, KafkaCluster.initContainerServiceAccountName(name), null));
         return CompositeFuture.join(result);
     }

--- a/documentation/book/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-cluster-resources.adoc
@@ -12,6 +12,8 @@ The following resources will created by the Cluster Operator in the {ProductPlat
 `_<cluster-name>_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients.
 `_<cluster-name>_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
 `_<cluster-name>_-kafka-brokers`:: Secret with Kafka broker keys.
+`_<cluster-name>_-kafka`:: Service account used by the Kafka brokers.
+`strimzi-_<namespace-name>_-_<cluster-name>_-kafka-init`:: Cluster role binding used by the Kafka brokers.
 `_<cluster-name>_-zookeeper`:: StatefulSet which is in charge of managing the Zookeeper node pods.
 `_<cluster-name>_-zookeeper-nodes`:: Service needed to have DNS resolve the Zookeeper pods IP addresses directly.
 `_<cluster-name>_-zookeeper-client`:: Service used by Kafka brokers to connect to Zookeeper nodes as clients.
@@ -21,6 +23,9 @@ The following resources will created by the Cluster Operator in the {ProductPlat
 `_<cluster-name>_-entity-topic-operator-config`:: Configmap with ancillary configuration for Topic Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
 `_<cluster-name>_-entity-user-operator-config`:: Configmap with ancillary configuration for User Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
 `_<cluster-name>_-entity-operator-certs`:: Secret with Entitiy operators keys for communication with Kafka and Zookeeper. This resource will be created only if Cluster Operator deployed Entity Operator.
+`_<cluster-name>_-entity-operator`:: Service account used by the Entity Operator.
+`strimzi-_<cluster-name>_-topic-operator`:: Role binding used by the Entity Operator.
+`strimzi-_<cluster-name>_-user-operator`:: Role binding used by the Entity Operator.
 `_<cluster-name>_-cluster-ca`:: Secret with the Cluster CA used to encrypt the cluster communication.
 `_<cluster-name>_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
 `_<cluster-name>_-clients-ca`::  Secret with the Clients CA used to encrypt the communication between Kafka brokers and Kafka clients.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, the names for the bindings created for TO and UO have fixed names. That could cause issues when multiple clusters would be deployed into the same namespace. Instead we should use dynamic names based on the cluster name.

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

