### PR TITLE
ST: Removed the meaningless use of replaceAll() in the JSON path

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -208,13 +208,11 @@ public class AbstractST {
     }
 
     String getValueFromJson(String json, String jsonPath) {
-        String value = JsonPath.parse(json).read(jsonPath).toString().replaceAll("\\p{P}", "");
-        return value;
+        return JsonPath.parse(json).read(jsonPath).toString();
     }
 
     String globalVariableJsonPathBuilder(String variable) {
-        String path = "$.spec.containers[*].env[?(@.name=='" + variable + "')].value";
-        return path;
+        return "$.spec.containers[*].env[?(@.name=='" + variable + "')].value";
     }
 
     List<Event> getEvents(String resourceType, String resourceName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -54,16 +54,16 @@ public class ConnectST extends AbstractST {
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
     public static final String CONNECT_CLUSTER_NAME = "my-cluster";
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka-bootstrap:9092";
-    private static final String EXPECTED_CONFIG = "group.id=connect-cluster\\n" +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
-            "internal.key.converter.schemas.enable=false\\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
-            "config.storage.topic=connect-cluster-configs\\n" +
-            "status.storage.topic=connect-cluster-status\\n" +
-            "offset.storage.topic=connect-cluster-offsets\\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
-            "internal.value.converter.schemas.enable=false\\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\\n";
+    private static final String EXPECTED_CONFIG = "group.id=connect-cluster\n" +
+            "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.key.converter.schemas.enable=false\n" +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "config.storage.topic=connect-cluster-configs\n" +
+            "status.storage.topic=connect-cluster-status\n" +
+            "offset.storage.topic=connect-cluster-offsets\n" +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.value.converter.schemas.enable=false\n" +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
 
     @Test
     @JUnitGroup(name = "regression")
@@ -90,10 +90,10 @@ public class ConnectST extends AbstractST {
         String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("my-cluster-connect-")).findFirst().get();
         String kafkaPodJson = kubeClient.getResourceAsJson("pod", podName);
 
-        assertEquals(KAFKA_CONNECT_BOOTSTRAP_SERVERS.replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
-                globalVariableJsonPathBuilder("KAFKA_CONNECT_BOOTSTRAP_SERVERS")));
-        assertEquals(EXPECTED_CONFIG.replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
-                globalVariableJsonPathBuilder("KAFKA_CONNECT_CONFIGURATION")));
+        assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
+                hasItem(KAFKA_CONNECT_BOOTSTRAP_SERVERS)));
+        assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONNECT_CONFIGURATION"),
+                hasItem(EXPECTED_CONFIG)));
         testDockerImagesForKafkaConnect();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -250,16 +250,16 @@ public class KafkaST extends AbstractST {
         LOGGER.info("Verify values before update");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("transaction.state.log.replication.factor=1\\ndefault.replication.factor=1\\noffsets.topic.replication.factor=1\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
-                    globalVariableJsonPathBuilder("KAFKA_CONFIGURATION")));
+            assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONFIGURATION"),
+                    hasItem("transaction.state.log.replication.factor=1\ndefault.replication.factor=1\noffsets.topic.replication.factor=1\n")));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(30)));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.timeoutSeconds", hasItem(10)));
         }
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
-            assertEquals("timeTick=2000\\nautopurge.purgeInterval=1\\nsyncLimit=2\\ninitLimit=5\\n".replaceAll("\\p{P}", ""), getValueFromJson(zkPodJson,
-                    globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION")));
+            assertThat(zkPodJson, hasJsonPath(globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION"),
+                    hasItem("timeTick=2000\nautopurge.purgeInterval=1\nsyncLimit=2\ninitLimit=5\n")));
             assertThat(zkPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(30)));
             assertThat(zkPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.timeoutSeconds", hasItem(10)));
         }
@@ -291,17 +291,16 @@ public class KafkaST extends AbstractST {
         LOGGER.info("Verify values after update");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("transaction.state.log.replication.factor=2\\ndefault.replication.factor=2\\noffsets.topic.replication.factor=2\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
-                    globalVariableJsonPathBuilder("KAFKA_CONFIGURATION")));
-
+            assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONFIGURATION"),
+                    hasItem("transaction.state.log.replication.factor=2\ndefault.replication.factor=2\noffsets.topic.replication.factor=2\n")));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(31)));
             assertThat(kafkaPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.timeoutSeconds", hasItem(11)));
         }
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
-            assertEquals("timeTick=2100\\nautopurge.purgeInterval=1\\nsyncLimit=3\\ninitLimit=6\\n".replaceAll("\\p{P}", ""), getValueFromJson(zkPodJson,
-                    globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION")));
+            assertThat(zkPodJson, hasJsonPath(globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION"),
+                    hasItem("timeTick=2100\nautopurge.purgeInterval=1\nsyncLimit=3\ninitLimit=6\n")));
             assertThat(zkPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.initialDelaySeconds", hasItem(31)));
             assertThat(zkPodJson, hasJsonPath("$.spec.containers[*].livenessProbe.timeoutSeconds", hasItem(11)));
         }
@@ -495,11 +494,11 @@ public class KafkaST extends AbstractST {
         while (m.find()) {
             String json = m.group();
             String name2 = getValueFromJson(json, "$.name");
-            if ("tooldata".equals(name2)) {
+            if ("tool_data".equals(name2)) {
                 assertEquals(String.valueOf(messagesCount), getValueFromJson(json, "$.sent"));
                 assertEquals(String.valueOf(messagesCount), getValueFromJson(json, "$.acked"));
                 producerSuccess = true;
-            } else if ("recordsconsumed".equals(name2)) {
+            } else if ("records_consumed".equals(name2)) {
                 assertEquals(String.valueOf(messagesCount), getValueFromJson(json, "$.count"));
                 consumerSuccess = true;
             }


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
Removed using `.replaceAll("\\p{P}", "")` in method to get value by JSON path that was added by mistake in PR #324 
This refactoring was necessary because more and more tests used an incorrect implementation of the method, which led to an additional method call `.replaceAll("\\p{P}", "")` inside the tests.



### Checklist
- [ ] Make sure all tests pass