### PR TITLE
Ignore missing Cluster Role Binding access when desired is null

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -398,9 +398,27 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaInitClusterRoleBinding() {
-            return withVoid(clusterRoleBindingOperator.reconcile(
+            ClusterRoleBindingOperator.ClusterRoleBinding desired = kafkaCluster.generateClusterRoleBinding(namespace);
+            Future<Void> fut = clusterRoleBindingOperator.reconcile(
                     KafkaCluster.initContainerClusterRoleBindingName(namespace, name),
-                    kafkaCluster.generateClusterRoleBinding(namespace)));
+                    desired);
+
+            Future replacementFut = Future.future();
+
+            fut.setHandler(res -> {
+                if (res.failed())    {
+                    if (desired == null && res.cause().getMessage().contains("403: Forbidden")) {
+                        log.debug("Ignoring forbidden access to ClusterRoleBindings which seems not needed while Kafka rack awareness is disabled.");
+                        replacementFut.complete();
+                    } else {
+                        replacementFut.fail(res.cause());
+                    }
+                } else {
+                    replacementFut.complete();
+                }
+            });
+
+            return withVoid(replacementFut);
         }
 
         Future<ReconciliationState> kafkaScaleDown() {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, we need access to Cluster Role Bindings even when the Kafka rack awareness feature is not used. Not everyone likes that and not everyone has the access to set it up. This changed will ignore any _403 Forbidden_ errors we get when the desired Cluster ROle Binding is null. That is when we are deleting it (which is unlikely to happen because we most probably never had the right to create it) or when we are just ignoring it as not needed because Kafka rack awareness is disabled. 

This should close issue #827.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
