### PR TITLE
Fixed typo in parent context for Kafka Connect

### DIFF
--- a/documentation/book/assembly-deployment-configuration-kafka-connect-s2i.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-connect-s2i.adoc
@@ -5,7 +5,7 @@
 // Save the context of the assembly that is including this one.
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
-:parent-context-deployment-cofiguration-kafka-connect-s2i: {context}
+:parent-context-deployment-configuration-kafka-connect-s2i: {context}
 
 [id='assembly-deployment-configuration-kafka-connect-s2i-{context}']
 = Kafka Connect cluster with Source2Image support
@@ -45,4 +45,4 @@ include::ref-list-of-kafka-connect-s2i-resources.adoc[leveloffset=+1]
 include::proc-using-openshift-builds-create-image.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.
-:context: {parent-context-deployment-cofiguration-kafka-connect-s2i}
+:context: {parent-context-deployment-configuration-kafka-connect-s2i}

--- a/documentation/book/assembly-deployment-configuration-kafka-connect.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-connect.adoc
@@ -5,7 +5,7 @@
 // Save the context of the assembly that is including this one.
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
-:parent-context-deployment-cofiguration-kafka-connect: {context}
+:parent-context-deployment-configuration-kafka-connect: {context}
 
 [id='assembly-deployment-configuration-kafka-connect-{context}']
 = Kafka Connect cluster configuration
@@ -43,4 +43,4 @@ include::assembly-scheduling.adoc[leveloffset=+1]
 include::ref-list-of-kafka-connect-resources.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.
-:context: {parent-context-deployment-cofiguration-kafka-connect}
+:context: {parent-context-deployment-configuration-kafka-connect}


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR just fixes a typo in the parent context name for Kafka Connect. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

