### PR TITLE
Clean up example YAML files

### DIFF
--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -4,15 +4,7 @@ metadata:
   name: my-connect-cluster
 spec:
   replicas: 1
-  readinessProbe:
-    initialDelaySeconds: 60
-    timeoutSeconds: 5
-  livenessProbe:
-    initialDelaySeconds: 60
-    timeoutSeconds: 5
   bootstrapServers: my-cluster-kafka-bootstrap:9093
-  metrics:
-    lowercaseOutputName: true
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -4,15 +4,7 @@ metadata:
   name: my-connect-cluster
 spec:
   replicas: 1
-  readinessProbe:
-    initialDelaySeconds: 60
-    timeoutSeconds: 5
-  livenessProbe:
-    initialDelaySeconds: 60
-    timeoutSeconds: 5
   bootstrapServers: my-cluster-kafka-bootstrap:9093
-  metrics:
-    lowercaseOutputName: true
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -8,39 +8,16 @@ spec:
     listeners:
       plain: {}
       tls: {}
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
     storage:
       type: ephemeral
-    metrics:
-      lowercaseOutputName: true
-      rules:
-        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count"
-          name: "kafka_server_$1_$2_total"
-        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*, topic=(.+)><>Count"
-          name: "kafka_server_$1_$2_total"
-          labels:
-            topic: "$3"
   zookeeper:
     replicas: 3
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     storage:
       type: ephemeral
-    metrics:
-      lowercaseOutputName: true
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -8,12 +8,6 @@ spec:
     listeners:
       plain: {}
       tls: {}
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -22,29 +16,12 @@ spec:
       type: persistent-claim
       size: 1Gi
       deleteClaim: false
-    metrics:
-      lowercaseOutputName: true
-      rules:
-        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count"
-          name: "kafka_server_$1_$2_total"
-        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*, topic=(.+)><>Count"
-          name: "kafka_server_$1_$2_total"
-          labels:
-            topic: "$3"
   zookeeper:
     replicas: 3
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: false
-    metrics:
-      lowercaseOutputName: true
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -96,5 +96,3 @@ objects:
       config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
       offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
       status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
-    metrics:
-      lowercaseOutputName: true

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -95,5 +95,3 @@ objects:
       config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
       offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
       status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
-    metrics:
-      lowercaseOutputName: true


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR does minor clean up to the example YAML files.
* It removes metrics from `kafka-persistent.yam` and `kafka-ephemeral.yaml`. The old metric configuration doesn't match anymore the metrics docs and dashboards after #877. Users who want to use metrics can use the metrics example and the dashboards.
* It removes also the liveness and readiness configuratiuon. This was part of the YAMLS, but was set to the default values. Removing it will IMHO help to make the example YAMLs cleaner and simpler. The liveness and readiness probe configurations are described in the docs like many other options and can be added.