### PR TITLE
Apache typo in the docs

### DIFF
--- a/documentation/book/assembly-kafka-broker-configuration.adoc
+++ b/documentation/book/assembly-kafka-broker-configuration.adoc
@@ -11,7 +11,7 @@
 = Kafka broker configuration
 
 {ProductName} allows you to customize the configuration of Apache Kafka brokers.
-You can specify and configure most of the options listed in {ApachaKafkaBrokerConfig}.
+You can specify and configure most of the options listed in {ApacheKafkaBrokerConfig}.
 
 The only options which cannot be configured are those related to the following areas:
 

--- a/documentation/book/assembly-kafka-connect-configuration.adoc
+++ b/documentation/book/assembly-kafka-connect-configuration.adoc
@@ -11,7 +11,7 @@
 
 = Kafka Connect configuration
 
-{ProductName} allows you to customize the configuration of Apache Kafka Connect nodes by editing most of the options listed in {ApachaKafkaConnectConfig}.
+{ProductName} allows you to customize the configuration of Apache Kafka Connect nodes by editing most of the options listed in {ApacheKafkaConnectConfig}.
 
 The only options which cannot be configured are those related to the following areas:
 

--- a/documentation/book/ref-kafka-broker-configuration.adoc
+++ b/documentation/book/ref-kafka-broker-configuration.adoc
@@ -14,7 +14,7 @@ The values could be in one of the following JSON types:
 * Number
 * Boolean
 
-Users can specify and configure the options listed in {ApachaKafkaBrokerConfig} with the exception of those options which are managed directly by {ProductName}.
+Users can specify and configure the options listed in {ApacheKafkaBrokerConfig} with the exception of those options which are managed directly by {ProductName}.
 Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `listeners`

--- a/documentation/book/ref-kafka-connect-configuration.adoc
+++ b/documentation/book/ref-kafka-connect-configuration.adoc
@@ -13,7 +13,7 @@ The values could be in one of the following JSON types:
 * Number
 * Boolean
 
-Users can specify and configure the options listed in the {ApachaKafkaConnectConfig} with the exception of those options which are managed directly by {ProductName}.
+Users can specify and configure the options listed in the {ApacheKafkaConnectConfig} with the exception of those options which are managed directly by {ProductName}.
 Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
 * `ssl.`

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -49,8 +49,9 @@
 :K8sManagingComputingResources: link:https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers^]
 :K8sLivenessReadinessProbes: link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Configure Liveness and Readiness Probes^]
 
-:ApachaKafkaBrokerConfig: link:http://kafka.apache.org/20/documentation.html#brokerconfigs[Apache Kafka documentation^]
-:ApachaKafkaConnectConfig: link:http://kafka.apache.org/20/documentation.html#connectconfigs[Apache Kafka documentation^]
+
+:ApacheKafkaBrokerConfig: link:http://kafka.apache.org/20/documentation.html#brokerconfigs[Apache Kafka documentation^]
+:ApacheKafkaConnectConfig: link:http://kafka.apache.org/20/documentation.html#connectconfigs[Apache Kafka documentation^]
 :ApacheZookeeperConfig: link:http://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html[Zookeeper documentation^]
 
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]


### PR DESCRIPTION
### Type of change
- Documentation

### Description
Typo in reference.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

