### PR TITLE
Use a default heap allocation config when no JVM memory or cgroup memory limit specified

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -185,11 +185,11 @@ Pass additional parameters to `mvn` by populating the `EXTRA_ARGS` env var.
     
 ### Running single test class
 
-Use the `test` build goal and provide a `-Dtest=TestClassName` system property.
+Use the `test` build goal and provide a `-Dtest=TestClassName[#testMethodName]` system property. 
 
 Ex)
 
-    mvn test -pl systemtest -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false -Djunitgroup=acceptance,regression -Dtest=KafkaClusterIT
+    mvn test -pl systemtest -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false -Djunitgroup=acceptance,regression -Dtest=KafkaST#testKafkaAndZookeeperScaleUpScaleDown
 
 
 ### Log level

--- a/HACKING.md
+++ b/HACKING.md
@@ -28,7 +28,7 @@ To build this project you must first install several command line utilities.
 - [`helm`](https://helm.sh/) - Helm Package Management System for Kubernetes
     - After installing Helm be sure to run `helm init`.
 - [`asciidoctor`](https://asciidoctor.org/) - Documentation generation (use `gem` to install latest version for your platform)
-- [`yq`](https://github.com/mikefarah/yq) - YAML manipulation tool
+- [`yq`](https://github.com/mikefarah/yq) - YAML manipulation tool.  **Warning: There are several different `yq` yaml projects in the wild.  [Use this one.](https://github.com/mikefarah/yq)** 
 
 In order to use `make` these all need to be available in your `$PATH`.
  

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,11 @@ import java.util.Map;
         @JsonSubTypes.Type(name = KafkaListenerAuthenticationScramSha512.SCRAM_SHA_512, value = KafkaListenerAuthenticationScramSha512.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
 public abstract class KafkaListenerAuthentication implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/Resources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Resources.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Representation for resource containts.
+ * Representation for resource constraints.
  */
 @Buildable(
         editableEnabled = false,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -99,6 +99,7 @@ public abstract class AbstractModel {
             System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
 
     protected static final int CERTS_EXPIRATION_DAYS = 365;
+    protected static final String DEFAULT_JVM_XMS = "128M";
 
     private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
     protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
@@ -975,16 +976,21 @@ public abstract class AbstractModel {
         } else {
             Resources resources = getResources();
             CpuMemory cpuMemory = resources == null ? null : resources.getLimits();
-            // Delegate to the container to figure out only when cgroup memory limits are defined to prevent allocating
-            // too much memory on the kubelet.  When no memory limit is defined let JVM allocate "just enough" memory
-            // by not trying to guess `Xms` or `Xmx`.
-            if (resources != null && cpuMemory != null && cpuMemory.getMemory() != null) {
+
+            // Delegate to the container to figure out only when CGroup memory limits are defined to prevent allocating
+            // too much memory on the kubelet.
+            if (cpuMemory != null && cpuMemory.getMemory() != null) {
                 envVars.add(buildEnvVar(ENV_VAR_DYNAMIC_HEAP_FRACTION, Double.toString(dynamicHeapFraction)));
                 if (dynamicHeapMaxBytes > 0) {
                     envVars.add(buildEnvVar(ENV_VAR_DYNAMIC_HEAP_MAX, Long.toString(dynamicHeapMaxBytes)));
                 }
+            // When no memory limit, `Xms`, and `Xmx` are defined then set a default `Xms` and
+            // leave `Xmx` undefined.
+            } else if (xms == null) {
+                kafkaHeapOpts.append("-Xms").append(DEFAULT_JVM_XMS);
             }
         }
+
         String trim = kafkaHeapOpts.toString().trim();
         if (!trim.isEmpty()) {
             envVars.add(buildEnvVar(ENV_VAR_KAFKA_HEAP_OPTS, trim));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.strimzi.api.kafka.model.CpuMemory;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -38,13 +39,14 @@ public class AbstractModelTest {
     @Test
     public void testJvmMemoryOptionsExplicit() {
         Map<String, String> env = getStringStringMap("4", "4",
-                0.5, 4_000_000_000L);
+                0.5, 4_000_000_000L, null);
         assertEquals("-Xms4 -Xmx4", env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
         assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
         assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
     }
 
-    private Map<String, String> getStringStringMap(String xmx, String xms, double dynamicFraction, long dynamicMax) {
+    private Map<String, String> getStringStringMap(String xmx, String xms, double dynamicFraction, long dynamicMax,
+                                                   Resources resources) {
         AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) {
             @Override
             protected String getDefaultLogConfigFileName() {
@@ -57,21 +59,32 @@ public class AbstractModelTest {
             }
         };
         am.setJvmOptions(jvmOptions(xmx, xms));
+        am.setResources(resources);
         List<EnvVar> envVars = new ArrayList<>(1);
         am.heapOptions(envVars, dynamicFraction, dynamicMax);
         return envVars.stream().collect(Collectors.toMap(e -> e.getName(), e -> e.getValue()));
     }
 
     @Test
-    public void testJvmMemoryOptionsDefault() {
+    public void testJvmMemoryOptionsDefaultWithNoMemoryLimit() {
         Map<String, String> env = getStringStringMap(null, "4",
-                0.5, 5_000_000_000L);
+                0.5, 5_000_000_000L, null);
         assertEquals("-Xms4", env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
-        assertEquals("0.5", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
-        assertEquals("5000000000", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
+    }
 
-        env = getStringStringMap(null, "4",
-                0.5, 5_000_000_000L);
+    private Resources getResourceLimit() {
+        CpuMemory limits = new CpuMemory();
+        limits.setMemory("16000000000");
+        Resources resources = new Resources(limits, null);
+        return resources;
+    }
+
+    @Test
+    public void testJvmMemoryOptionsDefaultWithMemoryLimit() {
+        Map<String, String> env = getStringStringMap(null, "4",
+                0.5, 5_000_000_000L, getResourceLimit());
         assertEquals("-Xms4", env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
         assertEquals("0.5", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
         assertEquals("5000000000", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
@@ -80,7 +93,7 @@ public class AbstractModelTest {
     @Test
     public void testJvmMemoryOptionsMemoryRequest() {
         Map<String, String> env = getStringStringMap(null, null,
-                0.7, 10_000_000_000L);
+                0.7, 10_000_000_000L, getResourceLimit());
         assertEquals(null, env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
         assertEquals("0.7", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
         assertEquals("10000000000", env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -66,10 +66,29 @@ public class AbstractModelTest {
     }
 
     @Test
-    public void testJvmMemoryOptionsDefaultWithNoMemoryLimit() {
+    public void testJvmMemoryOptionsXmsOnly() {
         Map<String, String> env = getStringStringMap(null, "4",
                 0.5, 5_000_000_000L, null);
         assertEquals("-Xms4", env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
+    }
+
+    @Test
+    public void testJvmMemoryOptionsXmxOnly() {
+        Map<String, String> env = getStringStringMap("4", null,
+                0.5, 5_000_000_000L, null);
+        assertEquals("-Xmx4", env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
+        assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
+    }
+
+
+    @Test
+    public void testJvmMemoryOptionsDefaultWithNoMemoryLimitOrJvmOptions() {
+        Map<String, String> env = getStringStringMap(null, null,
+                0.5, 5_000_000_000L, null);
+        assertEquals("-Xms" + AbstractModel.DEFAULT_JVM_XMS, env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS));
         assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION));
         assertEquals(null, env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -44,6 +44,7 @@ public class KafkaConnectClusterTest {
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String bootstrapServers = "foo-kafka:9092";
+    private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
             "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
             "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
@@ -113,6 +114,7 @@ public class KafkaConnectClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
+        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS).withValue(kafkaHeapOpts).build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -113,7 +113,6 @@ public class KafkaConnectClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
-        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -114,7 +114,6 @@ public class KafkaConnectS2IClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
-        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -53,6 +53,7 @@ public class KafkaConnectS2IClusterTest {
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String bootstrapServers = "foo-kafka:9092";
+    private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
             "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
             "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
@@ -114,6 +115,7 @@ public class KafkaConnectS2IClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
+        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS).withValue(kafkaHeapOpts).build());
         return expected;
     }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -56,7 +56,7 @@ import static java.util.Collections.emptyMap;
  * K8S CRD validation schema support, which is more limited that the full OpenAPI schema
  * supported in the rest of K8S.</p>
  *
- * <p>The tool works be recursing through class properties (in the JavaBeans sense)
+ * <p>The tool works by recursing through class properties (in the JavaBeans sense)
  * and the types of those properties, guided by the annotations.</p>
  *
  * <h3>Annotations</h3>

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -53,7 +53,7 @@ echo ""
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then
     . ./dynamic_resources.sh
     # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
-    # available to a jvm using 100% of the GCroup-aware memory
+    # available to a jvm using 100% of the CGroup-aware memory
     # up to some optional DYNAMIC_HEAP_MAX
     CALC_MAX_HEAP=$(get_heap_size ${DYNAMIC_HEAP_FRACTION} ${DYNAMIC_HEAP_MAX})
     if [ -n "$CALC_MAX_HEAP" ]; then

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -19,14 +19,18 @@ The following options are supported:
 
 `-Xmx` configures the maximum heap size.
 
+.-Xms
+
+`-Xms` configures the initial allocation heap size when the JVM starts.
+
 NOTE: The units accepted by JVM settings such as `-Xmx` and `-Xms` are those accepted by the JDK `java` binary in the corresponding image.
 Accordingly, `1g` or `1G` means 1,073,741,824 bytes, and `Gi` is not a valid unit suffix.
 This is in contrast to the units used for xref:assembly-resource-limits-and-requests-{context}[memory requests and limits], which follow the {ProductPlatformName} convention where `1G` means 1,000,000,000 bytes, and `1Gi` means 1,073,741,824 bytes
 
-The default value used for `-Xmx` depends on whether there is a xref:assembly-resource-limits-and-requests-{context}[memory request] configured for the container:
+The default values used for `-Xms` and `-Xmx` depends on whether there is a xref:assembly-resource-limits-and-requests-{context}[memory request] configured for the container:
 
-* If there is a memory request, the JVM's maximum memory will be set to a value corresponding to the limit.
-* When there is no memory request, the JVM's maximum memory will be set according to the RAM available to the container.
+* If there is a memory request, the JVM's minimum and maximum memory will be set to a value corresponding to the limit.
+* When there is no memory request, `-Xms` and `-Xmx` use the defaults provided by the Kafka release which are 512M for ZooKeeper and 1G for Kafka broker.
 
 [IMPORTANT]
 ====

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -15,22 +15,22 @@ JVM options can be configured using the `jvmOptions` property in following resou
 Only a selected subset of available JVM options can be configured.
 The following options are supported:
 
+.-Xms
+
+`-Xms` configures the minimum initial allocation heap size when the JVM starts.
+
 .-Xmx
 
 `-Xmx` configures the maximum heap size.
-
-.-Xms
-
-`-Xms` configures the initial allocation heap size when the JVM starts.
 
 NOTE: The units accepted by JVM settings such as `-Xmx` and `-Xms` are those accepted by the JDK `java` binary in the corresponding image.
 Accordingly, `1g` or `1G` means 1,073,741,824 bytes, and `Gi` is not a valid unit suffix.
 This is in contrast to the units used for xref:assembly-resource-limits-and-requests-{context}[memory requests and limits], which follow the {ProductPlatformName} convention where `1G` means 1,000,000,000 bytes, and `1Gi` means 1,073,741,824 bytes
 
-The default values used for `-Xms` and `-Xmx` depends on whether there is a xref:assembly-resource-limits-and-requests-{context}[memory request] configured for the container:
+The default values used for `-Xms` and `-Xmx` depends on whether there is a xref:assembly-resource-limits-and-requests-{context}[memory request] limit configured for the container:
 
-* If there is a memory request, the JVM's minimum and maximum memory will be set to a value corresponding to the limit.
-* When there is no memory request, `-Xms` and `-Xmx` use the defaults provided by the Kafka release which are 512M for ZooKeeper and 1G for Kafka broker.
+* If there is a memory limit then the JVM's minimum and maximum memory will be set to a value corresponding to the limit.
+* If there is no memory limit then the JVM's minimum memory will be set to `128M` and the JVM's maximum memory will not be defined.  This allows for the JVM's memory to grow as-needed, which is ideal for single node environments in test and development.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Fix for Issue #876 

> When a cgroup limit (pod spec resource request/limit) isn't defined in the `Kafka` resource for Kafka and ZooKeeper the cluster operator and `dynamic-resources.sh` script in the `kafka-base` docker image will attempt to calculate the appropriate settings for `-Xms` and `-Xmx` so that it uses some fraction of the total memory available to the container.  The formula to calculate the setting is `max(cap, fraction * jvm100pc)` where cap is hardcoded upper limit (~5GB) and fraction is some fraction of memory to allocate to the JVM.  This works alright when a kubelet is dedicated to a pod, but can cause an issue in memory-constrained environments, like `minishift`, `minikube`, or `oc cluster up` when everything is run on a single machine.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

