### PR TITLE
Fixed typo in Kafka Connect list resources

### DIFF
--- a/documentation/book/ref-list-of-kafka-connect-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-connect-resources.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-deployment-configuration-kafka-connect.adoc
 
-[id='ref-list-of-kafka-cluster-resources-{context}']
+[id='ref-list-of-kafka-connect-resources-{context}']
 = List of resources created as part of Kafka Connect cluster
 
 The following resources will created by the Cluster Operator in the {ProductPlatformName} cluster:

--- a/documentation/book/ref-list-of-kafka-connect-s2i-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-connect-s2i-resources.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-deployment-configuration-kafka-connect-s2i.adoc
 
-[id='ref-list-of-kafka-cluster-resources-{context}']
+[id='ref-list-of-kafka-connect-s2i-resources-{context}']
 = List of resources created as part of Kafka Connect cluster with Source2Image support
 
 The following resources will created by the Cluster Operator in the {ProductPlatformName} cluster:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Really trivial fixes for a couple of typo on contexts name.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

