### PR TITLE
Container names for EO in StrimziRunner

### DIFF
--- a/api/src/test/java/io/strimzi/test/StrimziRunner.java
+++ b/api/src/test/java/io/strimzi/test/StrimziRunner.java
@@ -575,8 +575,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     .getPo(zookeeperStatefulSetName)
                     .logs(zookeeperStatefulSetName + ".*", "zookeeper")
                     .getDep(eoDeploymentName)
-                    .logs(eoDeploymentName + ".*", "entity-operator")) {
-
+                    .logs(eoDeploymentName + ".*", "user-operator")
+                    .logs(eoDeploymentName + ".*", "topic-operator")
+                    .logs(eoDeploymentName + ".*", "tls-sidecar")) {
                     @Override
                     protected void before() {
                         LOGGER.info("Creating kafka cluster '{}' before test per @KafkaCluster annotation on {}", kafkaAssembly.getMetadata().getName(), name(element));

--- a/documentation/book/con-cluster-operator-rbac.adoc
+++ b/documentation/book/con-cluster-operator-rbac.adoc
@@ -52,7 +52,7 @@ include::examples/install/cluster-operator/050-Deployment-strimzi-cluster-operat
       # ...
 ----
 
-NOTE: line 12, where the the `strimzi-cluster-operator` `ServiceAccount` is specified as the `serviceAccountName`.
+Note line 12, where the the `strimzi-cluster-operator` `ServiceAccount` is specified as the `serviceAccountName`.
 
 == `ClusterRoles`
 

--- a/documentation/book/con-cluster-operator-rbac.adoc
+++ b/documentation/book/con-cluster-operator-rbac.adoc
@@ -52,7 +52,7 @@ include::examples/install/cluster-operator/050-Deployment-strimzi-cluster-operat
       # ...
 ----
 
-Note line 12, where the the `strimzi-cluster-operator` `ServiceAccount` is specified as the `serviceAccountName`.
+NOTE: line 12, where the the `strimzi-cluster-operator` `ServiceAccount` is specified as the `serviceAccountName`.
 
 == `ClusterRoles`
 


### PR DESCRIPTION
### Type of change
- Refactoring


### Description
To have correct logs for EO's containers, We need to add names of these containers as a parameter for method `logs()` in `StrimziRunner`. After these changes, we will have logs for every container of EO.

### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

