### PR TITLE
Cert renewal

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -27,7 +27,7 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "kafka", "zookeeper", "topicOperator" })
+@JsonPropertyOrder({ "kafka", "zookeeper", "topicOperator", "tlsCertificates"})
 public class KafkaSpec implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -36,6 +36,7 @@ public class KafkaSpec implements Serializable {
     private ZookeeperClusterSpec zookeeper;
     private TopicOperatorSpec topicOperator;
     private EntityOperatorSpec entityOperator;
+    private TlsCertificates tlsCertificates;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Configuration of the Kafka cluster")
@@ -76,6 +77,15 @@ public class KafkaSpec implements Serializable {
 
     public void setEntityOperator(EntityOperatorSpec entityOperator) {
         this.entityOperator = entityOperator;
+    }
+
+    @Description("Configuration of how TLS certificates are handled.")
+    public TlsCertificates getTlsCertificates() {
+        return tlsCertificates;
+    }
+
+    public void setTlsCertificates(TlsCertificates tlsCertificates) {
+        this.tlsCertificates = tlsCertificates;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsCertificates.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsCertificates.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+
+import java.io.Serializable;
+
+@Description("Configuration of how TLS certificates are used within the cluster." +
+        "This applies to certificates used for both internal communication within the cluster and to certificates " +
+        "used for client access via `Kafka.spec.kafka.listeners.tls`.")
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "generateCertificateAuthority", "validityDays", "renewalDays" })
+public class TlsCertificates implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    int validityDays;
+    boolean generateCertificateAuthority = true;
+    int renewalDays;
+
+    @Description("The number of days generated certificates should be valid for. Default is 365.")
+    @Minimum(1)
+    public int getValidityDays() {
+        return validityDays;
+    }
+
+    public void setValidityDays(int validityDays) {
+        this.validityDays = validityDays;
+    }
+
+    @Description("If true then Certificate Authority certificates will be generated automatically. " +
+            "Otherwise the user will need to provide a Secret with the CA certificate. " +
+            "Default is true.")
+    public boolean isGenerateCertificateAuthority() {
+        return generateCertificateAuthority;
+    }
+
+    public void setGenerateCertificateAuthority(boolean generateCertificateAuthority) {
+        this.generateCertificateAuthority = generateCertificateAuthority;
+    }
+
+    @Description("The number of days in the certificate renewal period. " +
+            "This is the number of days before the a certificate expires during which renewal actions may be performed." +
+            "When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. " +
+            "When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. " +
+            "Default is 30.")
+    @Minimum(1)
+    public int getRenewalDays() {
+        return renewalDays;
+    }
+
+    public void setRenewalDays(int renewalDays) {
+        this.renewalDays = renewalDays;
+    }
+}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -101,4 +101,8 @@ spec:
     reconciliationIntervalSeconds: 90
     zookeeperSessionTimeoutSeconds: 20
     topicMetadataMaxAttempts: 6
+  tlsCertificates:
+    generateCertificateAuthority: false
+    validityDays: 395
+    renewalDays: 32
   someExtraThing: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
@@ -103,4 +103,8 @@ spec:
     metrics: {}
   topicOperator:
     watchedNamespace: my-ns
+  tlsCertificates:
+    renewalDays: 32
+    validityDays: 395
+    generateCertificateAuthority: false
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertAndKey.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertAndKey.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.certs;
 
+import java.util.Base64;
+
 public class CertAndKey {
 
     private final byte[] key;
@@ -18,7 +20,15 @@ public class CertAndKey {
         return key;
     }
 
+    public String keyAsBase64String() {
+        return Base64.getEncoder().encodeToString(key());
+    }
+
     public byte[] cert() {
         return cert;
+    }
+
+    public String certAsBase64String() {
+        return Base64.getEncoder().encodeToString(cert());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -54,6 +54,7 @@ import io.strimzi.api.kafka.model.CpuMemory;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.JvmOptions;
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
@@ -1054,8 +1055,8 @@ public abstract class AbstractModel {
      * @return Collection with certificates
      * @throws IOException
      */
-    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName) throws IOException {
-        return maybeCopyOrGenerateCerts(certManager, secret, replicasInSecret, caCert, podName, null, Collections.EMPTY_MAP);
+    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Kafka kafka, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName) throws IOException {
+        return maybeCopyOrGenerateCerts(certManager, kafka, secret, replicasInSecret, caCert, podName, null, Collections.EMPTY_MAP);
     }
 
     /**
@@ -1072,7 +1073,8 @@ public abstract class AbstractModel {
      * @return Collection with certificates
      * @throws IOException
      */
-    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
+    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Kafka kafka, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
+
 
         Map<String, CertAndKey> certs = new HashMap<>();
 
@@ -1123,7 +1125,8 @@ public abstract class AbstractModel {
             sbj.setSubjectAltNames(sbjAltNames);
 
             certManager.generateCsr(brokerKeyFile, brokerCsrFile, sbj);
-            certManager.generateCert(brokerCsrFile, caCert.key(), caCert.cert(), brokerCertFile, sbj, CERTS_EXPIRATION_DAYS);
+            certManager.generateCert(brokerCsrFile, caCert.key(), caCert.cert(), brokerCertFile,
+                    sbj, ModelUtils.getCertificateValidity(kafka));
 
             certs.put(podName.apply(cluster, i),
                     new CertAndKey(Files.readAllBytes(brokerKeyFile.toPath()), Files.readAllBytes(brokerCertFile.toPath())));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -54,34 +54,26 @@ import io.strimzi.api.kafka.model.CpuMemory;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.JvmOptions;
-import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Storage;
-import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
-import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -93,11 +85,6 @@ import static java.util.Arrays.asList;
 public abstract class AbstractModel {
 
     protected static final Logger log = LogManager.getLogger(AbstractModel.class.getName());
-
-    // the Kubernetes service DNS domain is customizable on cluster creation but it's "cluster.local" by default
-    // there is no clean way to get it from a running application so we are passing it through an env var
-    public static final String KUBERNETES_SERVICE_DNS_DOMAIN =
-            System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
 
     protected static final int CERTS_EXPIRATION_DAYS = 365;
     protected static final String DEFAULT_JVM_XMS = "128M";
@@ -164,7 +151,6 @@ public abstract class AbstractModel {
     private String[] validLoggerValues = new String[]{"INFO", "ERROR", "WARN", "TRACE", "DEBUG", "FATAL", "OFF" };
     private Logging logging;
 
-    protected CertAndKey clusterCA;
 
     // Owner Reference information
     private String ownerApiVersion;
@@ -300,7 +286,7 @@ public abstract class AbstractModel {
         try {
             newSettings.store(sw, "Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warn("Error creating properties", e);
         }
         // remove date comment, because it is updated with each reconciliation which leads to restarting pods
         return sw.toString().replaceAll("#[A-Za-z]+ [A-Za-z]+ [0-9]+ [0-9]+:[0-9]+:[0-9]+ [A-Z]+ [0-9]+", "");
@@ -1033,119 +1019,6 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Decode from Base64 a keyed value from a Secret
-     *
-     * @param secret Secret from which decoding the value
-     * @param key Key of the value to decode
-     * @return decoded value
-     */
-    protected byte[] decodeFromSecret(Secret secret, String key) {
-        return Base64.getDecoder().decode(secret.getData().get(key));
-    }
-
-    /**
-     * Copy already existing certificates from provided Secret based on number of effective replicas
-     * and maybe generate new ones for new replicas (i.e. scale-up)
-     *
-     * @param certManager CertManager instance for handling certificates creation
-     * @param secret The Secret from which getting already existing certificates
-     * @param replicasInSecret How many certificates are in the Secret
-     * @param caCert CA certificate to use for signing new certificates
-     * @param podName A function for resolving the Pod name
-     * @return Collection with certificates
-     * @throws IOException
-     */
-    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Kafka kafka, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName) throws IOException {
-        return maybeCopyOrGenerateCerts(certManager, kafka, secret, replicasInSecret, caCert, podName, null, Collections.EMPTY_MAP);
-    }
-
-    /**
-     * Copy already existing certificates from provided Secret based on number of effective replicas
-     * and maybe generate new ones for new replicas (i.e. scale-up)
-     *
-     * @param certManager CertManager instance for handling certificates creation
-     * @param secret The Secret from which getting already existing certificates
-     * @param replicasInSecret How many certificates are in the Secret
-     * @param caCert CA certificate to use for signing new certificates
-     * @param podName A function for resolving the Pod name
-     * @param externalBootstrapAddress External address to the bootstrap service
-     * @param externalAddresses Map with external addresses under which the individual pods are available
-     * @return Collection with certificates
-     * @throws IOException
-     */
-    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Kafka kafka, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
-
-
-        Map<String, CertAndKey> certs = new HashMap<>();
-
-        // copying the minimum number of certificates already existing in the secret
-        // scale up -> it will copy all certificates
-        // scale down -> it will copy just the requested number of replicas
-        for (int i = 0; i < Math.min(replicasInSecret, replicas); i++) {
-            log.debug("{} already exists", podName.apply(cluster, i));
-            certs.put(
-                    podName.apply(cluster, i),
-                    new CertAndKey(
-                            decodeFromSecret(secret, podName.apply(cluster, i) + ".key"),
-                            decodeFromSecret(secret, podName.apply(cluster, i) + ".crt")));
-        }
-
-        File brokerCsrFile = File.createTempFile("tls", "broker-csr");
-        File brokerKeyFile = File.createTempFile("tls", "broker-key");
-        File brokerCertFile = File.createTempFile("tls", "broker-cert");
-
-        // generate the missing number of certificates
-        // scale up -> generate new certificates for added replicas
-        // scale down -> does nothing
-        for (int i = replicasInSecret; i < replicas; i++) {
-            log.debug("{} to generate", podName.apply(cluster, i));
-
-            Subject sbj = new Subject();
-            sbj.setOrganizationName("io.strimzi");
-            sbj.setCommonName(getName());
-
-            Map<String, String> sbjAltNames = new HashMap<>();
-            sbjAltNames.put("DNS.1", getServiceName());
-            sbjAltNames.put("DNS.2", String.format("%s.%s", getServiceName(), namespace));
-            sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", getServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-            sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", podName.apply(cluster, i), getHeadlessServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-
-            int nextDnsId = 5;
-
-            if (externalBootstrapAddress != null)   {
-                sbjAltNames.put("DNS." + nextDnsId, externalBootstrapAddress);
-                nextDnsId++;
-            }
-
-            if (externalAddresses.get(i) != null)   {
-                sbjAltNames.put("DNS." + nextDnsId, externalAddresses.get(i));
-                nextDnsId++;
-            }
-
-            sbj.setSubjectAltNames(sbjAltNames);
-
-            certManager.generateCsr(brokerKeyFile, brokerCsrFile, sbj);
-            certManager.generateCert(brokerCsrFile, caCert.key(), caCert.cert(), brokerCertFile,
-                    sbj, ModelUtils.getCertificateValidity(kafka));
-
-            certs.put(podName.apply(cluster, i),
-                    new CertAndKey(Files.readAllBytes(brokerKeyFile.toPath()), Files.readAllBytes(brokerCertFile.toPath())));
-        }
-
-        if (!brokerCsrFile.delete()) {
-            log.warn("{} cannot be deleted", brokerCsrFile.getName());
-        }
-        if (!brokerKeyFile.delete()) {
-            log.warn("{} cannot be deleted", brokerKeyFile.getName());
-        }
-        if (!brokerCertFile.delete()) {
-            log.warn("{} cannot be deleted", brokerCertFile.getName());
-        }
-
-        return certs;
-    }
-
-    /**
      * Generate the OwnerReference object to link newly created objects to their parent (the custom resource)
      *
      * @return
@@ -1200,6 +1073,10 @@ public abstract class AbstractModel {
     }
 
     public static String getClusterCaName(String cluster)  {
+        return cluster + "-cluster-ca-cert";
+    }
+
+    public static String getClusterCaKeyName(String cluster)  {
         return cluster + "-cluster-ca";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
+import io.strimzi.certs.Subject;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ClusterCa extends Ca {
+
+    // the Kubernetes service DNS domain is customizable on cluster creation but it's "cluster.local" by default
+    // there is no clean way to get it from a running application so we are passing it through an env var
+    public static final String KUBERNETES_SERVICE_DNS_DOMAIN =
+            System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
+    private final String clusterName;
+    private Secret entityOperatorSecret;
+    private Secret topicOperatorSecret;
+
+    private Secret brokersSecret;
+    private Secret zkNodesSecret;
+
+    public ClusterCa(CertManager certManager, String clusterName, Secret caCertSecret, Secret caKeySecret) {
+        this(certManager, clusterName, caCertSecret, caKeySecret, 365, 30, true);
+    }
+
+    public ClusterCa(CertManager certManager,
+                     String clusterName,
+                     Secret clusterCaCert,
+                     Secret clusterCaKey,
+                     int validityDays,
+                     int renewalDays,
+                     boolean generateCa) {
+        super(certManager, AbstractModel.getClusterCaName(clusterName), clusterCaCert,
+                AbstractModel.getClusterCaKeyName(clusterName), clusterCaKey,
+                validityDays, renewalDays, generateCa);
+        this.clusterName = clusterName;
+    }
+
+    @Override
+    public String toString() {
+        return "cluster-ca";
+    }
+
+    public void initCaSecrets(List<Secret> secrets) {
+        for (Secret secret: secrets) {
+            String name = secret.getMetadata().getName();
+            if (KafkaCluster.brokersSecretName(clusterName).equals(name)) {
+                brokersSecret = secret;
+            } else if (EntityOperator.secretName(clusterName).equals(name)) {
+                entityOperatorSecret = secret;
+            } else if (TopicOperator.secretName(clusterName).equals(name)) {
+                topicOperatorSecret = secret;
+            } else if (ZookeeperCluster.nodesSecretName(clusterName).equals(name)) {
+                zkNodesSecret = secret;
+            }
+        }
+    }
+
+    public Secret topicOperatorSecret() {
+        return topicOperatorSecret;
+    }
+
+    public Secret entityOperatorSecret() {
+        return entityOperatorSecret;
+    }
+
+    public Map<String, CertAndKey> generateZkCerts(Kafka kafka) throws IOException {
+        String cluster = kafka.getMetadata().getName();
+        String namespace = kafka.getMetadata().getNamespace();
+        Function<Integer, Subject> subjectFn = i -> {
+            Map<String, String> sbjAltNames = new HashMap<>();
+            sbjAltNames.put("DNS.1", ZookeeperCluster.serviceName(cluster));
+            sbjAltNames.put("DNS.2", String.format("%s.%s", ZookeeperCluster.serviceName(cluster), namespace));
+            sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", ZookeeperCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", ZookeeperCluster.zookeeperPodName(cluster, i), ZookeeperCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+
+            Subject subject = new Subject();
+            subject.setOrganizationName("io.strimzi");
+            subject.setCommonName(ZookeeperCluster.zookeeperClusterName(cluster));
+            subject.setSubjectAltNames(sbjAltNames);
+
+            return subject;
+        };
+
+        log.debug("{}: Reconciling zookeeper certificates", this);
+        return maybeCopyOrGenerateCerts(
+            kafka.getSpec().getZookeeper().getReplicas(),
+            subjectFn,
+            zkNodesSecret,
+            podNum -> ZookeeperCluster.zookeeperPodName(cluster, podNum));
+    }
+
+    public Map<String, CertAndKey> generateBrokerCerts(Kafka kafka, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
+        String cluster = kafka.getMetadata().getName();
+        String namespace = kafka.getMetadata().getNamespace();
+        Function<Integer, Subject> subjectFn = i -> {
+            Map<String, String> sbjAltNames = new HashMap<>();
+            sbjAltNames.put("DNS.1", KafkaCluster.serviceName(cluster));
+            sbjAltNames.put("DNS.2", String.format("%s.%s", KafkaCluster.serviceName(cluster), namespace));
+            sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", KafkaCluster.kafkaPodName(cluster, i), KafkaCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            int nextDnsId = 5;
+            if (externalBootstrapAddress != null)   {
+                sbjAltNames.put("DNS." + nextDnsId, externalBootstrapAddress);
+                nextDnsId++;
+            }
+
+            if (externalAddresses.get(i) != null)   {
+                sbjAltNames.put("DNS." + nextDnsId, externalAddresses.get(i));
+                nextDnsId++;
+            }
+
+            Subject subject = new Subject();
+            subject.setOrganizationName("io.strimzi");
+            subject.setCommonName(KafkaCluster.kafkaClusterName(cluster));
+            subject.setSubjectAltNames(sbjAltNames);
+
+            return subject;
+        };
+        log.debug("{}: Reconciling kafka broker certificates", this);
+        return maybeCopyOrGenerateCerts(
+            kafka.getSpec().getKafka().getReplicas(),
+            subjectFn,
+            brokersSecret,
+            podNum -> KafkaCluster.kafkaPodName(cluster, podNum));
+    }
+
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -18,21 +18,15 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Sidecar;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
-import io.strimzi.certs.Subject;
 import io.strimzi.operator.common.model.Labels;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
 import static java.util.Collections.singletonList;
 
 /**
@@ -43,8 +37,10 @@ public class EntityOperator extends AbstractModel {
     private static final String NAME_SUFFIX = "-entity-operator";
     private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
-    protected static final String TLS_SIDECAR_VOLUME_NAME = "tls-sidecar-certs";
-    protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
+    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
+    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
+    protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_NAME = "cluster-ca-certs";
+    protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
 
     // Entity Operator configuration keys
     public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
@@ -56,11 +52,6 @@ public class EntityOperator extends AbstractModel {
     private Sidecar tlsSidecar;
 
     private boolean isDeployed;
-
-    /**
-     * Private key and certificate for encrypting communication with Zookeeper and Kafka
-     */
-    private CertAndKey cert;
 
     /**
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
@@ -125,12 +116,10 @@ public class EntityOperator extends AbstractModel {
     /**
      * Create a Entity Operator from given desired resource
      *
-     * @param certManager Certificate manager for certificates generation
      * @param kafkaAssembly desired resource with cluster configuration containing the Entity Operator one
-     * @param secrets Secrets containing already generated certificates
      * @return Entity Operator instance, null if not configured in the ConfigMap
      */
-    public static EntityOperator fromCrd(CertManager certManager, Kafka kafkaAssembly, List<Secret> secrets) {
+    public static EntityOperator fromCrd(Kafka kafkaAssembly) {
         EntityOperator result = null;
         EntityOperatorSpec entityOperatorSpec = kafkaAssembly.getSpec().getEntityOperator();
         if (entityOperatorSpec != null) {
@@ -148,62 +137,8 @@ public class EntityOperator extends AbstractModel {
             result.setTopicOperator(EntityTopicOperator.fromCrd(kafkaAssembly));
             result.setUserOperator(EntityUserOperator.fromCrd(kafkaAssembly));
             result.setDeployed(result.getTopicOperator() != null || result.getUserOperator() != null);
-            if (result.isDeployed()) {
-                result.generateCertificates(certManager, kafkaAssembly, secrets);
-            }
         }
         return result;
-    }
-
-    /**
-     * Manage certificates generation based on those already present in the Secrets
-     *
-     * @param certManager CertManager instance for handling certificates creation
-     * @param secrets The Secrets storing certificates
-     */
-    public void generateCertificates(CertManager certManager, Kafka kafka, List<Secret> secrets) {
-        log.debug("Generating certificates");
-
-        try {
-            Secret clusterCaSecret = findSecretWithName(secrets, getClusterCaName(cluster));
-            if (clusterCaSecret != null) {
-                // get the generated CA private key + self-signed certificate for each broker
-                clusterCA = new CertAndKey(
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.key"),
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.crt"));
-
-                Secret entityOperatorSecret = findSecretWithName(secrets, EntityOperator.secretName(cluster));
-                if (entityOperatorSecret == null) {
-                    log.debug("Entity Operator certificate to generate");
-
-                    File csrFile = File.createTempFile("tls", "csr");
-                    File keyFile = File.createTempFile("tls", "key");
-                    File certFile = File.createTempFile("tls", "cert");
-
-                    Subject sbj = new Subject();
-                    sbj.setOrganizationName("io.strimzi");
-                    sbj.setCommonName(EntityOperator.entityOperatorName(cluster));
-
-                    certManager.generateCsr(keyFile, csrFile, sbj);
-                    certManager.generateCert(csrFile, clusterCA.key(), clusterCA.cert(),
-                            certFile, ModelUtils.getCertificateValidity(kafka));
-
-                    cert = new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
-                } else {
-                    log.debug("Entity Operator certificate already exists");
-                    cert = new CertAndKey(
-                            decodeFromSecret(entityOperatorSecret, "entity-operator.key"),
-                            decodeFromSecret(entityOperatorSecret, "entity-operator.crt"));
-                }
-            } else {
-                throw new NoCertificateSecretException("The cluster CA certificate Secret is missing");
-            }
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        log.debug("End generating certificates");
     }
 
     @Override
@@ -254,7 +189,8 @@ public class EntityOperator extends AbstractModel {
                 .withImage(tlsSidecarImage)
                 .withResources(resources(tlsSidecarResources))
                 .withEnv(singletonList(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect)))
-                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT))
+                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+                        createVolumeMount(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT))
                 .build();
 
         containers.add(tlsSidecarContainer);
@@ -270,7 +206,8 @@ public class EntityOperator extends AbstractModel {
         if (userOperator != null) {
             volumeList.addAll(userOperator.getVolumes());
         }
-        volumeList.add(createSecretVolume(TLS_SIDECAR_VOLUME_NAME, EntityOperator.secretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.secretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.getClusterCaName(cluster)));
         return volumeList;
     }
 
@@ -279,16 +216,28 @@ public class EntityOperator extends AbstractModel {
      * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
      * @return The generated Secret
      */
-    public Secret generateSecret() {
-
+    public Secret generateSecret(ClusterCa clusterCa) {
         if (!isDeployed()) {
             return null;
         }
-
         Map<String, String> data = new HashMap<>();
-        data.put("cluster-ca.crt", Base64.getEncoder().encodeToString(clusterCA.cert()));
-        data.put("entity-operator.key", cert.keyAsBase64String());
-        data.put("entity-operator.crt", cert.certAsBase64String());
+        Secret secret = clusterCa.entityOperatorSecret();
+        if (secret == null || clusterCa.certRenewed()) {
+            log.debug("Generating certificates");
+            try {
+                Ca.log.debug("Entity Operator certificate to generate");
+                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(name);
+                data.put("entity-operator.key", eoCertAndKey.keyAsBase64String());
+                data.put("entity-operator.crt", eoCertAndKey.certAsBase64String());
+            } catch (IOException e) {
+                log.warn("Error while generating certificates", e);
+            }
+
+            log.debug("End generating certificates");
+        } else {
+            data.put("entity-operator.key", secret.getData().get("entity-operator.key"));
+            data.put("entity-operator.crt", secret.getData().get("entity-operator.crt"));
+        }
         return createSecret(EntityOperator.secretName(cluster), data);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 /**
@@ -246,10 +247,9 @@ public class EntityTopicOperator extends AbstractModel {
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        List<VolumeMount> volumeMountList = new ArrayList<>();
-        volumeMountList.add(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
-        volumeMountList.add(createVolumeMount(EntityOperator.TLS_SIDECAR_VOLUME_NAME, EntityOperator.TLS_SIDECAR_VOLUME_MOUNT));
-        return volumeMountList;
+        return asList(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
+            createVolumeMount(EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+            createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }
 
     public RoleBindingOperator.RoleBinding generateRoleBinding(String namespace) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -39,7 +39,8 @@ public class EntityUserOperator extends AbstractModel {
     public static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
-    public static final String ENV_VAR_CLIENTS_CA_NAME = "STRIMZI_CA_NAME";
+    public static final String ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
+    public static final String ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
 
     private String zookeeperConnect;
     private String watchedNamespace;
@@ -189,7 +190,8 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_WATCHED_NAMESPACE, watchedNamespace));
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_NAME, KafkaCluster.clientsCASecretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCASecretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsPublicKeyName(cluster)));
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPort;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
-
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
@@ -50,16 +49,11 @@ import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Sidecar;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
-import io.strimzi.certs.Subject;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,7 +62,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
 import static java.util.Collections.singletonList;
 
 public class KafkaCluster extends AbstractModel {
@@ -109,12 +102,15 @@ public class KafkaCluster extends AbstractModel {
     protected static final String EXTERNAL_PORT_NAME = "external";
 
     protected static final String KAFKA_NAME = "kafka";
+    protected static final String CLUSTER_CA_CERTS_VOLUME = "cluster-ca";
     protected static final String BROKER_CERTS_VOLUME = "broker-certs";
     protected static final String CLIENT_CA_CERTS_VOLUME = "client-ca-cert";
+    protected static final String CLUSTER_CA_CERTS_VOLUME_MOUNT = "/opt/kafka/cluster-ca-certs";
     protected static final String BROKER_CERTS_VOLUME_MOUNT = "/opt/kafka/broker-certs";
-    protected static final String CLIENT_CA_CERTS_VOLUME_MOUNT = "/opt/kafka/client-ca-cert";
+    protected static final String CLIENT_CA_CERTS_VOLUME_MOUNT = "/opt/kafka/client-ca-certs";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
-    protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
+    protected static final String TLS_SIDECAR_KAFKA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/kafka-brokers/";
+    protected static final String TLS_SIDECAR_CLUSTER_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
 
     private static final String NAME_SUFFIX = "-kafka";
     private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-bootstrap";
@@ -143,7 +139,6 @@ public class KafkaCluster extends AbstractModel {
     private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     private static final boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
 
-    private CertAndKey clientsCA;
     /**
      * Private key and certificate for each Kafka Pod name
      * used as server certificates for Kafka brokers
@@ -235,7 +230,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String clusterPublicKeyName(String cluster) {
-        return getClusterCaName(cluster) + KafkaCluster.SECRET_CLUSTER_PUBLIC_KEY_SUFFIX;
+        return getClusterCaName(cluster);
     }
 
     public static KafkaCluster fromCrd(Kafka kafkaAssembly) {
@@ -296,65 +291,17 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Manage certificates generation based on those already present in the Secrets
-     * @param certManager CertManager instance for handling certificates creation
-     * @param kafka The kafka CR
-     * @param secrets The Secrets storing certificates
-     * @param externalBootstrapAddress External address to the bootstrap service
-     * @param externalAddresses Map with external addresses under which the individual pods are available
+     * @param clusterCa The certificates
      */
-    public void generateCertificates(CertManager certManager, Kafka kafka, List<Secret> secrets, String externalBootstrapAddress, Map<Integer, String> externalAddresses) {
+    public void generateCertificates(Kafka kafka, ClusterCa clusterCa, ClientsCa clientsCa, String externalBootstrapAddress, Map<Integer, String> externalAddresses) {
         log.debug("Generating certificates");
 
         try {
-            Secret clusterCaSecret = findSecretWithName(secrets, getClusterCaName(cluster));
-            if (clusterCaSecret != null) {
-                // get the generated CA private key + self-signed certificate for each broker
-                clusterCA = new CertAndKey(
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.key"),
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.crt"));
-
-                // CA private key + self-signed certificate for clients communications
-                Secret clientsCaSecret = findSecretWithName(secrets, KafkaCluster.clientsCASecretName(cluster));
-                if (clientsCaSecret == null) {
-                    log.debug("Clients CA to generate");
-                    File clientsCAkeyFile = File.createTempFile("tls", "clients-ca-key");
-                    File clientsCAcertFile = File.createTempFile("tls", "clients-ca-cert");
-
-                    Subject sbj = new Subject();
-                    sbj.setOrganizationName("io.strimzi");
-                    sbj.setCommonName("kafka-clients-ca");
-
-                    certManager.generateSelfSignedCert(clientsCAkeyFile, clientsCAcertFile, sbj, ModelUtils.getCertificateValidity(kafka));
-                    clientsCA =
-                            new CertAndKey(Files.readAllBytes(clientsCAkeyFile.toPath()), Files.readAllBytes(clientsCAcertFile.toPath()));
-                    if (!clientsCAkeyFile.delete()) {
-                        log.warn("{} cannot be deleted", clientsCAkeyFile.getName());
-                    }
-                    if (!clientsCAcertFile.delete()) {
-                        log.warn("{} cannot be deleted", clientsCAcertFile.getName());
-                    }
-                } else {
-                    log.debug("Clients CA already exists");
-                    clientsCA = new CertAndKey(
-                            decodeFromSecret(clientsCaSecret, "clients-ca.key"),
-                            decodeFromSecret(clientsCaSecret, "clients-ca.crt"));
-                }
-
-                // recover or generates the private key + certificate for each broker for internal and clients communication
-                Secret clusterSecret = findSecretWithName(secrets, KafkaCluster.brokersSecretName(cluster));
-
-                int replicasInternalSecret = clusterSecret == null ? 0 : (clusterSecret.getData().size() - 1) / 2;
-
-                log.debug("Internal communication certificates");
-                brokerCerts = maybeCopyOrGenerateCerts(certManager, kafka, clusterSecret, replicasInternalSecret,
-                        clusterCA, KafkaCluster::kafkaPodName, externalBootstrapAddress, externalAddresses);
-
-            } else {
-                throw new NoCertificateSecretException("The cluster CA certificate Secret is missing");
-            }
-
+            clientsCa.createOrRenew(kafka.getMetadata().getNamespace(), kafka.getMetadata().getName(),
+                    labels.toMap(), createOwnerReference());
+            brokerCerts = clusterCa.generateBrokerCerts(kafka, externalBootstrapAddress, externalAddresses);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warn("Error while generating certificates", e);
         }
 
         log.debug("End generating certificates");
@@ -567,41 +514,6 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generate the Secret containing CA private key and self-signed certificate used
-     * for signing brokers certificates used for communication with clients
-     * @return The generated Secret
-     */
-    public Secret generateClientsCASecret() {
-        Map<String, String> data = new HashMap<>();
-        data.put("clients-ca.key", clientsCA.keyAsBase64String());
-        data.put("clients-ca.crt", clientsCA.certAsBase64String());
-        return createSecret(KafkaCluster.clientsCASecretName(cluster), data);
-    }
-
-    /**
-     * Generate the Secret containing just the self-signed CA certificate used
-     * for signing client certificates. It is used for the broker truststore.
-     * @return The generated Secret
-     */
-    public Secret generateClientsPublicKeySecret() {
-        Map<String, String> data = new HashMap<>();
-        data.put("ca.crt", Base64.getEncoder().encodeToString(clientsCA.cert()));
-        return createSecret(KafkaCluster.clientsPublicKeyName(cluster), data);
-    }
-
-    /**
-     * Generate the Secret containing just the self-signed CA certificate used
-     * for signing brokers certificates used for communication with clients
-     * It's useful for users to extract the certificate itself to put as trusted on the clients
-     * @return The generated Secret
-     */
-    public Secret generateClusterPublicKeySecret() {
-        Map<String, String> data = new HashMap<>();
-        data.put("ca.crt", Base64.getEncoder().encodeToString(clusterCA.cert()));
-        return createSecret(KafkaCluster.clusterPublicKeyName(cluster), data);
-    }
-
-    /**
      * Generate the Secret containing CA self-signed certificate for TLS communication.
      * It also contains the private key-certificate (signed by cluster CA) for each brokers as well as for communicating
      * with Zookeeper as well
@@ -611,8 +523,6 @@ public class KafkaCluster extends AbstractModel {
     public Secret generateBrokersSecret() {
 
         Map<String, String> data = new HashMap<>();
-        data.put("cluster-ca.crt", clusterCA.certAsBase64String());
-
         for (int i = 0; i < replicas; i++) {
             CertAndKey cert = brokerCerts.get(KafkaCluster.kafkaPodName(cluster, i));
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".key", cert.keyAsBase64String());
@@ -653,6 +563,7 @@ public class KafkaCluster extends AbstractModel {
         if (rack != null || isExposedWithNodePort()) {
             volumeList.add(createEmptyDirVolume(INIT_VOLUME_NAME));
         }
+        volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.getClusterCaName(cluster)));
         volumeList.add(createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster)));
         volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.clientsPublicKeyName(cluster)));
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
@@ -672,6 +583,7 @@ public class KafkaCluster extends AbstractModel {
         List<VolumeMount> volumeMountList = new ArrayList<>();
         volumeMountList.add(createVolumeMount(VOLUME_NAME, mountPath));
 
+        volumeMountList.add(createVolumeMount(CLUSTER_CA_CERTS_VOLUME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
         volumeMountList.add(createVolumeMount(BROKER_CERTS_VOLUME, BROKER_CERTS_VOLUME_MOUNT));
         volumeMountList.add(createVolumeMount(CLIENT_CA_CERTS_VOLUME, CLIENT_CA_CERTS_VOLUME_MOUNT));
         volumeMountList.add(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
@@ -772,7 +684,8 @@ public class KafkaCluster extends AbstractModel {
                 .withImage(tlsSidecarImage)
                 .withResources(resources(tlsSidecarResources))
                 .withEnv(singletonList(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect)))
-                .withVolumeMounts(createVolumeMount(BROKER_CERTS_VOLUME, TLS_SIDECAR_VOLUME_MOUNT))
+                .withVolumeMounts(createVolumeMount(BROKER_CERTS_VOLUME, TLS_SIDECAR_KAFKA_CERTS_VOLUME_MOUNT),
+                        createVolumeMount(CLUSTER_CA_CERTS_VOLUME, TLS_SIDECAR_CLUSTER_CA_CERTS_VOLUME_MOUNT))
                 .build();
 
         containers.add(container);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -4,7 +4,10 @@
  */
 package io.strimzi.operator.cluster.model;
 
+
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.TlsCertificates;
 
 import java.util.List;
 
@@ -16,5 +19,26 @@ public class ModelUtils {
      */
     public static Secret findSecretWithName(List<Secret> secrets, String sname) {
         return secrets.stream().filter(s -> s.getMetadata().getName().equals(sname)).findFirst().orElse(null);
+    }
+
+    public static int getCertificateValidity(Kafka kafka) {
+        int validity = AbstractModel.CERTS_EXPIRATION_DAYS;
+        if (kafka.getSpec() != null) {
+            validity = getCertificateValidity(kafka.getSpec().getTlsCertificates());
+        }
+        return validity;
+    }
+
+    public static int getCertificateValidity(TlsCertificates tlsCertificates) {
+        int validity = AbstractModel.CERTS_EXPIRATION_DAYS;
+        if (tlsCertificates != null
+                && tlsCertificates.getValidityDays() > 0) {
+            validity = tlsCertificates.getValidityDays();
+        }
+        return validity;
+    }
+
+    public static int getRenewalDays(TlsCertificates tlsCertificates) {
+        return tlsCertificates != null ? tlsCertificates.getRenewalDays() : 30;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -21,21 +21,16 @@ import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Sidecar;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
-import io.strimzi.certs.Subject;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
 import static java.util.Collections.singletonList;
 
 /**
@@ -53,8 +48,11 @@ public class TopicOperator extends AbstractModel {
     private static final String NAME_SUFFIX = "-topic-operator";
     private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
-    protected static final String TLS_SIDECAR_VOLUME_NAME = "tls-sidecar-certs";
-    protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
+    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
+    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
+    protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_NAME = "cluster-ca-certs";
+    protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
+
 
     protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
@@ -87,11 +85,6 @@ public class TopicOperator extends AbstractModel {
     private int topicMetadataMaxAttempts;
 
     private Sidecar tlsSidecar;
-
-    /**
-     * Private key and certificate for encrypting communication with Zookeeper and Kafka
-     */
-    private CertAndKey cert;
 
     /**
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
@@ -217,12 +210,10 @@ public class TopicOperator extends AbstractModel {
     /**
      * Create a Topic Operator from given desired resource
      *
-     * @param certManager Certificate manager for certificates generation
      * @param kafkaAssembly desired resource with cluster configuration containing the topic operator one
-     * @param secrets Secrets containing already generated certificates
      * @return Topic Operator instance, null if not configured in the ConfigMap
      */
-    public static TopicOperator fromCrd(CertManager certManager, Kafka kafkaAssembly, List<Secret> secrets) {
+    public static TopicOperator fromCrd(Kafka kafkaAssembly) {
         TopicOperator result;
         if (kafkaAssembly.getSpec().getTopicOperator() != null) {
             String namespace = kafkaAssembly.getMetadata().getNamespace();
@@ -241,63 +232,11 @@ public class TopicOperator extends AbstractModel {
             result.setLogging(tcConfig.getLogging());
             result.setResources(tcConfig.getResources());
             result.setUserAffinity(tcConfig.getAffinity());
-            result.generateCertificates(certManager, kafkaAssembly, secrets);
             result.setTlsSidecar(tcConfig.getTlsSidecar());
         } else {
             result = null;
         }
         return result;
-    }
-
-    /**
-     * Manage certificates generation based on those already present in the Secrets
-     * @param certManager CertManager instance for handling certificates creation
-     * @param kafka The kafka CR
-     * @param secrets The Secrets storing certificates
-     */
-    public void generateCertificates(CertManager certManager, Kafka kafka, List<Secret> secrets) {
-        log.debug("Generating certificates");
-
-        try {
-            Secret clusterCaSecret = findSecretWithName(secrets, getClusterCaName(cluster));
-            if (clusterCaSecret != null) {
-                // get the generated CA private key + self-signed certificate for each broker
-                clusterCA = new CertAndKey(
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.key"),
-                        decodeFromSecret(clusterCaSecret, "cluster-ca.crt"));
-
-                Secret topicOperatorSecret = findSecretWithName(secrets, TopicOperator.secretName(cluster));
-                if (topicOperatorSecret == null) {
-                    log.debug("Topic Operator certificate to generate");
-
-                    File csrFile = File.createTempFile("tls", "csr");
-                    File keyFile = File.createTempFile("tls", "key");
-                    File certFile = File.createTempFile("tls", "cert");
-
-                    Subject sbj = new Subject();
-                    sbj.setOrganizationName("io.strimzi");
-                    sbj.setCommonName(TopicOperator.topicOperatorName(cluster));
-
-                    certManager.generateCsr(keyFile, csrFile, sbj);
-                    certManager.generateCert(csrFile, clusterCA.key(), clusterCA.cert(),
-                            certFile, ModelUtils.getCertificateValidity(kafka));
-
-                    cert = new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
-                } else {
-                    log.debug("Topic Operator certificate already exists");
-                    cert = new CertAndKey(
-                            decodeFromSecret(topicOperatorSecret, "entity-operator.key"),
-                            decodeFromSecret(topicOperatorSecret, "entity-operator.crt"));
-                }
-            } else {
-                throw new NoCertificateSecretException("The cluster CA certificate Secret is missing");
-            }
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        log.debug("End generating certificates");
     }
 
     public Deployment generateDeployment() {
@@ -340,7 +279,7 @@ public class TopicOperator extends AbstractModel {
                 .withImage(tlsSidecarImage)
                 .withResources(resources(tlsSidecarResources))
                 .withEnv(singletonList(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect)))
-                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT))
+                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT))
                 .build();
 
         containers.add(container);
@@ -403,14 +342,16 @@ public class TopicOperator extends AbstractModel {
     private List<Volume> getVolumes() {
         List<Volume> volumeList = new ArrayList<>();
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_VOLUME_NAME, TopicOperator.secretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TopicOperator.secretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.getClusterCaName(cluster)));
         return volumeList;
     }
 
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMountList = new ArrayList<>();
         volumeMountList.add(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
-        volumeMountList.add(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT));
+        volumeMountList.add(createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT));
+        volumeMountList.add(createVolumeMount(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
         return volumeMountList;
     }
 
@@ -419,11 +360,24 @@ public class TopicOperator extends AbstractModel {
      * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
      * @return The generated Secret
      */
-    public Secret generateSecret() {
+    public Secret generateSecret(ClusterCa clusterCa) {
         Map<String, String> data = new HashMap<>();
-        data.put("cluster-ca.crt", clusterCA.certAsBase64String());
-        data.put("entity-operator.key", cert.keyAsBase64String());
-        data.put("entity-operator.crt", cert.certAsBase64String());
+        Secret topicOperatorSecret = clusterCa.topicOperatorSecret();
+        if (topicOperatorSecret == null || clusterCa.certRenewed()) {
+            log.debug("Generating certificates");
+            try {
+                log.debug("Topic Operator certificate to generate");
+                CertAndKey toCertAndKey = clusterCa.generateSignedCert(name);
+                data.put("entity-operator.crt", toCertAndKey.certAsBase64String());
+                data.put("entity-operator.key", toCertAndKey.keyAsBase64String());
+            } catch (IOException e) {
+                log.warn("Error while generating certificates", e);
+            }
+            log.debug("End generating certificates");
+        } else {
+            data.put("entity-operator.crt", topicOperatorSecret.getData().get("entity-operator.crt"));
+            data.put("entity-operator.key", topicOperatorSecret.getData().get("entity-operator.key"));
+        }
         return createSecret(TopicOperator.secretName(cluster), data);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -32,7 +32,6 @@ import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Sidecar;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.certs.CertManager;
 import io.strimzi.operator.common.model.Labels;
 
 import java.io.IOException;
@@ -42,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -57,8 +55,10 @@ public class ZookeeperCluster extends AbstractModel {
 
     protected static final String ZOOKEEPER_NAME = "zookeeper";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
-    protected static final String TLS_SIDECAR_VOLUME_NAME = "tls-sidecar-certs";
-    protected static final String TLS_SIDECAR_VOLUME_MOUNT = "/etc/tls-sidecar/certs/";
+    protected static final String TLS_SIDECAR_NODES_VOLUME_NAME = "zookeeper-nodes";
+    protected static final String TLS_SIDECAR_NODES_VOLUME_MOUNT = "/etc/tls-sidecar/zookeeper-nodes/";
+    protected static final String TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME = "cluster-ca-certs";
+    protected static final String TLS_SIDECAR_CLUSTER_CA_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
     private static final String NAME_SUFFIX = "-zookeeper";
     private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-client";
     private static final String HEADLESS_SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-nodes";
@@ -79,12 +79,6 @@ public class ZookeeperCluster extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
     public static final String ENV_VAR_ZOOKEEPER_CONFIGURATION = "ZOOKEEPER_CONFIGURATION";
     public static final String ENV_VAR_ZOOKEEPER_LOG_CONFIGURATION = "ZOOKEEPER_LOG_CONFIGURATION";
-
-    /**
-     * Private key and certificate for each Zookeeper Pod name
-     * used for for encrypting the communication in the Zookeeper ensemble
-     */
-    private Map<String, CertAndKey> certs;
 
     public static String zookeeperClusterName(String cluster) {
         return cluster + ZookeeperCluster.NAME_SUFFIX;
@@ -148,7 +142,7 @@ public class ZookeeperCluster extends AbstractModel {
         this.validLoggerFields = getDefaultLogConfig();
     }
 
-    public static ZookeeperCluster fromCrd(CertManager certManager, Kafka kafkaAssembly, List<Secret> secrets) {
+    public static ZookeeperCluster fromCrd(Kafka kafkaAssembly) {
         ZookeeperCluster zk = new ZookeeperCluster(kafkaAssembly.getMetadata().getNamespace(), kafkaAssembly.getMetadata().getName(),
                 Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
         zk.setOwnerReference(kafkaAssembly);
@@ -184,45 +178,8 @@ public class ZookeeperCluster extends AbstractModel {
         zk.setJvmOptions(zookeeperClusterSpec.getJvmOptions());
         zk.setUserAffinity(zookeeperClusterSpec.getAffinity());
         zk.setTolerations(zookeeperClusterSpec.getTolerations());
-        zk.generateCertificates(certManager, kafkaAssembly, secrets);
         zk.setTlsSidecar(zookeeperClusterSpec.getTlsSidecar());
         return zk;
-    }
-
-    /**
-     * Manage certificates generation based on those already present in the Secrets
-     *
-     * @param certManager CertManager instance for handling certificates creation
-     * @param kafka The Kafka CR.
-     * @param secrets The Secrets storing certificates
-     */
-    public void generateCertificates(CertManager certManager, Kafka kafka, List<Secret> secrets) {
-        log.debug("Generating certificates");
-
-        try {
-            Secret internalCaSecret = findSecretWithName(secrets, getClusterCaName(cluster));
-            if (internalCaSecret != null) {
-
-                // get the generated CA private key + self-signed certificate for internal communications
-                clusterCA = new CertAndKey(
-                        decodeFromSecret(internalCaSecret, "cluster-ca.key"),
-                        decodeFromSecret(internalCaSecret, "cluster-ca.crt"));
-
-                // recover or generates the private key + certificate for each node
-                Secret nodesSecret = findSecretWithName(secrets, ZookeeperCluster.nodesSecretName(cluster));
-
-                int replicasSecret = nodesSecret == null ? 0 : (nodesSecret.getData().size() - 1) / 2;
-
-                log.debug("Cluster communication certificates");
-                certs = maybeCopyOrGenerateCerts(certManager, kafka, nodesSecret, replicasSecret, clusterCA, ZookeeperCluster::zookeeperPodName);
-            } else {
-                throw new NoCertificateSecretException("The cluster CA certificate Secret is missing");
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        log.debug("End generating certificates");
     }
 
     public Service generateService() {
@@ -315,16 +272,26 @@ public class ZookeeperCluster extends AbstractModel {
      * internally within the cluster
      * @return The generated Secret
      */
-    public Secret generateNodesSecret() {
+    public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka) {
 
         Map<String, String> data = new HashMap<>();
-        data.put("cluster-ca.crt", clusterCA.certAsBase64String());
 
-        for (int i = 0; i < replicas; i++) {
-            CertAndKey cert = certs.get(ZookeeperCluster.zookeeperPodName(cluster, i));
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
+        log.debug("Generating certificates");
+        Map<String, CertAndKey> certs;
+        try {
+            log.debug("Cluster communication certificates");
+            certs = clusterCa.generateZkCerts(kafka);
+            log.debug("End generating certificates");
+            for (int i = 0; i < replicas; i++) {
+                CertAndKey cert = certs.get(ZookeeperCluster.zookeeperPodName(cluster, i));
+                data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
+                data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
+            }
+
+        } catch (IOException e) {
+            log.warn("Error while generating certificates", e);
         }
+
         return createSecret(ZookeeperCluster.nodesSecretName(cluster), data);
     }
 
@@ -354,7 +321,8 @@ public class ZookeeperCluster extends AbstractModel {
                 .withImage(tlsSidecarImage)
                 .withResources(resources(tlsSidecarResources))
                 .withEnv(singletonList(buildEnvVar(ENV_VAR_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas))))
-                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_VOLUME_NAME, TLS_SIDECAR_VOLUME_MOUNT))
+                .withVolumeMounts(createVolumeMount(TLS_SIDECAR_NODES_VOLUME_NAME, TLS_SIDECAR_NODES_VOLUME_MOUNT),
+                        createVolumeMount(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, TLS_SIDECAR_CLUSTER_CA_VOLUME_MOUNT))
                 .withPorts(asList(createContainerPort(CLUSTERING_PORT_NAME, CLUSTERING_PORT, "TCP"),
                                 createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, "TCP"),
                                 createContainerPort(CLIENT_PORT_NAME, CLIENT_PORT, "TCP")))
@@ -401,7 +369,8 @@ public class ZookeeperCluster extends AbstractModel {
             volumeList.add(createEmptyDirVolume(VOLUME_NAME));
         }
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster)));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.getClusterCaName(cluster)));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -56,6 +56,8 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
     protected static final int LOCK_TIMEOUT_MS = 10000;
     protected static final int CERTS_EXPIRATION_DAYS = 365;
+    public static final String CLUSTER_CA_CRT = "cluster-ca.crt";
+    public static final String CLUSTER_CA_KEY = "cluster-ca.key";
 
     protected final Vertx vertx;
     protected final boolean isOpenShift;
@@ -131,7 +133,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * Reconciliation works by getting the assembly resource (e.g. {@code KafkaAssembly}) in the given namespace with the given name and
      * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
      * <ul>
-     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, T, List) created or updated} if ConfigMap is without same-named resources</li>
+     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, T) created or updated} if ConfigMap is without same-named resources</li>
      * <li>An assembly will be {@linkplain #delete(Reconciliation) deleted} if resources without same-named ConfigMap</li>
      * </ul>
      */
@@ -150,7 +152,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
                     if (cr != null) {
                         log.info("{}: Assembly {} should be created or updated", reconciliation, assemblyName);
-
                         createOrUpdate(reconciliation, cr)
                             .setHandler(createResult -> {
                                 lock.release();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -55,9 +55,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     private static final Logger log = LogManager.getLogger(AbstractAssemblyOperator.class.getName());
 
     protected static final int LOCK_TIMEOUT_MS = 10000;
-    protected static final int CERTS_EXPIRATION_DAYS = 365;
-    public static final String CLUSTER_CA_CRT = "cluster-ca.crt";
-    public static final String CLUSTER_CA_KEY = "cluster-ca.key";
+
 
     protected final Vertx vertx;
     protected final boolean isOpenShift;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -14,15 +14,16 @@ import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.Route;
 import io.strimzi.api.kafka.KafkaAssemblyList;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.TlsCertificates;
 import io.strimzi.certs.CertManager;
-import io.strimzi.certs.SecretCertProvider;
-import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.ClientsCa;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.EntityTopicOperator;
 import io.strimzi.operator.cluster.model.EntityUserOperator;
@@ -45,40 +46,18 @@ import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
-
-import io.fabric8.openshift.api.model.Route;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
-import static java.util.Collections.emptyMap;
 
 /**
  * <p>Assembly operator for a "Kafka" assembly, which manages:</p>
@@ -131,6 +110,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<Void> chainFuture = Future.future();
         new ReconciliationState(reconciliation, kafkaAssembly)
                 .reconcileClusterCa()
+                // Roll everything so the new CA is added to the trust store.
+                .compose(state -> state.rollingUpdateForNewCaCert())
+
                 .compose(state -> state.getZookeeperState())
                 .compose(state -> state.zkScaleDown())
                 .compose(state -> state.zkService())
@@ -202,23 +184,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private final Kafka kafkaAssembly;
         private final Reconciliation reconciliation;
 
-        private List<Secret> assemblySecrets;
+        private ClusterCa clusterCa;
+        private ClientsCa clientsCa;
 
         private ZookeeperCluster zkCluster;
         private Service zkService;
         private Service zkHeadlessService;
         private ConfigMap zkMetricsAndLogsConfigMap;
         private ReconcileResult<StatefulSet> zkDiffs;
-        private boolean zkForcedRestart;
+        private boolean zkAncillaryCmChange;
 
         private KafkaCluster kafkaCluster = null;
         private Service kafkaService;
         private Service kafkaHeadlessService;
         private ConfigMap kafkaMetricsAndLogsConfigMap;
         private ReconcileResult<StatefulSet> kafkaDiffs;
-        private boolean kafkaForcedRestart;
         private String kafkaExternalBootstrapAddress;
         private SortedMap<Integer, String> kafkaExternalAddresses = new TreeMap<>();
+        private boolean kafkaAncillaryCmChange;
 
         private TopicOperator topicOperator;
         private Deployment toDeployment = null;
@@ -252,25 +235,31 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        String clusterCaName = AbstractModel.getClusterCaName(reconciliation.name());
+                        String clusterCaCertName = AbstractModel.getClusterCaName(name);
+                        String clusterCaKeyName = AbstractModel.getClusterCaKeyName(name);
+                        String clientsCaCertName = KafkaCluster.clientsPublicKeyName(name);
+                        String clientsCaKeyName = KafkaCluster.clientsCASecretName(name);
+                        Secret clusterCaCertSecret = null;
+                        Secret clusterCaKeySecret = null;
+                        Secret clientCaCertSecret = null;
+                        Secret clientCaKeySecret = null;
                         List<Secret> clusterSecrets = secretOperations.list(reconciliation.namespace(), caLabels);
-                        Secret clusterCa = findSecretWithName(clusterSecrets, clusterCaName);
-                        SecretCertProvider secretCertProvider = new SecretCertProvider();
-                        Secret secret;
-                        X509Certificate currentCert = cert(clusterCa, CLUSTER_CA_CRT);
-                        boolean needsRenewal = currentCert != null && certNeedsRenewal(tlsCertificates, currentCert);
-                        final Map<String, String> newData;
-                        if (tlsCertificates != null && !tlsCertificates.isGenerateCertificateAuthority()) {
-                            newData = checkProvidedCert(reconciliation, clusterCaName, clusterCa, currentCert, needsRenewal);
-                        } else {
-                            if (clusterCa == null || needsRenewal) {
-                                newData = createOrRenewCert(reconciliation, tlsCertificates, clusterCaName, clusterCa, currentCert);
-                            } else {
-                                log.debug("{}: The cluster CA {} already exists and does not need renewing", reconciliation, clusterCaName);
-                                newData = clusterCa.getData();
+                        for (Secret secret : clusterSecrets) {
+                            String secretName = secret.getMetadata().getName();
+                            if (secretName.equals(clusterCaCertName)) {
+                                clusterCaCertSecret = secret;
+                            } else if (secretName.equals(clusterCaKeyName)) {
+                                clusterCaKeySecret = secret;
+                            } else if (secretName.equals(clientsCaKeyName)) {
+                                clientCaCertSecret = secret;
+                            } else if (secretName.equals(clientsCaCertName)) {
+                                clientCaKeySecret = secret;
                             }
-                            removeExpiredCerts(newData);
                         }
+                        this.clusterCa = new ClusterCa(certManager, name, clusterCaCertSecret, clusterCaKeySecret,
+                                ModelUtils.getCertificateValidity(tlsCertificates),
+                                ModelUtils.getRenewalDays(tlsCertificates),
+                                tlsCertificates == null || tlsCertificates.isGenerateCertificateAuthority());
                         OwnerReference ownerRef = new OwnerReferenceBuilder()
                                 .withApiVersion(kafkaAssembly.getApiVersion())
                                 .withKind(kafkaAssembly.getKind())
@@ -279,13 +268,22 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 .withBlockOwnerDeletion(false)
                                 .withController(false)
                                 .build();
-                        secret = secretCertProvider.createSecret(reconciliation.namespace(), clusterCaName,
-                                newData, caLabels.toMap(), ownerRef);
+                        clusterCa.createOrRenew(
+                                reconciliation.namespace(), reconciliation.name(), caLabels.toMap(),
+                                ownerRef);
 
-                        secretOperations.reconcile(reconciliation.namespace(), clusterCaName, secret)
-                                .compose(x -> {
-                                    clusterSecrets.add(secret);
-                                    this.assemblySecrets = clusterSecrets;
+                        this.clusterCa.initCaSecrets(clusterSecrets);
+
+                        this.clientsCa = new ClientsCa(certManager,
+                                clientsCaCertName, clientCaCertSecret,
+                                clientsCaKeyName, clientCaKeySecret,
+                                ModelUtils.getCertificateValidity(tlsCertificates),
+                                ModelUtils.getRenewalDays(tlsCertificates),
+                                tlsCertificates == null || tlsCertificates.isGenerateCertificateAuthority());
+
+                        secretOperations.reconcile(reconciliation.namespace(), clusterCaCertName, this.clusterCa.caCertSecret())
+                                .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clusterCaKeyName, this.clusterCa.caKeySecret()))
+                                .compose(ignored  -> {
                                     future.complete(this);
                                 }, future);
                     } catch (Throwable e) {
@@ -297,111 +295,52 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return result;
         }
 
-        private void removeExpiredCerts(Map<String, String> newData) {
-            Iterator<String> iter = newData.keySet().iterator();
-            while (iter.hasNext()) {
-                Pattern pattern = Pattern.compile("cluster-ca-" + "([0-9T:-]{19}).(crt|key)");
-                String key = iter.next();
-                Matcher matcher = pattern.matcher(key);
-
-                if (matcher.matches()) {
-                    String date = matcher.group(1) + "Z";
-                    Instant parse = DateTimeFormatter.ISO_DATE_TIME.parse(date, Instant::from);
-                    if (parse.isBefore(Instant.now())) {
-                        iter.remove();
-                    }
-                }
+        /**
+         * Perform a rolling update of the cluster so that renewed CA certificates get added to their truststores,
+         * or expired CA certificates get removed from their truststores .
+         */
+        Future<ReconciliationState> rollingUpdateForNewCaCert() {
+            String r = "";
+            if (this.clusterCa.certRenewed()) {
+                r = "trust new CA certificate, ";
+            }
+            if (this.clusterCa.certsRemoved()) {
+                r = r + "remove expired CA certificate";
+            }
+            String reason = r.trim();
+            if (!reason.isEmpty()) {
+                return zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name))
+                        .compose(ss -> {
+                            log.debug("{}: Rolling StatefulSet {} to {}", reconciliation, ss.getMetadata().getName(), reason);
+                            return zkSetOperations.maybeRollingUpdate(ss, true);
+                        })
+                        .compose(i -> kafkaSetOperations.getAsync(namespace, KafkaCluster.kafkaClusterName(name)))
+                        .compose(ss -> {
+                            log.debug("{}: Rolling StatefulSet {} to {}", reconciliation, ss.getMetadata().getName(), reason);
+                            return kafkaSetOperations.maybeRollingUpdate(ss, true);
+                        })
+                        .compose(i -> {
+                            if (topicOperator != null) {
+                                log.debug("{}: Rolling Deployment {} to {}", reconciliation, TopicOperator.topicOperatorName(name), reason);
+                                return deploymentOperations.rollingUpdate(namespace, TopicOperator.topicOperatorName(name), operationTimeoutMs);
+                            } else {
+                                return Future.succeededFuture();
+                            }
+                        })
+                        .compose(i -> {
+                            if (entityOperator != null) {
+                                log.debug("{}: Rolling Deployment {} to {}", reconciliation, EntityOperator.entityOperatorName(name), reason);
+                                return deploymentOperations.rollingUpdate(namespace, EntityOperator.entityOperatorName(name), operationTimeoutMs);
+                            } else {
+                                return Future.succeededFuture();
+                            }
+                        })
+                        .map(i -> this);
+            } else {
+                return Future.succeededFuture(this);
             }
         }
 
-        private Map<String, String> createOrRenewCert(Reconciliation reconciliation, TlsCertificates tlsCertificates, String clusterCaName, Secret clusterCa, X509Certificate currentCert) throws IOException {
-            Map<String, String> newData;
-            log.debug("{}: Generating cluster CA certificate {}", reconciliation, clusterCaName);
-            File clusterCaKeyFile = null;
-            File clusterCaCertFile = null;
-            Map<String, String> data;
-            try {
-                clusterCaKeyFile = File.createTempFile("tls", "cluster-ca-key");
-                clusterCaCertFile = File.createTempFile("tls", "cluster-ca-currentCert");
-
-                Subject sbj = new Subject();
-                sbj.setOrganizationName("io.strimzi");
-                sbj.setCommonName("cluster-ca");
-                certManager.generateSelfSignedCert(clusterCaKeyFile, clusterCaCertFile, sbj, ModelUtils.getCertificateValidity(tlsCertificates));
-
-                data = new HashMap<>();
-                if (currentCert != null) {
-                    // Add the current certificate as an old certificate (with date in UTC)
-                    String notAfterDate = DateTimeFormatter.ISO_DATE_TIME.format(currentCert.getNotAfter().toInstant().atZone(ZoneId.of("Z")));
-                    data.put("cluster-ca-" + notAfterDate + ".crt", clusterCa.getData().get(CLUSTER_CA_CRT));
-                    data.put("cluster-ca-" + notAfterDate + ".key", clusterCa.getData().get(CLUSTER_CA_KEY));
-                }
-                // Add the generated certificate as the current certificate
-                data.put(CLUSTER_CA_CRT, base64Contents(clusterCaCertFile));
-                data.put(CLUSTER_CA_KEY, base64Contents(clusterCaKeyFile));
-            } finally {
-                if (clusterCaKeyFile != null && !clusterCaKeyFile.delete()) {
-                    log.debug("Unable to delete temporary file {}", clusterCaKeyFile);
-                }
-                if (clusterCaCertFile != null && !clusterCaCertFile.delete()) {
-                    log.debug("Unable to delete temporary file {}", clusterCaKeyFile);
-                }
-            }
-            newData = data;
-            log.debug("{}: End generating cluster CA {}", reconciliation, clusterCaName);
-            return newData;
-        }
-
-        private Map<String, String> checkProvidedCert(Reconciliation reconciliation, String clusterCaName, Secret clusterCa, X509Certificate currentCert, boolean needsRenewal) {
-            Map<String, String> newData;
-            if (needsRenewal) {
-                log.warn("The {} certificate in Secret {} in namespace {} will expire on {} " +
-                                "and it is not configured to automatically renew.",
-                        CLUSTER_CA_CRT, clusterCaName, reconciliation.namespace(), currentCert.getNotAfter());
-            } else if (clusterCa == null) {
-                log.warn("The certificate (data.{}) and key (data.{}) in Secret {} in namespace {} " +
-                                "need to be configured with a Base64 encoded PEM-format certificate. " +
-                                "Alternatively, configure the Kafka resource with name {} in namespace {} for certificate renewal.",
-                        CLUSTER_CA_CRT, CLUSTER_CA_KEY, clusterCaName, reconciliation.namespace(),
-                        reconciliation.name(), reconciliation.namespace());
-            }
-            newData = clusterCa != null ? clusterCa.getData() : emptyMap();
-            return newData;
-        }
-
-        /** The contents of the given file, base64 encoded */
-        private String base64Contents(File file) throws IOException {
-            return Base64.getEncoder().encodeToString(Files.readAllBytes(file.toPath()));
-        }
-
-        private boolean certNeedsRenewal(TlsCertificates tlsCertificates, X509Certificate cert)  {
-            long msTillExpired = cert.getNotAfter().getTime() - System.currentTimeMillis();
-            return msTillExpired / (24L * 60L * 60L * 1000L) < ModelUtils.getRenewalDays(tlsCertificates);
-        }
-
-        private X509Certificate cert(Secret secret, String key)  {
-            if (secret == null || secret.getData().get(key) == null) {
-                return null;
-            }
-            Base64.Decoder decoder = Base64.getDecoder();
-            byte[] bytes = decoder.decode(secret.getData().get(key));
-            CertificateFactory factory = null;
-            try {
-                factory = CertificateFactory.getInstance("X.509");
-            } catch (CertificateException e) {
-                throw new RuntimeException("No security provider with support for X.509 certificates", e);
-            }
-            try {
-                Certificate certificate = factory.generateCertificate(new ByteArrayInputStream(bytes));
-                if (certificate instanceof X509Certificate) {
-                    return (X509Certificate) certificate;
-                } else {
-                    throw new RuntimeException("Certificate in key " + key + " of Secret " + secret.getMetadata().getName() + " is not an X509Certificate");
-                }
-            } catch (CertificateException e) {
-                throw new RuntimeException("Certificate in key " + key + " of Secret " + secret.getMetadata().getName() + " could not be parsed");
-            }
-        }
 
         Future<ReconciliationState> getZookeeperState() {
             Future<ReconciliationState> fut = Future.future();
@@ -409,7 +348,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
                 future -> {
                     try {
-                        this.zkCluster = ZookeeperCluster.fromCrd(certManager, kafkaAssembly, assemblySecrets);
+                        this.zkCluster = ZookeeperCluster.fromCrd(kafkaAssembly);
 
                         ConfigMap logAndMetricsConfigMap = zkCluster.generateMetricsAndLogConfigMap(zkCluster.getLogging() instanceof ExternalLogging ?
                                 configMapOperations.get(kafkaAssembly.getMetadata().getNamespace(), ((ExternalLogging) zkCluster.getLogging()).getName()) :
@@ -489,7 +428,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkNodesSecret() {
-            return withVoid(secretOperations.reconcile(namespace, ZookeeperCluster.nodesSecretName(name), zkCluster.generateNodesSecret()));
+            return withVoid(secretOperations.reconcile(namespace, ZookeeperCluster.nodesSecretName(name),
+                    zkCluster.generateNodesSecret(clusterCa, kafkaAssembly)));
         }
 
         Future<ReconciliationState> zkNetPolicy() {
@@ -501,7 +441,23 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkRollingUpdate() {
-            return withVoid(zkSetOperations.maybeRollingUpdate(zkDiffs.resource(), zkForcedRestart));
+            if (log.isDebugEnabled()) {
+                String reason = "";
+                if (this.clusterCa.certRenewed()) {
+                    reason += "cluster CA certificate renewal, ";
+                }
+                if (this.clusterCa.certsRemoved()) {
+                    reason += "cluster CA certificate removal, ";
+                }
+                if (zkAncillaryCmChange) {
+                    reason += "ancillary CM change, ";
+                }
+                if (!reason.isEmpty()) {
+                    log.debug("{}: Rolling ZK SS due to {}", reconciliation, reason.substring(0, reason.length() - 2));
+                }
+            }
+            return withVoid(zkSetOperations.maybeRollingUpdate(zkDiffs.resource(),
+                    zkAncillaryCmChange || this.clusterCa.certRenewed() || this.clusterCa.certsRemoved()));
         }
 
         Future<ReconciliationState> zkScaleUp() {
@@ -520,9 +476,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return r.map(rr -> {
                 if (onlyMetricsSettingChanged) {
                     log.debug("Only metrics setting changed - not triggering rolling update");
-                    this.zkForcedRestart = false;
+                    this.zkAncillaryCmChange = false;
                 } else {
-                    this.zkForcedRestart = rr instanceof ReconcileResult.Patched;
+                    this.zkAncillaryCmChange = rr instanceof ReconcileResult.Patched;
                 }
                 return this;
             });
@@ -571,9 +527,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return r.map(rr -> {
                 if (onlyMetricsSettingChanged) {
                     log.debug("Only metrics setting changed - not triggering rolling update");
-                    this.kafkaForcedRestart = false;
+                    this.kafkaAncillaryCmChange = false;
                 } else {
-                    this.kafkaForcedRestart = rr instanceof ReconcileResult.Patched;
+                    this.kafkaAncillaryCmChange = rr instanceof ReconcileResult.Patched;
                 }
                 return this;
             });
@@ -884,12 +840,25 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaGenerateCertificates() {
-            if (kafkaCluster.isExposedWithNodePort()) {
-                kafkaCluster.generateCertificates(certManager, kafkaAssembly, assemblySecrets, null, Collections.EMPTY_MAP);
-            } else  {
-                kafkaCluster.generateCertificates(certManager, kafkaAssembly, assemblySecrets, kafkaExternalBootstrapAddress, kafkaExternalAddresses);
-            }
-            return withVoid(Future.succeededFuture());
+            Future<ReconciliationState> result = Future.future();
+            vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
+                future -> {
+                    try {
+                        if (kafkaCluster.isExposedWithNodePort()) {
+                            kafkaCluster.generateCertificates(kafkaAssembly,
+                                    clusterCa, clientsCa, null, Collections.EMPTY_MAP);
+                        } else {
+                            kafkaCluster.generateCertificates(kafkaAssembly,
+                                    clusterCa, clientsCa, kafkaExternalBootstrapAddress, kafkaExternalAddresses);
+                        }
+                        future.complete(this);
+                    } catch (Throwable e) {
+                        future.fail(e);
+                    }
+                },
+                true,
+                result.completer());
+            return result;
         }
 
         Future<ReconciliationState> kafkaAncillaryCm() {
@@ -897,15 +866,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaClientsCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCASecretName(name), kafkaCluster.generateClientsCASecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCASecretName(name), clientsCa.caKeySecret()));
         }
 
         Future<ReconciliationState> kafkaClientsPublicKeySecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsPublicKeyName(name), kafkaCluster.generateClientsPublicKeySecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsPublicKeyName(name), clientsCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaClusterPublicKeySecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterPublicKeyName(name), kafkaCluster.generateClusterPublicKeySecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterPublicKeyName(name), clusterCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaBrokersSecret() {
@@ -922,7 +891,23 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaRollingUpdate() {
-            return withVoid(kafkaSetOperations.maybeRollingUpdate(kafkaDiffs.resource(), kafkaForcedRestart));
+            if (log.isDebugEnabled()) {
+                String reason = "";
+                if (this.clusterCa.certRenewed()) {
+                    reason += "cluster CA certificate renewal, ";
+                }
+                if (this.clusterCa.certsRemoved()) {
+                    reason += "cluster CA certificate removal, ";
+                }
+                if (kafkaAncillaryCmChange) {
+                    reason += "ancillary CM change, ";
+                }
+                if (!reason.isEmpty()) {
+                    log.debug("{}: Rolling Kafka SS due to {}", reconciliation, reason.substring(0, reason.length() - 2));
+                }
+            }
+            return withVoid(kafkaSetOperations.maybeRollingUpdate(kafkaDiffs.resource(),
+                    kafkaAncillaryCmChange || this.clusterCa.certRenewed() || this.clusterCa.certsRemoved()));
         }
 
         Future<ReconciliationState> kafkaScaleUp() {
@@ -943,7 +928,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        this.topicOperator = TopicOperator.fromCrd(certManager, kafkaAssembly, assemblySecrets);
+                        this.topicOperator = TopicOperator.fromCrd(kafkaAssembly);
 
                         if (topicOperator != null) {
                             ConfigMap logAndMetricsConfigMap = topicOperator.generateMetricsAndLogConfigMap(
@@ -996,11 +981,20 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> topicOperatorDeployment() {
-            return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment));
+            return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment)
+                .compose(reconcileResult -> {
+                    if (this.clusterCa.certRenewed()  && reconcileResult instanceof ReconcileResult.Noop<?>) {
+                        // roll the TO if the cluster CA was renewed and reconcile hasn't rolled it
+                        log.debug("{}: Restarting Topic Operator due to Cluster CA renewal", reconciliation);
+                        return deploymentOperations.rollingUpdate(namespace, TopicOperator.topicOperatorName(name), operationTimeoutMs);
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                }));
         }
 
         Future<ReconciliationState> topicOperatorSecret() {
-            return withVoid(secretOperations.reconcile(namespace, TopicOperator.secretName(name), topicOperator == null ? null : topicOperator.generateSecret()));
+            return withVoid(secretOperations.reconcile(namespace, TopicOperator.secretName(name), topicOperator == null ? null : topicOperator.generateSecret(clusterCa)));
         }
 
         private final Future<ReconciliationState> getEntityOperatorDescription() {
@@ -1009,7 +1003,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        EntityOperator entityOperator = EntityOperator.fromCrd(certManager, kafkaAssembly, assemblySecrets);
+                        EntityOperator entityOperator = EntityOperator.fromCrd(kafkaAssembly);
 
                         if (entityOperator != null) {
                             EntityTopicOperator topicOperator = entityOperator.getTopicOperator();
@@ -1090,11 +1084,21 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityOperatorDeployment() {
-            return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment));
+            return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment)
+                .compose(reconcileResult -> {
+                    if (this.clusterCa.certRenewed() && reconcileResult instanceof ReconcileResult.Noop<?>) {
+                        // roll the EO if the cluster CA was renewed and reconcile hasn't rolled it
+                        log.debug("{}: Restarting Entity Operator due to Cluster CA renewal", reconciliation);
+                        return deploymentOperations.rollingUpdate(namespace, EntityOperator.entityOperatorName(name), operationTimeoutMs);
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                }));
         }
 
         Future<ReconciliationState> entityOperatorSecret() {
-            return withVoid(secretOperations.reconcile(namespace, EntityOperator.secretName(name), entityOperator == null ? null : entityOperator.generateSecret()));
+            return withVoid(secretOperations.reconcile(namespace, EntityOperator.secretName(name),
+                    entityOperator == null ? null : entityOperator.generateSecret(clusterCa)));
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -70,7 +70,6 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
 
     @Override
     protected Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnect kafkaConnect) {
-
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
         KafkaConnectCluster connect;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -33,8 +33,7 @@ import java.util.List;
  * in addition to the usual operations.
  */
 public abstract class StatefulSetOperator extends AbstractScalableResourceOperator<KubernetesClient, StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> {
-    public static final String STRIMZI_CLUSTER_OPERATOR_DOMAIN = "operator.strimzi.io";
-    public static final String ANNOTATION_GENERATION = STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/statefulset-generation";
+
     private static final int NO_GENERATION = -1;
     private static final String NO_UID = "NULL";
     private static final int INIT_GENERATION = 0;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -30,6 +30,7 @@ import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.TestUtils;
 
 import java.io.IOException;
@@ -102,30 +103,28 @@ public class ResourceUtils {
         List<Secret> secrets = new ArrayList<>();
 
         secrets.add(
-                new SecretBuilder()
-                .withNewMetadata()
-                    .withName(AbstractModel.getClusterCaName(clusterName))
-                    .withNamespace(clusterCmNamespace)
-                .endMetadata()
-                .addToData("cluster-ca.key", Base64.getEncoder().encodeToString("cluster-ca-base64key".getBytes()))
-                .addToData("cluster-ca.crt", Base64.getEncoder().encodeToString("cluster-ca-base64crt".getBytes()))
-                .build()
+                createInitialClusterCaSecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaKey(), MockCertManager.clusterCaCert())
         );
         return secrets;
+    }
+
+    public static Secret createInitialClusterCaSecret(String clusterCmNamespace, String clusterName, String caKey, String caCert) {
+        return new SecretBuilder()
+        .withNewMetadata()
+            .withName(AbstractModel.getClusterCaName(clusterName))
+            .withNamespace(clusterCmNamespace)
+            .withLabels(Labels.forCluster(clusterName).withKind("Kafka").toMap())
+        .endMetadata()
+        .addToData("cluster-ca.key", caKey)
+        .addToData("cluster-ca.crt", caCert)
+        .build();
     }
 
     public static List<Secret> createKafkaClusterSecretsWithReplicas(String clusterCmNamespace, String clusterName, int kafkaReplicas, int zkReplicas) {
         List<Secret> secrets = new ArrayList<>();
 
         secrets.add(
-                new SecretBuilder()
-                        .withNewMetadata()
-                        .withName(AbstractModel.getClusterCaName(clusterName))
-                        .withNamespace(clusterCmNamespace)
-                        .endMetadata()
-                        .addToData("cluster-ca.key", Base64.getEncoder().encodeToString("cluster-ca-base64key".getBytes()))
-                        .addToData("cluster-ca.crt", Base64.getEncoder().encodeToString("cluster-ca-base64crt".getBytes()))
-                        .build()
+                createInitialClusterCaSecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaKey(), MockCertManager.clusterCaCert())
         );
 
         secrets.add(
@@ -135,8 +134,8 @@ public class ResourceUtils {
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
-                        .addToData("clients-ca.key", Base64.getEncoder().encodeToString("clients-ca-base64key".getBytes()))
-                        .addToData("clients-ca.crt", Base64.getEncoder().encodeToString("clients-ca-base64crt".getBytes()))
+                        .addToData("clients-ca.key", MockCertManager.clientsCaKey())
+                        .addToData("clients-ca.crt", MockCertManager.clientsCaCert())
                         .build()
         );
 
@@ -147,7 +146,7 @@ public class ResourceUtils {
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
-                        .addToData("clients-ca.crt", Base64.getEncoder().encodeToString("clients-ca-base64crt".getBytes()))
+                        .addToData("clients-ca.crt", MockCertManager.clientsCaCert())
                         .build()
         );
 
@@ -158,7 +157,7 @@ public class ResourceUtils {
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
-                        .addToData("cluster-ca.crt", Base64.getEncoder().encodeToString("cluster-ca-base64crt".getBytes()));
+                        .addToData("cluster-ca.crt", MockCertManager.clusterCaCert());
 
         for (int i = 0; i < kafkaReplicas; i++) {
             builder.addToData(KafkaCluster.kafkaPodName(clusterName, i) + ".key", Base64.getEncoder().encodeToString("brokers-internal-base64key".getBytes()))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static io.strimzi.test.TestUtils.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -168,7 +169,10 @@ public class EntityTopicOperatorTest {
         assertEquals(new Integer(EntityTopicOperator.HEALTHCHECK_PORT), container.getPorts().get(0).getContainerPort());
         assertEquals(EntityTopicOperator.HEALTHCHECK_PORT_NAME, container.getPorts().get(0).getName());
         assertEquals("TCP", container.getPorts().get(0).getProtocol());
-        assertEquals("/opt/entity-topic-operator/custom-config/", container.getVolumeMounts().get(0).getMountPath());
-        assertEquals("entity-topic-operator-metrics-and-logging", container.getVolumeMounts().get(0).getName());
+        assertEquals(map("entity-topic-operator-metrics-and-logging", "/opt/entity-topic-operator/custom-config/",
+                EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
+                EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+                EntityOperatorTest.volumeMounts(container.getVolumeMounts()));
     }
+
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -70,7 +70,8 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(uoWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAME).withValue(KafkaCluster.clientsCASecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCASecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsPublicKeyName(cluster)).build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -25,7 +25,6 @@ import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
-
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -84,7 +83,8 @@ public class KafkaConnectS2IClusterTest {
     private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource);
 
     @Rule
-    public ResourceTester<KafkaConnectS2I, KafkaConnectS2ICluster> resourceTester = new ResourceTester<>(KafkaConnectS2I.class, KafkaConnectS2ICluster::fromCrd);
+    public ResourceTester<KafkaConnectS2I, KafkaConnectS2ICluster> resourceTester = new ResourceTester<>(KafkaConnectS2I.class,
+        x -> KafkaConnectS2ICluster.fromCrd(x));
 
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -75,7 +75,7 @@ public class TopicOperatorTest {
 
     private final CertManager certManager = new MockCertManager();
     private final Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig, storage, topicOperator, kafkaLogJson, zooLogJson);
-    private final TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
+    private final TopicOperator tc = TopicOperator.fromCrd(resource);
 
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
@@ -95,7 +95,7 @@ public class TopicOperatorTest {
     public void testFromConfigMapNoConfig() {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, null, kafkaLogJson, zooLogJson);
-        TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
+        TopicOperator tc = TopicOperator.fromCrd(resource);
         assertNull(tc);
     }
 
@@ -104,7 +104,7 @@ public class TopicOperatorTest {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
                 storage, new TopicOperatorSpec(), kafkaLogJson, zooLogJson);
-        TopicOperator tc = TopicOperator.fromCrd(certManager, resource, ResourceUtils.createKafkaClusterInitialSecrets(namespace, cluster));
+        TopicOperator tc = TopicOperator.fromCrd(resource);
         Assert.assertEquals(TopicOperatorSpec.DEFAULT_IMAGE, tc.getImage());
         assertEquals(namespace, tc.getWatchedNamespace());
         assertEquals(TopicOperatorSpec.DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS * 1000, tc.getReconciliationIntervalMs());
@@ -167,14 +167,14 @@ public class TopicOperatorTest {
         assertEquals(TopicOperator.HEALTHCHECK_PORT_NAME, containers.get(0).getPorts().get(0).getName());
         assertEquals("TCP", containers.get(0).getPorts().get(0).getProtocol());
         assertEquals("Recreate", dep.getSpec().getStrategy().getType());
-        assertEquals(TopicOperator.TLS_SIDECAR_VOLUME_NAME, containers.get(0).getVolumeMounts().get(1).getName());
-        assertEquals(TopicOperator.TLS_SIDECAR_VOLUME_MOUNT, containers.get(0).getVolumeMounts().get(1).getMountPath());
+        assertEquals(TopicOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, containers.get(0).getVolumeMounts().get(1).getName());
+        assertEquals(TopicOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT, containers.get(0).getVolumeMounts().get(1).getMountPath());
         assertLoggingConfig(dep);
         // checks on the TLS sidecar container
         assertEquals(TopicOperatorSpec.DEFAULT_TLS_SIDECAR_IMAGE, containers.get(1).getImage());
         assertEquals(TopicOperator.defaultZookeeperConnect(cluster), AbstractModel.containerEnvVars(containers.get(1)).get(TopicOperator.ENV_VAR_ZOOKEEPER_CONNECT));
-        assertEquals(TopicOperator.TLS_SIDECAR_VOLUME_NAME, containers.get(1).getVolumeMounts().get(0).getName());
-        assertEquals(TopicOperator.TLS_SIDECAR_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(0).getMountPath());
+        assertEquals(TopicOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, containers.get(1).getVolumeMounts().get(0).getName());
+        assertEquals(TopicOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(0).getMountPath());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
@@ -15,6 +16,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 import io.strimzi.certs.CertManager;
+import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -23,11 +25,16 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
+import static io.strimzi.test.TestUtils.set;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -54,7 +61,7 @@ public class ZookeeperClusterTest {
 
     private final CertManager certManager = new MockCertManager();
     private final Kafka ka = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson, null, null, kafkaLogConfigJson, zooLogConfigJson);
-    private final ZookeeperCluster zc = ZookeeperCluster.fromCrd(certManager, ka, ResourceUtils.createKafkaClusterInitialSecrets(namespace, ka.getMetadata().getName()));
+    private final ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka);
 
     @Rule
     public ResourceTester<Kafka, ZookeeperCluster> resourceTester = new ResourceTester<>(Kafka.class, ZookeeperCluster::fromCrd);
@@ -161,8 +168,10 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(ZookeeperCluster.LEADER_ELECTION_PORT), containers.get(1).getPorts().get(1).getContainerPort());
         assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, containers.get(1).getPorts().get(2).getName());
         assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), containers.get(1).getPorts().get(2).getContainerPort());
-        assertEquals(ZookeeperCluster.TLS_SIDECAR_VOLUME_NAME, containers.get(1).getVolumeMounts().get(0).getName());
-        assertEquals(ZookeeperCluster.TLS_SIDECAR_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(0).getMountPath());
+        assertEquals(ZookeeperCluster.TLS_SIDECAR_NODES_VOLUME_NAME, containers.get(1).getVolumeMounts().get(0).getName());
+        assertEquals(ZookeeperCluster.TLS_SIDECAR_NODES_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(0).getMountPath());
+        assertEquals(ZookeeperCluster.TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, containers.get(1).getVolumeMounts().get(1).getName());
+        assertEquals(ZookeeperCluster.TLS_SIDECAR_CLUSTER_CA_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(1).getMountPath());
     }
 
     /**
@@ -177,7 +186,7 @@ public class ZookeeperClusterTest {
                     .endKafka()
                 .endSpec()
             .build();
-        ZookeeperCluster zc = ZookeeperCluster.fromCrd(certManager, ka, ResourceUtils.createKafkaClusterInitialSecrets(namespace, ka.getMetadata().getName()));
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka);
         StatefulSet ss = zc.generateStatefulSet(true);
         assertFalse(ZookeeperCluster.deleteClaim(ss));
 
@@ -188,7 +197,7 @@ public class ZookeeperClusterTest {
                     .endKafka()
                 .endSpec()
             .build();
-        zc = ZookeeperCluster.fromCrd(certManager, ka, ResourceUtils.createKafkaClusterInitialSecrets(namespace, ka.getMetadata().getName()));
+        zc = ZookeeperCluster.fromCrd(ka);
         ss = zc.generateStatefulSet(true);
         assertFalse(ZookeeperCluster.deleteClaim(ss));
 
@@ -199,7 +208,7 @@ public class ZookeeperClusterTest {
                     .endZookeeper()
                 .endSpec()
             .build();
-        zc = ZookeeperCluster.fromCrd(certManager, ka, ResourceUtils.createKafkaClusterInitialSecrets(namespace, ka.getMetadata().getName()));
+        zc = ZookeeperCluster.fromCrd(ka);
         ss = zc.generateStatefulSet(true);
         assertTrue(ZookeeperCluster.deleteClaim(ss));
     }
@@ -230,5 +239,27 @@ public class ZookeeperClusterTest {
     public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
         assertEquals(1, resource.getMetadata().getOwnerReferences().size());
         assertEquals(ownerRef, resource.getMetadata().getOwnerReferences().get(0));
+    }
+
+    @Test
+    public void testGenerateBrokerSecret() throws CertificateParsingException {
+        ClusterCa clusterCa = new ClusterCa(new OpenSslCertManager(), cluster, null, null);
+        clusterCa.createOrRenew(namespace, cluster, emptyMap(), null);
+
+        Secret secret = zc.generateNodesSecret(clusterCa, ka);
+        assertEquals(set(
+                "foo-zookeeper-0.crt",  "foo-zookeeper-0.key",
+                "foo-zookeeper-1.crt", "foo-zookeeper-1.key",
+                "foo-zookeeper-2.crt", "foo-zookeeper-2.key"),
+                secret.getData().keySet());
+        X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
+        assertEquals("CN=foo-zookeeper, O=io.strimzi", cert.getSubjectDN().getName());
+        assertEquals(set(
+                asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc.cluster.local"),
+                asList(2, "foo-zookeeper-client"),
+                asList(2, "foo-zookeeper-client.test"),
+                asList(2, "foo-zookeeper-client.test.svc.cluster.local")),
+                new HashSet<Object>(cert.getSubjectAlternativeNames()));
+
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.TlsCertificates;
+import io.strimzi.api.kafka.model.TlsCertificatesBuilder;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.OpenSslCertManager;
+import io.strimzi.certs.Subject;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.ResourceType;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.strimzi.test.TestUtils.set;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class CertificateRenewalTest {
+
+    public static final String NAMESPACE = "test";
+    public static final String NAME = "my-kafka";
+    private Vertx vertx = Vertx.vertx();
+    private OpenSslCertManager certManager = new OpenSslCertManager();
+    private List<Secret> secrets = new ArrayList();
+
+    @Before
+    public void clearSecrets() {
+        secrets = new ArrayList();
+    }
+
+    private ArgumentCaptor<Secret> reconcileCa(TestContext context, TlsCertificates tlsCertificates) {
+        SecretOperator secretOps = mock(SecretOperator.class);
+
+        when(secretOps.list(eq(NAMESPACE), any())).thenAnswer(invocation -> {
+            Map<String, String> requiredLabels = ((Labels) invocation.getArgument(1)).toMap();
+            return secrets.stream().filter(s -> {
+                Map<String, String> labels = new HashMap(s.getMetadata().getLabels());
+                labels.keySet().retainAll(requiredLabels.keySet());
+                return labels.equals(requiredLabels);
+            }).collect(Collectors.toList());
+        });
+        ArgumentCaptor<Secret> c = ArgumentCaptor.forClass(Secret.class);
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.getClusterCaName(NAME)), c.capture())).thenReturn(Future.succeededFuture(null));
+
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
+                new ResourceOperatorSupplier(null, null, null,
+                        null, null, secretOps, null, null,
+                        null, null, null, null, null));
+        Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
+
+        Kafka kafka = new KafkaBuilder()
+                .editOrNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withTlsCertificates(tlsCertificates)
+                .endSpec()
+            .build();
+
+        Async async = context.async();
+        op.new ReconciliationState(reconciliation, kafka).reconcileClusterCa().setHandler(ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.assertTrue(ar.succeeded());
+            async.complete();
+        });
+        async.await();
+        return c;
+    }
+
+    private CertAndKey generateCa(OpenSslCertManager certManager, TlsCertificates tlsCertificates, String commonName) throws IOException {
+        File clusterCaKeyFile = File.createTempFile("tls", "cluster-ca-key");
+        File clusterCaCertFile = File.createTempFile("tls", "cluster-ca-cert");
+        try {
+            Subject sbj = new Subject();
+            sbj.setOrganizationName("io.strimzi");
+            sbj.setCommonName(commonName);
+
+            certManager.generateSelfSignedCert(clusterCaKeyFile, clusterCaCertFile, sbj, ModelUtils.getCertificateValidity(tlsCertificates));
+            return new CertAndKey(Files.readAllBytes(clusterCaKeyFile.toPath()),
+                    Files.readAllBytes(clusterCaCertFile.toPath()));
+        } finally {
+            clusterCaKeyFile.delete();
+            clusterCaCertFile.delete();
+        }
+    }
+
+    private Secret initialSecret(TlsCertificates tlsCertificates) throws IOException {
+        String commonName = "cluster-ca";
+        CertAndKey result = generateCa(certManager, tlsCertificates, commonName);
+        return ResourceUtils.createInitialClusterCaSecret(NAMESPACE, NAME,
+                result.keyAsBase64String(),
+                result.certAsBase64String());
+    }
+
+    @Test
+    public void certsGetGeneratedInitiallyAuto(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+        secrets.clear();
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        assertEquals(set("cluster-ca.key", "cluster-ca.crt"), c.getValue().getData().keySet());
+        assertNotNull(c.getValue().getData().get("cluster-ca.key"));
+        assertNotNull(c.getValue().getData().get("cluster-ca.crt"));
+    }
+
+    @Test
+    public void certsNotGeneratedInitiallyManual(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(false)
+                .build();
+        secrets.clear();
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        assertTrue(c.getValue().getData().isEmpty());
+        // XXX It would be nice to be able to assert on the WARN log message
+    }
+
+    @Test
+    public void noCertsGetGeneratedOutsideRenewalPeriodAuto(TestContext context) throws IOException {
+        noCertsGetGeneratedOutsideRenewalPeriod(context, true);
+    }
+
+    private void noCertsGetGeneratedOutsideRenewalPeriod(TestContext context, boolean generateCertificateAuthority) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(generateCertificateAuthority)
+                .build();
+        Secret initialSecret = initialSecret(tlsCertificates);
+        secrets.add(initialSecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        assertEquals(set("cluster-ca.key", "cluster-ca.crt"), c.getValue().getData().keySet());
+        assertEquals(initialSecret.getData().get("cluster-ca.key"), c.getValue().getData().get("cluster-ca.key"));
+        assertEquals(initialSecret.getData().get("cluster-ca.crt"), c.getValue().getData().get("cluster-ca.crt"));
+    }
+
+    @Test
+    public void noCertsGetGeneratedOutsideRenewalPeriodManual(TestContext context) throws IOException {
+        noCertsGetGeneratedOutsideRenewalPeriod(context, false);
+    }
+
+    @Test
+    public void newCertsGetGeneratedWhenInRenewalPeriodAuto(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(true)
+                .build();
+        Secret initialSecret = initialSecret(tlsCertificates);
+        secrets.add(initialSecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        Map<String, String> data = c.getValue().getData();
+        assertEquals(4, data.size());
+        String expectedNewCrt = data.remove("cluster-ca.crt");
+        assertNotNull(expectedNewCrt);
+        String expectedNewKey = data.remove("cluster-ca.key");
+        assertNotNull(expectedNewKey);
+        Iterator<String> iterator = data.keySet().iterator();
+        String key = iterator.next();
+        if (key.endsWith(".crt")) {
+            assertEquals("Expected the original crt to be in the data key with expiry date",
+                    initialSecret.getData().get("cluster-ca.crt"), data.get(key));
+            assertNotEquals(expectedNewCrt, data.get(key));
+            assertEquals(key.replaceAll(".crt$", ".key"), iterator.next());
+        } else if (key.endsWith(".key")) {
+            assertEquals("Expected the original key to be in the data key with expiry date",
+                    initialSecret.getData().get("cluster-ca.key"), data.get(key));
+            assertNotEquals(expectedNewKey, data.get(key));
+            assertEquals(key.replaceAll(".key$", ".crt"), iterator.next());
+        } else {
+            fail();
+        }
+    }
+
+    @Test
+    public void newCertsNotGeneratedWhenInRenewalPeriodManual(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(2)
+                .withRenewalDays(3)
+                .withGenerateCertificateAuthority(false)
+                .build();
+        Secret initialSecret = initialSecret(tlsCertificates);
+        secrets.add(initialSecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        Map<String, String> data = c.getValue().getData();
+        assertEquals(initialSecret.getData(), data);
+    }
+
+    @Test
+    public void expiredCertsGetRemovedAuto(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(true)
+                .build();
+        Secret initialSecret = initialSecret(tlsCertificates);
+        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.crt", "whatever");
+        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.key", "whatever");
+        secrets.add(initialSecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        Map<String, String> data = c.getValue().getData();
+        assertEquals(data.keySet().toString(), 2, data.size());
+        assertEquals(initialSecret.getData().get("cluster-ca.crt"), data.get("cluster-ca.crt"));
+        assertEquals(initialSecret.getData().get("cluster-ca.key"), data.get("cluster-ca.key"));
+    }
+
+    @Test
+    public void expiredCertsNotRemovedManual(TestContext context) throws IOException {
+        TlsCertificates tlsCertificates = new TlsCertificatesBuilder()
+                .withValidityDays(100)
+                .withRenewalDays(10)
+                .withGenerateCertificateAuthority(false)
+                .build();
+        Secret initialSecret = initialSecret(tlsCertificates);
+        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.crt", "whatever");
+        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.key", "whatever");
+        secrets.add(initialSecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
+        Map<String, String> data = c.getValue().getData();
+        assertEquals(initialSecret.getData(), data);
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -35,17 +36,19 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static io.strimzi.operator.cluster.model.Ca.CA_CRT;
+import static io.strimzi.operator.cluster.model.Ca.CA_KEY;
 import static io.strimzi.test.TestUtils.set;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -77,7 +80,8 @@ public class CertificateRenewalTest {
             }).collect(Collectors.toList());
         });
         ArgumentCaptor<Secret> c = ArgumentCaptor.forClass(Secret.class);
-        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.getClusterCaName(NAME)), c.capture())).thenReturn(Future.succeededFuture(null));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.getClusterCaName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.getClusterCaKeyName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
                 new ResourceOperatorSupplier(null, null, null,
@@ -95,13 +99,23 @@ public class CertificateRenewalTest {
                 .endSpec()
             .build();
 
+        AtomicReference<Throwable> error = new AtomicReference<>();
         Async async = context.async();
         op.new ReconciliationState(reconciliation, kafka).reconcileClusterCa().setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.assertTrue(ar.succeeded());
+            error.set(ar.cause());
             async.complete();
         });
         async.await();
+        if (error.get() != null) {
+            Throwable t = error.get();
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            } else if (t instanceof Error) {
+                throw (Error) t;
+            } else {
+                throw new RuntimeException(t);
+            }
+        }
         return c;
     }
 
@@ -122,12 +136,18 @@ public class CertificateRenewalTest {
         }
     }
 
-    private Secret initialSecret(TlsCertificates tlsCertificates) throws IOException {
+    private Secret initialCaCertSecret(TlsCertificates tlsCertificates) throws IOException {
         String commonName = "cluster-ca";
         CertAndKey result = generateCa(certManager, tlsCertificates, commonName);
-        return ResourceUtils.createInitialClusterCaSecret(NAMESPACE, NAME,
-                result.keyAsBase64String(),
+        return ResourceUtils.createInitialClusterCaCertSecret(NAMESPACE, NAME,
                 result.certAsBase64String());
+    }
+
+    private Secret initialCaKeySecret(TlsCertificates tlsCertificates) throws IOException {
+        String commonName = "cluster-ca";
+        CertAndKey result = generateCa(certManager, tlsCertificates, commonName);
+        return ResourceUtils.createInitialClusterCaKeySecret(NAMESPACE, NAME,
+                result.keyAsBase64String());
     }
 
     @Test
@@ -139,9 +159,10 @@ public class CertificateRenewalTest {
                 .build();
         secrets.clear();
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        assertEquals(set("cluster-ca.key", "cluster-ca.crt"), c.getValue().getData().keySet());
-        assertNotNull(c.getValue().getData().get("cluster-ca.key"));
-        assertNotNull(c.getValue().getData().get("cluster-ca.crt"));
+        assertEquals(2, c.getAllValues().size());
+
+        assertEquals(singleton(CA_CRT), c.getAllValues().get(0).getData().keySet());
+        assertEquals(singleton(CA_KEY), c.getAllValues().get(1).getData().keySet());
     }
 
     @Test
@@ -153,8 +174,9 @@ public class CertificateRenewalTest {
                 .build();
         secrets.clear();
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        assertTrue(c.getValue().getData().isEmpty());
-        // XXX It would be nice to be able to assert on the WARN log message
+        assertEquals(c.getAllValues().toString(), 2, c.getAllValues().size());
+        assertTrue(c.getAllValues().get(0).getData().isEmpty());
+        assertTrue(c.getAllValues().get(1).getData().isEmpty());
     }
 
     @Test
@@ -168,12 +190,26 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(generateCertificateAuthority)
                 .build();
-        Secret initialSecret = initialSecret(tlsCertificates);
-        secrets.add(initialSecret);
+        Secret initialCaCertSecret = initialCaCertSecret(tlsCertificates);
+        Secret initialCaKeySecret = initialCaKeySecret(tlsCertificates);
+        Map<String, String> initialCertData = initialCaCertSecret.getData();
+        assertEquals(singleton(CA_CRT), initialCertData.keySet());
+        String initialCert = initialCertData.get(CA_CRT);
+        assertNotNull(initialCert);
+        Map<String, String> initialKeyData = initialCaKeySecret .getData();
+        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
+        String initialKey = initialKeyData.get(CA_KEY);
+        assertNotNull(initialKey);
+
+        secrets.add(initialCaCertSecret);
+        secrets.add(initialCaKeySecret);
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        assertEquals(set("cluster-ca.key", "cluster-ca.crt"), c.getValue().getData().keySet());
-        assertEquals(initialSecret.getData().get("cluster-ca.key"), c.getValue().getData().get("cluster-ca.key"));
-        assertEquals(initialSecret.getData().get("cluster-ca.crt"), c.getValue().getData().get("cluster-ca.crt"));
+
+        assertEquals(set(CA_CRT), c.getAllValues().get(0).getData().keySet());
+        assertEquals(initialCert, c.getAllValues().get(0).getData().get(CA_CRT));
+
+        assertEquals(set(CA_KEY), c.getAllValues().get(1).getData().keySet());
+        assertEquals(initialKey, c.getAllValues().get(1).getData().get(CA_KEY));
     }
 
     @Test
@@ -188,30 +224,37 @@ public class CertificateRenewalTest {
                 .withRenewalDays(3)
                 .withGenerateCertificateAuthority(true)
                 .build();
-        Secret initialSecret = initialSecret(tlsCertificates);
-        secrets.add(initialSecret);
+        Secret initialCaCertSecret = initialCaCertSecret(tlsCertificates);
+        Secret initialCaKeySecret = initialCaKeySecret(tlsCertificates);
+        Map<String, String> initialCertData = initialCaCertSecret.getData();
+        assertEquals(singleton(CA_CRT), initialCertData.keySet());
+        String initialCert = initialCertData.get(CA_CRT);
+        assertNotNull(initialCert);
+        Map<String, String> initialKeyData = initialCaKeySecret .getData();
+        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
+        String initialKey = initialKeyData.get(CA_KEY);
+        assertNotNull(initialKey);
+
+        secrets.add(initialCaCertSecret);
+        secrets.add(initialCaKeySecret);
+
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        Map<String, String> data = c.getValue().getData();
-        assertEquals(4, data.size());
-        String expectedNewCrt = data.remove("cluster-ca.crt");
-        assertNotNull(expectedNewCrt);
-        String expectedNewKey = data.remove("cluster-ca.key");
-        assertNotNull(expectedNewKey);
-        Iterator<String> iterator = data.keySet().iterator();
-        String key = iterator.next();
-        if (key.endsWith(".crt")) {
-            assertEquals("Expected the original crt to be in the data key with expiry date",
-                    initialSecret.getData().get("cluster-ca.crt"), data.get(key));
-            assertNotEquals(expectedNewCrt, data.get(key));
-            assertEquals(key.replaceAll(".crt$", ".key"), iterator.next());
-        } else if (key.endsWith(".key")) {
-            assertEquals("Expected the original key to be in the data key with expiry date",
-                    initialSecret.getData().get("cluster-ca.key"), data.get(key));
-            assertNotEquals(expectedNewKey, data.get(key));
-            assertEquals(key.replaceAll(".key$", ".crt"), iterator.next());
-        } else {
-            fail();
-        }
+        assertEquals(2, c.getAllValues().size());
+        Map<String, String> certData = c.getAllValues().get(0).getData();
+        assertEquals(2, certData.size());
+        String newCrt = certData.remove(CA_CRT);
+        assertNotNull(newCrt);
+        String oldKey = certData.keySet().iterator().next();
+        String oldCrt = certData.get(oldKey);
+        assertNotNull(oldCrt);
+        assertNotEquals(newCrt, oldCrt);
+        assertEquals(initialCert, oldCrt);
+
+        Map<String, String> keyData = c.getAllValues().get(1).getData();
+        assertEquals(singleton(CA_KEY), keyData.keySet());
+        String newKey = keyData.remove(CA_KEY);
+        assertNotNull(newKey);
+        assertNotEquals(initialKey, newKey);
     }
 
     @Test
@@ -221,11 +264,26 @@ public class CertificateRenewalTest {
                 .withRenewalDays(3)
                 .withGenerateCertificateAuthority(false)
                 .build();
-        Secret initialSecret = initialSecret(tlsCertificates);
-        secrets.add(initialSecret);
+        Secret initialCaCertSecret = initialCaCertSecret(tlsCertificates);
+        Secret initialCaKeySecret = initialCaKeySecret(tlsCertificates);
+        Map<String, String> initialCertData = initialCaCertSecret.getData();
+        assertEquals(singleton(CA_CRT), initialCertData.keySet());
+        String initialCert = initialCertData.get(CA_CRT);
+        assertNotNull(initialCert);
+        Map<String, String> initialKeyData = initialCaKeySecret .getData();
+        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
+        String initialKey = initialKeyData.get(CA_KEY);
+        assertNotNull(initialKey);
+
+        secrets.add(initialCaCertSecret);
+        secrets.add(initialCaKeySecret);
+
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        Map<String, String> data = c.getValue().getData();
-        assertEquals(initialSecret.getData(), data);
+        assertEquals(2, c.getAllValues().size());
+        Map<String, String> certData = c.getAllValues().get(0).getData();
+        assertEquals(initialCertData, certData);
+        Map<String, String> keyData = c.getAllValues().get(1).getData();
+        assertEquals(initialKeyData, keyData);
     }
 
     @Test
@@ -235,15 +293,28 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(true)
                 .build();
-        Secret initialSecret = initialSecret(tlsCertificates);
-        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.crt", "whatever");
-        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.key", "whatever");
-        secrets.add(initialSecret);
+        Secret initialCaCertSecret = initialCaCertSecret(tlsCertificates);
+        Secret initialCaKeySecret = initialCaKeySecret(tlsCertificates);
+        Map<String, String> initialCertData = initialCaCertSecret.getData();
+        assertEquals(singleton(CA_CRT), initialCertData.keySet());
+        String initialCert = initialCertData.get(CA_CRT);
+        initialCertData.put("ca-2018-07-01T09-00-00.crt", "whatever");
+        assertNotNull(initialCert);
+        Map<String, String> initialKeyData = initialCaKeySecret .getData();
+        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
+        String initialKey = initialKeyData.get(CA_KEY);
+        assertNotNull(initialKey);
+
+        secrets.add(initialCaCertSecret);
+        secrets.add(initialCaKeySecret);
+
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        Map<String, String> data = c.getValue().getData();
-        assertEquals(data.keySet().toString(), 2, data.size());
-        assertEquals(initialSecret.getData().get("cluster-ca.crt"), data.get("cluster-ca.crt"));
-        assertEquals(initialSecret.getData().get("cluster-ca.key"), data.get("cluster-ca.key"));
+        assertEquals(2, c.getAllValues().size());
+        Map<String, String> certData = c.getAllValues().get(0).getData();
+        assertEquals(certData.keySet().toString(), 1, certData.size());
+        assertEquals(initialCert, certData.get(CA_CRT));
+        Map<String, String> keyData = c.getAllValues().get(1).getData();
+        assertEquals(initialKey, keyData.get(CA_KEY));
     }
 
     @Test
@@ -253,12 +324,24 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(false)
                 .build();
-        Secret initialSecret = initialSecret(tlsCertificates);
-        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.crt", "whatever");
-        initialSecret.getData().put("cluster-ca-2018-07-01T09:00:00.key", "whatever");
-        secrets.add(initialSecret);
+        Secret initialCaCertSecret = initialCaCertSecret(tlsCertificates);
+        Secret initialCaKeySecret = initialCaKeySecret(tlsCertificates);
+        Map<String, String> initialCertData = initialCaCertSecret.getData();
+        assertEquals(singleton(CA_CRT), initialCertData.keySet());
+        String initialCert = initialCertData.get(CA_CRT);
+        initialCertData.put("cluster-ca-2018-07-01T09-00-00.crt", "whatever");
+        assertNotNull(initialCert);
+        Map<String, String> initialKeyData = initialCaKeySecret .getData();
+        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
+        String initialKey = initialKeyData.get(CA_KEY);
+        assertNotNull(initialKey);
+
+        secrets.add(initialCaCertSecret);
+        secrets.add(initialCaKeySecret);
+
         ArgumentCaptor<Secret> c = reconcileCa(context, tlsCertificates);
-        Map<String, String> data = c.getValue().getData();
-        assertEquals(initialSecret.getData(), data);
+        assertEquals(2, c.getAllValues().size());
+        Map<String, String> certData = c.getAllValues().get(0).getData();
+        assertEquals(initialCertData, certData);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -275,7 +275,7 @@ public class KafkaAssemblyOperatorTest {
 
     private void createCluster(TestContext context, Kafka clusterCm, List<Secret> secrets) {
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm);
-        kafkaCluster.generateCertificates(certManager, secrets,  null, Collections.EMPTY_MAP);
+        kafkaCluster.generateCertificates(certManager, clusterCm, secrets,  null, Collections.EMPTY_MAP);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(certManager, clusterCm, secrets);
         TopicOperator topicOperator = TopicOperator.fromCrd(certManager, clusterCm, secrets);
         EntityOperator entityOperator = EntityOperator.fromCrd(certManager, clusterCm, secrets);
@@ -612,9 +612,9 @@ public class KafkaAssemblyOperatorTest {
 
     private void updateCluster(TestContext context, Kafka originalAssembly, Kafka updatedAssembly, List<Secret> secrets) {
         KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(originalAssembly);
-        originalKafkaCluster.generateCertificates(certManager, secrets,  null, Collections.EMPTY_MAP);
+        originalKafkaCluster.generateCertificates(certManager, originalAssembly, secrets,  null, Collections.EMPTY_MAP);
         KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(updatedAssembly);
-        updatedKafkaCluster.generateCertificates(certManager, secrets,  null, Collections.EMPTY_MAP);
+        updatedKafkaCluster.generateCertificates(certManager, updatedAssembly, secrets,  null, Collections.EMPTY_MAP);
         ZookeeperCluster originalZookeeperCluster = ZookeeperCluster.fromCrd(certManager, originalAssembly, secrets);
         ZookeeperCluster updatedZookeeperCluster = ZookeeperCluster.fromCrd(certManager, updatedAssembly, secrets);
         TopicOperator originalTopicOperator = TopicOperator.fromCrd(certManager, originalAssembly, secrets);
@@ -868,7 +868,7 @@ public class KafkaAssemblyOperatorTest {
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
         KafkaCluster barCluster = KafkaCluster.fromCrd(bar);
-        barCluster.generateCertificates(certManager, barSecrets,  null, Collections.EMPTY_MAP);
+        barCluster.generateCertificates(certManager, bar, barSecrets,  null, Collections.EMPTY_MAP);
         when(mockKsOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(barCluster.generateStatefulSet(openShift))
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -14,6 +14,8 @@ import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpecBuilder;
@@ -31,8 +33,11 @@ import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.ClientsCa;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.TopicOperator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
@@ -56,9 +61,6 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
-
-import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.api.model.RouteBuilder;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -72,16 +74,17 @@ import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
@@ -270,15 +273,18 @@ public class KafkaAssemblyOperatorTest {
 
     @Test
     public void testCreateCluster(TestContext context) {
-        createCluster(context, getKafkaAssembly("foo"), getInitialSecrets(getKafkaAssembly("foo").getMetadata().getName()));
+        createCluster(context, getKafkaAssembly("foo"),
+                emptyList()); //getInitialCertificates(getKafkaAssembly("foo").getMetadata().getName()));
     }
 
     private void createCluster(TestContext context, Kafka clusterCm, List<Secret> secrets) {
+        ClusterCa clusterCa = new ClusterCa(new MockCertManager(), clusterCm.getMetadata().getName(),
+                ModelUtils.findSecretWithName(secrets, AbstractModel.getClusterCaName(clusterCm.getMetadata().getName())),
+                ModelUtils.findSecretWithName(secrets, AbstractModel.getClusterCaKeyName(clusterCm.getMetadata().getName())));
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm);
-        kafkaCluster.generateCertificates(certManager, clusterCm, secrets,  null, Collections.EMPTY_MAP);
-        ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(certManager, clusterCm, secrets);
-        TopicOperator topicOperator = TopicOperator.fromCrd(certManager, clusterCm, secrets);
-        EntityOperator entityOperator = EntityOperator.fromCrd(certManager, clusterCm, secrets);
+        ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(clusterCm);
+        TopicOperator topicOperator = TopicOperator.fromCrd(clusterCm);
+        EntityOperator entityOperator = EntityOperator.fromCrd(clusterCm);
 
         // create CM, Service, headless service, statefulset and so on
         ResourceOperatorSupplier supplier = supplierWithMocks();
@@ -316,6 +322,7 @@ public class KafkaAssemblyOperatorTest {
                 KafkaCluster.clientsCASecretName(clusterCmName),
                 KafkaCluster.clientsPublicKeyName(clusterCmName),
                 KafkaCluster.clusterPublicKeyName(clusterCmName),
+                KafkaCluster.getClusterCaKeyName(clusterCmName),
                 KafkaCluster.brokersSecretName(clusterCmName),
                 ZookeeperCluster.nodesSecretName(clusterCmName));
         expectedSecrets.addAll(secrets.stream().map(s -> s.getMetadata().getName()).collect(Collectors.toSet()));
@@ -409,7 +416,7 @@ public class KafkaAssemblyOperatorTest {
                     capturedSs.stream().map(ss -> ss.getMetadata().getName()).collect(Collectors.toSet()));
 
             // expected Secrets with certificates
-            context.assertEquals(expectedSecrets, createdOrUpdatedSecrets);
+            context.assertEquals(new TreeSet(expectedSecrets), new TreeSet(createdOrUpdatedSecrets));
 
             // Verify deleted routes
             if (openShift) {
@@ -453,12 +460,12 @@ public class KafkaAssemblyOperatorTest {
         return kafka;
     }
 
-    private List<Secret> getInitialSecrets(String clusterName) {
+    private List<Secret> getInitialCertificates(String clusterName) {
         String clusterCmNamespace = "test";
         return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, clusterName);
     }
 
-    private List<Secret> getClusterSecrets(String clusterCmName, int kafkaReplicas, int zkReplicas) {
+    private List<Secret> getClusterCertificates(String clusterCmName, int kafkaReplicas, int zkReplicas) {
         String clusterCmNamespace = "test";
         return ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, clusterCmName, kafkaReplicas, zkReplicas);
     }
@@ -470,30 +477,21 @@ public class KafkaAssemblyOperatorTest {
     @Test
     public void testUpdateClusterNoop(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateKafkaClusterChangeImage(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getKafka().setImage("a-changed-image");
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateZookeeperClusterChangeImage(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getZookeeper().setImage("a-changed-image");
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
@@ -503,60 +501,42 @@ public class KafkaAssemblyOperatorTest {
                 .editSpec().editZookeeper()
                     .editOrNewTlsSidecar().withImage("a-changed-tls-sidecar-image")
                     .endTlsSidecar().endZookeeper().endSpec().build();
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateKafkaClusterScaleUp(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getKafka().setReplicas(4);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateKafkaClusterScaleDown(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getKafka().setReplicas(2);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateZookeeperClusterScaleUp(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getZookeeper().setReplicas(4);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateZookeeperClusterScaleDown(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getZookeeper().setReplicas(2);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateClusterMetricsConfig(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getKafka().setMetrics(singletonMap("something", "changed"));
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
@@ -565,20 +545,14 @@ public class KafkaAssemblyOperatorTest {
         InlineLogging logger = new InlineLogging();
         logger.setLoggers(singletonMap("kafka.root.logger.level", "DEBUG"));
         kafkaAssembly.getSpec().getKafka().setLogging(logger);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
     public void testUpdateZkClusterMetricsConfig(TestContext context) {
         Kafka kafkaAssembly = getKafkaAssembly("bar");
         kafkaAssembly.getSpec().getZookeeper().setMetrics(singletonMap("something", "changed"));
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
@@ -587,10 +561,7 @@ public class KafkaAssemblyOperatorTest {
         InlineLogging logger = new InlineLogging();
         logger.setLoggers(singletonMap("zookeeper.root.logger", "DEBUG"));
         kafkaAssembly.getSpec().getZookeeper().setLogging(logger);
-        List<Secret> secrets = getClusterSecrets("bar",
-                kafkaAssembly.getSpec().getKafka().getReplicas(),
-                kafkaAssembly.getSpec().getZookeeper().getReplicas());
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
     @Test
@@ -602,23 +573,17 @@ public class KafkaAssemblyOperatorTest {
                     .editSpec().editTopicOperator()
                     .editOrNewTlsSidecar().withImage("a-changed-tls-sidecar-image")
                     .endTlsSidecar().endTopicOperator().endSpec().build();
-            List<Secret> secrets = getClusterSecrets("bar",
-                    kafkaAssembly.getSpec().getKafka().getReplicas(),
-                    kafkaAssembly.getSpec().getZookeeper().getReplicas());
-            updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly, secrets);
+            updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
         }
     }
 
-
-    private void updateCluster(TestContext context, Kafka originalAssembly, Kafka updatedAssembly, List<Secret> secrets) {
+    private void updateCluster(TestContext context, Kafka originalAssembly, Kafka updatedAssembly) {
         KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(originalAssembly);
-        originalKafkaCluster.generateCertificates(certManager, originalAssembly, secrets,  null, Collections.EMPTY_MAP);
         KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(updatedAssembly);
-        updatedKafkaCluster.generateCertificates(certManager, updatedAssembly, secrets,  null, Collections.EMPTY_MAP);
-        ZookeeperCluster originalZookeeperCluster = ZookeeperCluster.fromCrd(certManager, originalAssembly, secrets);
-        ZookeeperCluster updatedZookeeperCluster = ZookeeperCluster.fromCrd(certManager, updatedAssembly, secrets);
-        TopicOperator originalTopicOperator = TopicOperator.fromCrd(certManager, originalAssembly, secrets);
-        EntityOperator originalEntityOperator = EntityOperator.fromCrd(certManager, originalAssembly, secrets);
+        ZookeeperCluster originalZookeeperCluster = ZookeeperCluster.fromCrd(originalAssembly);
+        ZookeeperCluster updatedZookeeperCluster = ZookeeperCluster.fromCrd(updatedAssembly);
+        TopicOperator originalTopicOperator = TopicOperator.fromCrd(originalAssembly);
+        EntityOperator originalEntityOperator = EntityOperator.fromCrd(originalAssembly);
 
         // create CM, Service, headless service, statefulset and so on
         ResourceOperatorSupplier supplier = supplierWithMocks();
@@ -695,19 +660,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock Secret gets
         when(mockSecretOps.list(anyString(), any())).thenReturn(
-                secrets
-        );
-        when(mockSecretOps.get(clusterNamespace, KafkaCluster.clientsCASecretName(clusterName))).thenReturn(
-                originalKafkaCluster.generateClientsCASecret()
-        );
-        when(mockSecretOps.get(clusterNamespace, KafkaCluster.clientsPublicKeyName(clusterName))).thenReturn(
-                originalKafkaCluster.generateClientsPublicKeySecret()
-        );
-        when(mockSecretOps.get(clusterNamespace, KafkaCluster.clusterPublicKeyName(clusterNamespace))).thenReturn(
-                originalKafkaCluster.generateClusterPublicKeySecret()
-        );
-        when(mockSecretOps.get(clusterNamespace, KafkaCluster.brokersSecretName(clusterName))).thenReturn(
-                originalKafkaCluster.generateBrokersSecret()
+                emptyList()
         );
 
         // Mock NetworkPolicy get
@@ -852,9 +805,16 @@ public class KafkaAssemblyOperatorTest {
 
         // providing certificates Secrets for existing clusters
         List<Secret> fooSecrets = ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, "foo");
+        //ClusterCa fooCerts = ResourceUtils.createInitialClusterCa("foo", ModelUtils.findSecretWithName(fooSecrets, AbstractModel.getClusterCaName("foo")));
         List<Secret> barSecrets = ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, "bar",
                 bar.getSpec().getKafka().getReplicas(),
                 bar.getSpec().getZookeeper().getReplicas());
+        ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaKeyName("bar")));
+        ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsPublicKeyName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCASecretName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
@@ -862,19 +822,23 @@ public class KafkaAssemblyOperatorTest {
                 asList(KafkaCluster.fromCrd(bar).generateStatefulSet(openShift))
         );
 
-        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName())))).thenReturn(fooSecrets.get(0));
+        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName()))))
+                .thenReturn(
+                        fooSecrets.get(0));
         when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
         KafkaCluster barCluster = KafkaCluster.fromCrd(bar);
-        barCluster.generateCertificates(certManager, bar, barSecrets,  null, Collections.EMPTY_MAP);
         when(mockKsOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(barCluster.generateStatefulSet(openShift))
         );
-        when(mockSecretOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
-                new ArrayList<>(asList(barCluster.generateClientsCASecret(), barCluster.generateClientsPublicKeySecret(),
-                        barCluster.generateBrokersSecret(), barCluster.generateClusterPublicKeySecret()))
+        when(mockSecretOps.list(eq(clusterCmNamespace), eq(barLabels))).thenAnswer(
+            invocation -> new ArrayList<>(asList(
+                    barClientsCa.caKeySecret(),
+                    barClientsCa.caCertSecret(),
+                    barCluster.generateBrokersSecret(),
+                    barClusterCa.caCertSecret()))
         );
         when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
         when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -23,7 +23,6 @@ import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
-
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
@@ -13,12 +12,10 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.common.operator.MockCertManager;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.AbstractModel.containerEnvVars;
@@ -70,11 +67,6 @@ public class KafkaSetOperatorTest {
                     .endZookeeper()
                 .endSpec()
             .build();
-    }
-
-    private List<Secret> getInitialSecrets(String clusterName) {
-        String clusterCmNamespace = "test";
-        return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, clusterName);
     }
 
     private StatefulSetDiff diff() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
@@ -5,18 +5,16 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.operator.MockCertManager;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.AbstractModel.containerEnvVars;
@@ -36,8 +34,8 @@ public class ZookeeperSetOperatiorTest {
     @Before
     public void before() {
         MockCertManager certManager = new MockCertManager();
-        a = ZookeeperCluster.fromCrd(certManager, getResource(), getInitialSecrets(getResource().getMetadata().getName())).generateStatefulSet(true);
-        b = ZookeeperCluster.fromCrd(certManager, getResource(), getInitialSecrets(getResource().getMetadata().getName())).generateStatefulSet(true);
+        a = ZookeeperCluster.fromCrd(getResource()).generateStatefulSet(true);
+        b = ZookeeperCluster.fromCrd(getResource()).generateStatefulSet(true);
     }
 
     private Kafka getResource() {
@@ -50,9 +48,9 @@ public class ZookeeperSetOperatiorTest {
         return ResourceUtils.createKafkaCluster(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout);
     }
 
-    private List<Secret> getInitialSecrets(String clusterName) {
+    private ClusterCa getInitialSecrets(String clusterName) {
         String clusterCmNamespace = "test";
-        return ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, clusterName);
+        return ResourceUtils.createInitialClusterCa(clusterCmNamespace, clusterName);
     }
 
     private StatefulSetDiff diff() {

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# path were the Secret with certificates is mounted
-CERTS=/etc/tls-sidecar/certs
+# path were the Secret with EO certificates is mounted
+EO_CERTS_KEYS=/etc/tls-sidecar/eo-certs
+# Combine all the certs in the cluster CA into one file
+CA_CERTS=/tmp/cluster-ca.crt
+cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
 
 echo "pid = /usr/local/var/run/stunnel.pid"
 echo "foreground = yes"
@@ -10,9 +13,9 @@ echo "debug = info"
 cat <<-EOF
 [zookeeper-2181]
 client = yes
-CAfile = ${CERTS}/cluster-ca.crt
-cert = ${CERTS}/entity-operator.crt
-key = ${CERTS}/entity-operator.key
+CAfile = ${CA_CERTS}
+cert = ${EO_CERTS_KEYS}/entity-operator.crt
+key = ${EO_CERTS_KEYS}/entity-operator.key
 accept = 127.0.0.1:2181
 connect = ${STRIMZI_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
 verify = 2

--- a/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# path were the Secret with certificates is mounted
-CERTS=/etc/tls-sidecar/certs
+# path were the Secret with broker certificates is mounted
+KAFKA_CERTS_KEYS=/etc/tls-sidecar/kafka-brokers
+# Combine all the certs in the cluster CA into one file
+CA_CERTS=/tmp/cluster-ca.crt
+cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
 
 CURRENT=${BASE_HOSTNAME}-${KAFKA_BROKER_ID}
 
@@ -12,9 +15,9 @@ echo "debug = info"
 cat <<-EOF
 [zookeeper-2181]
 client = yes
-CAfile = ${CERTS}/cluster-ca.crt
-cert = ${CERTS}/${CURRENT}.crt
-key = ${CERTS}/${CURRENT}.key
+CAfile = ${CA_CERTS}
+cert = ${KAFKA_CERTS_KEYS}/${CURRENT}.crt
+key = ${KAFKA_CERTS_KEYS}/${CURRENT}.key
 accept = 127.0.0.1:2181
 connect = ${KAFKA_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
 verify = 2

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -17,17 +17,33 @@ function create_truststore {
 # $5: CA public key to be imported
 # $6: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $6 -password pass:$2 -out $1
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $6 -password pass:$2 -out $1
 }
 
 echo "Preparing truststore for replication listener"
-create_truststore /tmp/kafka/cluster.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/broker-certs/cluster-ca.crt cluster-ca
+# Add each certificate to the trust store
+STORE=/tmp/kafka/cluster.truststore.p12
+for CRT in /opt/kafka/cluster-ca-certs/*.crt; do
+  ALIAS=$(basename "$CRT" .crt)
+  echo "Adding $CRT to truststore $STORE with alias $ALIAS"
+  create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+done
 echo "Preparing truststore for replication listener is complete"
 
 echo "Preparing keystore for replication and clienttls listener"
-create_keystore /tmp/kafka/cluster.keystore.p12 $CERTS_STORE_PASSWORD /opt/kafka/broker-certs/$HOSTNAME.crt /opt/kafka/broker-certs/$HOSTNAME.key /opt/kafka/broker-certs/cluster-ca.crt $HOSTNAME
+create_keystore /tmp/kafka/cluster.keystore.p12 $CERTS_STORE_PASSWORD \
+    /opt/kafka/broker-certs/$HOSTNAME.crt \
+    /opt/kafka/broker-certs/$HOSTNAME.key \
+    /opt/kafka/cluster-ca-certs/ca.crt \
+    $HOSTNAME
 echo "Preparing keystore for replication and clienttls listener is complete"
 
 echo "Preparing truststore for clienttls listener"
-create_truststore /tmp/kafka/clients.truststore.p12 $CERTS_STORE_PASSWORD /opt/kafka/client-ca-cert/ca.crt clients-ca
+# Add each certificate to the trust store
+STORE=/tmp/kafka/clients.truststore.p12
+for CRT in /opt/kafka/client-ca-certs/*.crt; do
+  ALIAS=$(basename "$CRT" .crt)
+  echo "Adding $CRT to truststore $STORE with alias $ALIAS"
+  create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+done
 echo "Preparing truststore for clienttls listener is complete"

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
+    #!/bin/bash
 
-# path were the Secret with certificates is mounted
-CERTS=/etc/tls-sidecar/certs
+# path were the Secret with ZK nodes certificates is mounted
+NODE_CERTS_KEYS=/etc/tls-sidecar/zookeeper-nodes
+# Combine all the certs in the cluster CA into one file
+CA_CERTS=/tmp/cluster-ca.crt
+cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
 
 echo "pid = /usr/local/var/run/stunnel.pid"
 echo "foreground = yes"
@@ -24,9 +27,9 @@ do
 			cat <<-EOF
 			[${PEER}-$port]
 			client = yes
-			CAfile = ${CERTS}/cluster-ca.crt
-			cert = ${CERTS}/${CURRENT}.crt
-			key = ${CERTS}/${CURRENT}.key
+			CAfile = ${CA_CERTS}
+			cert = ${NODE_CERTS_KEYS}/${CURRENT}.crt
+			key = ${NODE_CERTS_KEYS}/${CURRENT}.key
 			accept = 127.0.0.1:$(expr $port \* 10 + $NODE - 1)
 			connect = ${PEER}.${BASE_FQDN}:$port
 			verify = 2
@@ -43,9 +46,9 @@ do
 	cat <<-EOF
 	[listener-$port]
 	client = no
-	CAfile = ${CERTS}/cluster-ca.crt
-	cert = ${CERTS}/${CURRENT}.crt
-	key = ${CERTS}/${CURRENT}.key
+	CAfile = ${CA_CERTS}
+	cert = ${NODE_CERTS_KEYS}/${CURRENT}.crt
+	key = ${NODE_CERTS_KEYS}/${CURRENT}.key
 	accept = $port
 	connect = 127.0.0.1:$CONNECTOR_PORT
 	verify = 2
@@ -59,9 +62,9 @@ CLIENT_PORT=$(expr 21810 + $ZOOKEEPER_ID - 1)
 cat <<-EOF
 [listener-2181]
 client = no
-CAfile = ${CERTS}/cluster-ca.crt
-cert = ${CERTS}/${CURRENT}.crt
-key = ${CERTS}/${CURRENT}.key
+CAfile = ${CA_CERTS}
+cert = ${NODE_CERTS_KEYS}/${CURRENT}.crt
+key = ${NODE_CERTS_KEYS}/${CURRENT}.key
 accept = 2181
 connect = 127.0.0.1:$CLIENT_PORT
 verify = 2

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -20,14 +20,16 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Field                  |Description
-|kafka           1.2+<.<|Configuration of the Kafka cluster.
+|Field                   |Description
+|kafka            1.2+<.<|Configuration of the Kafka cluster.
 |xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
-|zookeeper       1.2+<.<|Configuration of the Zookeeper cluster.
+|zookeeper        1.2+<.<|Configuration of the Zookeeper cluster.
 |xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
-|topicOperator   1.2+<.<|Configuration of the Topic Operator.
+|topicOperator    1.2+<.<|Configuration of the Topic Operator.
 |xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
-|entityOperator  1.2+<.<|Configuration of the Entity Operator.
+|tlsCertificates  1.2+<.<|Configuration of how TLS certificates are handled.
+|xref:type-TlsCertificates-{context}[`TlsCertificates`]
+|entityOperator   1.2+<.<|Configuration of the Entity Operator.
 |xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |====
 
@@ -453,6 +455,24 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-Sidecar-{context}[`Sidecar`]
 |logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|====
+
+[id='type-TlsCertificates-{context}']
+### `TlsCertificates` schema reference
+
+Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
+
+Configuration of how TLS certificates are used within the cluster.This applies to certificates used for both internal communication within the cluster and to certificates used for client access via `Kafka.spec.kafka.listeners.tls`.
+
+[options="header"]
+|====
+|Field                                |Description
+|generateCertificateAuthority  1.2+<.<|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
+|boolean
+|validityDays                  1.2+<.<|The number of days generated certificates should be valid for. Default is 365.
+|integer
+|renewalDays                   1.2+<.<|The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed.When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
+|integer
 |====
 
 [id='type-EntityOperatorSpec-{context}']

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -943,6 +943,17 @@ spec:
                       type: string
                     type:
                       type: string
+            tlsCertificates:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
             entityOperator:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -947,6 +947,17 @@ spec:
                       type: string
                     type:
                       type: string
+            tlsCertificates:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
             entityOperator:
               type: object
               properties:

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
+import io.strimzi.certs.SecretCertProvider;
+import io.strimzi.certs.Subject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+/**
+ * A Certificate Authority which can renew its own (self-signed) certificates, and generate signed certificates
+ */
+public abstract class Ca {
+
+    protected static final Logger log = LogManager.getLogger(Ca.class);
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('-')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral('-')
+            .appendValue(DAY_OF_MONTH, 2)
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral('-')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .optionalStart()
+            .appendOffsetId()
+            .toFormatter().withChronology(IsoChronology.INSTANCE);
+    public static final String CA_KEY = "ca.key";
+    public static final String CA_CRT = "ca.crt";
+    public static final String IO_STRIMZI = "io.strimzi";
+
+    protected final CertManager certManager;
+    protected final int validityDays;
+    protected final int renewalDays;
+    private final boolean generateCa;
+    protected String caCertSecretName;
+    private Secret caCertSecret;
+    protected String caKeySecretName;
+    private Secret caKeySecret;
+    private boolean needsRenewal;
+    private boolean certsRemoved;
+
+    public Ca(CertManager certManager,
+              String caCertSecretName, Secret caCertSecret,
+              String caKeySecretName, Secret caKeySecret,
+              int validityDays, int renewalDays, boolean generateCa) {
+        this.caCertSecret = caCertSecret;
+        this.caCertSecretName = caCertSecretName;
+        this.caKeySecret = caKeySecret;
+        this.caKeySecretName = caKeySecretName;
+        this.certManager = certManager;
+        this.validityDays = validityDays;
+        this.renewalDays = renewalDays;
+        this.generateCa = generateCa;
+    }
+
+    private static void delete(File brokerCsrFile) {
+        if (!brokerCsrFile.delete()) {
+            log.warn("{} cannot be deleted", brokerCsrFile.getName());
+        }
+    }
+
+    private static CertAndKey asCertAndKey(Secret secret, String key, String cert) {
+        Base64.Decoder decoder = Base64.getDecoder();
+        return secret == null ? null : new CertAndKey(
+                decoder.decode(secret.getData().get(key)),
+                decoder.decode(secret.getData().get(cert)));
+    }
+
+    private CertAndKey generateSignedCert(Subject subject,
+                                            File csrFile, File keyFile, File certFile) throws IOException {
+
+        log.debug("Generating certificate {} with SAN {}, signed by CA {}", subject, subject.subjectAltNames(), this);
+
+        certManager.generateCsr(keyFile, csrFile, subject);
+        certManager.generateCert(csrFile, currentCaKey(), currentCaCertBytes(),
+                certFile, subject, validityDays);
+
+        return new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
+    }
+
+    /**
+     * Generates a certificate signed by this CA
+     */
+    public CertAndKey generateSignedCert(String commonName) throws IOException {
+        File csrFile = File.createTempFile("tls", "csr");
+        File keyFile = File.createTempFile("tls", "key");
+        File certFile = File.createTempFile("tls", "cert");
+
+        Subject subject = new Subject();
+        subject.setOrganizationName("io.strimzi");
+        subject.setCommonName(commonName);
+
+        CertAndKey result = generateSignedCert(subject,
+                csrFile, keyFile, certFile);
+
+        delete(csrFile);
+        delete(keyFile);
+        delete(certFile);
+        return result;
+    }
+
+    /**
+     * Copy already existing certificates from provided Secret based on number of effective replicas
+     * and maybe generate new ones for new replicas (i.e. scale-up).
+     */
+    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(
+           int replicas,
+           Function<Integer, Subject> subjectFn,
+           Secret secret,
+           Function<Integer, String> podNameFn) throws IOException {
+        int replicasInSecret = secret == null || this.certRenewed() ? 0 : (secret.getData().size() - 1) / 2;
+        Map<String, CertAndKey> certs = new HashMap<>();
+        // copying the minimum number of certificates already existing in the secret
+        // scale up -> it will copy all certificates
+        // scale down -> it will copy just the requested number of replicas
+        for (int i = 0; i < Math.min(replicasInSecret, replicas); i++) {
+
+            String podName = podNameFn.apply(i);
+            log.debug("Certificate for {} already exists", podName);
+            certs.put(
+                    podName,
+                    asCertAndKey(secret, podName + ".key", podName + ".crt"));
+        }
+
+        File brokerCsrFile = File.createTempFile("tls", "broker-csr");
+        File brokerKeyFile = File.createTempFile("tls", "broker-key");
+        File brokerCertFile = File.createTempFile("tls", "broker-cert");
+
+        // generate the missing number of certificates
+        // scale up -> generate new certificates for added replicas
+        // scale down -> does nothing
+        for (int i = replicasInSecret; i < replicas; i++) {
+            String podName = podNameFn.apply(i);
+            log.debug("Certificate for {} to generate", podName);
+            CertAndKey k = generateSignedCert(subjectFn.apply(i),
+                    brokerCsrFile, brokerKeyFile, brokerCertFile);
+            certs.put(podName, k);
+        }
+        delete(brokerCsrFile);
+        delete(brokerKeyFile);
+        delete(brokerCertFile);
+
+        return certs;
+    }
+
+    /**
+     * Replaces the CA secret if it is within the renewal period.
+     * After calling this method {@link #certRenewed()} and {@link #certsRemoved()}
+     * will return whether the certificate was renewed and whether expired secrets were removed from the Secret.
+     */
+    public void createOrRenew(String namespace, String clusterName, Map<String, String> labels, OwnerReference ownerRef) {
+        X509Certificate currentCert = cert(caCertSecret, CA_CRT);
+        this.needsRenewal = currentCert != null && certNeedsRenewal(currentCert);
+        if (needsRenewal) {
+            log.debug("{}: CA certificate in secret {} needs to be renewed", this, caCertSecretName);
+        }
+        Map<String, String> certData;
+        Map<String, String> keyData;
+        if (!generateCa) {
+            certData = checkProvidedCert(namespace, clusterName, caCertSecret, currentCert);
+            keyData = caKeySecret != null ? singletonMap(CA_KEY, caKeySecret.getData().get(CA_KEY)) : emptyMap();
+            certsRemoved = false;
+        } else {
+            if (caCertSecret == null
+                    || caCertSecret.getData().get(CA_CRT) == null
+                    || caKeySecret == null
+                    || caKeySecret.getData().get(CA_KEY) == null
+                    || needsRenewal) {
+                try {
+                    Map<String, String>[] newData = createOrRenewCert(currentCert);
+                    certData = newData[0];
+                    keyData = newData[1];
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                log.debug("{}: The CA certificate in secret {} already exists and does not need renewing", this, caCertSecretName);
+                certData = caCertSecret.getData();
+                keyData = caKeySecret.getData();
+            }
+            this.certsRemoved = removeExpiredCerts(certData) > 0;
+        }
+        SecretCertProvider secretCertProvider = new SecretCertProvider();
+
+        if (certsRemoved) {
+            log.info("{}: Expired CA certificates removed", this);
+        }
+        if (needsRenewal) {
+            log.info("{}: Certificates renewed", this);
+        }
+
+        caCertSecret = secretCertProvider.createSecret(namespace, caCertSecretName, certData, labels, ownerRef);
+        caKeySecret = secretCertProvider.createSecret(namespace, caKeySecretName, keyData, labels, ownerRef);
+    }
+
+    /**
+     * Gets the CA cert secret, which contains both the current CA cert and also previous, still valid certs.
+     */
+    public Secret caCertSecret() {
+        return caCertSecret;
+    }
+
+    /**
+     * Gets the CA key secret, which contains the current CA private key.
+     */
+    public Secret caKeySecret() {
+        return caKeySecret;
+    }
+
+    public byte[] currentCaCertBytes() {
+        Base64.Decoder decoder = Base64.getDecoder();
+        return decoder.decode(caCertSecret().getData().get(CA_CRT));
+    }
+
+    public String currentCaCertBase64() {
+        return caCertSecret().getData().get(CA_CRT);
+    }
+
+    public byte[] currentCaKey() {
+        Base64.Decoder decoder = Base64.getDecoder();
+        return decoder.decode(caKeySecret().getData().get(CA_KEY));
+    }
+
+    /**
+     * True if the last call to {@link #createOrRenew(String, String, Map, OwnerReference)}
+     * resulted in expired certificates being removed from the CA Secret.
+     */
+    public boolean certsRemoved() {
+        return this.certsRemoved;
+    }
+
+    /**
+     * True if the last call to {@link #createOrRenew(String, String, Map, OwnerReference)}
+     * resulted in a renewed CA certificate.
+     */
+    public boolean certRenewed() {
+        return this.needsRenewal;
+    }
+
+    private int removeExpiredCerts(Map<String, String> newData) {
+        int removed = 0;
+        Iterator<String> iter = newData.keySet().iterator();
+        while (iter.hasNext()) {
+            Pattern pattern = Pattern.compile("ca-" + "([0-9T:-]{19}).(crt|key)");
+            String key = iter.next();
+            Matcher matcher = pattern.matcher(key);
+
+            if (matcher.matches()) {
+                String date = matcher.group(1) + "Z";
+                Instant parse = DATE_TIME_FORMATTER.parse(date, Instant::from);
+                if (parse.isBefore(Instant.now())) {
+                    log.debug("Removing {} from Secret because it has expired", key);
+                    iter.remove();
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+
+    private Map<String, String>[] createOrRenewCert(X509Certificate currentCert) throws IOException {
+        Map<String, String> newData;
+        log.debug("Generating new certificate {} to be stored in {}", CA_CRT, caCertSecretName);
+        // TODO factor out the common name
+        CertAndKey ca = generateCa("cluster-ca");
+        Map<String, String> certData = new HashMap<>();
+        Map<String, String> keyData = new HashMap<>();
+        if (currentCert != null) {
+            // Add the current certificate as an old certificate (with date in UTC)
+            String notAfterDate = DATE_TIME_FORMATTER.format(currentCert.getNotAfter().toInstant().atZone(ZoneId.of("Z")));
+            // TODO factor out this naming scheme
+            certData.put("ca-" + notAfterDate + ".crt", caCertSecret.getData().get(CA_CRT));
+        }
+        // Add the generated certificate as the current certificate
+        certData.put(CA_CRT, ca.certAsBase64String());
+        keyData.put(CA_KEY, ca.keyAsBase64String());
+
+        log.debug("End generating certificate {} to be stored in {}", CA_CRT, caCertSecretName);
+        return new Map[]{certData, keyData};
+    }
+
+    private Map<String, String> checkProvidedCert(String namespace, String clusterName,
+                                                  Secret clusterCa, X509Certificate currentCert) {
+        Map<String, String> newData;
+        if (needsRenewal) {
+            log.warn("The {} certificate in Secret {} in namespace {} will expire on {} " +
+                            "and it is not configured to automatically renew. This needs to be manually updated before that date. " +
+                            "Alternatively, configure Kafka.spec.tlsCertificates.generateCertificateAuthority=true in the Kafka resource with name {} in namespace {}.",
+                    CA_CRT, caCertSecretName, namespace, currentCert.getNotAfter());
+        } else if (clusterCa == null) {
+            log.warn("The certificate (data.{}) in Secret {} and the private key (data.{}) in Secret {} in namespace {} " +
+                            "needs to be configured with a Base64 encoded PEM-format certificate. " +
+                            "Alternatively, configure Kafka.spec.tlsCertificates.generateCertificateAuthority=true in the Kafka resource with name {} in namespace {}.",
+                    CA_CRT, this.caCertSecretName,
+                    CA_KEY, this.caKeySecretName, namespace,
+                    clusterName, namespace);
+        }
+        newData = clusterCa != null ? clusterCa.getData() : emptyMap();
+        return newData;
+    }
+
+    private boolean certNeedsRenewal(X509Certificate cert)  {
+        Date notAfter = cert.getNotAfter();
+        log.trace("Certificate {} expires on {}", cert.getSubjectDN(), notAfter);
+        long msTillExpired = notAfter.getTime() - System.currentTimeMillis();
+        return msTillExpired < renewalDays * 24L * 60L * 60L * 1000L;
+    }
+
+    static X509Certificate cert(Secret secret, String key)  {
+        if (secret == null || secret.getData().get(key) == null) {
+            return null;
+        }
+        Base64.Decoder decoder = Base64.getDecoder();
+        byte[] bytes = decoder.decode(secret.getData().get(key));
+        return x509Certificate("Certificate in key " + key + " of Secret " + secret.getMetadata().getName(), bytes);
+    }
+
+    static X509Certificate x509Certificate(String logCtx, byte[] bytes) {
+        CertificateFactory factory = certificateFactory();
+        return x509Certificate(logCtx, factory, bytes);
+    }
+
+    static X509Certificate x509Certificate(String logCtx, CertificateFactory factory, byte[] bytes) {
+        try {
+            Certificate certificate = factory.generateCertificate(new ByteArrayInputStream(bytes));
+            if (certificate instanceof X509Certificate) {
+                return (X509Certificate) certificate;
+            } else {
+                throw new RuntimeException(logCtx + " is not an X509Certificate");
+            }
+        } catch (CertificateException e) {
+            throw new RuntimeException(logCtx + " could not be parsed");
+        }
+    }
+
+    static CertificateFactory certificateFactory() {
+        CertificateFactory factory = null;
+        try {
+            factory = CertificateFactory.getInstance("X.509");
+        } catch (CertificateException e) {
+            throw new RuntimeException("No security provider with support for X.509 certificates", e);
+        }
+        return factory;
+    }
+
+    private CertAndKey generateCa(String commonName) throws IOException {
+        log.debug("Generating CA with cn={}, org={}", commonName, IO_STRIMZI);
+        File keyFile = File.createTempFile("tls", commonName + "-key");
+        try {
+            File certFile = File.createTempFile("tls", commonName + "-cert");
+            try {
+
+                Subject sbj = new Subject();
+                sbj.setOrganizationName(IO_STRIMZI);
+                sbj.setCommonName(commonName);
+
+                certManager.generateSelfSignedCert(keyFile, certFile, sbj, validityDays);
+                return new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
+            } finally {
+                delete(certFile);
+            }
+        } finally {
+            delete(keyFile);
+        }
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.certs.CertManager;
+
+public class ClientsCa extends Ca {
+    public ClientsCa(CertManager certManager, String caCertSecretName, Secret clientsCaCert,
+                     String caSecretKeyName, Secret clientsCaKey,
+                     int validityDays, int renewalDays, boolean generateCa) {
+        super(certManager, caCertSecretName, clientsCaCert,
+                caSecretKeyName, clientsCaKey,
+                validityDays, renewalDays, generateCa);
+    }
+
+    @Override
+    public String toString() {
+        return "clients-ca";
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -163,6 +163,23 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
     }
 
     /**
+     * Asynchronously gets the resource with the given {@code name} in the given {@code namespace}.
+     * @param namespace The namespace.
+     * @param name The name.
+     * @return A Future for the result.
+     */
+    public Future<T> getAsync(String namespace, String name) {
+        Future<T> result = Future.future();
+        vertx.createSharedWorkerExecutor("kubernetes-ops-tool").executeBlocking(
+            future -> {
+                T resource = get(namespace, name);
+                future.complete(resource);
+            }, true, result.completer()
+        );
+        return result;
+    }
+
+    /**
      * Synchronously list the resources in the given {@code namespace} with the given {@code selector}.
      * @param namespace The namespace.
      * @param selector The selector.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -30,6 +30,9 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
             R extends ScalableResource<T, D>>
         extends AbstractReadyResourceOperator<C, T, L, D, R> {
 
+    public static final String STRIMZI_CLUSTER_OPERATOR_DOMAIN = "operator.strimzi.io";
+    public static final String ANNOTATION_GENERATION = STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/generation";
+
     private final Logger log = LogManager.getLogger(getClass());
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -5,17 +5,20 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentList;
 import io.fabric8.kubernetes.api.model.extensions.DoneableDeployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
  * Operations for {@code Deployment}s.
  */
 public class DeploymentOperator extends AbstractScalableResourceOperator<KubernetesClient, Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>> {
+
     /**
      * Constructor
      * @param vertx The Vertx instance
@@ -38,5 +41,33 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
         } else {
             return null;
         }
+    }
+
+    /**
+     * Asynchronously roll the deployment returning a Future which will complete once all the pods have been rolled
+     * and the Deployment is ready.
+     */
+    public Future<Void> rollingUpdate(String namespace, String name, long operationTimeoutMs) {
+        return getAsync(namespace, name)
+                .compose(deployment -> reconcile(namespace, name, incrementGeneration(deployment)))
+                .compose(ignored -> readiness(namespace, name, 1_000, operationTimeoutMs));
+    }
+
+    private Deployment incrementGeneration(Deployment deployment) {
+        String generationStr = deployment.getSpec().getTemplate().getMetadata().getAnnotations().get(ANNOTATION_GENERATION);
+        int generation = 0;
+        if (generationStr != null && !generationStr.isEmpty()) {
+            generation = Integer.parseInt(generationStr);
+            generation++;
+        }
+        return new DeploymentBuilder(deployment)
+                .editSpec()
+                    .editTemplate()
+                        .editMetadata()
+                            .addToAnnotations(ANNOTATION_GENERATION, Integer.toString(generation))
+                        .endMetadata()
+                    .endTemplate()
+                .endSpec()
+            .build();
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
@@ -11,11 +11,18 @@ public abstract class ReconcileResult<R> {
             return "DELETED";
         }
     };
-    private static final ReconcileResult NOOP = new ReconcileResult(null) {
+
+    public static class Noop<R> extends ReconcileResult<R> {
+        private Noop() {
+            super(null);
+        }
+
         public String toString() {
             return "NOOP";
         }
-    };
+    }
+
+    private static final ReconcileResult NOOP = new Noop();
 
     public static class Created<R> extends ReconcileResult<R> {
         private Created(R resource) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -10,8 +10,125 @@ import io.strimzi.certs.Subject;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Base64;
 
 public class MockCertManager implements CertManager {
+
+    private static final String CLUSTER_KEY = "-----BEGIN PRIVATE KEY-----\n" +
+            "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDbFnJj90sKoM35\n" +
+            "VszJsfwNvO5dshoeFIb2idf7h+l0h3GMv29j+1XtmLJGzxiYy320KFZr3IKWbq+D\n" +
+            "abqdlqEqZm9NZ1Kq9d7mB10zulQce5JwVZ3FqpCmLku2jHCaDXzTKC3T/Xp0O9Oe\n" +
+            "8+42ysSMCTd8p8aZ4vAyJMCKcoyVCGHrUWVba40D7cQNOlhJplSzHZdLFYZ13kwz\n" +
+            "pT5GpDEPhGVmtF8qV918lSxvdpuepyeFdOSYY88FEMMLLrlZG4QCPyES4FpcUXMz\n" +
+            "zvZeLIlZnKNIYbao3Kx+yZv//wjC80/pqdyoZ5+K5hDxjby2+f+2dh0TadKRZC2p\n" +
+            "p+j3/z63AgMBAAECggEBAJN5iai25uGRmvSzNAi08VkCC2YwpBoJcUv1P9jGBST2\n" +
+            "oz2+AypHHfFgruixMPpxR/2EhZ/3gEPo3+ZSvlaj9XrIFzYATgpclR08acWPMF03\n" +
+            "5TwOtbQ/+zyRv09zO7zHRXYR/r9LSimBuBKwWnKxjRpCfgJAIZSmyU7HpH/NWcpa\n" +
+            "6khQen5zQVsjnlv3L5OSN8exP8okVYY01JmrKTyo3IWsOiTogr1ebe84xvG2QzkV\n" +
+            "fdL99poVfXXSBivLwgGPiCNkZFtwcjDRECzBHAcrwYT1AIHsvsWvdbrXilAh/388\n" +
+            "1v3HWw7lfnJi8WV9iAplq1YOEwqKN6z5Y/wwAZQafHECgYEA8F3lGtOUIMeaTXeI\n" +
+            "9xlXAM1MXQPPxguMFS9ilcnqlTdNJjJ18FBWM/Kn73RF9mTCQCYn+5o6MmoyMQIq\n" +
+            "rreBchP7Bzg7RCKVvPnippqwVDeLY7khdA0I1lH6mD7urhBvO5Fby3wKZeJfi2N9\n" +
+            "suQzEuRDEw5EDHQf/0rP4RBnrg8CgYEA6VZBUKuur885Q/knRUKdIG/mXYAcvmAV\n" +
+            "I6kjFCVRx7lQ8xLTiagKo0SKr0TM0Qf1+4vqTUZCOBtGlW/UBdGW8yPvXegyMHQg\n" +
+            "pMoNCTnxgXS77f4pnluQRQux8M8oWJnf11oGxDHhLw0T7kqBHl9K/dw/cItRS5Ui\n" +
+            "Dch/2YDMDNkCgYBNqZjXxRrsSHHTq9amOBrDWJHez9d3Hs4BHlFVImtYEQktWUp/\n" +
+            "/gUMPdAC72eXh9C3l1x9z8QT+/oBmbiewQ3jBQ+rsoB7sEz/RSH1QK/OVjAEZZGo\n" +
+            "hHmhfdVhEZxew1KdRYcKRSa66pyCVgAMJ+1UokoFwys7dt3Lx6lJB9roAwKBgCRN\n" +
+            "OxQl4aOQhcRBew6XcoKdZiWdzNsBb8iAg+iadcKw3hszDp4X+q+z9i+WcJcEugxM\n" +
+            "lEM5bwvzkmOlZkMRfH6PVKozebt4FawNk0GgNiaB1ssMA8WTUTqsux5P3GMMbXq/\n" +
+            "ktXrPLFpQ3SLOtNS2APuxB/qTNeJeCbUzq80DorhAoGBALAU7AWjjxgjCJlVKcfc\n" +
+            "iFeFh0W3HnNMQfn/ukha2Mg4Nl4GdLN18wx5VGpSCMEZ415cCy5S0SXxuUE5l6G1\n" +
+            "Pb2gYF9JyGhXJLMF2x9k4he4j/qHu9RCvixYlbb/jN59aifJxTeOG53g0Fo+H9U1\n" +
+            "432A3bs1MPT1Ew7zgnxjznt8\n" +
+            "-----END PRIVATE KEY-----\n";
+    private static final String CLUSTER_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDhjCCAm6gAwIBAgIJANzx2pPcYgmlMA0GCSqGSIb3DQEBCwUAMFcxCzAJBgNV\n" +
+            "BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg\n" +
+            "Q29tcGFueSBMdGQxEzARBgNVBAMMCmNsdXN0ZXItY2EwIBcNMTgwODIzMTYxOTU0\n" +
+            "WhgPMjExODA3MzAxNjE5NTRaMFcxCzAJBgNVBAYTAlhYMRUwEwYDVQQHDAxEZWZh\n" +
+            "dWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEzARBgNVBAMM\n" +
+            "CmNsdXN0ZXItY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDbFnJj\n" +
+            "90sKoM35VszJsfwNvO5dshoeFIb2idf7h+l0h3GMv29j+1XtmLJGzxiYy320KFZr\n" +
+            "3IKWbq+DabqdlqEqZm9NZ1Kq9d7mB10zulQce5JwVZ3FqpCmLku2jHCaDXzTKC3T\n" +
+            "/Xp0O9Oe8+42ysSMCTd8p8aZ4vAyJMCKcoyVCGHrUWVba40D7cQNOlhJplSzHZdL\n" +
+            "FYZ13kwzpT5GpDEPhGVmtF8qV918lSxvdpuepyeFdOSYY88FEMMLLrlZG4QCPyES\n" +
+            "4FpcUXMzzvZeLIlZnKNIYbao3Kx+yZv//wjC80/pqdyoZ5+K5hDxjby2+f+2dh0T\n" +
+            "adKRZC2pp+j3/z63AgMBAAGjUzBRMB0GA1UdDgQWBBThuvddCb/5TPSKYNOHkCTL\n" +
+            "VghhRzAfBgNVHSMEGDAWgBThuvddCb/5TPSKYNOHkCTLVghhRzAPBgNVHRMBAf8E\n" +
+            "BTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBA6oTI27dJgbVtyWxQWznKrkznZ9+t\n" +
+            "mQQGbpfl9zEg7/0X7fFb+m84QHro+aNnQ4kTgZ6QBvusIpwfx1F6lQrraVrPr142\n" +
+            "4DqGmY9xReNu/fj+C+8lTI5PA+mE7tMrLpQvKxI+AMttvlz8eo1SITUA+kJEiWZX\n" +
+            "mjvyHXmhic4K8SnnB0gnFzHN4y09wLqRMNCRH+aI+sa9Wu8cqvpTqlelVcYV83zu\n" +
+            "ydx4VZkC+zTzjI418znN/NU2CMpxLZNl0/zCrspID7v34NRmJ1AHFcrn7/XhsSvz\n" +
+            "D0z+vgrfionoRhyWUDh7POlWwdUOWiBDBOFrkgeKNphSC0glYFN+2IW7\n" +
+            "-----END CERTIFICATE-----\n";
+    private static final String CLIENTS_KEY = "-----BEGIN PRIVATE KEY-----\n" +
+            "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCWws5FEJOpfZ/s\n" +
+            "FJWYbYdJVxmZB+5PjCwA2TUZxF/3P4w/5g2KZaXNy89AfBC5vRDRgyDyj/RwcDg8\n" +
+            "0kDGKobcGhTx5YkWoNvR/2WuTN6KC8DM78bfEREDHDxiXfAXrMIi7Ux2FvUX13l7\n" +
+            "6Sp9kiG3ETLjFom3n/qhg1ITJqPJSJi3tey0o2Pd5Arv0MIhQyep++URtZfND5fg\n" +
+            "F5x7hgnSf9Q1P1dJnVadu+ohUmmG7g+zX4rTqjN2jmHcf9V4lLKdPGWwLQEGnP9y\n" +
+            "Dqlm8x12M/BcIJasRgcciVsKYFuXe09NEYBvUjW8L6gaQ6U9wcYZ2MlKW/8LMGkS\n" +
+            "FfO4quAJAgMBAAECggEAQ1NdsEQV3UQHrfMHV1naZ6so+EktaILNh9d4OjiTLqRH\n" +
+            "aqW++EYqhDv3IvIEuh2vrBCmHwygebHzu12dpaGKNjLDlb8OuHc/k4k9jFgxrW5Q\n" +
+            "PHT719QUR9JNORSASuJQlC5qzfW0oGAOlYJsAkXHHqzkj7sZ51HfKE+v0HOaAyHj\n" +
+            "8gOeBNk1Mtb3Sj5mXpWFQGpXXuG01Vsjj7Nj/91a4KtWAWOqeagc2Bk+C0aZ7d1p\n" +
+            "SQcLVWjJYwoejgCc2elZxzbfmDtVSAgFtdTPxwf9uflMducTfp/RyaQbzuYSrSmz\n" +
+            "rnZq/59i9lYl314rjjkCusDaDSPdK5QziN54tQ+BcQKBgQDE9ulPecHtZhOsI9zT\n" +
+            "J+xTJtZq1w8kFV5jMqXnL3jAFBXsC3s02KLq36ppvf8kVzUHrHE+DiWnHKEIiy/U\n" +
+            "luMnPvJb/6qqdQNDpcrF+CE2JevvoPl5hrKdyzAI4TNu96aU+9qVrO2rB7bWBvlA\n" +
+            "dVwIZ8zkk3pwbdEj9rYpMA1VVQKBgQDD8rJAEd9fLtX53NQh8XWEJ1dEfncmg/ib\n" +
+            "0vyoYlqSDjPTot85sCunVZNHwUoKUsukzi+Tc9hxaXCjEB6ICVeXqWc4PYnbK79H\n" +
+            "N+2X6YaO/rKAzbxM1F/Km3IzzvoXFJnPG4hxvBmpdApKgBGOVixnjD7PzNz4jh9u\n" +
+            "1qhDocdf5QKBgQCDsLqporTgr0Ez9P5uR+Egb3UpFgVPkOH83R5Dhl/rvQIzQjHs\n" +
+            "UXQMKeNcs+XlPFF+gfNtFDRkmSWp+rXOI9xYnyOYE0belUHLdwwudQpvk8c9/pkO\n" +
+            "gdrm2bWSGlAzP22nawTo0ihOE+hRDXSVfmI8VHqP0XMpvKL6srd0rmYbyQKBgAYD\n" +
+            "PXr/0WXfTwuSviOogB2lA2WDp+5ToF5PtBcKpZLTwr1cwxLHGB/TXWiXQslcTwlo\n" +
+            "lkclB+A7BwzJ4tXzy29I8HTmVoOWLRFnYvAFZ26d3CZdqciFv8a8zF1QnZX1uN6F\n" +
+            "DsPGrNbpS6OLmH5QoJ4wzICd3a321noVNiaVIUQNAoGAYu4RrGcBKRuy75lfKARD\n" +
+            "gNxxVlvuI33ieK/3A9nUWc3LXl5D/yiSePCUs4giOwi2gFrGjcmIqLXZE5XUYGEu\n" +
+            "zXWWQCGbMqyX15/A2/eTuj658F292nkSyU/5U2999WjCm79sfnGJB1zavfv2fzGK\n" +
+            "g4trXCUkjAVG3Toaq05saGM=\n" +
+            "-----END PRIVATE KEY-----\n";
+    private static final String CLIENTS_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDhjCCAm6gAwIBAgIJAOKzFJgrn+rZMA0GCSqGSIb3DQEBCwUAMFcxCzAJBgNV\n" +
+            "BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg\n" +
+            "Q29tcGFueSBMdGQxEzARBgNVBAMMCmNsaWVudHMtY2EwIBcNMTgwODIzMTYyMTI1\n" +
+            "WhgPMjExODA3MzAxNjIxMjVaMFcxCzAJBgNVBAYTAlhYMRUwEwYDVQQHDAxEZWZh\n" +
+            "dWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEzARBgNVBAMM\n" +
+            "CmNsaWVudHMtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCWws5F\n" +
+            "EJOpfZ/sFJWYbYdJVxmZB+5PjCwA2TUZxF/3P4w/5g2KZaXNy89AfBC5vRDRgyDy\n" +
+            "j/RwcDg80kDGKobcGhTx5YkWoNvR/2WuTN6KC8DM78bfEREDHDxiXfAXrMIi7Ux2\n" +
+            "FvUX13l76Sp9kiG3ETLjFom3n/qhg1ITJqPJSJi3tey0o2Pd5Arv0MIhQyep++UR\n" +
+            "tZfND5fgF5x7hgnSf9Q1P1dJnVadu+ohUmmG7g+zX4rTqjN2jmHcf9V4lLKdPGWw\n" +
+            "LQEGnP9yDqlm8x12M/BcIJasRgcciVsKYFuXe09NEYBvUjW8L6gaQ6U9wcYZ2MlK\n" +
+            "W/8LMGkSFfO4quAJAgMBAAGjUzBRMB0GA1UdDgQWBBQUwNmfsNj+PM240pVPxYx9\n" +
+            "Q9eQhDAfBgNVHSMEGDAWgBQUwNmfsNj+PM240pVPxYx9Q9eQhDAPBgNVHRMBAf8E\n" +
+            "BTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAnhbNKwMmnayHsT6kKgyyDV6RUUYs6\n" +
+            "nYf3nx+GIQWSw4c5TOHDcTWdKpOxVnLNXYKQoSkb1RBoSMLBdQwidZ5K2DB5eXaG\n" +
+            "rcfEbKNBc5ZCFgFEAyy35pitJOmU/KzCdKyvx+TR5hIgGoKajYX5JZxj+1rTPGKO\n" +
+            "ePT9iFp1ZbzHjgw6vFeJ+D2ov6HfW6C/KuK9Y6xUpvRQLVjMJYCyzxkxQAxZvu/0\n" +
+            "0HVYYH6UJ7kuWywFMWoBdZ8US/vuUSBYyCGNL9p6ol+h9rsz3cIWBVBjx8C3qKki\n" +
+            "QtlIdmFljGSaGGY6aJjUvUdgoPp1yQPa5oS+afr5g9gaEp4lxP6mc+Li\n" +
+            "-----END CERTIFICATE-----\n";
+
+    public static String clusterCaCert() {
+        return Base64.getEncoder().encodeToString(CLUSTER_CERT.getBytes(Charset.defaultCharset()));
+    }
+
+    public static String clusterCaKey() {
+        return Base64.getEncoder().encodeToString(CLUSTER_KEY.getBytes(Charset.defaultCharset()));
+    }
+
+    public static String clientsCaCert() {
+        return Base64.getEncoder().encodeToString(CLUSTER_CERT.getBytes(Charset.defaultCharset()));
+    }
+
+    public static String clientsCaKey() {
+        return Base64.getEncoder().encodeToString(CLUSTER_KEY.getBytes(Charset.defaultCharset()));
+    }
 
     private void write(File keyFile, String str) throws IOException {
         try (FileWriter writer = new FileWriter(keyFile)) {
@@ -30,8 +147,9 @@ public class MockCertManager implements CertManager {
      */
     @Override
     public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
-        write(keyFile, "key file for self-signed cert");
-        write(certFile, "cert file for self-signed cert");
+
+        write(keyFile, CLUSTER_KEY);
+        write(certFile, CLUSTER_CERT);
     }
 
     /**
@@ -44,8 +162,7 @@ public class MockCertManager implements CertManager {
      */
     @Override
     public void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException {
-        write(keyFile, "key file for self-signed cert");
-        write(certFile, "cert file for self-signed cert");
+        generateSelfSignedCert(keyFile, certFile, null, days);
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -63,7 +63,7 @@ public class Main {
         ScramShaCredentialsOperator scramShaCredentialsOperator = new ScramShaCredentialsOperator(vertx, scramShaCredentials);
 
         KafkaUserOperator kafkaUserOperations = new KafkaUserOperator(vertx,
-                certManager, crdOperations, secretOperations, scramShaCredentialsOperator, aclOperations, config.getCaName(), config.getCaNamespace());
+                certManager, crdOperations, secretOperations, scramShaCredentialsOperator, aclOperations, config.getCaCertSecretName(), config.getCaKeySecretName(), config.getCaNamespace());
 
         Future<String> fut = Future.future();
         UserOperator operator = new UserOperator(config.getNamespace(),

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -17,7 +17,8 @@ public class UserOperatorConfig {
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String STRIMZI_LABELS = "STRIMZI_LABELS";
-    public static final String STRIMZI_CA_NAME = "STRIMZI_CA_NAME";
+    public static final String STRIMZI_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
+    public static final String STRIMZI_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
     public static final String STRIMZI_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
     public static final String STRIMZI_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     public static final String STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
@@ -31,7 +32,8 @@ public class UserOperatorConfig {
     private final String zookeperConnect;
     private final long zookeeperSessionTimeoutMs;
     private Labels labels;
-    private final String caName;
+    private final String caCertSecretName;
+    private final String caKeySecretName;
     private final String caNamespace;
 
     /**
@@ -42,16 +44,17 @@ public class UserOperatorConfig {
      * @param zookeperConnect Connecton URL for Zookeeper
      * @param zookeeperSessionTimeoutMs Session timeout for Zookeeper connections
      * @param labels    Map with labels which should be used to find the KafkaUser resources
-     * @param caName    Name of the secret containing the Certification Authority
+     * @param caCertSecretName    Name of the secret containing the Certification Authority
      * @param caNamespace   Namespace with the CA secret
      */
-    public UserOperatorConfig(String namespace, long reconciliationIntervalMs, String zookeperConnect, long zookeeperSessionTimeoutMs, Labels labels, String caName, String caNamespace) {
+    public UserOperatorConfig(String namespace, long reconciliationIntervalMs, String zookeperConnect, long zookeeperSessionTimeoutMs, Labels labels, String caCertSecretName, String caKeySecretName, String caNamespace) {
         this.namespace = namespace;
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.zookeperConnect = zookeperConnect;
         this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
         this.labels = labels;
-        this.caName = caName;
+        this.caCertSecretName = caCertSecretName;
+        this.caKeySecretName = caKeySecretName;
         this.caNamespace = caNamespace;
     }
 
@@ -94,9 +97,14 @@ public class UserOperatorConfig {
             throw new InvalidConfigurationException("Failed to parse labels from " + STRIMZI_LABELS, e);
         }
 
-        String caName = map.get(UserOperatorConfig.STRIMZI_CA_NAME);
-        if (caName == null || caName.isEmpty()) {
-            throw new InvalidConfigurationException(UserOperatorConfig.STRIMZI_CA_NAME + " cannot be null");
+        String caCertSecretName = map.get(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME);
+        if (caCertSecretName == null || caCertSecretName.isEmpty()) {
+            throw new InvalidConfigurationException(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME + " cannot be null");
+        }
+
+        String caKeySecretName = map.get(UserOperatorConfig.STRIMZI_CA_KEY_SECRET_NAME);
+        if (caKeySecretName == null || caKeySecretName.isEmpty()) {
+            throw new InvalidConfigurationException(UserOperatorConfig.STRIMZI_CA_KEY_SECRET_NAME + " cannot be null");
         }
 
         String caNamespace = map.get(UserOperatorConfig.STRIMZI_CA_NAMESPACE);
@@ -104,7 +112,7 @@ public class UserOperatorConfig {
             caNamespace = namespace;
         }
 
-        return new UserOperatorConfig(namespace, reconciliationInterval, zookeeperConnect, zookeeperSessionTimeoutMs, labels, caName, caNamespace);
+        return new UserOperatorConfig(namespace, reconciliationInterval, zookeeperConnect, zookeeperSessionTimeoutMs, labels, caCertSecretName, caKeySecretName, caNamespace);
     }
 
     /**
@@ -131,8 +139,15 @@ public class UserOperatorConfig {
     /**
      * @return  The name of the secret with the Client CA
      */
-    public String getCaName() {
-        return caName;
+    public String getCaCertSecretName() {
+        return caCertSecretName;
+    }
+
+    /**
+     * @return  The name of the secret with the Client CA
+     */
+    public String getCaKeySecretName() {
+        return caKeySecretName;
     }
 
     /**
@@ -164,7 +179,7 @@ public class UserOperatorConfig {
                 ",zookeperConnect=" + zookeperConnect +
                 ",zookeeperSessionTimeoutMs=" + zookeeperSessionTimeoutMs +
                 ",labels=" + labels +
-                ",caName=" + caName +
+                ",caName=" + caCertSecretName +
                 ",caNamespace=" + caNamespace +
                 ")";
     }

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -107,9 +107,9 @@ public class KafkaUserModel {
     public Secret generateSecret()  {
         if (authentication instanceof KafkaUserTlsClientAuthentication) {
             Map<String, String> data = new HashMap<>();
-            data.put("ca.crt", Base64.getEncoder().encodeToString(caCertAndKey.cert()));
-            data.put("user.key", Base64.getEncoder().encodeToString(userCertAndKey.key()));
-            data.put("user.crt", Base64.getEncoder().encodeToString(userCertAndKey.cert()));
+            data.put("ca.crt", caCertAndKey.certAsBase64String());
+            data.put("user.key", userCertAndKey.keyAsBase64String());
+            data.put("user.crt", userCertAndKey.certAsBase64String());
             return createSecret(data);
         } else if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
             Map<String, String> data = new HashMap<>();
@@ -168,7 +168,8 @@ public class KafkaUserModel {
                 userSubject.setCommonName(name);
 
                 certManager.generateCsr(userKeyFile, userCsrFile, userSubject);
-                certManager.generateCert(userCsrFile, caCertAndKey.key(), caCertAndKey.cert(), userCrtFile, userSubject, CERTS_EXPIRATION_DAYS);
+                certManager.generateCert(userCsrFile, caCertAndKey.key(), caCertAndKey.cert(), userCrtFile,
+                        userSubject, CERTS_EXPIRATION_DAYS);
                 this.userCertAndKey = new CertAndKey(Files.readAllBytes(userKeyFile.toPath()), Files.readAllBytes(userCrtFile.toPath()));
 
                 if (!userCsrFile.delete()) {

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
-import io.strimzi.certs.Subject;
+import io.strimzi.operator.cluster.model.ClientsCa;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 import io.strimzi.operator.user.operator.PasswordGenerator;
@@ -23,10 +23,8 @@ import org.apache.logging.log4j.Logger;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,7 +44,7 @@ public class KafkaUserModel {
     protected final Labels labels;
 
     protected KafkaUserAuthentication authentication;
-    protected CertAndKey caCertAndKey;
+    protected String caCert;
     protected CertAndKey userCertAndKey;
     protected String scramSha512Password;
 
@@ -71,21 +69,22 @@ public class KafkaUserModel {
      * @param certManager   CertManager instance for work with certificates
      * @param passwordGenerator A password generator
      * @param kafkaUser     The Custom Resource based on which the model should be created
-     * @param clientsCa     Kubernetes secret with the clients certification authority
      * @param userSecret    Kubernetes secret with existing user certificate
      * @return
      */
     public static KafkaUserModel fromCrd(CertManager certManager,
                                          PasswordGenerator passwordGenerator,
                                          KafkaUser kafkaUser,
-                                         Secret clientsCa, Secret userSecret) {
+                                         Secret clientsCaCert,
+                                         Secret clientsCaKey,
+                                         Secret userSecret) {
         KafkaUserModel result = new KafkaUserModel(kafkaUser.getMetadata().getNamespace(),
                 kafkaUser.getMetadata().getName(),
                 Labels.fromResource(kafkaUser).withKind(kafkaUser.getKind()));
         result.setAuthentication(kafkaUser.getSpec().getAuthentication());
 
         if (kafkaUser.getSpec().getAuthentication() instanceof KafkaUserTlsClientAuthentication) {
-            result.maybeGenerateCertificates(certManager, clientsCa, userSecret);
+            result.maybeGenerateCertificates(certManager, clientsCaCert, clientsCaKey, userSecret);
         } else if (kafkaUser.getSpec().getAuthentication() instanceof KafkaUserScramSha512ClientAuthentication) {
             result.maybeGeneratePassword(passwordGenerator, userSecret);
         }
@@ -107,7 +106,7 @@ public class KafkaUserModel {
     public Secret generateSecret()  {
         if (authentication instanceof KafkaUserTlsClientAuthentication) {
             Map<String, String> data = new HashMap<>();
-            data.put("ca.crt", caCertAndKey.certAsBase64String());
+            data.put("ca.crt", caCert);
             data.put("user.key", userCertAndKey.keyAsBase64String());
             data.put("user.crt", userCertAndKey.certAsBase64String());
             return createSecret(data);
@@ -124,71 +123,50 @@ public class KafkaUserModel {
      * Manage certificates generation based on those already present in the Secrets
      *
      * @param certManager CertManager instance for handling certificates creation
-     * @param clientsCa Secret with the CA
      * @param userSecret Secret with the user certificate
      */
-    public void maybeGenerateCertificates(CertManager certManager, Secret clientsCa, Secret userSecret) {
-        try {
-            if (clientsCa != null) {
-                this.caCertAndKey = new CertAndKey(
-                        decodeFromSecret(clientsCa, "clients-ca.key"),
-                        decodeFromSecret(clientsCa, "clients-ca.crt")
-                );
-
-                if (userSecret != null) {
-                    // Secret already exists -> lets verify if it has keys from the same CA
-                    String originalCaCrt = clientsCa.getData().get("clients-ca.crt");
-                    String caCrt = userSecret.getData().get("ca.crt");
-                    String userCrt = userSecret.getData().get("user.crt");
-                    String userKey = userSecret.getData().get("user.key");
-
-                    if (originalCaCrt != null
-                            && originalCaCrt.equals(caCrt)
-                            && userCrt != null
-                            && !userCrt.isEmpty()
-                            && userKey != null
-                            && !userKey.isEmpty())    {
-                        // User certificate already exists and and is from the right CA -> no need to generate new certificate
-                        log.debug("Reusing existing user certificate");
-                        this.userCertAndKey = new CertAndKey(
-                                decodeFromSecret(userSecret, "user.key"),
-                                decodeFromSecret(userSecret, "user.crt")
-                        );
-                        return;
-                    }
+    public void maybeGenerateCertificates(CertManager certManager,
+                                          Secret clientsCaCertSecret, Secret clientsCaKeySecret,
+                                          Secret userSecret) {
+        if (clientsCaCertSecret == null) {
+            throw new NoCertificateSecretException("The Clients CA Cert Secret is missing");
+        } else if (clientsCaKeySecret == null) {
+            throw new NoCertificateSecretException("The Clients CA Key Secret is missing");
+        } else {
+            ClientsCa clientsCa = new ClientsCa(certManager,
+                    clientsCaCertSecret.getMetadata().getName(),
+                    clientsCaCertSecret,
+                    clientsCaCertSecret.getMetadata().getName(),
+                    clientsCaKeySecret,
+                    CERTS_EXPIRATION_DAYS,
+                    30,
+                    false);
+            this.caCert = clientsCa.currentCaCertBase64();
+            if (userSecret != null) {
+                // Secret already exists -> lets verify if it has keys from the same CA
+                String originalCaCrt = clientsCaCertSecret.getData().get("ca.crt");
+                String caCrt = userSecret.getData().get("ca.crt");
+                String userCrt = userSecret.getData().get("user.crt");
+                String userKey = userSecret.getData().get("user.key");
+                if (originalCaCrt != null
+                        && originalCaCrt.equals(caCrt)
+                        && userCrt != null
+                        && !userCrt.isEmpty()
+                        && userKey != null
+                        && !userKey.isEmpty()) {
+                    this.userCertAndKey = new CertAndKey(
+                            decodeFromSecret(userSecret, "user.key"),
+                            decodeFromSecret(userSecret, "user.crt"));
+                    return;
                 }
-
-                log.debug("Generating user certificate");
-
-                File userCsrFile = File.createTempFile("tls", name + ".csr");
-                File userKeyFile = File.createTempFile("tls", name + ".key");
-                File userCrtFile = File.createTempFile("tls", name + ".crt");
-
-                Subject userSubject = new Subject();
-                userSubject.setCommonName(name);
-
-                certManager.generateCsr(userKeyFile, userCsrFile, userSubject);
-                certManager.generateCert(userCsrFile, caCertAndKey.key(), caCertAndKey.cert(), userCrtFile,
-                        userSubject, CERTS_EXPIRATION_DAYS);
-                this.userCertAndKey = new CertAndKey(Files.readAllBytes(userKeyFile.toPath()), Files.readAllBytes(userCrtFile.toPath()));
-
-                if (!userCsrFile.delete()) {
-                    log.warn("{} cannot be deleted", userCsrFile.getName());
-                }
-                if (!userKeyFile.delete()) {
-                    log.warn("{} cannot be deleted", userKeyFile.getName());
-                }
-                if (!userCrtFile.delete()) {
-                    log.warn("{} cannot be deleted", userCrtFile.getName());
-                }
-
-                log.debug("End generating user certificate");
-            } else {
-                throw new NoCertificateSecretException("The Clients CA Secret is missing");
             }
 
-        } catch (IOException e) {
-            e.printStackTrace();
+            try {
+                this.userCertAndKey = clientsCa.generateSignedCert(name);
+            } catch (IOException e) {
+                log.error("Error generating signed certificate for user {}", name, e);
+            }
+
         }
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -28,7 +28,8 @@ public class ResourceUtils {
     public static final Map LABELS = Collections.singletonMap("foo", "bar");
     public static final String NAMESPACE = "namespace";
     public static final String NAME = "user";
-    public static final String CA_NAME = "somename";
+    public static final String CA_CERT_NAME = NAME + "-cert";
+    public static final String CA_KEY_NAME = NAME + "-key";
 
     public static KafkaUser createKafkaUser(KafkaUserAuthentication authentication) {
         return new KafkaUserBuilder()
@@ -73,14 +74,23 @@ public class ResourceUtils {
         return createKafkaUser(new KafkaUserScramSha512ClientAuthentication());
     }
 
-    public static Secret createClientsCa()  {
+    public static Secret createClientsCaCertSecret()  {
         return new SecretBuilder()
                 .withNewMetadata()
-                    .withName(CA_NAME)
+                    .withName(ResourceUtils.CA_CERT_NAME)
                     .withNamespace(NAMESPACE)
                 .endMetadata()
-                .addToData("clients-ca.key", Base64.getEncoder().encodeToString("clients-ca-key".getBytes()))
-                .addToData("clients-ca.crt", Base64.getEncoder().encodeToString("clients-ca-crt".getBytes()))
+                .addToData("ca.crt", Base64.getEncoder().encodeToString("clients-ca-crt".getBytes()))
+                .build();
+    }
+
+    public static Secret createClientsCaKeySecret()  {
+        return new SecretBuilder()
+                .withNewMetadata()
+                .withName(ResourceUtils.CA_KEY_NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .addToData("ca.key", Base64.getEncoder().encodeToString("clients-ca-key".getBytes()))
                 .build();
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -6,11 +6,10 @@ package io.strimzi.operator.user;
 
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.model.Labels;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -22,7 +21,8 @@ public class UserOperatorConfigTest {
         envVars.put(UserOperatorConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "30000");
         envVars.put(UserOperatorConfig.STRIMZI_LABELS, "label1=value1,label2=value2");
-        envVars.put(UserOperatorConfig.STRIMZI_CA_NAME, "ca-secret");
+        envVars.put(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME, "ca-secret-cert");
+        envVars.put(UserOperatorConfig.STRIMZI_CA_KEY_SECRET_NAME, "ca-secret-key");
         envVars.put(UserOperatorConfig.STRIMZI_CA_NAMESPACE, "differentnamespace");
         envVars.put(UserOperatorConfig.STRIMZI_ZOOKEEPER_CONNECT, "somehost:2181");
         envVars.put(UserOperatorConfig.STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS, "6000");
@@ -41,7 +41,7 @@ public class UserOperatorConfigTest {
         assertEquals(envVars.get(UserOperatorConfig.STRIMZI_NAMESPACE), config.getNamespace());
         assertEquals(Long.parseLong(envVars.get(UserOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS)), config.getReconciliationIntervalMs());
         assertEquals(expectedLabels, config.getLabels());
-        assertEquals(envVars.get(UserOperatorConfig.STRIMZI_CA_NAME), config.getCaName());
+        assertEquals(envVars.get(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME), config.getCaCertSecretName());
         assertEquals(envVars.get(UserOperatorConfig.STRIMZI_CA_NAMESPACE), config.getCaNamespace());
         assertEquals(envVars.get(UserOperatorConfig.STRIMZI_ZOOKEEPER_CONNECT), config.getZookeperConnect());
         assertEquals(Long.parseLong(envVars.get(UserOperatorConfig.STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS)), config.getZookeeperSessionTimeoutMs());
@@ -58,7 +58,7 @@ public class UserOperatorConfigTest {
     @Test(expected = InvalidConfigurationException.class)
     public void testMissingCaName()  {
         Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
-        envVars.remove(UserOperatorConfig.STRIMZI_CA_NAME);
+        envVars.remove(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME);
 
         UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
     }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -76,12 +76,13 @@ public class KafkaUserOperatorTest {
 
         when(scramOps.reconcile(any(), any())).thenReturn(Future.succeededFuture());
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
 
         Async async = context.async();
-        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, null, res -> {
+        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, clientsCaKey, null, res -> {
             context.assertTrue(res.succeeded());
 
             List<String> capturedNames = secretNameCaptor.getAllValues();
@@ -138,13 +139,14 @@ public class KafkaUserOperatorTest {
         ArgumentCaptor<Set<SimpleAclRule>> aclRulesCaptor = ArgumentCaptor.forClass(Set.class);
         when(aclOps.reconcile(aclNameCaptor.capture(), aclRulesCaptor.capture())).thenReturn(Future.succeededFuture());
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         Async async = context.async();
-        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, userCert, res -> {
+        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, clientsCaKey, userCert, res -> {
             context.assertTrue(res.succeeded());
 
             List<String> capturedNames = secretNameCaptor.getAllValues();
@@ -206,15 +208,16 @@ public class KafkaUserOperatorTest {
         ArgumentCaptor<Set<SimpleAclRule>> aclRulesCaptor = ArgumentCaptor.forClass(Set.class);
         when(aclOps.reconcile(aclNameCaptor.capture(), aclRulesCaptor.capture())).thenReturn(Future.succeededFuture());
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
         user.getSpec().setAuthorization(null);
         user.getSpec().setAuthentication(null);
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         Async async = context.async();
-        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, userCert, res -> {
+        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, clientsCaKey, userCert, res -> {
             context.assertTrue(res.succeeded());
 
             List<String> capturedNames = secretNameCaptor.getAllValues();
@@ -264,15 +267,16 @@ public class KafkaUserOperatorTest {
 
         when(scramOps.reconcile(any(), any())).thenReturn(Future.succeededFuture());
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
-        clientsCa.getData().put("clients-ca.key", Base64.getEncoder().encodeToString("different-clients-ca-key".getBytes()));
-        clientsCa.getData().put("clients-ca.crt", Base64.getEncoder().encodeToString("different-clients-ca-crt".getBytes()));
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        clientsCa.getData().put("ca.crt", Base64.getEncoder().encodeToString("different-clients-ca-crt".getBytes()));
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
+        clientsCaKey.getData().put("ca.key", Base64.getEncoder().encodeToString("different-clients-ca-key".getBytes()));
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         Async async = context.async();
-        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, userCert, res -> {
+        op.createOrUpdate(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, clientsCa, clientsCaKey, userCert, res -> {
             context.assertTrue(res.succeeded());
 
             List<String> capturedNames = secretNameCaptor.getAllValues();
@@ -315,7 +319,7 @@ public class KafkaUserOperatorTest {
         ArgumentCaptor<String> aclNameCaptor = ArgumentCaptor.forClass(String.class);
         when(aclOps.reconcile(aclNameCaptor.capture(), isNull())).thenReturn(Future.succeededFuture());
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
 
         Async async = context.async();
         op.delete(new Reconciliation("test-trigger", ResourceType.USER, ResourceUtils.NAMESPACE, ResourceUtils.NAME), res -> {
@@ -344,9 +348,11 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps,
+                ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
 
         ArgumentCaptor<String> secretNamespaceCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> secretNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -359,7 +365,8 @@ public class KafkaUserOperatorTest {
 
         when(scramOps.reconcile(any(), any())).thenReturn(Future.succeededFuture());
 
-        when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(clientsCa.getMetadata().getName()))).thenReturn(clientsCa);
+        when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(ResourceUtils.CA_CERT_NAME))).thenReturn(clientsCa);
+        when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(ResourceUtils.CA_KEY_NAME))).thenReturn(clientsCaKey);
         when(mockSecretOps.get(eq(user.getMetadata().getNamespace()), eq(user.getMetadata().getName()))).thenReturn(null);
 
         when(mockCrdOps.get(eq(user.getMetadata().getNamespace()), eq(user.getMetadata().getName()))).thenReturn(user);
@@ -411,9 +418,10 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
+        Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         ArgumentCaptor<String> secretNamespaceCaptor = ArgumentCaptor.forClass(String.class);
@@ -428,6 +436,7 @@ public class KafkaUserOperatorTest {
         when(aclOps.reconcile(aclNameCaptor.capture(), aclRulesCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(clientsCa.getMetadata().getName()))).thenReturn(clientsCa);
+        when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(clientsCaKey.getMetadata().getName()))).thenReturn(clientsCaKey);
         when(mockSecretOps.get(eq(user.getMetadata().getNamespace()), eq(user.getMetadata().getName()))).thenReturn(userCert);
 
         when(mockCrdOps.get(eq(user.getMetadata().getNamespace()), eq(user.getMetadata().getName()))).thenReturn(user);
@@ -479,9 +488,9 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         ArgumentCaptor<String> secretNamespaceCaptor = ArgumentCaptor.forClass(String.class);
@@ -531,7 +540,7 @@ public class KafkaUserOperatorTest {
         newScramShaUser.getMetadata().setName("new-scram-sha-user");
         KafkaUser existingTlsUser = ResourceUtils.createKafkaUserTls();
         existingTlsUser.getMetadata().setName("existing-tls-user");
-        Secret clientsCa = ResourceUtils.createClientsCa();
+        Secret clientsCa = ResourceUtils.createClientsCaCertSecret();
         Secret existingTlsUserSecret = ResourceUtils.createUserSecretTls();
         existingTlsUserSecret.getMetadata().setName("existing-tls-user");
         Secret existingScramShaUserSecret = ResourceUtils.createUserSecretScramSha();
@@ -566,10 +575,10 @@ public class KafkaUserOperatorTest {
                 mockCertManager,
                 mockCrdOps,
                 mockSecretOps, scramOps,
-                aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE) {
+                aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE) {
 
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaUser user, Secret clientCa, Secret userSecret, Handler<AsyncResult<Void>> h) {
+            public void createOrUpdate(Reconciliation reconciliation, KafkaUser user, Secret clientCa, Secret clientCaKey, Secret userSecret, Handler<AsyncResult<Void>> h) {
                 createdOrUpdated.add(user.getMetadata().getName());
                 async.countDown();
                 h.handle(Future.succeededFuture());
@@ -599,7 +608,7 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
 
         ArgumentCaptor<String> secretNamespaceCaptor = ArgumentCaptor.forClass(String.class);
@@ -666,7 +675,7 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
         Secret userCert = ResourceUtils.createUserSecretScramSha();
         String password = new String(Base64.getDecoder().decode(userCert.getData().get(KafkaUserModel.KEY_PASSWORD)));
@@ -734,7 +743,7 @@ public class KafkaUserOperatorTest {
         SimpleAclOperator aclOps = mock(SimpleAclOperator.class);
         ScramShaCredentialsOperator scramOps = mock(ScramShaCredentialsOperator.class);
 
-        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
+        KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
         Secret userCert = ResourceUtils.createUserSecretTls();
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is some initial work on certificate renewal. 

The user can specify a window for certificate renewal, measured from the end of the period of validity:
```
    <------------------------ validity ----------------------->
                                        <---renewal ---------->
```

When the CO reconciles the cluster CA and it is within this validity period it will generate a new CA (if it's configured to generate CAs, otherwise it will just log a warning that the user-provided cert will expire). The old CA will be renamed with the `cluster-ca` secret (with the notAfter date suffixed) and the new CA cert+key will added to the secret. Thus the `cluster-ca.crt` and `cluster-ca.key` will always have the most recent cert.

That's as far as this PR goes. The rest of the plan is, roughly:

1. Add all these CA certs to the trust store.
2. Rolling update of Kafka + Zookeeper
3. Generate new broker and ZK node (+TO, UO) client certs signed with the new CA cert.
4. Rolling update of Kafka + Zookeeper, TO, UO
5. Remove the old CA certs from the trust store. 
6. Rolling bounce.

However, we don't want to necessarily do the rolling updates during the same reconciliation. So really 3. will either be triggered by a test for whether all the pods trust TLS connections using client certs signed with the new CA cert (which could be quite hard to do), or some proxy for that (like observing that those containers have restarted since the new CA was prepared). A similar test will be used for 5.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

