### PR TITLE
Exposing Kafka using OpenShift Routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.0
 
+* Exposing Kafka to the outside of OpenShift using OpenShift Routes
 * Use less wide RBAC permissions (`ClusterRoleBindings` where converted to `RoleBindings` where possible)
 
 ## 0.6.0

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public abstract class KafkaListenerExternal implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private KafkaListenerAuthentication serverAuthentication;
+    //private KafkaListenerAuthentication serverAuthentication;
     private Map<String, Object> additionalProperties;
 
     @Description("Type of the external listener. " +
@@ -37,15 +38,23 @@ public abstract class KafkaListenerExternal implements Serializable {
     @JsonIgnore
     public abstract String getType();
 
-    @Description("Authorization configuration for Kafka brokers")
+    /*@Description("Authorization configuration for Kafka brokers")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("authentication")
     public KafkaListenerAuthentication getAuthentication() {
         return serverAuthentication;
     }
 
     public void setAuthentication(KafkaListenerAuthentication serverAuthentication) {
         this.serverAuthentication = serverAuthentication;
-    }
+    }*/
+
+    @Description("Authorization configuration for Kafka brokers")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("authentication")
+    public abstract KafkaListenerAuthentication getAuth();
+
+    public abstract void setAuth(KafkaListenerAuthentication auth);
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Configures the external listener which exposes Kafka outside of OpenShift
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = KafkaListenerExternalRoute.TYPE_ROUTE, value = KafkaListenerExternalRoute.class),
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class KafkaListenerExternal implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private KafkaListenerAuthentication serverAuthentication;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Type of the external listener. " +
+            "Currently the only supported type is `route`. " +
+            "`route` type uses OpenShift Route for exposing Kafka to the outside.")
+    @JsonIgnore
+    public abstract String getType();
+
+    @Description("Authorization configuration for Kafka brokers")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaListenerAuthentication getAuthentication() {
+        return serverAuthentication;
+    }
+
+    public void setAuthentication(KafkaListenerAuthentication serverAuthentication) {
+        this.serverAuthentication = serverAuthentication;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.crdgenerator.annotations.Description;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * Configures the external listener which exposes Kafka outside of OpenShift using Routes
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KafkaListenerExternalRoute extends KafkaListenerExternal {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_ROUTE = "route";
+
+    @Description("Must be `" + TYPE_ROUTE + "`")
+    @Override
+    public String getType() {
+        return TYPE_ROUTE;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.sundr.builder.annotations.Buildable;
 
 /**
@@ -23,9 +24,22 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
 
     public static final String TYPE_ROUTE = "route";
 
+    private KafkaListenerAuthentication auth;
+
     @Description("Must be `" + TYPE_ROUTE + "`")
     @Override
     public String getType() {
         return TYPE_ROUTE;
+    }
+
+    @Description("Authorization configuration for Kafka brokers")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("authentication")
+    public KafkaListenerAuthentication getAuth() {
+        return auth;
+    }
+
+    public void setAuth(KafkaListenerAuthentication auth) {
+        this.auth = auth;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListeners.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListeners.java
@@ -27,12 +27,13 @@ import static java.util.Collections.emptyMap;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"plain", "tls"})
+@JsonPropertyOrder({"plain", "tls", "external"})
 public class KafkaListeners implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private KafkaListenerTls tls;
     private KafkaListenerPlain plain;
+    private KafkaListenerExternal external;
     private Map<String, Object> additionalProperties;
 
     @Description("Configures TLS listener on port 9093.")
@@ -53,6 +54,16 @@ public class KafkaListeners implements Serializable {
 
     public void setPlain(KafkaListenerPlain plain) {
         this.plain = plain;
+    }
+
+    @Description("Configures external listener on port 9094.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public KafkaListenerExternal getExternal() {
+        return external;
+    }
+
+    public void setExternal(KafkaListenerExternal external) {
+        this.external = external;
     }
 
     @JsonAnyGetter

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -20,6 +20,10 @@ spec:
       tls:
         authentication:
           type: "tls"
+      external:
+        type: "route"
+        authentication:
+          type: "tls"
     authorization:
       type: "simple"
       superUsers:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
@@ -43,6 +43,10 @@ spec:
       tls:
         authentication:
           type: tls
+      external:
+        type: route
+        authentication:
+          type: tls
     authorization:
       type: simple
       superUsers:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -89,7 +89,7 @@ public class Main {
 
         OpenSslCertManager certManager = new OpenSslCertManager();
         KafkaAssemblyOperator kafkaClusterOperations = new KafkaAssemblyOperator(vertx, isOpenShift,
-                config.getOperationTimeoutMs(), certManager, new ResourceOperatorSupplier(vertx, client, config.getOperationTimeoutMs()));
+                config.getOperationTimeoutMs(), certManager, new ResourceOperatorSupplier(vertx, client, isOpenShift, config.getOperationTimeoutMs()));
         KafkaConnectAssemblyOperator kafkaConnectClusterOperations = new KafkaConnectAssemblyOperator(vertx, isOpenShift, certManager, kco, configMapOperations, deploymentOperations, serviceOperations, secretOperations, networkPolicyOperator);
 
         KafkaConnectS2IAssemblyOperator kafkaConnectS2IClusterOperations = null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1048,7 +1048,7 @@ public abstract class AbstractModel {
      * @return Collection with certificates
      * @throws IOException
      */
-    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName, String externalBootstrapAddress, Map<String, String> externalAddresses) throws IOException {
+    protected Map<String, CertAndKey> maybeCopyOrGenerateCerts(CertManager certManager, Secret secret, int replicasInSecret, CertAndKey caCert, BiFunction<String, Integer, String> podName, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
 
         Map<String, CertAndKey> certs = new HashMap<>();
 
@@ -1091,8 +1091,8 @@ public abstract class AbstractModel {
                 nextDnsId++;
             }
 
-            if (externalAddresses.get(podName.apply(cluster, i)) != null)   {
-                sbjAltNames.put("DNS." + nextDnsId, externalAddresses.get(podName.apply(cluster, i)));
+            if (externalAddresses.get(i) != null)   {
+                sbjAltNames.put("DNS." + nextDnsId, externalAddresses.get(i));
                 nextDnsId++;
             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -700,7 +700,7 @@ public abstract class AbstractModel {
     }
 
     protected Service createService(String type, List<ServicePort> ports,  Map<String, String> annotations) {
-        return createService(serviceName, type, ports, getLabelsWithName(serviceName), getSelectorLabels(), Collections.emptyMap());
+        return createService(serviceName, type, ports, getLabelsWithName(serviceName), getSelectorLabels(), annotations);
     }
 
     protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {
@@ -1043,6 +1043,8 @@ public abstract class AbstractModel {
      * @param replicasInSecret How many certificates are in the Secret
      * @param caCert CA certificate to use for signing new certificates
      * @param podName A function for resolving the Pod name
+     * @param externalBootstrapAddress External address to the bootstrap service
+     * @param externalAddresses Map with external addresses under which the individual pods are available
      * @return Collection with certificates
      * @throws IOException
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1083,6 +1083,7 @@ public abstract class AbstractModel {
 
             int nextDnsId = 4;
 
+            // TODO: We need to refresh the certificates when the external addresses change!
             if (externalBootstrapAddress != null)   {
                 sbjAltNames.put("DNS." + nextDnsId, externalBootstrapAddress);
                 nextDnsId++;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1085,7 +1085,6 @@ public abstract class AbstractModel {
 
             int nextDnsId = 4;
 
-            // TODO: We need to refresh the certificates when the external addresses change!
             if (externalBootstrapAddress != null)   {
                 sbjAltNames.put("DNS." + nextDnsId, externalBootstrapAddress);
                 nextDnsId++;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -695,22 +695,26 @@ public abstract class AbstractModel {
         return probe;
     }
 
-    protected Service createService(String name, List<ServicePort> ports) {
-        return createService(name, ports, Collections.emptyMap());
+    protected Service createService(String type, List<ServicePort> ports) {
+        return createService(type, ports, Collections.emptyMap());
     }
 
     protected Service createService(String type, List<ServicePort> ports,  Map<String, String> annotations) {
+        return createService(serviceName, type, ports, getLabelsWithName(serviceName), getSelectorLabels(), Collections.emptyMap());
+    }
+
+    protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
-                    .withName(serviceName)
-                    .withLabels(getLabelsWithName(serviceName))
-                    .withNamespace(namespace)
-                    .withAnnotations(annotations)
+                .withName(name)
+                .withLabels(labels)
+                .withNamespace(namespace)
+                .withAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
-                    .withType(type)
-                    .withSelector(getSelectorLabels())
-                    .withPorts(ports)
+                .withType(type)
+                .withSelector(selector)
+                .withPorts(ports)
                 .endSpec()
                 .build();
         log.trace("Created service {}", service);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -361,7 +361,7 @@ public class KafkaCluster extends AbstractModel {
             ports.add(createServicePort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, CLIENT_TLS_PORT, "TCP"));
         }
 
-        if (listeners != null && listeners.getExternal() != null) {
+        if (isExposed()) {
             ports.add(createServicePort(EXTERNAL_PORT_NAME, EXTERNAL_PORT, EXTERNAL_PORT, "TCP"));
         }
 
@@ -389,7 +389,7 @@ public class KafkaCluster extends AbstractModel {
             ports.add(createServicePort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, CLIENT_TLS_PORT, "TCP"));
         }
 
-        if (listeners != null && listeners.getExternal() != null) {
+        if (isExposed()) {
             ports.add(createServicePort(EXTERNAL_PORT_NAME, EXTERNAL_PORT, EXTERNAL_PORT, "TCP"));
         }
 
@@ -411,7 +411,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Service
      */
     public Service generateExternalService(int pod) {
-        if (listeners != null && listeners.getExternal() != null) {
+        if (isExposed()) {
             String perPodServiceName = externalServiceName(cluster, pod);
 
             List<ServicePort> ports = new ArrayList<>(1);
@@ -432,7 +432,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Route
      */
     public Route generateExternalRoute(int pod) {
-        if (listeners != null && listeners.getExternal() != null && KafkaListenerExternalRoute.TYPE_ROUTE.equals(listeners.getExternal().getType())) {
+        if (isExposedWithRoute()) {
             String perPodServiceName = externalServiceName(cluster, pod);
 
             Route route = new RouteBuilder()
@@ -467,7 +467,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Routes
      */
     public Route generateExternalBootstrapRoute() {
-        if (listeners != null && listeners.getExternal() != null && KafkaListenerExternalRoute.TYPE_ROUTE.equals(listeners.getExternal().getType())) {
+        if (isExposedWithRoute()) {
             Route route = new RouteBuilder()
                     .withNewMetadata()
                         .withName(serviceName)
@@ -600,7 +600,7 @@ public class KafkaCluster extends AbstractModel {
             portList.add(createContainerPort(CLIENT_TLS_PORT_NAME, CLIENT_TLS_PORT, "TCP"));
         }
 
-        if (listeners != null && listeners.getExternal() != null) {
+        if (isExposed()) {
             portList.add(createContainerPort(EXTERNAL_PORT_NAME, EXTERNAL_PORT, "TCP"));
         }
 
@@ -943,6 +943,6 @@ public class KafkaCluster extends AbstractModel {
      * @return
      */
     public boolean isExposedWithRoute()  {
-        return isExposed() && KafkaListenerExternalRoute.TYPE_ROUTE.equals(listeners.getExternal().getType());
+        return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalRoute;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -572,16 +572,9 @@ public class KafkaCluster extends AbstractModel {
      * It also contains the private key-certificate (signed by cluster CA) for each brokers as well as for communicating
      * with Zookeeper as well
      *
-     * @param certManager CertManager instance for handling certificates creation
-     * @param secrets The Secrets storing certificates
-     * @param externalBootstrapAddress External address to the bootstrap service
-     * @param externalAddresses Map with external addresses under which the individual pods are available
-     *
      * @return The generated Secret
      */
-    public Secret generateBrokersSecret(CertManager certManager, List<Secret> assemblySecrets, String externalBootstrapAddress, Map<String, String> externalAddresses) {
-        generateCertificates(certManager, assemblySecrets, externalBootstrapAddress, externalAddresses);
-
+    public Secret generateBrokersSecret() {
         Base64.Encoder encoder = Base64.getEncoder();
 
         Map<String, String> data = new HashMap<>();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -83,11 +83,13 @@ public class KafkaCluster extends AbstractModel {
     /** The authentication to configure for the CLIENTTLS listener (TLS transport) . */
     private static final String ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION = "KAFKA_CLIENTTLS_AUTHENTICATION";
     private static final String ENV_VAR_KAFKA_EXTERNAL_ENABLED = "KAFKA_EXTERNAL_ENABLED";
-    private static final String ENV_VAR_KAFKA_EXTERNAL_TYPE = "KAFKA_EXTERNAL_TYPE";
     private static final String ENV_VAR_KAFKA_EXTERNAL_ADDRESSES = "KAFKA_EXTERNAL_ADDRESSES";
     private static final String ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION = "KAFKA_EXTERNAL_AUTHENTICATION";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_TYPE = "KAFKA_AUTHORIZATION_TYPE";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_SUPER_USERS = "KAFKA_AUTHORIZATION_SUPER_USERS";
+    public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
+    private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
+    protected static final String ENV_VAR_KAFKA_CONFIGURATION = "KAFKA_CONFIGURATION";
 
     protected static final int CLIENT_PORT = 9092;
     protected static final String CLIENT_PORT_NAME = "clients";
@@ -135,12 +137,6 @@ public class KafkaCluster extends AbstractModel {
     private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     private static final boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
-
-    // Kafka configuration keys (EnvVariables)
-    public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
-    private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
-    protected static final String ENV_VAR_KAFKA_CONFIGURATION = "KAFKA_CONFIGURATION";
-    protected static final String ENV_VAR_KAFKA_LOG_CONFIGURATION = "KAFKA_LOG_CONFIGURATION";
 
     private CertAndKey clientsCA;
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -571,9 +571,17 @@ public class KafkaCluster extends AbstractModel {
      * Generate the Secret containing CA self-signed certificate for TLS communication.
      * It also contains the private key-certificate (signed by cluster CA) for each brokers as well as for communicating
      * with Zookeeper as well
+     *
+     * @param certManager CertManager instance for handling certificates creation
+     * @param secrets The Secrets storing certificates
+     * @param externalBootstrapAddress External address to the bootstrap service
+     * @param externalAddresses Map with external addresses under which the individual pods are available
+     *
      * @return The generated Secret
      */
-    public Secret generateBrokersSecret() {
+    public Secret generateBrokersSecret(CertManager certManager, List<Secret> assemblySecrets, String externalBootstrapAddress, Map<String, String> externalAddresses) {
+        generateCertificates(certManager, assemblySecrets, externalBootstrapAddress, externalAddresses);
+
         Base64.Encoder encoder = Base64.getEncoder();
 
         Map<String, String> data = new HashMap<>();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -82,9 +82,9 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_CLIENTTLS_ENABLED = "KAFKA_CLIENTTLS_ENABLED";
     /** The authentication to configure for the CLIENTTLS listener (TLS transport) . */
     private static final String ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION = "KAFKA_CLIENTTLS_AUTHENTICATION";
-    private static final String ENV_VAR_KAFKA_EXTERNAL_ENABLED = "KAFKA_EXTERNAL_ENABLED";
-    private static final String ENV_VAR_KAFKA_EXTERNAL_ADDRESSES = "KAFKA_EXTERNAL_ADDRESSES";
-    private static final String ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION = "KAFKA_EXTERNAL_AUTHENTICATION";
+    protected static final String ENV_VAR_KAFKA_EXTERNAL_ENABLED = "KAFKA_EXTERNAL_ENABLED";
+    protected static final String ENV_VAR_KAFKA_EXTERNAL_ADDRESSES = "KAFKA_EXTERNAL_ADDRESSES";
+    protected static final String ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION = "KAFKA_EXTERNAL_AUTHENTICATION";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_TYPE = "KAFKA_AUTHORIZATION_TYPE";
     private static final String ENV_VAR_KAFKA_AUTHORIZATION_SUPER_USERS = "KAFKA_AUTHORIZATION_SUPER_USERS";
     public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -451,7 +451,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 return withVoid(Future.failedFuture("Exposing Kafka cluster " + name + " using OpenShift Routes is available only on OpenShift"));
             }
 
-            return withVoid(Future.succeededFutre())
+            return withVoid(Future.succeededFuture());
         }
 
         Future<ReconciliationState> kafkaReplicaRoutes() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -486,7 +486,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             address.setHandler(res -> {
                 if (res.succeeded())    {
                     this.kafkaExternalBootstrapAddress = routeOperations.get(namespace, routeName).getSpec().getHost();
-                    log.warn("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+
+                    if (log.isTraceEnabled()) {
+                        log.trace("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+                    }
+
                     future.complete();
                 } else {
                     log.warn("{}: No address found for Route {}", reconciliation, routeName);
@@ -514,7 +518,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 address.setHandler(res -> {
                     if (res.succeeded()) {
                         this.kafkaExternalAddresses.put(kafkaCluster.getPodName(podNumber), routeOperations.get(namespace, routeName).getSpec().getHost());
-                        log.warn("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+
+                        if (log.isTraceEnabled()) {
+                            log.trace("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+                        }
+
                         future.complete();
                     } else {
                         log.warn("{}: No address found for Route {}", reconciliation, routeName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -442,7 +442,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaBootstrapRoute() {
-            Future future = Future.succeededFuture();
             Route route = kafkaCluster.generateExternalBootstrapRoute();
 
             if (routeOperations != null) {
@@ -452,7 +451,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 return withVoid(Future.failedFuture("Exposing Kafka cluster " + name + " using OpenShift Routes is available only on OpenShift"));
             }
 
-            return withVoid(future);
+            return withVoid(Future.succeededFutre())
         }
 
         Future<ReconciliationState> kafkaReplicaRoutes() {
@@ -488,7 +487,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     this.kafkaExternalBootstrapAddress = routeOperations.get(namespace, routeName).getSpec().getHost();
 
                     if (log.isTraceEnabled()) {
-                        log.trace("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+                        log.trace("{}: Found address {} for Route {}", reconciliation, routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
                     }
 
                     future.complete();
@@ -520,7 +519,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         this.kafkaExternalAddresses.put(kafkaCluster.getPodName(podNumber), routeOperations.get(namespace, routeName).getSpec().getHost());
 
                         if (log.isTraceEnabled()) {
-                            log.trace("Found address {} for Route {}", routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
+                            log.trace("{}: Found address {} for Route {}", reconciliation, routeOperations.get(namespace, routeName).getSpec().getHost(), routeName);
                         }
 
                         future.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -17,6 +17,7 @@ import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +39,7 @@ import static java.util.Arrays.asList;
 public class ResourceOperatorSupplier {
     public final SecretOperator secretOperations;
     public final ServiceOperator serviceOperations;
+    public final RouteOperator routeOperations;
     public final ZookeeperSetOperator zkSetOperations;
     public final KafkaSetOperator kafkaSetOperations;
     public final ConfigMapOperator configMapOperations;
@@ -48,8 +51,9 @@ public class ResourceOperatorSupplier {
     public final CrdOperator<KubernetesClient, Kafka, KafkaAssemblyList, DoneableKafka> kafkaOperator;
     public final NetworkPolicyOperator networkPolicyOperator;
 
-    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
+    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, boolean isOpenShift, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
+            isOpenShift ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
             new ZookeeperSetOperator(vertx, client, operationTimeoutMs),
             new KafkaSetOperator(vertx, client, operationTimeoutMs),
             new ConfigMapOperator(vertx, client),
@@ -64,6 +68,7 @@ public class ResourceOperatorSupplier {
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
+                                    RouteOperator routeOperations,
                                     ZookeeperSetOperator zkSetOperations,
                                     KafkaSetOperator kafkaSetOperations,
                                     ConfigMapOperator configMapOperations,
@@ -76,6 +81,7 @@ public class ResourceOperatorSupplier {
                                     NetworkPolicyOperator networkPolicyOperator,
                                     CrdOperator<KubernetesClient, Kafka, KafkaAssemblyList, DoneableKafka> kafkaOperator) {
         this.serviceOperations = serviceOperations;
+        this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
         this.kafkaSetOperations = kafkaSetOperations;
         this.configMapOperations = configMapOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -59,10 +59,11 @@ public class KafkaClusterTest {
 
     private final CertManager certManager = new MockCertManager();
     private final Kafka kafkaAssembly = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, configuration, kafkaLog, zooLog);
-    private final KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
+    private final List<Secret> assemblySecrets = ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName());
+    private final KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
 
     @Rule
-    public ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, (ResourceTester.TriFunction<CertManager, Kafka, List<Secret>, KafkaCluster>) KafkaCluster::fromCrd);
+    public ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, KafkaCluster::fromCrd);
 
     @Test
     public void testMetricsConfigMap() {
@@ -148,7 +149,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
         StatefulSet ss = kc.generateStatefulSet(false);
         assertEquals(selector, ss.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector().getMatchLabels());
     }
@@ -163,7 +164,7 @@ public class KafkaClusterTest {
                 .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
         StatefulSet ss = kc.generateStatefulSet(false);
         assertEquals(null, ss.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector());
     }
@@ -178,7 +179,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
         StatefulSet ss = kc.generateStatefulSet(true);
         checkStatefulSet(ss, kafkaAssembly, true);
     }
@@ -194,7 +195,7 @@ public class KafkaClusterTest {
                                 .withNewRack().withTopologyKey("rack-key").endRack()
                             .endKafka()
                         .endSpec().build();
-        KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
         StatefulSet ss = kc.generateStatefulSet(false);
         checkStatefulSet(ss, kafkaAssembly, false);
     }
@@ -280,7 +281,7 @@ public class KafkaClusterTest {
     public void testDeleteClaim() {
         Kafka assembly = ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap());
-        KafkaCluster kc = KafkaCluster.fromCrd(certManager, assembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, assembly.getMetadata().getName()));
+        KafkaCluster kc = KafkaCluster.fromCrd(assembly);
         StatefulSet ss = kc.generateStatefulSet(true);
         assertFalse(KafkaCluster.deleteClaim(ss));
 
@@ -292,7 +293,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        kc = KafkaCluster.fromCrd(certManager, assembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, assembly.getMetadata().getName()));
+        kc = KafkaCluster.fromCrd(assembly);
         ss = kc.generateStatefulSet(true);
         assertFalse(KafkaCluster.deleteClaim(ss));
 
@@ -304,7 +305,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        kc = KafkaCluster.fromCrd(certManager, assembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, assembly.getMetadata().getName()));
+        kc = KafkaCluster.fromCrd(assembly);
         ss = kc.generateStatefulSet(true);
         assertTrue(KafkaCluster.deleteClaim(ss));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
@@ -61,7 +62,7 @@ public class KafkaClusterTest {
     private final KafkaCluster kc = KafkaCluster.fromCrd(certManager, kafkaAssembly, ResourceUtils.createKafkaClusterInitialSecrets(namespace, kafkaAssembly.getMetadata().getName()));
 
     @Rule
-    public ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, KafkaCluster::fromCrd);
+    public ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, (ResourceTester.TriFunction<CertManager, Kafka, List<Secret>, KafkaCluster>) KafkaCluster::fromCrd);
 
     @Test
     public void testMetricsConfigMap() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.PodSpec;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -216,7 +216,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     private ResourceOperatorSupplier supplierWithMocks() {
-        return new ResourceOperatorSupplier(vertx, mockClient, 2_000);
+        return new ResourceOperatorSupplier(vertx, mockClient, true, 2_000);
     }
 
     private KafkaAssemblyOperator createCluster(TestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -19,6 +19,8 @@ import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaListeners;
+import io.strimzi.api.kafka.model.KafkaListenersBuilder;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
@@ -50,6 +52,9 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -105,6 +110,7 @@ public class KafkaAssemblyOperatorTest {
     }
     private final boolean openShift;
     private final boolean metrics;
+    private final KafkaListeners kafkaListeners;
     private final Map<String, Object> kafkaConfig;
     private final Map<String, Object> zooConfig;
     private final Storage storage;
@@ -116,16 +122,18 @@ public class KafkaAssemblyOperatorTest {
     public static class Params {
         private final boolean openShift;
         private final boolean metrics;
+        private final KafkaListeners kafkaListeners;
         private final Map<String, Object> kafkaConfig;
         private final Map<String, Object> zooConfig;
         private final Storage storage;
         private final TopicOperatorSpec toConfig;
         private final EntityOperatorSpec eoConfig;
 
-        public Params(boolean openShift, boolean metrics, Map<String, Object> kafkaConfig, Map<String, Object> zooConfig, Storage storage, TopicOperatorSpec toConfig, EntityOperatorSpec eoConfig) {
+        public Params(boolean openShift, boolean metrics, KafkaListeners kafkaListeners, Map<String, Object> kafkaConfig, Map<String, Object> zooConfig, Storage storage, TopicOperatorSpec toConfig, EntityOperatorSpec eoConfig) {
             this.openShift = openShift;
             this.metrics = metrics;
             this.kafkaConfig = kafkaConfig;
+            this.kafkaListeners = kafkaListeners;
             this.zooConfig = zooConfig;
             this.storage = storage;
             this.toConfig = toConfig;
@@ -135,6 +143,7 @@ public class KafkaAssemblyOperatorTest {
         public String toString() {
             return "openShift=" + openShift +
                     ",metrics=" + metrics +
+                    ",kafkaListeners=" + kafkaListeners +
                     ",kafkaConfig=" + kafkaConfig +
                     ",zooConfig=" + zooConfig +
                     ",storage=" + storage +
@@ -181,14 +190,43 @@ public class KafkaAssemblyOperatorTest {
         List<Params> result = new ArrayList();
         for (boolean shift: shiftiness) {
             for (boolean metric: metrics) {
-                for (Map kafkaConfig: kafkaConfigs) {
-                    for (Map zooConfig: zooConfigs) {
+                for (Map kafkaConfig : kafkaConfigs) {
+                    for (Map zooConfig : zooConfigs) {
                         for (Storage storage : storageConfigs) {
                             for (TopicOperatorSpec toConfig : toConfigs) {
-                                for (EntityOperatorSpec eoConfig: eoConfigs) {
+                                for (EntityOperatorSpec eoConfig : eoConfigs) {
+                                    KafkaListeners listeners;
+                                    if (shift)   {
+                                        listeners = new KafkaListenersBuilder()
+                                                .withNewPlain()
+                                                    .withNewKafkaListenerAuthenticationScramSha512Authentication()
+                                                    .endKafkaListenerAuthenticationScramSha512Authentication()
+                                                .endPlain()
+                                                .withNewTls()
+                                                    .withNewKafkaListenerAuthenticationTlsAuth()
+                                                    .endKafkaListenerAuthenticationTlsAuth()
+                                                .endTls()
+                                                .withNewKafkaListenerExternalRouteExternal()
+                                                    .withNewKafkaListenerAuthenticationTlsAuth()
+                                                    .endKafkaListenerAuthenticationTlsAuth()
+                                                .endKafkaListenerExternalRouteExternal()
+                                                .build();
+                                    } else {
+                                        listeners = new KafkaListenersBuilder()
+                                                .withNewPlain()
+                                                .withNewKafkaListenerAuthenticationScramSha512Authentication()
+                                                    .endKafkaListenerAuthenticationScramSha512Authentication()
+                                                    .endPlain()
+                                                .withNewTls()
+                                                    .withNewKafkaListenerAuthenticationTlsAuth()
+                                                    .endKafkaListenerAuthenticationTlsAuth()
+                                                .endTls()
+                                                .build();
+                                    }
+
                                     // TO and EO cannot be deployed together so no need for testing this case
                                     if (!(toConfig != null && eoConfig != null)) {
-                                        result.add(new Params(shift, metric, kafkaConfig, zooConfig, storage, toConfig, eoConfig));
+                                        result.add(new Params(shift, metric, listeners, kafkaConfig, zooConfig, storage, toConfig, eoConfig));
                                     }
                                 }
                             }
@@ -203,6 +241,7 @@ public class KafkaAssemblyOperatorTest {
     public KafkaAssemblyOperatorTest(Params params) {
         this.openShift = params.openShift;
         this.metrics = params.metrics;
+        this.kafkaListeners = params.kafkaListeners;
         this.kafkaConfig = params.kafkaConfig;
         this.zooConfig = params.zooConfig;
         this.storage = params.storage;
@@ -246,6 +285,7 @@ public class KafkaAssemblyOperatorTest {
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
         NetworkPolicyOperator mockPolicyOps = supplier.networkPolicyOperator;
+        RouteOperator mockRotueOps = supplier.routeOperations;
 
         // Create a CM
         String clusterCmName = clusterCm.getMetadata().getName();
@@ -314,6 +354,12 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> logNameCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.reconcile(anyString(), logNameCaptor.capture(), logCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
+        ArgumentCaptor<Route> routeCaptor = ArgumentCaptor.forClass(Route.class);
+        ArgumentCaptor<String> routeNameCaptor = ArgumentCaptor.forClass(String.class);
+        if (openShift) {
+            when(mockRotueOps.reconcile(eq(clusterCmNamespace), routeNameCaptor.capture(), routeCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
+        }
+
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
@@ -338,17 +384,15 @@ public class KafkaAssemblyOperatorTest {
                     KafkaCluster.serviceName(clusterCmName),
                     KafkaCluster.headlessServiceName(clusterCmName));
 
-            for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
-                expectedServices.add(KafkaCluster.externalServiceName(clusterCmName, i));
+            if (openShift && kafkaListeners != null && kafkaListeners.getExternal() != null) {
+                for (int i = 0; i < kafkaCluster.getReplicas(); i++) {
+                    expectedServices.add(KafkaCluster.externalServiceName(clusterCmName, i));
+                }
             }
 
             List<Service> capturedServices = serviceCaptor.getAllValues();
             context.assertEquals(7, capturedServices.size());
-            context.assertEquals(set(
-                    ZookeeperCluster.headlessServiceName(clusterCmName),
-                    ZookeeperCluster.serviceName(clusterCmName),
-                    KafkaCluster.serviceName(clusterCmName),
-                    KafkaCluster.headlessServiceName(clusterCmName)), capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()));
+            context.assertEquals(expectedServices, capturedServices.stream().filter(svc -> svc != null).map(svc -> svc.getMetadata().getName()).collect(Collectors.toSet()));
 
             // Assertions on the statefulset
             List<StatefulSet> capturedSs = ssCaptor.getAllValues();
@@ -358,6 +402,20 @@ public class KafkaAssemblyOperatorTest {
 
             // expected Secrets with certificates
             context.assertEquals(expectedSecrets, createdOrUpdatedSecrets);
+
+            // Verify deleted routes
+            if (openShift) {
+                Set<String> expectedRoutes = set(KafkaCluster.serviceName(clusterCmName));
+
+                for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
+                    expectedRoutes.add(KafkaCluster.externalServiceName(clusterCmName, i));
+                }
+
+                context.assertEquals(expectedRoutes,
+                        captured(routeNameCaptor));
+            } else {
+                context.assertEquals(0, routeNameCaptor.getAllValues().size());
+            }
 
             verifyNoMoreInteractions(mockPvcOps);
             async.complete();
@@ -385,6 +443,7 @@ public class KafkaAssemblyOperatorTest {
         ServiceAccountOperator mockSao = supplier.serviceAccountOperator;
         RoleBindingOperator mockRbo = supplier.roleBindingOperator;
         ClusterRoleBindingOperator mockCrbo = supplier.clusterRoleBindingOperator;
+        RouteOperator mockRouteOps = supplier.routeOperations;
 
         String assemblyName = clusterCm.getMetadata().getName();
         String assemblyNamespace = clusterCm.getMetadata().getNamespace();
@@ -466,6 +525,11 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> pvcCaptor = ArgumentCaptor.forClass(String.class);
         when(mockPvcOps.reconcile(eq(assemblyNamespace), pvcCaptor.capture(), isNull())).thenReturn(Future.succeededFuture());
 
+        ArgumentCaptor<String> routeCaptor = ArgumentCaptor.forClass(String.class);
+        if (openShift) {
+            when(mockRouteOps.reconcile(eq(assemblyNamespace), routeCaptor.capture(), isNull())).thenReturn(Future.succeededFuture());
+        }
+
         Set<String> existingDepNames = new HashSet<>();
         when(mockDepOps.reconcile(eq(assemblyNamespace), anyString(), isNull())).thenAnswer(invocation -> {
             String name = invocation.getArgument(1);
@@ -502,6 +566,7 @@ public class KafkaAssemblyOperatorTest {
 
             verify(mockZsOps).reconcile(eq(assemblyNamespace), eq(ZookeeperCluster.zookeeperClusterName(assemblyName)), isNull());
 
+            //Verify deleted services
             Set<String> expectedServices = set(
                     ZookeeperCluster.headlessServiceName(assemblyName),
                     ZookeeperCluster.serviceName(assemblyName),
@@ -512,7 +577,6 @@ public class KafkaAssemblyOperatorTest {
                 expectedServices.add(KafkaCluster.externalServiceName(assemblyName, i));
             }
 
-            //Verify deleted services
             context.assertEquals(expectedServices,
                     captured(serviceCaptor));
 
@@ -544,6 +608,18 @@ public class KafkaAssemblyOperatorTest {
                 context.assertEquals(existingDepNames, existingDepNames);
             }
 
+            // Verify deleted routes
+            if (openShift) {
+                Set<String> expectedRoutes = set(KafkaCluster.serviceName(assemblyName));
+
+                for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
+                    expectedRoutes.add(KafkaCluster.externalServiceName(assemblyName, i));
+                }
+
+                context.assertEquals(expectedRoutes,
+                        captured(routeCaptor));
+            }
+
             async.complete();
         });
     }
@@ -560,6 +636,9 @@ public class KafkaAssemblyOperatorTest {
 
         Kafka kafka = new KafkaBuilder(resource)
                 .editSpec()
+                    .editKafka()
+                        .withListeners(kafkaListeners)
+                    .endKafka()
                     .withTopicOperator(toConfig)
                     .withEntityOperator(eoConfig)
                 .endSpec()
@@ -1051,9 +1130,11 @@ public class KafkaAssemblyOperatorTest {
         context.assertEquals(singleton("baz"), deleted);
     }
 
-    private static ResourceOperatorSupplier supplierWithMocks() {
+    private ResourceOperatorSupplier supplierWithMocks() {
+        RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
+
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(
-                mock(ServiceOperator.class), mock(RouteOperator.class), mock(ZookeeperSetOperator.class),
+                mock(ServiceOperator.class), routeOps, mock(ZookeeperSetOperator.class),
                 mock(KafkaSetOperator.class), mock(ConfigMapOperator.class), mock(SecretOperator.class),
                 mock(PvcOperator.class), mock(DeploymentOperator.class),
                 mock(ServiceAccountOperator.class), mock(RoleBindingOperator.class), mock(ClusterRoleBindingOperator.class),
@@ -1061,7 +1142,19 @@ public class KafkaAssemblyOperatorTest {
         when(supplier.serviceAccountOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());
-        when(supplier.routeOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        if (openShift) {
+            when(supplier.routeOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+            when(supplier.routeOperations.hasAddress(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+            when(supplier.routeOperations.get(anyString(), anyString())).thenAnswer(i -> {
+                return new RouteBuilder()
+                        .withNewSpec()
+                        .withHost(i.getArgument(0) + "." + i.getArgument(1) + ".mydomain.com")
+                        .endSpec()
+                        .build();
+            });
+        }
+
         return supplier;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -45,6 +45,7 @@ import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
@@ -1027,7 +1028,7 @@ public class KafkaAssemblyOperatorTest {
 
     private static ResourceOperatorSupplier supplierWithMocks() {
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(
-                mock(ServiceOperator.class), mock(ZookeeperSetOperator.class),
+                mock(ServiceOperator.class), mock(RouteOperator.class), mock(ZookeeperSetOperator.class),
                 mock(KafkaSetOperator.class), mock(ConfigMapOperator.class), mock(SecretOperator.class),
                 mock(PvcOperator.class), mock(DeploymentOperator.class),
                 mock(ServiceAccountOperator.class), mock(RoleBindingOperator.class), mock(ClusterRoleBindingOperator.class),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -102,7 +102,7 @@ public class PartialRollingUpdateTest {
                 .end()
                 .build();
 
-        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, bootstrapClient, 60_000L);
+        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, bootstrapClient, true, 60_000L);
         KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,
                 new MockCertManager(), supplier);
 
@@ -139,7 +139,7 @@ public class PartialRollingUpdateTest {
                 .withInitialPods(set(zkPod0, zkPod1, zkPod2, kafkaPod0, kafkaPod1, kafkaPod2, kafkaPod3, kafkaPod4))
                 .build();
 
-        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, mockClient, 60_000L);
+        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, mockClient, true, 60_000L);
 
         this.kco = new KafkaAssemblyOperator(vertx, true, 2_000,
                 new MockCertManager(), supplier);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -43,8 +43,8 @@ public class KafkaSetOperatorTest {
     @Before
     public void before() {
         MockCertManager certManager = new MockCertManager();
-        a = KafkaCluster.fromCrd(certManager, getResource(), getInitialSecrets(getResource().getMetadata().getName())).generateStatefulSet(true);
-        b = KafkaCluster.fromCrd(certManager, getResource(), getInitialSecrets(getResource().getMetadata().getName())).generateStatefulSet(true);
+        a = KafkaCluster.fromCrd(getResource()).generateStatefulSet(true);
+        b = KafkaCluster.fromCrd(getResource()).generateStatefulSet(true);
     }
 
     private Kafka getResource() {

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -126,11 +126,13 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 
 [options="header"]
 |====
-|Field         |Description
-|plain  1.2+<.<|Configures plain listener on port 9092.
+|Field            |Description
+|plain     1.2+<.<|Configures plain listener on port 9092.
 |xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`]
-|tls    1.2+<.<|Configures TLS listener on port 9093.
+|tls       1.2+<.<|Configures TLS listener on port 9093.
 |xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+|external  1.2+<.<|Configures external listener on port 9094. The type depends on the value of the `external.type` property within the given object, which must be one of [route].
+|xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`]
 |====
 
 [id='type-KafkaListenerPlain-{context}']
@@ -164,7 +166,11 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 [id='type-KafkaListenerAuthenticationScramSha512-{context}']
 ### `KafkaListenerAuthenticationScramSha512` schema reference
 
+<<<<<<< HEAD
 Used in: xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+=======
+Used in: xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+>>>>>>> WIP
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationScramSha512` from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`].
@@ -176,17 +182,34 @@ It must have the value `scram-sha-512` for the type `KafkaListenerAuthentication
 |string
 |====
 
+<<<<<<< HEAD
 [id='type-KafkaListenerTls-{context}']
 ### `KafkaListenerTls` schema reference
+=======
+[id='type-KafkaListenerExternalRoute-{context}']
+### `KafkaListenerExternalRoute` schema reference
+>>>>>>> WIP
 
 Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 
+<<<<<<< HEAD
 [options="header"]
 |====
 |Field                  |Description
 |authentication  1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+=======
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalRoute` from other subtypes which may be added in the future.
+It must have the value `route` for the type `KafkaListenerExternalRoute`.
+[options="header"]
+|====
+|Field                  |Description
+|authentication  1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
+|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`]
+|type            1.2+<.<|Must be `route`.
+|string
+>>>>>>> WIP
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -151,7 +151,7 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 [id='type-KafkaListenerAuthenticationTls-{context}']
 ### `KafkaListenerAuthenticationTls` schema reference
 
-Used in: xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+Used in: xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationTls` from xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`].
@@ -166,11 +166,7 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 [id='type-KafkaListenerAuthenticationScramSha512-{context}']
 ### `KafkaListenerAuthenticationScramSha512` schema reference
 
-<<<<<<< HEAD
-Used in: xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
-=======
-Used in: xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
->>>>>>> WIP
+Used in: xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationScramSha512` from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`].
@@ -182,34 +178,34 @@ It must have the value `scram-sha-512` for the type `KafkaListenerAuthentication
 |string
 |====
 
-<<<<<<< HEAD
 [id='type-KafkaListenerTls-{context}']
 ### `KafkaListenerTls` schema reference
-=======
-[id='type-KafkaListenerExternalRoute-{context}']
-### `KafkaListenerExternalRoute` schema reference
->>>>>>> WIP
 
 Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 
-<<<<<<< HEAD
 [options="header"]
 |====
 |Field                  |Description
 |authentication  1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-=======
+|====
+
+[id='type-KafkaListenerExternalRoute-{context}']
+### `KafkaListenerExternalRoute` schema reference
+
+Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
+
+
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalRoute` from other subtypes which may be added in the future.
 It must have the value `route` for the type `KafkaListenerExternalRoute`.
 [options="header"]
 |====
 |Field                  |Description
-|authentication  1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls].
-|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`]
+|authentication  1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
 |type            1.2+<.<|Must be `route`.
 |string
->>>>>>> WIP
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']

--- a/examples/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/examples/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -199,6 +199,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
   - create
   - delete
   - patch

--- a/examples/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/examples/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -199,6 +199,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - patch
+  - update
 - apiGroups:
   - route.openshift.io
   resources:

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -60,6 +60,16 @@ spec:
                           properties:
                             type:
                               type: string
+                    external:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                        type:
+                          type: string
                 authorization:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -208,3 +208,14 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -64,6 +64,16 @@ spec:
                           properties:
                             type:
                               type: string
+                    external:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                        type:
+                          type: string
                 authorization:
                   type: object
                   properties:

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -48,6 +48,11 @@ public class Labels {
     public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "name";
 
     /**
+     * Used to identify individual pods
+     */
+    public static final String STRIMZI_POD_LABEL = STRIMZI_DOMAIN + "pod";
+
+    /**
      * The empty set of labels.
      */
     public static final Labels EMPTY = new Labels(emptyMap());
@@ -178,6 +183,13 @@ public class Labels {
      */
     public Labels withName(String name) {
         return with(STRIMZI_NAME_LABEL, name);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code name} for the {@code strimzi.io/name} key.
+     */
+    public Labels withPod(String name) {
+        return with(STRIMZI_POD_LABEL, name);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -50,7 +50,7 @@ public class Labels {
     /**
      * Used to identify individual pods
      */
-    public static final String STRIMZI_POD_LABEL = STRIMZI_DOMAIN + "pod";
+    public static final String KUBERNETES_STATEFULSET_POD_LABEL = "statefulset.kubernetes.io/pod-name";
 
     /**
      * The empty set of labels.
@@ -188,8 +188,8 @@ public class Labels {
     /**
      * The same labels as this instance, but with the given {@code name} for the {@code strimzi.io/name} key.
      */
-    public Labels withPod(String name) {
-        return with(STRIMZI_POD_LABEL, name);
+    public Labels withStatefulSetPod(String name) {
+        return with(KUBERNETES_STATEFULSET_POD_LABEL, name);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -12,12 +12,14 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 
 /**
  * Abstract resource creation, for a generic resource type {@code R}.
@@ -179,5 +181,63 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
                     .list()
                     .getItems();
         }
+    }
+
+    /**
+     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     *
+     * @param namespace The namespace.
+     * @param name The resource name.
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param predicate The predicate.
+     */
+    public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        Future<Void> fut = Future.future();
+        log.debug("Waiting for {} resource {} in namespace {} to get ready", resourceKind, name, namespace);
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        Handler<Long> handler = new Handler<Long>() {
+            @Override
+            public void handle(Long timerId) {
+                vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+                    future -> {
+                        try {
+                            if (predicate.test(namespace, name))   {
+                                future.complete();
+                            } else {
+                                log.trace("{} {} in namespace {} is not ready", resourceKind, name, namespace);
+                                future.fail("Not ready yet");
+                            }
+                        } catch (Throwable e) {
+                            log.warn("Caught exception while waiting for {} {} in namespace {} to get ready", resourceKind, name, namespace, e);
+                            future.fail(e);
+                        }
+                    },
+                    true,
+                    res -> {
+                        if (res.succeeded()) {
+                            log.debug("{} {} in namespace {} is ready", resourceKind, name, namespace);
+                            fut.complete();
+                        } else {
+                            long timeLeft = deadline - System.currentTimeMillis();
+                            if (timeLeft <= 0) {
+                                String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s %s in namespace %s to be ready", timeoutMs, resourceKind, name, namespace);
+                                log.error(exceptionMessage);
+                                fut.fail(new TimeoutException(exceptionMessage));
+                            } else {
+                                // Schedule ourselves to run again
+                                vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
+                            }
+                        }
+                    }
+                );
+            }
+        };
+
+        // Call the handler ourselves the first time
+        handler.handle(null);
+
+        return fut;
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -31,15 +31,24 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
         return client.routes();
     }
 
+    /**
+     * Succeeds when the Route has an assigned address
+     *
+     * @param namespace     Namespace
+     * @param name          Name of the route
+     * @param pollIntervalMs    Interval in which we poll
+     * @param timeoutMs     Timeout
+     * @return
+     */
     public Future<Void> hasAddress(String namespace, String name, long pollIntervalMs, long timeoutMs) {
         return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isAddressReady);
     }
 
     /**
-     * Check if a resource is in the Ready state.
+     * Checks if the Route already has an assigned address.
      *
      * @param namespace The namespace.
-     * @param name The resource name.
+     * @param name The route name.
      */
     public boolean isAddressReady(String namespace, String name) {
         Resource<Route, DoneableRoute> resourceOp = operation().inNamespace(namespace).withName(name);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is the first PR which looks into exposing Kafka to the outside of OpenShift and Kubernetes. I started with OpenShift Routes because they are easier to test locally. Loadbalancers should be quite easy to add afterwards.

Documentation will be done in separate PR.

This relates to #128 (however its just one part of the solution).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

