### PR TITLE
Add Network policies to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.0
 
 * Use less wide RBAC permissions (`ClusterRoleBindings` where converted to `RoleBindings` where possible)
-* Network policies for managing access to Zookeeper and Kafka replication ports
+* Network policies for managing access to Zookeeper ports and Kafka replication ports
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.0
 
 * Use less wide RBAC permissions (`ClusterRoleBindings` where converted to `RoleBindings` where possible)
+* Network policies for managing access to Zookeeper and Kafka replication ports
 
 ## 0.6.0
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems we forgot to add the Network policies to the `CHANGELOG.md`. Opening a PR to get some language check ;-).