### PR TITLE
Fixed whitelist as required in the Mirror Maker CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -72,7 +72,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions." +
             "Mirroring two topics named A and B can be achieved by using `--whitelist 'A|B'`. Or you could mirror all topics using `--whitelist '*'`.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
     public String getWhitelist() {
         return whitelist;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -71,7 +71,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     }
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions." +
-            "Mirroring two topics named A and B can be achieved by using `--whitelist 'A|B'`. Or you could mirror all topics using `--whitelist '*'`.")
+            "Mirroring two topics named A and B can be achieved by using the whitelist `'A|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'`.")
     @JsonProperty(required = true)
     public String getWhitelist() {
         return whitelist;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -49,6 +49,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
         } catch (KubeClusterException.InvalidResource e) {
             assertTrue(e.getMessage(), e.getMessage().contains("spec.consumer.bootstrapServers in body is required"));
             assertTrue(e.getMessage(), e.getMessage().contains("spec.producer in body is required"));
+            assertTrue(e.getMessage(), e.getMessage().contains("spec.whitelist in body is required"));
         }
     }
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-minimal.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-kafka-mirror-maker
 spec:
   replicas: 1
+  whitelist: "*"
   consumer:
     bootstrapServers: my-source-kafka:9092
     groupId: my-source-group-id

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
@@ -9,5 +9,6 @@ spec:
     groupId: my-source-group-id
   producer:
     bootstrapServers: my-target-kafka:9092
+  whitelist: "*"
   extra: true
 extra: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-scram-sha-512-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-scram-sha-512-auth.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-kafka-mirror-maker
 spec:
   replicas: 1
+  whitelist: "*"
   consumer:
     bootstrapServers: my-source-kafka:9092
     groupId: my-source-group-id

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls-auth.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-kafka-mirror-maker
 spec:
   replicas: 1
+  whitelist: "*"
   consumer:
     bootstrapServers: my-source-kafka:9093
     groupId: my-source-group-id

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-tls.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-kafka-mirror-maker
 spec:
   replicas: 1
+  whitelist: "*"
   consumer:
     bootstrapServers: my-source-kafka:9093
     groupId: my-source-group-id

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -955,7 +955,7 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 |integer
 |image        1.2+<.<|The docker image for the pods.
 |string
-|whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions.Mirroring two topics named A and B can be achieved by using `--whitelist 'A|B'`. Or you could mirror all topics using `--whitelist '*'`.
+|whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions.Mirroring two topics named A and B can be achieved by using the whitelist `'A|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'`.
 |string
 |consumer     1.2+<.<|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]

--- a/examples/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/examples/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -389,5 +389,6 @@ spec:
               type: object
           required:
           - replicas
+          - whitelist
           - consumer
           - producer

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -393,5 +393,6 @@ spec:
               type: object
           required:
           - replicas
+          - whitelist
           - consumer
           - producer


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixed `whitelist` field for the Mirror Maker CRD which is mandatory for the `kafka-mirror-maker.sh` tool. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

