### PR TITLE
ST: Updated container image names in assertion methods 

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -641,9 +641,9 @@ public class KafkaST extends AbstractST {
         //Verifying docker image for entity-operator
         String entityOperatorPodName = kubeClient.listResourcesByLabel("pod",
                 "strimzi.io/name=" + clusterName + "-entity-operator").get(0);
-        String imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "topic-operator");
+        String imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-topic-operator");
         assertEquals(imgFromDeplConf.get(TO_IMAGE), imgFromPod);
-        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "user-operator");
+        imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "entity-user-operator");
         assertEquals(imgFromDeplConf.get(UO_IMAGE), imgFromPod);
         imgFromPod = getContainerImageNameFromPod(entityOperatorPodName, "tls-sidecar");
         assertEquals(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE), imgFromPod);


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Updated container image names from `topic-operator` to `entity-topic-operator` and `user-operator` to `entity-user-operator` 

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

