### PR TITLE
createOrUpdate() and delete to return Futures

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -131,7 +131,8 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         return null;
     }
 
-    private final void reconcileClusterCa(Reconciliation reconciliation, Labels labels, Handler<AsyncResult<List<Secret>>> handler) {
+    protected final Future<List<Secret>> reconcileClusterCa(Reconciliation reconciliation, Labels labels) {
+        Future<List<Secret>> result = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<List<Secret>>executeBlocking(
             future -> {
                 String clusterCaName = AbstractModel.getClusterCaName(reconciliation.name());
@@ -179,13 +180,9 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                             future.complete(clusterSecrets);
                         }, future);
             }, true,
-            res -> {
-                if (res.succeeded())
-                    handler.handle(Future.succeededFuture(res.result()));
-                else
-                    handler.handle(Future.failedFuture(res.cause()));
-            }
+            result.completer()
         );
+        return result;
     }
 
     private final void deleteClusterCa(Reconciliation reconciliation, Handler<AsyncResult<Void>> handler) {
@@ -237,25 +234,22 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                     if (cr != null) {
                         log.info("{}: Assembly {} should be created or updated", reconciliation, assemblyName);
                         Labels caLabels = Labels.userLabels(cr.getMetadata().getLabels()).withKind(reconciliation.type().toString()).withCluster(reconciliation.name());
-                        reconcileClusterCa(reconciliation, caLabels, certResult -> {
-                            if (certResult.succeeded()) {
-                                List<Secret> secrets = certResult.result();
-                                createOrUpdate(reconciliation, cr, secrets, createResult -> {
-                                    lock.release();
-                                    log.debug("{}: Lock {} released", reconciliation, lockName);
-                                    if (createResult.failed()) {
-                                        if (createResult.cause() instanceof InvalidConfigParameterException) {
-                                            log.error(createResult.cause().getMessage());
-                                        } else {
-                                            log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());
-                                        }
-                                    } else {
-                                        handler.handle(createResult);
-                                    }
-                                });
+                        Future<Void> f = Future.future();
+                        reconcileClusterCa(reconciliation, caLabels)
+                            .compose(secrets -> createOrUpdate(reconciliation, cr, secrets, createResult -> {
+                                f.complete();
+                            }), f);
+                        f.setHandler(createResult -> {
+                            lock.release();
+                            log.debug("{}: Lock {} released", reconciliation, lockName);
+                            if (createResult.failed()) {
+                                if (createResult.cause() instanceof InvalidConfigParameterException) {
+                                    log.error(createResult.cause().getMessage());
+                                } else {
+                                    log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());
+                                }
                             } else {
-                                log.error("{}: reconcileClusterCa failed", reconciliation, certResult.cause());
-                                lock.release();
+                                handler.handle(createResult);
                             }
                         });
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ClusterCa.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+public class ClusterCa {
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ClusterCa.java
@@ -1,8 +1,0 @@
-/*
- * Copyright 2018, Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
- */
-package io.strimzi.operator.cluster.operator.assembly;
-
-public class ClusterCa {
-}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -21,8 +21,8 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Storage;
-import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
+import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -49,9 +49,7 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -316,7 +314,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Now try to create a KafkaCluster based on this CM
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.KAFKA, clusterCmNamespace, clusterCmName), clusterCm, secrets, createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.KAFKA, clusterCmNamespace, clusterCmName), clusterCm, secrets).setHandler(createResult -> {
             if (createResult.failed()) {
                 createResult.cause().printStackTrace();
             }
@@ -477,7 +475,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Now try to delete a KafkaCluster based on this CM
         Async async = context.async();
-        ops.delete(new Reconciliation("test-trigger", ResourceType.KAFKA, assemblyNamespace, assemblyName), createResult -> {
+        ops.delete(new Reconciliation("test-trigger", ResourceType.KAFKA, assemblyNamespace, assemblyName)).setHandler(createResult -> {
             if (createResult.failed()) {
                 createResult.cause().printStackTrace();
             }
@@ -893,7 +891,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Now try to update a KafkaCluster based on this CM
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.KAFKA, clusterNamespace, clusterName), updatedAssembly, secrets, createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.KAFKA, clusterNamespace, clusterName), updatedAssembly, secrets).setHandler(createResult -> {
             if (createResult.failed()) createResult.cause().printStackTrace();
             context.assertTrue(createResult.succeeded());
 
@@ -998,16 +996,16 @@ public class KafkaAssemblyOperatorTest {
                 certManager,
                 supplier) {
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+            public Future<Void> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly, List<Secret> assemblySecrets) {
                 createdOrUpdated.add(kafkaAssembly.getMetadata().getName());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
             @Override
-            public void delete(Reconciliation reconciliation, Handler h) {
+            public Future<Void> delete(Reconciliation reconciliation) {
                 deleted.add(reconciliation.name());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
         };
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -25,9 +25,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -117,7 +115,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(clusterCm);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // No metrics config  => no CMs created
@@ -188,7 +186,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Vertify service
@@ -277,7 +275,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             KafkaConnectCluster compareTo = KafkaConnectCluster.fromCrd(clusterCm);
@@ -357,7 +355,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertFalse(createResult.succeeded());
 
             async.complete();
@@ -405,7 +403,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
@@ -455,7 +453,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
@@ -496,7 +494,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps);
 
         Async async = context.async();
-        ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName), createResult -> {
+        ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT, clusterCmNamespace, clusterCmName)).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Vertify service
@@ -562,16 +560,16 @@ public class KafkaConnectAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps) {
 
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaConnect kafkaConnectAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+            public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnect kafkaConnectAssembly, List<Secret> assemblySecrets) {
                 createdOrUpdated.add(kafkaConnectAssembly.getMetadata().getName());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
             @Override
-            public void delete(Reconciliation reconciliation, Handler h) {
+            public Future<Void> delete(Reconciliation reconciliation) {
                 deleted.add(reconciliation.name());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
         };
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -29,9 +29,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -129,7 +127,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Vertify service
@@ -235,7 +233,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Vertify service
@@ -342,7 +340,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromCrd(clusterCm);
@@ -453,7 +451,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertFalse(createResult.succeeded());
 
             async.complete();
@@ -510,7 +508,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             verify(mockDcOps).scaleUp(clusterCmNamespace, connect.getName(), scaleTo);
@@ -569,7 +567,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
-        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList(), createResult -> {
+        ops.createOrUpdate(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), clusterCm, Collections.emptyList()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Verify ScaleDown
@@ -622,7 +620,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator);
 
         Async async = context.async();
-        ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName), createResult -> {
+        ops.delete(new Reconciliation("test-trigger", ResourceType.CONNECT_S2I, clusterCmNamespace, clusterCmName)).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
 
             // Verify service
@@ -705,16 +703,16 @@ public class KafkaConnectS2IAssemblyOperatorTest {
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator) {
 
             @Override
-            public void createOrUpdate(Reconciliation reconciliation, KafkaConnectS2I kafkaConnectS2IAssembly, List<Secret> assemblySecrets, Handler<AsyncResult<Void>> h) {
+            public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnectS2I kafkaConnectS2IAssembly, List<Secret> assemblySecrets) {
                 createdOrUpdated.add(kafkaConnectS2IAssembly.getMetadata().getName());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
             @Override
-            public void delete(Reconciliation reconciliation, Handler h) {
+            public Future<Void> delete(Reconciliation reconciliation) {
                 deleted.add(reconciliation.name());
                 async.countDown();
-                h.handle(Future.succeededFuture());
+                return Future.succeededFuture();
             }
         };
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Make `AbstractAssemblyOperator.createOrUpdate()` and `delete()` return `Future<Void>` rather than accept `Handler<AsyncResult<Void>>`. It might not be clear why this is beneficial: Where I'm ultimately going with these refactorings is for `reconcileClusterCa()` to form the initial step in the `compose()` chain, so it can much more naturally pass information to later steps.

### Checklist

- [x] Make sure all tests pass

