### PR TITLE
Support standalone ZooKeeper in Grafana dashboard

### DIFF
--- a/metrics/examples/grafana/strimzi-zookeeper.json
+++ b/metrics/examples/grafana/strimzi-zookeeper.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.0"
+      "version": "5.2.4"
     },
     {
       "type": "panel",
@@ -54,7 +54,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1536953244583,
+  "iteration": 1537901015481,
   "links": [],
   "panels": [
     {
@@ -1258,7 +1258,7 @@
         "multi": false,
         "name": "kubernetes_namespace",
         "options": [],
-        "query": "query_result(zookeeper_quorumsize)",
+        "query": "query_result(zookeeper_inmemorydatatree_nodecount)",
         "refresh": 1,
         "regex": "/.*namespace=\"([^\"]*).*/",
         "sort": 0,
@@ -1278,7 +1278,7 @@
         "multi": false,
         "name": "strimzi_cluster_name",
         "options": [],
-        "query": "query_result(zookeeper_quorumsize{namespace=\"$kubernetes_namespace\"})",
+        "query": "query_result(zookeeper_inmemorydatatree_nodecount{namespace=\"$kubernetes_namespace\"})",
         "refresh": 1,
         "regex": "/.*strimzi_io_cluster=\"([^\"]*).*/",
         "sort": 0,
@@ -1298,7 +1298,7 @@
         "multi": false,
         "name": "zk_node",
         "options": [],
-        "query": "query_result(zookeeper_quorumsize{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"})",
+        "query": "query_result(zookeeper_inmemorydatatree_nodecount{namespace=\"$kubernetes_namespace\",strimzi_io_cluster=\"$strimzi_cluster_name\"})",
         "refresh": 1,
         "regex": "/.*statefulset_kubernetes_io_pod_name=\"$strimzi_cluster_name-([^\"]*).*/",
         "sort": 0,

--- a/metrics/examples/kafka/kafka-metrics.yaml
+++ b/metrics/examples/kafka/kafka-metrics.yaml
@@ -156,8 +156,8 @@ spec:
       # standalone Zookeeper
       - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
         name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
-        name: "zookeeper_$2"
+      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=(InMemoryDataTree)><>(\\w+)"
+        name: "zookeeper_$2_$3"
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When ZooKeeper is deployed with a replica of 1 certain JMX metrics are not exposed which were depended upon by the Grafana dashboard.  I've updated the ZooKeeper prometheus JMX exporter rules and Strimzi ZooKeeper Grafana dashboard to accomodate 1 node ZooKeeper clusters.

The "Quorum Size" widget will display "N/A", but IMO this is valid because it's only one node.

This issue was raised in a comment by @Tombar in this comment: https://github.com/strimzi/strimzi-kafka-operator/pull/877#issuecomment-424347052 .

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

