### PR TITLE
Add docu for exposing Kafka to the outside - Closes #128

### DIFF
--- a/documentation/book/assembly-configuring-kafka-listeners.adoc
+++ b/documentation/book/assembly-configuring-kafka-listeners.adoc
@@ -24,4 +24,10 @@ include::con-kafka-listeners.adoc[leveloffset=+1]
 
 include::proc-configuring-kafka-listeners.adoc[leveloffset=+1]
 
+include::proc-accessing-kafka-using-routes.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
+
 :context: {parent-context}

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -35,14 +35,14 @@ listeners:
 
 == External listener
 
-The external listener is used to connect to Kafka cluster from outside of an {ProductPlatformName} environment.
+The external listener is used to connect to a Kafka cluster from outside of an {ProductPlatformName} environment.
 {ProductName} supports three types of external listeners:
 
 * `route`
 * `loadbalancer`
 * `nodeport`
 
-All types of the external listener are using TLS encryption.
+Each type of external listener uses TLS encryption.
 
 .Exposing Kafka using {OpenShiftName} routes
 

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -6,10 +6,11 @@
 = Kafka listeners
 
 Kafka broker listeners can be configured using the `listeners` property in the `Kafka.spec.kafka` resource.
-The `listeners` property contains two sub-properties:
+The `listeners` property contains three sub-properties:
 
 * `plain`
 * `tls`
+* `external`
 
 When these sub-properties are not defined, the listener will be disabled.
 
@@ -32,6 +33,60 @@ listeners:
 # ...
 ----
 
+== External listener
+
+The external listener is used to connect to Kafka cluster from outside of an {ProductPlatformName} environment.
+{ProductName} supports three types of external listeners:
+
+* `route`
+* `loadbalancer`
+* `nodeport`
+
+All types of the external listener are using TLS encryption.
+
+.Exposing Kafka using {OpenShiftName} routes
+
+The external listener with type `route` is using {OpenShiftName} `Routes` and HAProxy to expose Kafka.
+For every Kafka broker `Pod`, a dedicated `Route` will be created.
+Additional `Route` will be created to serve as a Kafka _bootstrap_ address.
+All `Routes` use port 443.
+Kafka clients can use these `Routes` to connect to Kafka.
+
+ifdef::Kubernetes[]
+NOTE: `Routes` are available only on {OpenShiftName}. The external listener of type `route` cannot be used on {KubernetesName}.
+endif::Kubernetes[]
+
+For more information about using `Routes` to access Kafka see xref:proc-accessing-kafka-using-routes-{context}[].
+
+.Exposing Kafka using loadbalancers
+
+The external listener with type `loadbalancer` is using `Loadbalancer` type `Services` to expose Kafka.
+A loadbalancer service will be created for every Kafka broker `Pod`.
+Additional loadbalancer will be created to serve as a Kafka _bootstrap_ address.
+The loadbalancers will listen to connections on port 9094.
+For more information about using loadbalancers to access Kafka see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
+
+.Exposing Kafka using node ports
+
+The external listener with type `nodeport` is using `NodePort` type `Services` to expose Kafka.
+When exposing Kafka using node ports, the Kafka clients will be connecting directly to the nodes of the {ProductPlatformName}.
+The access to the ports on the {ProductPlatformName} nodes needs to be enabled for the clients (for example in firewalls or security groups).
+Each Kafka broker `Pod` will be accessible on a different port.
+Additional `NodePort` type `Services` will be created to serve as a Kafka _bootstrap_ address.
+
+When configuring the advertised addresses for the Kafka broker `Pods`, {ProductName} will use the address of the node on which given pod is running.
+When selecting the node address, the different address types will be used with following priority:
+
+. ExternalDNS
+. ExternalIP
+. Hostname
+. InternalDNS
+. InternalIP
+
+NOTE: Exposing Kafka cluster using node ports currently does not support TLS hostname verification.
+
+For more information about using node ports to access Kafka see xref:proc-accessing-kafka-using-nodeports-{context}[].
+
 == Listener authentication
 
 The listener sub-properties can also contain additional configuration.
@@ -51,6 +106,10 @@ listeners:
     authentication:
       type: scram-sha-512
   tls:
+    authentication:
+      type: tls
+  external:
+    type: loadbalancer
     authentication:
       type: tls
 # ...

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -72,10 +72,10 @@ For more information on using loadbalancers to access Kafka, see xref:proc-acces
 External listeners of type `nodeport` expose Kafka by using `NodePort` type `Services`.
 When exposing Kafka in this way, Kafka clients connect directly to the nodes of {ProductPlatformName}.
 You must enable access to the ports on the {ProductPlatformName} nodes for each client (for example, in firewalls or security groups).
-Each Kafka broker Pod is then accessible on a separate port.
+Each Kafka broker pod is then accessible on a separate port.
 Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
 
-When configuring the advertised addresses for the Kafka broker `Pods`, {ProductName} uses the address of the node on which given pod is running.
+When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
 When selecting the node address, the different address types are used with the following priority:
 
 . ExternalDNS

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -5,14 +5,14 @@
 [id='con-kafka-listeners-{context}']
 = Kafka listeners
 
-Kafka broker listeners can be configured using the `listeners` property in the `Kafka.spec.kafka` resource.
+You can configure Kafka broker listeners using the `listeners` property in the `Kafka.spec.kafka` resource.
 The `listeners` property contains three sub-properties:
 
 * `plain`
 * `tls`
 * `external`
 
-When these sub-properties are not defined, the listener will be disabled.
+If these sub-properties are not defined, the listener is disabled.
 
 .An example of `listeners` property with all listeners enabled
 [source,yaml,subs="attributes+"]
@@ -44,38 +44,39 @@ The external listener is used to connect to a Kafka cluster from outside of an {
 
 Each type of external listener uses TLS encryption.
 
-.Exposing Kafka using {OpenShiftName} routes
+.Exposing Kafka using {OpenShiftName} Routes
 
-The external listener with type `route` is using {OpenShiftName} `Routes` and HAProxy to expose Kafka.
-For every Kafka broker `Pod`, a dedicated `Route` will be created.
-Additional `Route` will be created to serve as a Kafka _bootstrap_ address.
-All `Routes` use port 443.
-Kafka clients can use these `Routes` to connect to Kafka.
+
+An external listener of type `route` exposes Kafka by using {OpenShiftName} `Routes` and the HAProxy router.
+A dedicated `Route` is created for every Kafka broker pod.
+An additional `Route` is created to serve as a Kafka bootstrap address.
+Kafka clients can use these `Routes` to connect to Kafka on port 443.
 
 ifdef::Kubernetes[]
-NOTE: `Routes` are available only on {OpenShiftName}. The external listener of type `route` cannot be used on {KubernetesName}.
+NOTE: `Routes` are available only on {OpenShiftName}. External listeners of type `route` cannot be used on {KubernetesName}.
 endif::Kubernetes[]
 
-For more information about using `Routes` to access Kafka see xref:proc-accessing-kafka-using-routes-{context}[].
+For more information on using `Routes` to access Kafka, see xref:proc-accessing-kafka-using-routes-{context}[].
 
 .Exposing Kafka using loadbalancers
 
-The external listener with type `loadbalancer` is using `Loadbalancer` type `Services` to expose Kafka.
-A loadbalancer service will be created for every Kafka broker `Pod`.
-Additional loadbalancer will be created to serve as a Kafka _bootstrap_ address.
-The loadbalancers will listen to connections on port 9094.
-For more information about using loadbalancers to access Kafka see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
+External listeners of type `loadbalancer` expose Kafka by using `Loadbalancer` type `Services`.
+A new loadbalancer service is created for every Kafka broker pod.
+An additional loadbalancer is created to serve as a Kafka _bootstrap_ address.
+Loadbalancers listen to connections on port 9094.
+
+For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
 
 .Exposing Kafka using node ports
 
-The external listener with type `nodeport` is using `NodePort` type `Services` to expose Kafka.
-When exposing Kafka using node ports, the Kafka clients will be connecting directly to the nodes of the {ProductPlatformName}.
-The access to the ports on the {ProductPlatformName} nodes needs to be enabled for the clients (for example in firewalls or security groups).
-Each Kafka broker `Pod` will be accessible on a different port.
-Additional `NodePort` type `Services` will be created to serve as a Kafka _bootstrap_ address.
+External listeners of type `nodeport` expose Kafka by using `NodePort` type `Services`.
+When exposing Kafka in this way, Kafka clients connect directly to the nodes of {ProductPlatformName}.
+You must enable access to the ports on the {ProductPlatformName} nodes for each client (for example, in firewalls or security groups).
+Each Kafka broker Pod is then accessible on a separate port.
+Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
 
-When configuring the advertised addresses for the Kafka broker `Pods`, {ProductName} will use the address of the node on which given pod is running.
-When selecting the node address, the different address types will be used with following priority:
+When configuring the advertised addresses for the Kafka broker `Pods`, {ProductName} uses the address of the node on which given pod is running.
+When selecting the node address, the different address types are used with the following priority:
 
 . ExternalDNS
 . ExternalIP
@@ -83,9 +84,9 @@ When selecting the node address, the different address types will be used with f
 . InternalDNS
 . InternalIP
 
-NOTE: Exposing Kafka cluster using node ports currently does not support TLS hostname verification.
+NOTE: TLS hostname verification is not currently supported when exposing Kafka clusters using node ports.
 
-For more information about using node ports to access Kafka see xref:proc-accessing-kafka-using-nodeports-{context}[].
+For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].
 
 == Listener authentication
 

--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Deploy Kafka cluster with external listener enabled and configured to the type `loadbalancer`.
+. Deploy Kafka cluster with an external listener enabled and configured to the type `loadbalancer`.
 +
 An example configuration with an external listener configured to use loadbalancers:
 +
@@ -48,17 +48,17 @@ oc apply -f _<your-file>_
 . Find the hostname of the bootstrap loadbalancer.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
 oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
 +
-If no hostname was found (the command did not return anything), the loadbalancer IP address has to be used.
+If no hostname was found (nothing was returned by the command), use the loadbalancer IP address.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
@@ -71,9 +71,9 @@ On {OpenShiftName} this can be done using `oc apply`:
 [source,shell,subs=+quotes]
 oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
 +
-Use the hostname or IP address together with the port 9094 in your Kafka client as the _bootstrap_ address.
+Use the hostname or IP address together with port 9094 in your Kafka client as the _bootstrap_ address.
 
-. Extract the public certificate of the broker certification authority
+. Extract the public certificate of the broker certification authority.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:

--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -61,12 +61,12 @@ oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.l
 If no hostname was found (nothing was returned by the command), use the loadbalancer IP address.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
 oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
@@ -76,12 +76,12 @@ Use the hostname or IP address together with port 9094 in your Kafka client as t
 . Extract the public certificate of the broker certification authority.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc extract`:
 +
 [source,shell,subs=+quotes]
 oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt

--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring-kafka-listeners.adoc
+
+[id='proc-accessing-kafka-using-loadbalancers-{context}']
+= Accessing Kafka using loadbalancers routes
+
+.Prerequisites
+
+* An {ProductPlatformName} cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Deploy Kafka cluster with external listener enabled and configured to the type `loadbalancer`.
++
+An example configuration with an external listener configured to use loadbalancers:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    listeners:
+      external:
+        type: loadbalancer
+        # ...
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _<your-file>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+. Find the hostname of the bootstrap loadbalancer.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
++
+If no hostname was found (the command did not return anything), the loadbalancer IP address has to be used.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
++
+Use the hostname or IP address together with the port 9094 in your Kafka client as the _bootstrap_ address.
+
+. Extract the public certificate of the broker certification authority
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
++
+Use the extracted certificate in your Kafka client to configure TLS connection.
+If you enabled any authentication, you will also need to configure SASL or TLS authentication.
+
+.Additional resources
+* For more information about the schema, see xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring-kafka-listeners.adoc
+
+[id='proc-accessing-kafka-using-nodeports-{context}']
+= Accessing Kafka using node ports routes
+
+.Prerequisites
+
+* An {ProductPlatformName} cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Deploy Kafka cluster with external listener enabled and configured to the type `nodeport`.
++
+An example configuration with an external listener configured to use node ports:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    listeners:
+      external:
+        type: nodeport
+        # ...
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _<your-file>_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+. Find the port number of the bootstrap service.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
++
+The port should be used in the Kafka _bootstrap_ address.
+
+. Find the address of the {ProductPlatformName} node.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
++
+The command might print different types of addresses.
+Select the right address type according to following order:
++
+.. ExternalDNS
+.. ExternalIP
+.. Hostname
+.. InternalDNS
+.. InternalIP
++
+The address should be used together with the port from previous step in the Kafka _bootstrap_ address.
+
+. Extract the public certificate of the broker certification authority
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
++
+Use the extracted certificate in your Kafka client to configure TLS connection.
+If you enabled any authentication, you will also need to configure SASL or TLS authentication.
+
+.Additional resources
+* For more information about the schema, see xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Deploy Kafka cluster with external listener enabled and configured to the type `nodeport`.
+. Deploy Kafka cluster with an external listener enabled and configured to the type `nodeport`.
 +
 An example configuration with an external listener configured to use node ports:
 +
@@ -73,8 +73,7 @@ On {OpenShiftName} this can be done using `oc apply`:
 [source,shell,subs=+quotes]
 oc get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
 +
-The command might print different types of addresses.
-Select the right address type according to following order:
+If several different addresses are returned, select the address type you want based on the following order:
 +
 .. ExternalDNS
 .. ExternalIP

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -48,12 +48,12 @@ oc apply -f _<your-file>_
 . Find the port number of the bootstrap service.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
 oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
@@ -63,12 +63,12 @@ The port should be used in the Kafka _bootstrap_ address.
 . Find the address of the {ProductPlatformName} node.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
 oc get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
@@ -81,17 +81,17 @@ If several different addresses are returned, select the address type you want ba
 .. InternalDNS
 .. InternalIP
 +
-The address should be used together with the port from previous step in the Kafka _bootstrap_ address.
+Use the address with the port found in the previous step in the Kafka _bootstrap_ address.
 
 . Extract the public certificate of the broker certification authority
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
 kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} this can be done using `oc extract`:
 +
 [source,shell,subs=+quotes]
 oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt

--- a/documentation/book/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/book/proc-accessing-kafka-using-routes.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring-kafka-listeners.adoc
+
+[id='proc-accessing-kafka-using-routes-{context}']
+= Accessing Kafka using {OpenShiftName} routes
+
+.Prerequisites
+
+* An {OpenShiftName} cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Deploy Kafka cluster with external listener enabled and configured to the type `route`.
++
+An example configuration with an external listener configured to use `Routes`:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    listeners:
+      external:
+        type: route
+        # ...
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+[source,shell,subs=+quotes]
+oc apply -f _<your-file>_
+
+. Find the address of the bootstrap `Route`.
++
+[source,shell]
+oc get routes _<cluster-name>_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
++
+Use the address together with the port 443 in your Kafka client as the _bootstrap_ address.
+
+. Extract the public certificate of the broker certification authority
++
+[source,shell]
+oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
++
+Use the extracted certificate in your Kafka client to configure TLS connection.
+If you enabled any authentication, you will also need to configure SASL or TLS authentication.
+
+.Additional resources
+* For more information about the schema, see xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/book/proc-accessing-kafka-using-routes.adoc
@@ -12,7 +12,7 @@
 
 .Procedure
 
-. Deploy Kafka cluster with external listener enabled and configured to the type `route`.
+. Deploy Kafka cluster with an external listener enabled and configured to the type `route`.
 +
 An example configuration with an external listener configured to use `Routes`:
 +
@@ -42,7 +42,7 @@ oc apply -f _<your-file>_
 [source,shell]
 oc get routes _<cluster-name>_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
 +
-Use the address together with the port 443 in your Kafka client as the _bootstrap_ address.
+Use the address together with port 443 in your Kafka client as the _bootstrap_ address.
 
 . Extract the public certificate of the broker certification authority
 +

--- a/documentation/book/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-cluster-resources.adoc
@@ -10,6 +10,10 @@ The following resources will created by the Cluster Operator in the {ProductPlat
 `_<cluster-name>_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods.
 `_<cluster-name>_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
 `_<cluster-name>_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients.
+`_<cluster-name>_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled.
+`_<cluster-name>_-kafka-_<pod-id>_`:: Service used to route traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled.
+`_<cluster-name>_-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled and set to type `route`.
+`_<cluster-name>_-kafka-_<pod-id>_`:: Route for traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled and set to type `route`.
 `_<cluster-name>_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
 `_<cluster-name>_-kafka-brokers`:: Secret with Kafka broker keys.
 `_<cluster-name>_-kafka`:: Service account used by the Kafka brokers.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds documentation about exposing Kafka to the outside. This should be the last piece for #128 

### Checklist

- [x] Update documentation

