### PR TITLE
Use SHA1PRNG as the ssl.secure.random.implementation 

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -76,6 +76,7 @@ ssl.truststore.password=${CERTS_STORE_PASSWORD}
 ssl.keystore.type=PKCS12
 ssl.truststore.type=PKCS12
 ssl.endpoint.identification.algorithm=HTTPS
+ssl.secure.random.implementation=SHA1PRNG
 
 listener.name.replication.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 listener.name.replication.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As suggested in #800, this PR adds `ssl.secure.random.implementation` to our Docker images which sets it to `SHA1PRNG`.