### PR TITLE
Fixed references to the defaults picked for container images

### DIFF
--- a/documentation/book/ref-configuring-container-images.adoc
+++ b/documentation/book/ref-configuring-container-images.adoc
@@ -17,36 +17,35 @@ Container image which should be used for given components can be specified using
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
 
-The `image` property can be used to configure the container image which will be used.
-When the `image` field is missing, the following images will be used (in the order of priority):
+The `image` specified in the component-specific custom resource will be used during deployment. If the `image` field is missing, the `image` specified in the Cluster Operator configuration will be used. If the `image` name is not defined in the Cluster Operator configuration, then the default value will be used.
 
 * For Kafka brokers:
-** Container image specified in the `STRIMZI_DEFAULT_KAFKA_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/kafka:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_KAFKA_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/kafka:latest` container image.
 * For Kafka broker TLS sidecar:
-** Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/kafka-stunnel:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/kafka-stunnel:latest` container image.
 * For Zookeeper nodes:
-** Container image specified in the `STRIMZI_DEFAULT_ZOOKEEPER_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/zookeeper:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_ZOOKEEPER_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/zookeeper:latest` container image.
 * For Zookeeper node TLS sidecar:
-** Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/zookeeper-stunnel:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/zookeeper-stunnel:latest` container image.
 * For Topic Operator:
-** Container image specified in the `STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/topic-operator:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
+.** `strimzi/topic-operator:latest` container image.
 * For User Operator:
-** Container image specified in the `STRIMZI_DEFAULT_USER_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/user-operator:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_USER_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/user-operator:latest` container image.
 * For Entity Operator TLS sidecar:
-** Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/entity-operator-stunnel:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/entity-operator-stunnel:latest` container image.
 * For Kafka Connect:
-** Container image specified in the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/kafka-connect:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/kafka-connect:latest` container image.
 * For Kafka Connect with Source2image support:
-** Container image specified in the `STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE` environment variable from the Cluster Operator configuration.
-** `strimzi/kafka-connect-s2i:latest` container image.
+. Container image specified in the `STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE` environment variable from the Cluster Operator configuration.
+. `strimzi/kafka-connect-s2i:latest` container image.
 
 WARNING: Overriding container images is recommended only in special situations, where you need to use a different container registry.
 For example, because your network does not allow access to the container repository used by {ProductName}.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Updated section 3.1.15. Container image configurations to clarify the order in which the defaults are picked.
