### PR TITLE
Removed old log level env var

### DIFF
--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -24,9 +24,6 @@ export GC_LOG_ENABLED="false"
 # ... but enable equivalent GC logging to stdout
 export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
 
-if [ -z "$KAFKA_CONNECT_LOG_LEVEL" ]; then
-KAFKA_CONNECT_LOG_LEVEL="INFO"
-fi
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This trivial PR just remove the old log level env var for Kafka Connect which is not used anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

