### PR TITLE
add support to have strimzi watch multiple namespaces

### DIFF
--- a/helm-charts/strimzi-kafka-operator/README.md
+++ b/helm-charts/strimzi-kafka-operator/README.md
@@ -1,13 +1,13 @@
 # Strimzi: Kafka as a Service
 
-Strimzi provides a way to run an [Apache Kafka](https://kafka.apache.org/) cluster on 
+Strimzi provides a way to run an [Apache Kafka](https://kafka.apache.org/) cluster on
 [Kubernetes](https://kubernetes.io/) or [OpenShift](https://www.openshift.com/) in various deployment configurations.
 See our [website](https://github.com/strimzi/strimzi-kafka-operator) for more details about the project.
 
 ## Introduction
 
-This chart bootstraps the Strimzi Cluster Operator Deployment, Cluster Roles, Cluster Role Bindings, Service Accounts, and 
-Custom Resource Definitions for running [Apache Kafka](https://kafka.apache.org/) on [Kubernetes](http://kubernetes.io) 
+This chart bootstraps the Strimzi Cluster Operator Deployment, Cluster Roles, Cluster Role Bindings, Service Accounts, and
+Custom Resource Definitions for running [Apache Kafka](https://kafka.apache.org/) on [Kubernetes](http://kubernetes.io)
 cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
@@ -29,7 +29,7 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release strimzi/strimzi-kafka-operator
 ```
 
-The command deploys the Strimzi Cluster Operator on the Kubernetes cluster with the default configuration. 
+The command deploys the Strimzi Cluster Operator on the Kubernetes cluster with the default configuration.
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
@@ -44,12 +44,13 @@ The command removes all the Kubernetes components associated with the operator a
 
 ## Configuration
 
-The following table lists the configurable parameters of the Strimzi chart and their default values.  Runtime 
+The following table lists the configurable parameters of the Strimzi chart and their default values.  Runtime
 configuration of Kafka and other components are defined within their respective Custom Resource Definitions.  See
 the documentation for more details.
 
 | Parameter                            | Description                               | Default                                              |
 | ------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
+| `strimzi.watch_namespaces`           | Comma separated list of namespaces to watch | namespace where helm is applied                    |
 | `image.repository`                   | Cluster Operator image repository         | `strimzi`                                            |
 | `image.name`                         | Cluster Operator image name               | `cluster-operator`                                   |
 | `image.tag`                          | Cluster Operator image tag                | `latest`                                             |

--- a/helm-charts/strimzi-kafka-operator/README.md
+++ b/helm-charts/strimzi-kafka-operator/README.md
@@ -50,7 +50,7 @@ the documentation for more details.
 
 | Parameter                            | Description                               | Default                                              |
 | ------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
-| `strimzi.watch_namespaces`           | Comma separated list of additional namespaces for the strimzi-operator to watch | []                    |
+| `watchNamespaces`                    | Comma separated list of additional namespaces for the strimzi-operator to watch | []                    |
 | `image.repository`                   | Cluster Operator image repository         | `strimzi`                                            |
 | `image.name`                         | Cluster Operator image name               | `cluster-operator`                                   |
 | `image.tag`                          | Cluster Operator image tag                | `latest`                                             |

--- a/helm-charts/strimzi-kafka-operator/README.md
+++ b/helm-charts/strimzi-kafka-operator/README.md
@@ -50,7 +50,7 @@ the documentation for more details.
 
 | Parameter                            | Description                               | Default                                              |
 | ------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
-| `strimzi.watch_namespaces`           | Comma separated list of namespaces to watch | namespace where helm is applied                    |
+| `strimzi.watch_namespaces`           | Comma separated list of additional namespaces for the strimzi-operator to watch | []                    |
 | `image.repository`                   | Cluster Operator image repository         | `strimzi`                                            |
 | `image.name`                         | Cluster Operator image name               | `cluster-operator`                                   |
 | `image.tag`                          | Cluster Operator image tag                | `latest`                                             |

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -9,6 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
+  {{ if .Values.strimzi.watch_namespaces }}
+  {{ range .Values.strimzi.watch_namespaces }}
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+  {{ end }}
+  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -9,13 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
-  {{ if .Values.strimzi.watch_namespaces }}
-  {{ range .Values.strimzi.watch_namespaces }}
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ . }}
-  {{ end }}
-  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}
@@ -23,3 +17,25 @@ roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced
   apiGroup: rbac.authorization.k8s.io
+{{ $root := . }}
+{{ range .Values.strimzi.watch_namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: {{ template "strimzi.name" $root }}
+    chart: {{ template "strimzi.chart" $root }}
+    component: role-binding
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-namespaced
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator
+  namespace: {{ . }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}
@@ -14,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: {{ . }}
+    namespace: {{ $root.Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -17,8 +17,8 @@ roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced
   apiGroup: rbac.authorization.k8s.io
-{{ $root := . }}
-{{ range .Values.strimzi.watch_namespaces }}
+{{- $root := . -}}
+{{- range .Values.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -38,4 +38,4 @@ roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
+{{- end }}

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-namespaced
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -9,6 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
+  {{ if .Values.strimzi.watch_namespaces }}
+  {{ range .Values.strimzi.watch_namespaces }}
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+  {{ end }}
+  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-entity-operator-delegation
+  namespace: {{ . }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}
@@ -14,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: {{ . }}
+    namespace: {{ $root.Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -17,8 +17,8 @@ roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator
   apiGroup: rbac.authorization.k8s.io
-{{ $root := . }}
-{{ range .Values.strimzi.watch_namespaces }}
+{{- $root := . -}}
+{{- range .Values.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -38,4 +38,4 @@ roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
+{{- end }}

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-entity-operator-delegation
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: entity-operator-role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-entity-operator
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -9,13 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
-  {{ if .Values.strimzi.watch_namespaces }}
-  {{ range .Values.strimzi.watch_namespaces }}
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ . }}
-  {{ end }}
-  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}
@@ -23,3 +17,25 @@ roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator
   apiGroup: rbac.authorization.k8s.io
+{{ $root := . }}
+{{ range .Values.strimzi.watch_namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  labels:
+    app: {{ template "strimzi.name" $root }}
+    chart: {{ template "strimzi.chart" $root }}
+    component: entity-operator-role-binding
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-entity-operator
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -9,6 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
+  {{ if .Values.strimzi.watch_namespaces }}
+  {{ range .Values.strimzi.watch_namespaces }}
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+  {{ end }}
+  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -17,8 +17,8 @@ roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator
   apiGroup: rbac.authorization.k8s.io
-{{ $root := . }}
-{{ range .Values.strimzi.watch_namespaces }}
+{{- $root := . -}}
+{{- range .Values.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -38,4 +38,4 @@ roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
+{{- end }}

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-topic-operator-delegation
+  namespace: {{ . }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}
@@ -14,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: {{ . }}
+    namespace: {{ $root.Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -9,13 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 subjects:
-  {{ if .Values.strimzi.watch_namespaces }}
-  {{ range .Values.strimzi.watch_namespaces }}
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ . }}
-  {{ end }}
-  {{ end }}
   - kind: ServiceAccount
     name: strimzi-cluster-operator
     namespace: {{ .Release.Namespace }}
@@ -23,3 +17,25 @@ roleRef:
   kind: ClusterRole
   name: strimzi-topic-operator
   apiGroup: rbac.authorization.k8s.io
+{{ $root := . }}
+{{ range .Values.strimzi.watch_namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-topic-operator-delegation
+  labels:
+    app: {{ template "strimzi.name" $root }}
+    chart: {{ template "strimzi.chart" $root }}
+    component: topic-operator-role-binding
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ . }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-topic-operator
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,24 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-topic-operator-delegation
-  labels:
-    app: {{ template "strimzi.name" . }}
-    chart: {{ template "strimzi.chart" . }}
-    component: topic-operator-role-binding
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: strimzi-topic-operator
-  apiGroup: rbac.authorization.k8s.io
 {{- $root := . -}}
-{{- range .Values.watchNamespaces }}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -22,9 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           env:
             - name: STRIMZI_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: {{ include "strimzi.watched_namespaces" . }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -22,7 +22,15 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           env:
             - name: STRIMZI_NAMESPACE
-              value: {{ template "strimzi.watchNamespaces" . }}
+              {{- if .Values.watchNamespaces -}}
+              {{- $ns := .Values.watchNamespaces -}}
+              {{- $ns := append $ns .Release.Namespace }}
+              value: "{{ join "," $ns }}"
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -22,15 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           env:
             - name: STRIMZI_NAMESPACE
-              {{- if .Values.watchNamespaces -}}
-              {{- $ns := .Values.watchNamespaces -}}
-              {{- $ns := append $ns .Release.Namespace }}
-              value: {{ join "," $ns }}
-              {{- else }}
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-              {{- end }}
+              value: {{ template "strimzi.watchNamespaces" . }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -22,7 +22,15 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           env:
             - name: STRIMZI_NAMESPACE
-              value: {{ include "strimzi.watched_namespaces" . }}
+              {{- if .Values.watchNamespaces -}}
+              {{- $ns := .Values.watchNamespaces -}}
+              {{- $ns := append $ns .Release.Namespace }}
+              value: {{ join "," $ns }}
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}
             - name: STRIMZI_OPERATION_TIMEOUT_MS

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+helper function to have strimzi watch multiple namespaces
+*/}}
+{{- define "strimzi.watched_namespaces" -}}
+{{- if .Values.strimzi.watch_namespaces -}}
+{{- join "," .Values.strimzi.watch_namespaces -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "strimzi.chart" -}}

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -32,6 +32,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Comma delimited list of namespaces to watch
+*/}}
+{{- define "strimzi.watchNamespaces" -}}
+{{- $namespaces := append .Values.watchNamespaces .Release.Namespace -}}
+{{- join "," $namespaces | quote -}}
+{{- end -}}
+
+{{/*
 Generate a docker registry prefix or empty string.
 
 NOTE: Not currently being used.  Is this useful?

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -25,19 +25,6 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-helper function to complete STRIMZI_NAMESPACE.
-*/}}
-{{- define "strimzi.watched_namespaces" -}}
-{{- if .Values.strimzi.watch_namespaces -}}
-{{- $ns := .Values.strimzi.watch_namespaces -}}
-{{- $ns := append $ns .Release.Namespace -}}
-{{- join "," $ns -}}
-{{- else -}}
-{{- .Release.Namespace -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "strimzi.chart" -}}

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -32,14 +32,6 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Comma delimited list of namespaces to watch
-*/}}
-{{- define "strimzi.watchNamespaces" -}}
-{{- $namespaces := append .Values.watchNamespaces .Release.Namespace -}}
-{{- join "," $namespaces | quote -}}
-{{- end -}}
-
-{{/*
 Generate a docker registry prefix or empty string.
 
 NOTE: Not currently being used.  Is this useful?

--- a/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_helpers.tpl
@@ -25,11 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-helper function to have strimzi watch multiple namespaces
+helper function to complete STRIMZI_NAMESPACE.
 */}}
 {{- define "strimzi.watched_namespaces" -}}
 {{- if .Values.strimzi.watch_namespaces -}}
-{{- join "," .Values.strimzi.watch_namespaces -}}
+{{- $ns := .Values.strimzi.watch_namespaces -}}
+{{- $ns := append $ns .Release.Namespace -}}
+{{- join "," $ns -}}
 {{- else -}}
 {{- .Release.Namespace -}}
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,7 +1,6 @@
 # Default values for strimzi-kafka-operator.
 
-strimzi:
-  watch_namespaces: []
+watchNamespaces: []
 
 image:
   repository: strimzi

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,5 +1,8 @@
 # Default values for strimzi-kafka-operator.
 
+strimzi:
+  watch_namespaces: false
+
 image:
   repository: strimzi
   name: cluster-operator

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for strimzi-kafka-operator.
 
 strimzi:
-  watch_namespaces: false
+  watch_namespaces: []
 
 image:
   repository: strimzi


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Parametrized helm chart Helm chart to support watching multiple namespace

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

this PR relates to issue #852 and the way i'm using it is:

```
helm upgrade strimzi --install  ./strimzi-kafka-operator/helm-charts/strimzi-kafka-operator/ \
 --namespace ns-strimzi-operator \
 --set strimzi.watch_namespaces="{namespace-1,namespace-2,namespace-n}"
```

I'm not sure the `RoleBindings` are 100% correct, so if someone is better at RBAC than I'am please take a look :) 

Last but not least, this PR won't solve issues like topic operator watching on multiple namespaces for example. so manual work is still needed to get a multi-namespace deployment working.



