### PR TITLE
Set default log level for authorizer to INFO to log access denied events

### DIFF
--- a/cluster-operator/src/main/resources/kafkaDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaDefaultLoggingProperties
@@ -14,4 +14,4 @@ log4j.logger.kafka.network.RequestChannel$=WARN
 log4j.logger.kafka.controller=TRACE
 log4j.logger.kafka.log.LogCleaner=INFO
 log4j.logger.state.change.logger=TRACE
-log4j.logger.kafka.authorizer.logger=WARN
+log4j.logger.kafka.authorizer.logger=INFO


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Usually it is a good practice to log _access denied_ eventy by default. In Kafka, this is done at INFO level in `log4j.logger.kafka.authorizer.logger`. This PR changes the default log level for this logger.