### PR TITLE
Added security. as forbidden prefix

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -22,7 +22,7 @@ import java.util.Map;
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 
-    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl.";
+    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
 
     private int numStreams;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 
-    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl.";
+    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
 
     @Override
     @Description("The mirror maker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -972,7 +972,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |string
 |authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
-|config            1.2+<.<|The mirror maker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.
+|config            1.2+<.<|The mirror maker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security.
 |map
 |tls               1.2+<.<|TLS configuration for connecting to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]
@@ -1040,7 +1040,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |string
 |authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
-|config            1.2+<.<|The mirror maker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl.
+|config            1.2+<.<|The mirror maker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
 |map
 |tls               1.2+<.<|TLS configuration for connecting to the cluster.
 |xref:type-KafkaMirrorMakerTls-{context}[`KafkaMirrorMakerTls`]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This trivial PR just add `security.` as forbidden prefix for Kafka Mirror Maker configuration (producer and consumer) because it's handled by auth stuff. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

