### PR TITLE
For TLS client authentication for Zookeeper Stunnel on port 2181

### DIFF
--- a/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
@@ -64,4 +64,5 @@ cert = ${CERTS}/${CURRENT}.crt
 key = ${CERTS}/${CURRENT}.key
 accept = 2181
 connect = 127.0.0.1:$CLIENT_PORT
+verify = 2
 EOF


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Due to a mistake the Zookeeper sidecar doesn't enforce TLS Client authenticationon port 2181. This PR should fix that.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally