### PR TITLE
Added not FQDN in the SAN list

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1093,10 +1093,11 @@ public abstract class AbstractModel {
 
             Map<String, String> sbjAltNames = new HashMap<>();
             sbjAltNames.put("DNS.1", getServiceName());
-            sbjAltNames.put("DNS.2", String.format("%s.%s.svc.%s", getServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-            sbjAltNames.put("DNS.3", String.format("%s.%s.%s.svc.%s", podName.apply(cluster, i), getHeadlessServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.2", String.format("%s.%s", getServiceName(), namespace));
+            sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", getServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", podName.apply(cluster, i), getHeadlessServiceName(), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
 
-            int nextDnsId = 4;
+            int nextDnsId = 5;
 
             if (externalBootstrapAddress != null)   {
                 sbjAltNames.put("DNS." + nextDnsId, externalBootstrapAddress);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #870 adding a not FQDN to the SAN list for broker certificates.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

