### PR TITLE
Fix broken certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -40,7 +40,7 @@ public class ClusterCa extends Ca {
                      int validityDays,
                      int renewalDays,
                      boolean generateCa) {
-        super(certManager, AbstractModel.getClusterCaName(clusterName), clusterCaCert,
+        super(certManager, "cluster-ca", AbstractModel.getClusterCaName(clusterName), clusterCaCert,
                 AbstractModel.getClusterCaKeyName(clusterName), clusterCaKey,
                 validityDays, renewalDays, generateCa);
         this.clusterName = clusterName;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -226,7 +226,7 @@ public class EntityOperator extends AbstractModel {
             log.debug("Generating certificates");
             try {
                 Ca.log.debug("Entity Operator certificate to generate");
-                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(name);
+                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(name, Ca.IO_STRIMZI);
                 data.put("entity-operator.key", eoCertAndKey.keyAsBase64String());
                 data.put("entity-operator.crt", eoCertAndKey.certAsBase64String());
             } catch (IOException e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -368,7 +368,7 @@ public class TopicOperator extends AbstractModel {
             log.debug("Generating certificates");
             try {
                 log.debug("Topic Operator certificate to generate");
-                CertAndKey toCertAndKey = clusterCa.generateSignedCert(name);
+                CertAndKey toCertAndKey = clusterCa.generateSignedCert(name, Ca.IO_STRIMZI);
                 data.put("entity-operator.crt", toCertAndKey.certAsBase64String());
                 data.put("entity-operator.key", toCertAndKey.keyAsBase64String());
             } catch (IOException e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -249,9 +249,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 clusterCaCertSecret = secret;
                             } else if (secretName.equals(clusterCaKeyName)) {
                                 clusterCaKeySecret = secret;
-                            } else if (secretName.equals(clientsCaKeyName)) {
-                                clientCaCertSecret = secret;
                             } else if (secretName.equals(clientsCaCertName)) {
+                                clientCaCertSecret = secret;
+                            } else if (secretName.equals(clientsCaKeyName)) {
                                 clientCaKeySecret = secret;
                             }
                         }
@@ -274,7 +274,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                         this.clusterCa.initCaSecrets(clusterSecrets);
 
-                        CertificateAuthority clientsCaConfig = kafkaAssembly.getSpec().getClusterCa();
+                        CertificateAuthority clientsCaConfig = kafkaAssembly.getSpec().getClientsCa();
                         this.clientsCa = new ClientsCa(certManager,
                                 clientsCaCertName, clientCaCertSecret,
                                 clientsCaKeyName, clientCaKeySecret,

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -11,7 +11,7 @@ public class ClientsCa extends Ca {
     public ClientsCa(CertManager certManager, String caCertSecretName, Secret clientsCaCert,
                      String caSecretKeyName, Secret clientsCaKey,
                      int validityDays, int renewalDays, boolean generateCa) {
-        super(certManager, caCertSecretName, clientsCaCert,
+        super(certManager, "clients-ca", caCertSecretName, clientsCaCert,
                 caSecretKeyName, clientsCaKey,
                 validityDays, renewalDays, generateCa);
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This Pr fixes several issues which were probably introduced by the renewal work:
* Users genereated by OU should not have organization `strimzi.io`. They are not Strimzi components and it also breaks the ACLs.
* ClientsCA needs to have different subject with common name `clients-ca`.
* The Clients CA was constantly regenerated because the secrets were incorrectly discovered and passed to the CA class which in result considered them invalid and generated new certificate.
* Every loop generated new certificate for the last pod of the statefulset because of wrongly calculated number of certificates inside the secret.
