### PR TITLE
The password must be base64 encoded

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -713,7 +714,7 @@ public class KafkaST extends AbstractST {
     String saslConfigs(KafkaUser kafkaUser) {
         Secret secret = namespacedClient().secrets().withName(kafkaUser.getMetadata().getName()).get();
 
-        String password = secret.getData().get("password");
+        String password = new String(Base64.getDecoder().decode(secret.getData().get("password")));
         if (password == null) {
             LOGGER.info("Secret {}:\n{}", kafkaUser.getMetadata().getName(), TestUtils.toYamlString(secret));
             throw new RuntimeException("The Secret " + kafkaUser.getMetadata().getName() + " lacks the 'password' key");

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -25,6 +25,7 @@ import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Base64;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class KafkaUserModel {
             return createSecret(data);
         } else if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
             Map<String, String> data = new HashMap<>();
-            data.put(KafkaUserModel.KEY_PASSWORD, scramSha512Password);
+            data.put(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(scramSha512Password.getBytes(Charset.defaultCharset())));
             return createSecret(data);
         } else {
             return null;
@@ -195,7 +196,7 @@ public class KafkaUserModel {
             // Secret already exists -> lets verify if it has a password
             String password = userSecret.getData().get(KEY_PASSWORD);
             if (password != null && !password.isEmpty()) {
-                this.scramSha512Password = password;
+                this.scramSha512Password = new String(Base64.getDecoder().decode(password), Charset.defaultCharset());
                 return;
             }
         }

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -113,7 +113,7 @@ public class KafkaUserModel {
             return createSecret(data);
         } else if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
             Map<String, String> data = new HashMap<>();
-            data.put(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(scramSha512Password.getBytes(Charset.defaultCharset())));
+            data.put(KafkaUserModel.KEY_PASSWORD, Base64.getEncoder().encodeToString(scramSha512Password.getBytes(Charset.forName("US-ASCII"))));
             return createSecret(data);
         } else {
             return null;
@@ -196,7 +196,7 @@ public class KafkaUserModel {
             // Secret already exists -> lets verify if it has a password
             String password = userSecret.getData().get(KEY_PASSWORD);
             if (password != null && !password.isEmpty()) {
-                this.scramSha512Password = new String(Base64.getDecoder().decode(password), Charset.defaultCharset());
+                this.scramSha512Password = new String(Base64.getDecoder().decode(password), Charset.forName("US-ASCII"));
                 return;
             }
         }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -29,7 +29,9 @@ import io.vertx.core.shareddata.Lock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -119,7 +121,7 @@ public class KafkaUserOperator {
         log.debug("{}: Updating User", reconciliation, userName, namespace);
         Secret desired = user.generateSecret();
         CompositeFuture.join(
-                scramShaCredentialOperator.reconcile(user.getName(), desired != null ? desired.getData().get("password") : null),
+                scramShaCredentialOperator.reconcile(user.getName(), (desired != null && desired.getData().get("password") != null) ? new String(Base64.getDecoder().decode(desired.getData().get("password")), Charset.forName("US-ASCII")) : null),
                 secretOperations.reconcile(namespace, user.getSecretName(), desired),
                 aclOperations.reconcile(user.getUserName(), user.getSimpleAclRules()))
                 .map((Void) null).setHandler(handler);

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -104,7 +104,7 @@ public class ResourceUtils {
                 .withNamespace(NAMESPACE)
                 .withLabels(Labels.userLabels(LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap())
                 .endMetadata()
-                .addToData("password", "my-password")
+                .addToData("password", Base64.getEncoder().encodeToString("my-password".getBytes()))
                 .build();
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -113,14 +113,14 @@ public class KafkaUserModelTest {
         assertEquals(Labels.userLabels(ResourceUtils.LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap(), generated.getMetadata().getLabels());
 
         assertEquals(singleton(KafkaUserModel.KEY_PASSWORD), generated.getData().keySet());
-        assertEquals("aaaaaaaaaa", generated.getData().get(KafkaUserModel.KEY_PASSWORD));
+        assertEquals("aaaaaaaaaa", new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))));
     }
 
     @Test
     public void testGeneratePasswordKeepExistingScramSha()    {
-        Secret userCert = ResourceUtils.createUserSecretScramSha();
-        String existing = userCert.getData().get(KafkaUserModel.KEY_PASSWORD);
-        KafkaUserModel model = KafkaUserModel.fromCrd(mockCertManager, passwordGenerator, scramShaUser, clientsCa, userCert);
+        Secret userPassword = ResourceUtils.createUserSecretScramSha();
+        String existing = userPassword.getData().get(KafkaUserModel.KEY_PASSWORD);
+        KafkaUserModel model = KafkaUserModel.fromCrd(mockCertManager, passwordGenerator, scramShaUser, clientsCa, userPassword);
         Secret generated = model.generateSecret();
 
         assertEquals(ResourceUtils.NAME, generated.getMetadata().getName());
@@ -142,7 +142,7 @@ public class KafkaUserModelTest {
         assertEquals(Labels.userLabels(ResourceUtils.LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap(), generated.getMetadata().getLabels());
 
         assertEquals(singleton("password"), generated.getData().keySet());
-        assertEquals("aaaaaaaaaa", generated.getData().get(KafkaUserModel.KEY_PASSWORD));
+        assertEquals("aaaaaaaaaa", new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))));
     }
 
     @Test

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -641,7 +641,7 @@ public class KafkaUserOperatorTest {
             context.assertEquals(Labels.userLabels(user.getMetadata().getLabels()).withKind(KafkaUser.RESOURCE_KIND).toMap(), captured.getMetadata().getLabels());
 
             context.assertEquals(scramPasswordCaptor.getValue(), captured.getData().get(KafkaUserModel.KEY_PASSWORD));
-            context.assertTrue(captured.getData().get(KafkaUserModel.KEY_PASSWORD).matches("[a-zA-Z0-9]{12}"));
+            context.assertTrue(new String(Base64.getDecoder().decode(captured.getData().get(KafkaUserModel.KEY_PASSWORD))).matches("[a-zA-Z0-9]{12}"));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
             context.assertEquals(1, capturedAclNames.size());

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -640,7 +640,7 @@ public class KafkaUserOperatorTest {
             context.assertEquals(user.getMetadata().getNamespace(), captured.getMetadata().getNamespace());
             context.assertEquals(Labels.userLabels(user.getMetadata().getLabels()).withKind(KafkaUser.RESOURCE_KIND).toMap(), captured.getMetadata().getLabels());
 
-            context.assertEquals(scramPasswordCaptor.getValue(), captured.getData().get(KafkaUserModel.KEY_PASSWORD));
+            context.assertEquals(scramPasswordCaptor.getValue(), new String(Base64.getDecoder().decode(captured.getData().get(KafkaUserModel.KEY_PASSWORD))));
             context.assertTrue(new String(Base64.getDecoder().decode(captured.getData().get(KafkaUserModel.KEY_PASSWORD))).matches("[a-zA-Z0-9]{12}"));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -669,7 +669,7 @@ public class KafkaUserOperatorTest {
         KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, mockSecretOps, scramOps, aclOps, ResourceUtils.CA_NAME, ResourceUtils.NAMESPACE);
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
         Secret userCert = ResourceUtils.createUserSecretScramSha();
-        String password = userCert.getData().get(KafkaUserModel.KEY_PASSWORD);
+        String password = new String(Base64.getDecoder().decode(userCert.getData().get(KafkaUserModel.KEY_PASSWORD)));
 
         ArgumentCaptor<String> secretNamespaceCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> secretNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -708,7 +708,7 @@ public class KafkaUserOperatorTest {
             context.assertEquals(user.getMetadata().getName(), captured.getMetadata().getName());
             context.assertEquals(user.getMetadata().getNamespace(), captured.getMetadata().getNamespace());
             context.assertEquals(Labels.userLabels(user.getMetadata().getLabels()).withKind(KafkaUser.RESOURCE_KIND).toMap(), captured.getMetadata().getLabels());
-            context.assertEquals(password, captured.getData().get(KafkaUserModel.KEY_PASSWORD));
+            context.assertEquals(password, new String(Base64.getDecoder().decode(captured.getData().get(KafkaUserModel.KEY_PASSWORD))));
             context.assertEquals(password, scramPasswordCaptor.getValue());
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The password in the Secret generated by the User Operator has to be base64 encoded.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
