### PR TITLE
Kafka Connect bootstrap servers doc files renaming

### DIFF
--- a/documentation/book/assembly-deployment-configuration-kafka-connect-s2i.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-connect-s2i.adoc
@@ -18,7 +18,7 @@ This provides a convenient mechanism for those resources to be labelled in whate
 
 include::assembly-kafka-connect-replicas.adoc[leveloffset=+1]
 
-include::assembly-bootstrap-servers.adoc[leveloffset=+1]
+include::assembly-kafka-connect-bootstrap-servers.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-tls.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-deployment-configuration-kafka-connect.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-connect.adoc
@@ -18,7 +18,7 @@ This provides a convenient mechanism for those resources to be labelled in whate
 
 include::assembly-kafka-connect-replicas.adoc[leveloffset=+1]
 
-include::assembly-bootstrap-servers.adoc[leveloffset=+1]
+include::assembly-kafka-connect-bootstrap-servers.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-tls.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-kafka-connect-bootstrap-servers.adoc
+++ b/documentation/book/assembly-kafka-connect-bootstrap-servers.adoc
@@ -7,7 +7,7 @@
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
 
-[id='assembly-bootstrap-servers-{context}']
+[id='assembly-kafka-connect-bootstrap-servers-{context}']
 
 = Bootstrap servers
 
@@ -19,4 +19,4 @@ The list of bootstrap servers can be configured in the `bootstrapServers` proper
 
 When using Kafka Connect with a Kafka cluster not managed by {ProductName}, you can specify the bootstrap servers list according to the configuration of a given cluster.
 
-include::proc-configuring-bootstrap-servers.adoc[leveloffset=+1]
+include::proc-configuring-kafka-connect-bootstrap-servers.adoc[leveloffset=+1]

--- a/documentation/book/proc-configuring-kafka-connect-bootstrap-servers.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-bootstrap-servers.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// assembly-bootstrap-servers.adoc
+// assembly-kafka-connect-bootstrap-servers.adoc
 
-[id='proc-configuring-bootstrap-servers-{context}']
+[id='proc-configuring-kafka-connect-bootstrap-servers-{context}']
 = Configuring bootstrap servers
 
 .Prerequisites

--- a/documentation/book/proc-configuring-kafka-connect-replicas.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-replicas.adoc
@@ -5,7 +5,7 @@
 [id='proc-configuring-kafka-connect-replicas-{context}']
 = Configuring the number of broker nodes
 
-Number of Kafka broker nodes can be configured using the `replicas` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`.
+Number of Kafka Connect nodes can be configured using the `replicas` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`.
 
 .Prerequisites
 

--- a/documentation/book/proc-configuring-kafka-connect-replicas.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-replicas.adoc
@@ -3,7 +3,7 @@
 // assembly-kafka-connect-replicas.adoc
 
 [id='proc-configuring-kafka-connect-replicas-{context}']
-= Configuring the number of broker nodes
+= Configuring the number of nodes
 
 Number of Kafka Connect nodes can be configured using the `replicas` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Because I'm going to add configuring bootstrap servers for Mirror Maker as well, this PR renames files for same configuration in Kafka Connect.
It's fix a typo in Kafka Connect replicas configuration as well. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

