### PR TITLE
Fix name of the deployment file in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -101,15 +101,15 @@ you can push the images to OpenShift's Docker repo like this:
 
         DOCKER_REGISTRY=172.30.1.1:5000 DOCKER_ORG=`oc project -q` make all
         
-4. In order to use the built images, you need to update the `examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yml` to obtain the images from the registry at `172.30.1.1:5000`, rather than from DockerHub.
+4. In order to use the built images, you need to update the `examples/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yml` to obtain the images from the registry at `172.30.1.1:5000`, rather than from DockerHub.
   That can be done using the following command:
 
     ```
     sed -Ei 's#(image|value): strimzi/([a-z0-9-]+):latest#\1: 172.30.1.1:5000/myproject/\2:latest#' \
-      examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml 
+      examples/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml 
     ```
 
-    This will update `05-Deployment-strimzi-cluster-operator.yaml` replacing all the image references (in `image` and `value` properties) with ones with the same name from `172.30.1.1:5000/myproject`.
+    This will update `050-Deployment-strimzi-cluster-operator.yaml` replacing all the image references (in `image` and `value` properties) with ones with the same name from `172.30.1.1:5000/myproject`.
 
 5. Then you can deploy the Cluster Operator running:
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When renaming the example files, I didn't rename the names in the deployment in `HACKING.md`