### PR TITLE
Docs: Add warning about unsupported storage resizing

### DIFF
--- a/documentation/book/ref-storage-persistent.adoc
+++ b/documentation/book/ref-storage-persistent.adoc
@@ -26,6 +26,9 @@ It contains a `matchLabels` field which contains key:value pairs representing la
 Boolean value which specifies if the Persistent Volume Claim has to be deleted when the cluster is undeployed.
 Default is `false`.
 
+WARNING: Resizing persistent storage for existing {ProductName} clusters is currently not supported.
+The desired storage size has to be be carefully decided before deploying the cluster.
+
 .Example fragment of persistent storage configuration with 1000Gi `size`
 [source,yaml]
 ----

--- a/documentation/book/ref-storage-persistent.adoc
+++ b/documentation/book/ref-storage-persistent.adoc
@@ -26,8 +26,8 @@ It contains a `matchLabels` field which contains key:value pairs representing la
 Boolean value which specifies if the Persistent Volume Claim has to be deleted when the cluster is undeployed.
 Default is `false`.
 
-WARNING: Resizing persistent storage for existing {ProductName} clusters is currently not supported.
-The desired storage size has to be be carefully decided before deploying the cluster.
+WARNING: Resizing persistent storage for existing {ProductName} clusters is not currently supported.
+You must decide the necessary storage size before deploying the cluster.
 
 .Example fragment of persistent storage configuration with 1000Gi `size`
 [source,yaml]


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds a warning to the documentation about unsupported persisitent volume resizing. The idea is to make users aware of this and make sure they carefully consider how bit should the storage be.