### PR TITLE
Only Helm client on local machine

### DIFF
--- a/documentation/book/proc-deploying-cluster-operator-helm-chart.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-helm-chart.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* Helm has to be installed on the local machine.
+* Helm client has to be installed on the local machine.
 * Helm has to be installed in the {ProductPlatformName} cluster.
 
 .Procedure


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR makes clear that for deploying using Helm charts,the local machine needs only Helm client and not Helm as a whole (with Tiller as well).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

