### PR TITLE
Do not use kubectl create or oc create on YAML files to keep consiste…

### DIFF
--- a/documentation/book/appendix_metrics.adoc
+++ b/documentation/book/appendix_metrics.adoc
@@ -27,7 +27,7 @@ where `[namespace]` is the namespace/project where the Apache Kafka cluster was 
 Finally, create the Prometheus service by running
 
 [source,shell]
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/prometheus/kubernetes.yaml
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/prometheus/kubernetes.yaml
 
 ==== Grafana
 
@@ -36,7 +36,7 @@ A Grafana server is necessary only to get a visualisation of the Prometheus metr
 To deploy Grafana on {OpenShiftName}, the following commands should be executed:
 
 [source,shell]
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/grafana/kubernetes.yaml
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/grafana/kubernetes.yaml
 
 ifdef::Kubernetes[]
 === Deploying on {KubernetesName}
@@ -49,7 +49,7 @@ If the RBAC is enabled in your {KubernetesName} deployment then in order to have
 [source,shell]
 export NAMESPACE=[namespace]
 kubectl create sa prometheus-server
-kubectl create -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/prometheus/cluster-reader.yaml
+kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/metrics/examples/prometheus/cluster-reader.yaml
 kubectl create clusterrolebinding read-pods-binding --clusterrole=cluster-reader --serviceaccount=${NAMESPACE}:prometheus-server
 
 where `[namespace]` is the namespace/project where the Apache Kafka cluster was deployed.

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
@@ -20,7 +20,7 @@ sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-
 +
 [source]
 ----
-kubectl create -f examples/install/cluster-operator
+kubectl apply -f examples/install/cluster-operator
 ----
 
 . Verify whether the Cluster Operator has been deployed successfully, the {KubernetesName} Dashboard or the command line:

--- a/documentation/book/proc-deploying-cluster-operator-openshift.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-openshift.adoc
@@ -21,8 +21,8 @@ sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-
 +
 [source]
 ----
-oc create -f examples/install/cluster-operator
-oc create -f examples/templates/cluster-operator
+oc apply -f examples/install/cluster-operator
+oc apply -f examples/templates/cluster-operator
 ----
 
 . Verify whether the Cluster Operator has been deployed successfully, the {OpenShiftName} console or the command line:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

99% of our documentation uses `kubectl apply` and `oc apply` to deploy YAML files into Kubernetes / OpenShift. There are only few places whgere we used `kubectl create` or `oc create`. This PR tries to unify this and use `apply` everywhere. This should close #664.

### Checklist

- [x] Update documentation
