### PR TITLE
Fixed required and not required fields in the Mirror Maker CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import java.util.Map;
 
@@ -24,7 +25,7 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
 
-    private int numStreams;
+    private Integer numStreams;
 
     private String groupId;
 
@@ -36,12 +37,13 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     }
 
     @Description("Specifies the number of consumer stream threads to create.")
-    @JsonProperty(required = true)
-    public int getNumStreams() {
+    @Minimum(1)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getNumStreams() {
         return numStreams;
     }
 
-    public void setNumStreams(int numStreams) {
+    public void setNumStreams(Integer numStreams) {
         this.numStreams = numStreams;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -25,7 +25,11 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"replicas", "whitelist", "consumer", "producer", "logging", "metrics"})
+@JsonPropertyOrder({
+        "replicas", "image", "whitelist",
+        "consumer", "producer", "resources",
+        "affinity", "tolerations", "jvmOptions",
+        "logging", "metrics"})
 public class KafkaMirrorMakerSpec implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -34,23 +38,15 @@ public class KafkaMirrorMakerSpec implements Serializable {
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_MIRRORMAKER_IMAGE", "strimzi/kafka-mirror-maker:latest");
 
     private int replicas;
-
+    private String image;
     private String whitelist;
-
     private KafkaMirrorMakerConsumerSpec consumer;
-
     private KafkaMirrorMakerProducerSpec producer;
-
     private Resources resources;
-
     private Affinity affinity;
-
     private List<Toleration> tolerations;
-
     private JvmOptions jvmOptions;
-
     private Logging logging;
-
     private Map<String, Object> metrics = new HashMap<>(0);
 
     @Description("The number of pods in the `Deployment`.")
@@ -64,8 +60,19 @@ public class KafkaMirrorMakerSpec implements Serializable {
         this.replicas = replicas;
     }
 
+    @Description("The docker image for the pods.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions." +
             "Mirroring two topics named A and B can be achieved by using `--whitelist 'A|B'`. Or you could mirror all topics using `--whitelist '*'`.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getWhitelist() {
         return whitelist;
     }
@@ -75,6 +82,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     }
 
     @Description("Configuration of source cluster.")
+    @JsonProperty(required = true)
     public KafkaMirrorMakerConsumerSpec getConsumer() {
         return consumer;
     }
@@ -84,6 +92,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     }
 
     @Description("Configuration of target cluster.")
+    @JsonProperty(required = true)
     public KafkaMirrorMakerProducerSpec getProducer() {
         return producer;
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.test.Namespace;
+import io.strimzi.test.Resources;
+import io.strimzi.test.StrimziRunner;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The purpose of this test is to confirm that we can create a
+ * resource from the POJOs, serialize it and create the resource in K8S.
+ * I.e. that such instance resources obtained from POJOs are valid according to the schema
+ * validation done by K8S.
+ */
+@RunWith(StrimziRunner.class)
+@Namespace(KafkaMirrorMakerCrdIT.NAMESPACE)
+@Resources(value = TestUtils.CRD_KAFKA_MIRROR_MAKER, asAdmin = true)
+public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
+
+    public static final String NAMESPACE = "kafkamirrormaker-crd-it";
+
+    @Test
+    public void testKafkaMirrorMaker() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker.yaml");
+    }
+
+    @Test
+    public void testKafkaMirrorMakerMinimal() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-minimal.yaml");
+    }
+
+    @Test
+    public void testKafkaMirrorMakerWithExtraProperty() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-extra-property.yaml");
+    }
+
+    @Test
+    public void testKafkaMirrorMakerWithMissingRequired() {
+        try {
+            createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-missing-required-property.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("spec.consumer.bootstrapServers in body is required"));
+            assertTrue(e.getMessage(), e.getMessage().contains("spec.producer in body is required"));
+        }
+    }
+
+    @Test
+    public void testKafkaMirrorMakerWithTls() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls.yaml");
+    }
+
+    @Test
+    public void testKafkaMirrorMakerWithTlsAuth() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth.yaml");
+    }
+
+    @Test
+    public void testKafkaWithTlsAuthWithMissingRequired() {
+        try {
+            createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.producer.authentication.certificateAndKey.certificate in body is required"));
+            assertTrue(e.getMessage().contains("spec.producer.authentication.certificateAndKey.key in body is required"));
+        }
+    }
+
+    @Test
+    public void testKafkaWithScramSha512Auth() {
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-scram-sha-512-auth.yaml");
+    }
+}
+

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * The purpose of this test is to ensure:
+ *
+ * 1. we get a correct tree of POJOs when reading a JSON/YAML `KafkaMirrorMaker` resource.
+ */
+public class KafkaMirrorMakerTest extends AbstractCrdTest<KafkaMirrorMaker, KafkaMirrorMakerBuilder> {
+
+    public KafkaMirrorMakerTest() {
+        super(KafkaMirrorMaker.class, KafkaMirrorMakerBuilder.class);
+    }
+}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-minimal.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9092
+    groupId: my-source-group-id
+  producer:
+    bootstrapServers: my-target-kafka:9092

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9092
+    groupId: my-source-group-id
+  producer:
+    bootstrapServers: my-target-kafka:9092
+  extra: true
+extra: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-missing-required-property.yaml
@@ -1,0 +1,10 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    # required bootstrapServers is missing
+    groupId: my-source-group-id
+  # required producer is missing

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-scram-sha-512-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-scram-sha-512-auth.yaml
@@ -1,0 +1,23 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9092
+    groupId: my-source-group-id
+    authentication:
+      type: scram-sha-512
+      username: johndoe
+      passwordSecret:
+        secretName: my-user-secret
+        password: password
+  producer:
+    bootstrapServers: my-target-kafka:9092
+    authentication:
+      type: scram-sha-512
+      username: johndoe
+      passwordSecret:
+        secretName: my-user-secret
+        password: password

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml
@@ -1,0 +1,34 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9093
+    groupId: my-source-group-id
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt
+    authentication:
+      type: tls
+      certificateAndKey:
+        secretName: my-user-secret
+        key: user.key
+        certificate: user.crt
+  producer:
+    bootstrapServers: my-target-kafka:9093
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt
+    authentication:
+      type: tls
+      certificateAndKey:
+        secretName: my-user-secret
+        # required key and certificate are missing

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth.yaml
@@ -1,0 +1,35 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9093
+    groupId: my-source-group-id
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt
+    authentication:
+      type: tls
+      certificateAndKey:
+        secretName: my-user-secret
+        key: user.key
+        certificate: user.crt
+  producer:
+    bootstrapServers: my-target-kafka:9093
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt
+    authentication:
+      type: tls
+      certificateAndKey:
+        secretName: my-user-secret
+        key: user.key
+        certificate: user.crt

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls.yaml
@@ -1,0 +1,23 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  replicas: 1
+  consumer:
+    bootstrapServers: my-source-kafka:9093
+    groupId: my-source-group-id
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt
+  producer:
+    bootstrapServers: my-target-kafka:9093
+    tls:
+      trustedCertificates:
+        - secretName: my-secret
+          certificate: ca.crt
+        - secretName: my-another-secret
+          certificate: another-ca.crt

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.out.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: "kafka.strimzi.io/v1alpha1"
+kind: "KafkaMirrorMaker"
+metadata:
+  finalizers: []
+  name: "test-kafka-mirror-maker"
+  ownerReferences: []
+spec:
+  replicas: 1
+  image: "foo"
+  whitelist: "*"
+  consumer:
+    numStreams: 2
+    groupId: "my-source-group-id"
+    bootstrapServers: "my-source-kafka:9092"
+  producer:
+    bootstrapServers: "my-target-kafka:9092"
+  metrics: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaMirrorMaker
+metadata:
+  name: test-kafka-mirror-maker
+spec:
+  image: foo
+  replicas: 1
+  whitelist: "*"
+  consumer:
+    numStreams: 2
+    groupId: my-source-group-id
+    bootstrapServers: my-source-kafka:9092
+  producer:
+    bootstrapServers: my-target-kafka:9092

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -931,28 +931,30 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 |Field               |Description
 |replicas     1.2+<.<|The number of pods in the `Deployment`.
 |integer
+|image        1.2+<.<|The docker image for the pods.
+|string
 |whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions.Mirroring two topics named A and B can be achieved by using `--whitelist 'A|B'`. Or you could mirror all topics using `--whitelist '*'`.
 |string
 |consumer     1.2+<.<|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]
 |producer     1.2+<.<|Configuration of target cluster.
 |xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
-|logging      1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
-|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics      1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
-|map
+|resources    1.2+<.<|Resource constraints (limits and requests).
+|xref:type-Resources-{context}[`Resources`]
 |affinity     1.2+<.<|Pod affinity rules.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[core/v1 affinity].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#affinity-v1-core[Affinity]
-|jvmOptions   1.2+<.<|JVM Options for pods.
-|xref:type-JvmOptions-{context}[`JvmOptions`]
-|resources    1.2+<.<|Resource constraints (limits and requests).
-|xref:type-Resources-{context}[`Resources`]
 |tolerations  1.2+<.<|Pod's tolerations.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[core/v1 tolerations].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
+|jvmOptions   1.2+<.<|JVM Options for pods.
+|xref:type-JvmOptions-{context}[`JvmOptions`]
+|logging      1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
+|metrics      1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
+|map
 |====
 
 [id='type-KafkaMirrorMakerConsumerSpec-{context}']

--- a/examples/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/examples/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -25,6 +25,8 @@ spec:
             replicas:
               type: integer
               minimum: 1
+            image:
+              type: string
             whitelist:
               type: string
             consumer:
@@ -32,6 +34,7 @@ spec:
               properties:
                 numStreams:
                   type: integer
+                  minimum: 1
                 groupId:
                   type: string
                 bootstrapServers:
@@ -86,7 +89,6 @@ spec:
                   required:
                   - trustedCertificates
               required:
-              - numStreams
               - groupId
               - bootstrapServers
             producer:
@@ -145,17 +147,27 @@ spec:
                   - trustedCertificates
               required:
               - bootstrapServers
-            logging:
+            resources:
               type: object
               properties:
-                loggers:
+                limits:
                   type: object
-                name:
-                  type: string
-                type:
-                  type: string
-            metrics:
-              type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
             affinity:
               type: object
               properties:
@@ -338,38 +350,6 @@ spec:
                               type: string
                           topologyKey:
                             type: string
-            jvmOptions:
-              type: object
-              properties:
-                -XX:
-                  type: object
-                -Xms:
-                  type: string
-                  pattern: '[0-9]+[mMgG]?'
-                -Xmx:
-                  type: string
-                  pattern: '[0-9]+[mMgG]?'
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      pattern: '[0-9]+m?$'
-                    memory:
-                      type: string
-                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                requests:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      pattern: '[0-9]+m?$'
-                    memory:
-                      type: string
-                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
             tolerations:
               type: array
               items:
@@ -385,5 +365,29 @@ spec:
                     type: integer
                   value:
                     type: string
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+            metrics:
+              type: object
           required:
           - replicas
+          - consumer
+          - producer

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -29,6 +29,8 @@ spec:
             replicas:
               type: integer
               minimum: 1
+            image:
+              type: string
             whitelist:
               type: string
             consumer:
@@ -36,6 +38,7 @@ spec:
               properties:
                 numStreams:
                   type: integer
+                  minimum: 1
                 groupId:
                   type: string
                 bootstrapServers:
@@ -90,7 +93,6 @@ spec:
                   required:
                   - trustedCertificates
               required:
-              - numStreams
               - groupId
               - bootstrapServers
             producer:
@@ -149,17 +151,27 @@ spec:
                   - trustedCertificates
               required:
               - bootstrapServers
-            logging:
+            resources:
               type: object
               properties:
-                loggers:
+                limits:
                   type: object
-                name:
-                  type: string
-                type:
-                  type: string
-            metrics:
-              type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
             affinity:
               type: object
               properties:
@@ -342,38 +354,6 @@ spec:
                               type: string
                           topologyKey:
                             type: string
-            jvmOptions:
-              type: object
-              properties:
-                -XX:
-                  type: object
-                -Xms:
-                  type: string
-                  pattern: '[0-9]+[mMgG]?'
-                -Xmx:
-                  type: string
-                  pattern: '[0-9]+[mMgG]?'
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      pattern: '[0-9]+m?$'
-                    memory:
-                      type: string
-                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
-                requests:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      pattern: '[0-9]+m?$'
-                    memory:
-                      type: string
-                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
             tolerations:
               type: array
               items:
@@ -389,5 +369,29 @@ spec:
                     type: integer
                   value:
                     type: string
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+            metrics:
+              type: object
           required:
           - replicas
+          - consumer
+          - producer

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -51,6 +51,8 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_USER = "../examples/install/cluster-operator/044-Crd-kafkauser.yaml";
 
+    public static final String CRD_KAFKA_MIRROR_MAKER = "../examples/install/cluster-operator/045-Crd-kafkamirrormaker.yaml";
+
     private TestUtils() {
         // All static methods
     }


### PR DESCRIPTION
Added unit tests and ITs for the Mirror Maker CRD

### Type of change

- Bugfix

### Description

This PR fixes wrong required and not required fields for the Mirror Maker CRD in relation to the `kafka-mirror-maker.sh` tool.
It also adds unit tests and ITs for Mirror Maker CRD

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

