### PR TITLE
changing metrics setting does not need to restart pods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.BiFunction;
 
 import static io.strimzi.operator.cluster.model.ModelUtils.findSecretWithName;
 
@@ -326,8 +327,33 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return withVoid(serviceOperations.reconcile(namespace, zkCluster.getHeadlessServiceName(), zkHeadlessService));
         }
 
+        Future<ReconciliationState> getReconciliationStateOfConfigMap(AbstractModel cluster, ConfigMap configMap, BiFunction<Boolean, Future<ReconcileResult<ConfigMap>>, Future<ReconciliationState>> function) {
+            Future<ReconciliationState> result = Future.future();
+
+            vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<Boolean>executeBlocking(
+                future -> {
+                    ConfigMap current = configMapOperations.get(namespace, cluster.getAncillaryConfigName());
+                    boolean onlyMetricsSettingChanged = onlyMetricsSettingChanged(current, configMap);
+                    future.complete(onlyMetricsSettingChanged);
+                }, res -> {
+                    if (res.succeeded())  {
+                        boolean onlyMetricsSettingChanged = res.result();
+                        function.apply(onlyMetricsSettingChanged, configMapOperations.reconcile(namespace, cluster.getAncillaryConfigName(), configMap)).setHandler(res2 -> {
+                            if (res2.succeeded())   {
+                                result.complete(res2.result());
+                            } else {
+                                result.fail(res2.cause());
+                            }
+                        });
+                    } else {
+                        result.fail(res.cause());
+                    }
+                });
+            return result;
+        }
+
         Future<ReconciliationState> zkAncillaryCm() {
-            return withZkAncillaryCmChanged(configMapOperations.reconcile(namespace, zkCluster.getAncillaryConfigName(), zkMetricsAndLogsConfigMap));
+            return getReconciliationStateOfConfigMap(zkCluster, zkMetricsAndLogsConfigMap, this::withZkAncillaryCmChanged);
         }
 
         Future<ReconciliationState> zkNodesSecret() {
@@ -358,9 +384,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return withVoid(serviceOperations.endpointReadiness(namespace, zkHeadlessService, 1_000, operationTimeoutMs));
         }
 
-        Future<ReconciliationState> withZkAncillaryCmChanged(Future<ReconcileResult<ConfigMap>> r) {
+        Future<ReconciliationState> withZkAncillaryCmChanged(boolean onlyMetricsSettingChanged, Future<ReconcileResult<ConfigMap>> r) {
             return r.map(rr -> {
-                this.zkForcedRestart = rr instanceof ReconcileResult.Patched;
+                if (onlyMetricsSettingChanged) {
+                    log.debug("Only metrics setting changed - not triggering rolling update");
+                    this.zkForcedRestart = false;
+                } else {
+                    this.zkForcedRestart = rr instanceof ReconcileResult.Patched;
+                }
                 return this;
             });
         }
@@ -404,9 +435,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             });
         }
 
-        Future<ReconciliationState> withKafkaAncillaryCmChanged(Future<ReconcileResult<ConfigMap>> r) {
+        Future<ReconciliationState> withKafkaAncillaryCmChanged(boolean onlyMetricsSettingChanged, Future<ReconcileResult<ConfigMap>> r) {
             return r.map(rr -> {
-                this.kafkaForcedRestart = rr instanceof ReconcileResult.Patched;
+                if (onlyMetricsSettingChanged) {
+                    log.debug("Only metrics setting changed - not triggering rolling update");
+                    this.kafkaForcedRestart = false;
+                } else {
+                    this.kafkaForcedRestart = rr instanceof ReconcileResult.Patched;
+                }
                 return this;
             });
         }
@@ -726,7 +762,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaAncillaryCm() {
-            return withKafkaAncillaryCmChanged(configMapOperations.reconcile(namespace, kafkaCluster.getAncillaryConfigName(), kafkaMetricsAndLogsConfigMap));
+            return getReconciliationStateOfConfigMap(kafkaCluster, kafkaMetricsAndLogsConfigMap, this::withKafkaAncillaryCmChanged);
         }
 
         Future<ReconciliationState> kafkaClientsCaSecret() {


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Changing metrics settings is a minor change which should not restart pods. JMX-Prometheus exporter is able to reload the configuration which can be used.

### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging https://github.com/strimzi/strimzi-kafka-operator/issues/814
- [ ] Update CHANGELOG.md

