### PR TITLE
Allow external interfaces using nodeports or loadbalancers to use pla…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.0
 
 * Support for TLS hostname verification when connecting through IP address from outside of the Kafka cluster 
+* Support for unencrypted connections on LoadBalancers and NodePorts.
 
 ## 0.7.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -25,6 +25,7 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
     public static final String TYPE_LOADBALANCER = "loadbalancer";
 
     private KafkaListenerAuthentication auth;
+    private boolean tls = true;
 
     @Description("Must be `" + TYPE_LOADBALANCER + "`")
     @Override
@@ -41,5 +42,16 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
 
     public void setAuth(KafkaListenerAuthentication auth) {
         this.auth = auth;
+    }
+
+    @Description("Enables TLS encryption on the listener. " +
+            "By default set to `true` for enabled TLS encryption.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public boolean isTls() {
+        return tls;
+    }
+
+    public void setTls(boolean tls) {
+        this.tls = tls;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -25,6 +25,7 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     public static final String TYPE_NODEPORT = "nodeport";
 
     private KafkaListenerAuthentication auth;
+    private boolean tls = true;
 
     @Description("Must be `" + TYPE_NODEPORT + "`")
     @Override
@@ -41,5 +42,16 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
 
     public void setAuth(KafkaListenerAuthentication auth) {
         this.auth = auth;
+    }
+
+    @Description("Enables TLS encryption on the listener. " +
+            "By default set to `true` for enabled TLS encryption.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public boolean isTls() {
+        return tls;
+    }
+
+    public void setTls(boolean tls) {
+        this.tls = tls;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -610,8 +610,6 @@ public class KafkaClusterTest {
                         .withNewListeners()
                             .withNewKafkaListenerExternalNodePortExternal()
                                 .withTls(false)
-                                .withNewKafkaListenerAuthenticationTlsAuth()
-                                .endKafkaListenerAuthenticationTlsAuth()
                             .endKafkaListenerExternalNodePortExternal()
                         .endListeners()
                     .endKafka()
@@ -633,7 +631,6 @@ public class KafkaClusterTest {
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "nodeport")));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "false")));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
-        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
     }
 
     public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -413,6 +413,7 @@ public class KafkaClusterTest {
 
         List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "route")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "true")));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
 
@@ -487,6 +488,7 @@ public class KafkaClusterTest {
 
         List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "loadbalancer")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "true")));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
 
@@ -510,6 +512,38 @@ public class KafkaClusterTest {
             assertEquals(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP")), srv.getSpec().getPorts());
             checkOwnerReference(kc.createOwnerReference(), srv);
         }
+    }
+
+    @Test
+    public void testExternalLoadBalancersWithoutTls() {
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalLoadBalancerExternal()
+                                .withTls(false)
+                            .endKafkaListenerExternalLoadBalancerExternal()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        ClusterCa clusterCa = ResourceUtils.createInitialClusterCa(namespace, cluster);
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
+
+        SortedMap<Integer, String> addresses = new TreeMap<>();
+        addresses.put(0, "my-address-0");
+        addresses.put(1, "my-address-1");
+        addresses.put(2, "my-address-2");
+        kc.setExternalAddresses(addresses);
+
+        // Check StatefulSet changes
+        StatefulSet ss = kc.generateStatefulSet(true);
+
+        List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "loadbalancer")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "false")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
     }
 
     @Test
@@ -541,6 +575,7 @@ public class KafkaClusterTest {
 
         List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "nodeport")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "true")));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
         assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
 
@@ -564,6 +599,41 @@ public class KafkaClusterTest {
             assertEquals(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP")), srv.getSpec().getPorts());
             checkOwnerReference(kc.createOwnerReference(), srv);
         }
+    }
+
+    @Test
+    public void testExternalNodePortsWithoutTls() {
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalNodePortExternal()
+                                .withTls(false)
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                            .endKafkaListenerExternalNodePortExternal()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        ClusterCa clusterCa = ResourceUtils.createInitialClusterCa(namespace, cluster);
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly);
+
+        SortedMap<Integer, String> addresses = new TreeMap<>();
+        addresses.put(0, "32123");
+        addresses.put(1, "32456");
+        addresses.put(2, "32789");
+        kc.setExternalAddresses(addresses);
+
+        // Check StatefulSet changes
+        StatefulSet ss = kc.generateStatefulSet(true);
+
+        List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "nodeport")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "false")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses.values()))));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
     }
 
     public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -225,6 +225,8 @@ It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBal
 |Field                  |Description
 |authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
+|boolean
 |type            1.2+<.<|Must be `loadbalancer`.
 |string
 |====
@@ -242,6 +244,8 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 |Field                  |Description
 |authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
+|boolean
 |type            1.2+<.<|Must be `nodeport`.
 |string
 |====

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -42,10 +42,7 @@ The external listener is used to connect to a Kafka cluster from outside of an {
 * `loadbalancer`
 * `nodeport`
 
-Each type of external listener uses TLS encryption.
-
 .Exposing Kafka using {OpenShiftName} Routes
-
 
 An external listener of type `route` exposes Kafka by using {OpenShiftName} `Routes` and the HAProxy router.
 A dedicated `Route` is created for every Kafka broker pod.
@@ -56,6 +53,8 @@ ifdef::Kubernetes[]
 NOTE: `Routes` are available only on {OpenShiftName}. External listeners of type `route` cannot be used on {KubernetesName}.
 endif::Kubernetes[]
 
+When exposing Kafka using {OpenShiftName} `Routes`, TLS encryption is always used.
+
 For more information on using `Routes` to access Kafka, see xref:proc-accessing-kafka-using-routes-{context}[].
 
 .Exposing Kafka using loadbalancers
@@ -64,6 +63,9 @@ External listeners of type `loadbalancer` expose Kafka by using `Loadbalancer` t
 A new loadbalancer service is created for every Kafka broker pod.
 An additional loadbalancer is created to serve as a Kafka _bootstrap_ address.
 Loadbalancers listen to connections on port 9094.
+
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
 
 For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
 
@@ -84,6 +86,9 @@ When selecting the node address, the different address types are used with the f
 . InternalDNS
 . InternalIP
 
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
+
 NOTE: TLS hostname verification is not currently supported when exposing Kafka clusters using node ports.
 
 For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].
@@ -93,7 +98,7 @@ For more information on using node ports to access Kafka, see xref:proc-accessin
 The listener sub-properties can also contain additional configuration.
 Both listeners support the `authentication` property. This is used to specify an authentication mechanism specific to that listener:
 
-* mutual TLS authentication (only on the `tls` listener)
+* mutual TLS authentication (only on the listeners with TLS encryption)
 * SCRAM-SHA authentication
 
 If no `authentication` property is specified then the listener does not authenticate clients which connect though that listener.
@@ -111,6 +116,7 @@ listeners:
       type: tls
   external:
     type: loadbalancer
+    tls: true
     authentication:
       type: tls
 # ...

--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -26,6 +26,7 @@ spec:
     listeners:
       external:
         type: loadbalancer
+        tls: true
         # ...
     # ...
   zookeeper:
@@ -73,7 +74,7 @@ oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.l
 +
 Use the hostname or IP address together with port 9094 in your Kafka client as the _bootstrap_ address.
 
-. Extract the public certificate of the broker certification authority.
+. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -26,6 +26,7 @@ spec:
     listeners:
       external:
         type: nodeport
+        tls: true
         # ...
     # ...
   zookeeper:
@@ -83,7 +84,7 @@ If several different addresses are returned, select the address type you want ba
 +
 Use the address with the port found in the previous step in the Kafka _bootstrap_ address.
 
-. Extract the public certificate of the broker certification authority
+. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -84,7 +84,7 @@ If several different addresses are returned, select the address type you want ba
 +
 Use the address with the port found in the previous step in the Kafka _bootstrap_ address.
 
-. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority
+. Unless TLS encryption was disabled, extract the public certificate of the broker certification authority.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -68,6 +68,8 @@ spec:
                           properties:
                             type:
                               type: string
+                        tls:
+                          type: boolean
                         type:
                           type: string
                 authorization:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -72,6 +72,8 @@ spec:
                           properties:
                             type:
                               type: string
+                        tls:
+                          type: boolean
                         type:
                           type: string
                 authorization:


### PR DESCRIPTION
…intext connections

### Type of change

- Enhancement / new feature

### Description

This PR adds the possibility to expose Kafka with `PLAINTEXT` connections (without TLS encryption) when nodeports or loadbalancers are used. When using Routes, TLS has to be always used as we use TLS passthrough to get TCP connections through the HAProxy.

This also updated the relevant docs.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

