### PR TITLE
Fixed reference to old 1.1 Kafka documentation upstream

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -49,8 +49,8 @@
 :K8sManagingComputingResources: link:https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers^]
 :K8sLivenessReadinessProbes: link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Configure Liveness and Readiness Probes^]
 
-:ApachaKafkaBrokerConfig: link:http://kafka.apache.org/11/documentation.html#brokerconfigs[Apache Kafka documentation^]
-:ApachaKafkaConnectConfig: link:http://kafka.apache.org/11/documentation.html#connectconfigs[Apache Kafka documentation^]
+:ApachaKafkaBrokerConfig: link:http://kafka.apache.org/20/documentation.html#brokerconfigs[Apache Kafka documentation^]
+:ApachaKafkaConnectConfig: link:http://kafka.apache.org/20/documentation.html#connectconfigs[Apache Kafka documentation^]
 :ApacheZookeeperConfig: link:http://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html[Zookeeper documentation^]
 
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR fixes links to old 1.1 Kafka upstream documentation instead using the new 2.0

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

