### PR TITLE
Add support for Scram SHA 512 authentication to Kafka Connect CRDs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaConnectAuthenticationTls.TYPE_TLS, value = KafkaConnectAuthenticationTls.class),
+        @JsonSubTypes.Type(name = KafkaConnectAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaConnectAuthenticationScramSha512.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class KafkaConnectAuthentication implements Serializable {
@@ -30,8 +31,10 @@ public abstract class KafkaConnectAuthentication implements Serializable {
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the only supported type is `tls`. " +
-            "`tls` type uses TLS Client Authentication. ")
+            "Currently the only supported types are `tls` and `scram-sha-512`. " +
+            "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
+            "`tls` type uses TLS Client Authentication. " +
+            "`tls` type is supported only over TLS connections.")
     @JsonIgnore
     public abstract String getType();
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationScramSha512.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Configures the Kafka Connect authentication
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaConnectAuthenticationScramSha512 extends KafkaConnectAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
+
+    private String username;
+    private PasswordSecretSource passwordSecret;
+
+    @Description("Must be `" + TYPE_SCRAM_SHA_512 + "`")
+    @Override
+    public String getType() {
+        return TYPE_SCRAM_SHA_512;
+    }
+
+    @Description("Password used for the authentication.")
+    public PasswordSecretSource getPasswordSecret() {
+        return passwordSecret;
+    }
+
+    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
+        this.passwordSecret = passwordSecret;
+    }
+
+    @Description("Username used for the authentication.")
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthenticationTls.java
@@ -5,7 +5,6 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -32,7 +31,6 @@ public class KafkaConnectAuthenticationTls extends KafkaConnectAuthentication {
     }
 
     @Description("Certificate and private key pair for TLS authentication.")
-    @JsonProperty(required = true)
     public CertAndKeySecretSource getCertificateAndKey() {
         return certificateAndKey;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Represents a password inside a Secret
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PasswordSecretSource implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected String secretName;
+    protected String password;
+
+    protected Map<String, Object> additionalProperties;
+
+    @Description("The name of the Secret containing the password.")
+    @JsonProperty(required = true)
+    public String getSecretName() {
+        return secretName;
+    }
+
+    public void setSecretName(String secretName) {
+        this.secretName = secretName;
+    }
+
+    @Description("The name of the key in the Secret under which the password is stored.")
+    @JsonProperty(required = true)
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -78,4 +78,9 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
             assertTrue(e.getMessage().contains("spec.authentication.certificateAndKey.key in body is required"));
         }
     }
+
+    @Test
+    public void testKafkaWithScramSha512Auth() {
+        createDelete(KafkaConnect.class, "KafkaConnect-with-scram-sha-512-auth.yaml");
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-scram-sha-512-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-scram-sha-512-auth.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: test-kafka-connect
+spec:
+  image: foo
+  replicas: 6
+  bootstrapServers: kafka:9092
+  authentication:
+    type: scram-sha-512
+    username: johndoe
+    passwordSecret:
+      secretName: my-user-secret
+      password: password

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -517,8 +517,8 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |metrics           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|authentication    1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
-|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`]
+|authentication    1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`], xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`]
 |bootstrapServers  1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
 |config            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers.
@@ -535,7 +535,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaConnectAuthenticationTls` from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes the use of the type `KafkaConnectAuthenticationTls` from xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`].
 It must have the value `tls` for the type `KafkaConnectAuthenticationTls`.
 [options="header"]
 |====
@@ -560,6 +560,40 @@ Used in: xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenti
 |key          1.2+<.<|The name of the private key in the Secret.
 |string
 |secretName   1.2+<.<|The name of the Secret containing the certificate.
+|string
+|====
+
+[id='type-KafkaConnectAuthenticationScramSha512-{context}']
+### `KafkaConnectAuthenticationScramSha512` schema reference
+
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaConnectAuthenticationScramSha512` from xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`].
+It must have the value `scram-sha-512` for the type `KafkaConnectAuthenticationScramSha512`.
+[options="header"]
+|====
+|Field                  |Description
+|passwordSecret  1.2+<.<|Password used for the authentication.
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|type            1.2+<.<|Must be `scram-sha-512`.
+|string
+|username        1.2+<.<|Username used for the authentication.
+|string
+|====
+
+[id='type-PasswordSecretSource-{context}']
+### `PasswordSecretSource` schema reference
+
+Used in: xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`]
+
+
+[options="header"]
+|====
+|Field              |Description
+|password    1.2+<.<|The name of the key in the Secret under which the password is stored.
+|string
+|secretName  1.2+<.<|The name of the Secret containing the password.
 |string
 |====
 
@@ -627,8 +661,8 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
 |metrics                   1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
-|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`]
+|authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|xref:type-KafkaConnectAuthenticationTls-{context}[`KafkaConnectAuthenticationTls`], xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`]
 |bootstrapServers          1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
 |config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers.

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -277,10 +277,20 @@ spec:
                   - certificate
                   - key
                   - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
                 type:
                   type: string
-              required:
-              - certificateAndKey
+                username:
+                  type: string
             bootstrapServers:
               type: string
             config:

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -253,10 +253,20 @@ spec:
                   - certificate
                   - key
                   - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
                 type:
                   type: string
-              required:
-              - certificateAndKey
+                username:
+                  type: string
             bootstrapServers:
               type: string
             config:

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnect.yaml
@@ -281,10 +281,20 @@ spec:
                   - certificate
                   - key
                   - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
                 type:
                   type: string
-              required:
-              - certificateAndKey
+                username:
+                  type: string
             bootstrapServers:
               type: string
             config:

--- a/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/04-Crd-kafkaconnects2i.yaml
@@ -257,10 +257,20 @@ spec:
                   - certificate
                   - key
                   - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
                 type:
                   type: string
-              required:
-              - certificateAndKey
+                username:
+                  type: string
             bootstrapServers:
               type: string
             config:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Now with SCRAM-SHA-512 support in User Operator and in broker, we should add it also to Kafka Connect. This PR as a preparation adds the required fields to the `KafkaConnect` and `KafkaConnectS2I` resources. The auctual authentication will be done in separate PR.