### PR TITLE
Entity Topic Operator and Topic Operator should use different role bi…

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -167,7 +167,7 @@ public class EntityTopicOperator extends AbstractModel {
      * Get the name of the TO role binding given the name of the {@code cluster}.
      */
     public static String roleBindingName(String cluster) {
-        return "strimzi-" + cluster + "-topic-operator";
+        return "strimzi-" + cluster + "-entity-topic-operator";
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -123,7 +123,7 @@ public class EntityUserOperator extends AbstractModel {
      * Get the name of the UO role binding given the name of the {@code cluster}.
      */
     public static String roleBindingName(String cluster) {
-        return "strimzi-" + cluster + "-user-operator";
+        return "strimzi-" + cluster + "-entity-user-operator";
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Topic Operator and Entity Topic Operator are currently using the Role Binding with the same name. That is a problem, because when you want to use old style TO instead of EO, the EO will actually wipe its role binding. And the TO therefore doesn't work.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

