### PR TITLE
Docs: Add User Operator and Kafka Connect S2I to the list of loggers

### DIFF
--- a/documentation/book/ref-kafka-logging.adoc
+++ b/documentation/book/ref-kafka-logging.adoc
@@ -28,11 +28,14 @@ Components and their loggers are listed below.
 * Zookeeper
 ** `zookeeper.root.logger`
 
-* Kafka Connect
+* Kafka Connect and Kafka Connect with Source2Image support
 ** `connect.root.logger.level`
 ** `log4j.logger.org.apache.zookeeper`
 ** `log4j.logger.org.I0Itec.zkclient`
 ** `log4j.logger.org.reflections`
 
 * Topic Operator
+** `rootLogger.level`
+
+* User Operator
 ** `rootLogger.level`


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The list of loggers in this reference is missing the User Operator. We should also make it more clear that Kafka Connect S2I is using the same loggers as regular Kafka Connect.

### Checklist

- [x] Update documentation