### PR TITLE
Split up the Kafka.spec.tlsCertificates into Kafka.spec.clusterCa and…

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "generateCertificateAuthority", "validityDays", "renewalDays" })
-public class TlsCertificates implements Serializable {
+public class CertificateAuthority implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -36,7 +36,9 @@ public class KafkaSpec implements Serializable {
     private ZookeeperClusterSpec zookeeper;
     private TopicOperatorSpec topicOperator;
     private EntityOperatorSpec entityOperator;
-    private TlsCertificates tlsCertificates;
+    private CertificateAuthority clusterCa;
+
+    private CertificateAuthority clientsCa;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Configuration of the Kafka cluster")
@@ -79,13 +81,22 @@ public class KafkaSpec implements Serializable {
         this.entityOperator = entityOperator;
     }
 
-    @Description("Configuration of how TLS certificates are handled.")
-    public TlsCertificates getTlsCertificates() {
-        return tlsCertificates;
+    @Description("Configuration of the cluster certificate authority")
+    public CertificateAuthority getClusterCa() {
+        return clusterCa;
     }
 
-    public void setTlsCertificates(TlsCertificates tlsCertificates) {
-        this.tlsCertificates = tlsCertificates;
+    public void setClusterCa(CertificateAuthority clusterCa) {
+        this.clusterCa = clusterCa;
+    }
+
+    @Description("Configuration of the clients certificate authority")
+    public CertificateAuthority getClientsCa() {
+        return clientsCa;
+    }
+
+    public void setClientsCa(CertificateAuthority clientsCa) {
+        this.clientsCa = clientsCa;
     }
 
     @JsonAnyGetter

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -101,8 +101,12 @@ spec:
     reconciliationIntervalSeconds: 90
     zookeeperSessionTimeoutSeconds: 20
     topicMetadataMaxAttempts: 6
-  tlsCertificates:
+  clusterCa:
     generateCertificateAuthority: false
     validityDays: 395
     renewalDays: 32
+  clientsCa:
+    generateCertificateAuthority: false
+    validityDays: 400
+    renewalDays: 20
   someExtraThing: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
@@ -103,8 +103,12 @@ spec:
     metrics: {}
   topicOperator:
     watchedNamespace: my-ns
-  tlsCertificates:
+  clusterCa:
     renewalDays: 32
     validityDays: 395
+    generateCertificateAuthority: false
+  clientsCa:
+    renewalDays: 20
+    validityDays: 400
     generateCertificateAuthority: false
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -6,8 +6,7 @@ package io.strimzi.operator.cluster.model;
 
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.strimzi.api.kafka.model.Kafka;
-import io.strimzi.api.kafka.model.TlsCertificates;
+import io.strimzi.api.kafka.model.CertificateAuthority;
 
 import java.util.List;
 
@@ -21,24 +20,16 @@ public class ModelUtils {
         return secrets.stream().filter(s -> s.getMetadata().getName().equals(sname)).findFirst().orElse(null);
     }
 
-    public static int getCertificateValidity(Kafka kafka) {
+    public static int getCertificateValidity(CertificateAuthority certificateAuthority) {
         int validity = AbstractModel.CERTS_EXPIRATION_DAYS;
-        if (kafka.getSpec() != null) {
-            validity = getCertificateValidity(kafka.getSpec().getTlsCertificates());
+        if (certificateAuthority != null
+                && certificateAuthority.getValidityDays() > 0) {
+            validity = certificateAuthority.getValidityDays();
         }
         return validity;
     }
 
-    public static int getCertificateValidity(TlsCertificates tlsCertificates) {
-        int validity = AbstractModel.CERTS_EXPIRATION_DAYS;
-        if (tlsCertificates != null
-                && tlsCertificates.getValidityDays() > 0) {
-            validity = tlsCertificates.getValidityDays();
-        }
-        return validity;
-    }
-
-    public static int getRenewalDays(TlsCertificates tlsCertificates) {
-        return tlsCertificates != null ? tlsCertificates.getRenewalDays() : 30;
+    public static int getRenewalDays(CertificateAuthority certificateAuthority) {
+        return certificateAuthority != null ? certificateAuthority.getRenewalDays() : 30;
     }
 }

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -20,16 +20,18 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Field                   |Description
-|kafka            1.2+<.<|Configuration of the Kafka cluster.
+|Field                  |Description
+|kafka           1.2+<.<|Configuration of the Kafka cluster.
 |xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
-|zookeeper        1.2+<.<|Configuration of the Zookeeper cluster.
+|zookeeper       1.2+<.<|Configuration of the Zookeeper cluster.
 |xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
-|topicOperator    1.2+<.<|Configuration of the Topic Operator.
+|topicOperator   1.2+<.<|Configuration of the Topic Operator.
 |xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
-|tlsCertificates  1.2+<.<|Configuration of how TLS certificates are handled.
-|xref:type-TlsCertificates-{context}[`TlsCertificates`]
-|entityOperator   1.2+<.<|Configuration of the Entity Operator.
+|clientsCa       1.2+<.<|Configuration of the clients certificate authority.
+|xref:type-CertificateAuthority-{context}[`CertificateAuthority`]
+|clusterCa       1.2+<.<|Configuration of the cluster certificate authority.
+|xref:type-CertificateAuthority-{context}[`CertificateAuthority`]
+|entityOperator  1.2+<.<|Configuration of the Entity Operator.
 |xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |====
 
@@ -457,8 +459,8 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |====
 
-[id='type-TlsCertificates-{context}']
-### `TlsCertificates` schema reference
+[id='type-CertificateAuthority-{context}']
+### `CertificateAuthority` schema reference
 
 Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -943,7 +943,18 @@ spec:
                       type: string
                     type:
                       type: string
-            tlsCertificates:
+            clientsCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
+            clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -947,7 +947,18 @@ spec:
                       type: string
                     type:
                       type: string
-            tlsCertificates:
+            clientsCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
+            clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:


### PR DESCRIPTION
… clientsCa

### Type of change

- Enhancement / new feature

### Description

Allow configuring the cluster CA differently from the clients CA.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

