### PR TITLE
Added TlsSidecar derived class for supporting TLS log level

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -44,7 +44,7 @@ public class EntityOperatorSpec implements Serializable {
     private EntityUserOperatorSpec userOperator;
     private Affinity affinity;
     private List<Toleration> tolerations;
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Configuration of the Topic Operator")
@@ -91,11 +91,11 @@ public class EntityOperatorSpec implements Serializable {
 
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public Sidecar getTlsSidecar() {
+    public TlsSidecar getTlsSidecar() {
         return tlsSidecar;
     }
 
-    public void setTlsSidecar(Sidecar tlsSidecar) {
+    public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -63,7 +63,7 @@ public class KafkaClusterSpec implements Serializable {
 
     private Logging logging;
 
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
     private int replicas;
     private String image;
     private Resources resources;
@@ -130,11 +130,11 @@ public class KafkaClusterSpec implements Serializable {
 
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public Sidecar getTlsSidecar() {
+    public TlsSidecar getTlsSidecar() {
         return tlsSidecar;
     }
 
-    public void setTlsSidecar(Sidecar tlsSidecar) {
+    public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import io.vertx.core.cli.annotations.DefaultValue;
+
+/**
+ * Representation of a TLS sidecar container configuration
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TlsSidecar extends Sidecar {
+    private static final long serialVersionUID = 1L;
+
+    private TlsSidecarLogLevel logLevel = TlsSidecarLogLevel.NOTICE;
+
+    @Description("The log level for the TLS sidecar." +
+            "Default value is `notice`.")
+    @DefaultValue("notice")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public TlsSidecarLogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    public void setLogLevel(TlsSidecarLogLevel logLevel) {
+        this.logLevel = logLevel;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecarLogLevel.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecarLogLevel.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum TlsSidecarLogLevel {
+
+    EMERG,
+    ALERT,
+    CRIT,
+    ERR,
+    WARNING,
+    NOTICE,
+    INFO,
+    DEBUG;
+
+    @JsonCreator
+    public static TlsSidecarLogLevel forValue(String value) {
+        switch (value) {
+            case "emerg":
+                return EMERG;
+            case "alert":
+                return ALERT;
+            case "crit":
+                return CRIT;
+            case "err":
+                return ERR;
+            case "warning":
+                return WARNING;
+            case "notice":
+                return  NOTICE;
+            case "info":
+                return INFO;
+            case "debug":
+                return DEBUG;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case EMERG:
+                return "emerg";
+            case ALERT:
+                return "alert";
+            case CRIT:
+                return "crit";
+            case ERR:
+                return "err";
+            case WARNING:
+                return "warning";
+            case NOTICE:
+                return "notice";
+            case INFO:
+                return "info";
+            case DEBUG:
+                return "debug";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -31,7 +31,7 @@ public class TopicOperatorSpec extends EntityTopicOperatorSpec {
     public static final String DEFAULT_TLS_SIDECAR_IMAGE = EntityOperatorSpec.DEFAULT_TLS_SIDECAR_IMAGE;
 
     private Affinity affinity;
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
 
     @Description("Pod affinity rules.")
     @KubeLink(group = "core", version = "v1", kind = "affinity")
@@ -45,11 +45,11 @@ public class TopicOperatorSpec extends EntityTopicOperatorSpec {
 
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public Sidecar getTlsSidecar() {
+    public TlsSidecar getTlsSidecar() {
         return tlsSidecar;
     }
 
-    public void setTlsSidecar(Sidecar tlsSidecar) {
+    public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -54,7 +54,7 @@ public class ZookeeperClusterSpec implements Serializable {
 
     private Logging logging;
 
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
     private int replicas;
     private String image;
     private Resources resources;
@@ -98,11 +98,11 @@ public class ZookeeperClusterSpec implements Serializable {
 
     @Description("TLS sidecar configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public Sidecar getTlsSidecar() {
+    public TlsSidecar getTlsSidecar() {
         return tlsSidecar;
     }
 
-    public void setTlsSidecar(Sidecar tlsSidecar) {
+    public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Resources;
-import io.strimzi.api.kafka.model.Sidecar;
+import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.model.Labels;
 
@@ -49,7 +49,7 @@ public class EntityOperator extends AbstractModel {
     private String zookeeperConnect;
     private EntityTopicOperator topicOperator;
     private EntityUserOperator userOperator;
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
 
     private boolean isDeployed;
 
@@ -65,7 +65,7 @@ public class EntityOperator extends AbstractModel {
         this.zookeeperConnect = defaultZookeeperConnect(cluster);
     }
 
-    protected void setTlsSidecar(Sidecar tlsSidecar) {
+    protected void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -47,7 +47,7 @@ import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.Resources;
-import io.strimzi.api.kafka.model.Sidecar;
+import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
@@ -128,7 +128,7 @@ public class KafkaCluster extends AbstractModel {
     private String zookeeperConnect;
     private Rack rack;
     private String initImage;
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
     private KafkaListeners listeners;
     private KafkaAuthorization authorization;
     private SortedMap<Integer, String> externalAddresses = new TreeMap<>();
@@ -763,7 +763,7 @@ public class KafkaCluster extends AbstractModel {
         this.initImage = initImage;
     }
 
-    protected void setTlsSidecar(Sidecar tlsSidecar) {
+    protected void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -18,7 +18,7 @@ import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Resources;
-import io.strimzi.api.kafka.model.Sidecar;
+import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.model.Labels;
@@ -84,7 +84,7 @@ public class TopicOperator extends AbstractModel {
     private String topicConfigMapLabels;
     private int topicMetadataMaxAttempts;
 
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
 
     /**
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
@@ -382,7 +382,7 @@ public class TopicOperator extends AbstractModel {
         return createSecret(TopicOperator.secretName(cluster), data);
     }
 
-    protected void setTlsSidecar(Sidecar tlsSidecar) {
+    protected void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -29,7 +29,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
-import io.strimzi.api.kafka.model.Sidecar;
+import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.model.Labels;
@@ -67,7 +67,7 @@ public class ZookeeperCluster extends AbstractModel {
     private static final String NODES_CERTS_SUFFIX = NAME_SUFFIX + "-nodes";
 
     // Zookeeper configuration
-    private Sidecar tlsSidecar;
+    private TlsSidecar tlsSidecar;
 
     // Configuration defaults
     private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
@@ -390,7 +390,7 @@ public class ZookeeperCluster extends AbstractModel {
         return volumeMountList;
     }
 
-    protected void setTlsSidecar(Sidecar tlsSidecar) {
+    protected void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -81,7 +81,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |logging              1.2+<.<|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |tlsSidecar           1.2+<.<|TLS sidecar configuration.
-|xref:type-Sidecar-{context}[`Sidecar`]
+|xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |====
 
 [id='type-EphemeralStorage-{context}']
@@ -311,7 +311,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 [id='type-Resources-{context}']
 ### `Resources` schema reference
 
-Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`], xref:type-Sidecar-{context}[`Sidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -372,8 +372,8 @@ It must have the value `external` for the type `ExternalLogging`.
 |string
 |====
 
-[id='type-Sidecar-{context}']
-### `Sidecar` schema reference
+[id='type-TlsSidecar-{context}']
+### `TlsSidecar` schema reference
 
 Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
@@ -383,6 +383,8 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type
 |Field             |Description
 |image      1.2+<.<|The docker image for the container.
 |string
+|logLevel   1.2+<.<|The log level for the TLS sidecar.Default value is `notice`.
+|string (one of [emerg, debug, crit, err, alert, warning, notice, info])
 |resources  1.2+<.<|Resource constraints (limits and requests).
 |xref:type-Resources-{context}[`Resources`]
 |====
@@ -425,7 +427,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |logging         1.2+<.<|Logging configuration for Zookeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |tlsSidecar      1.2+<.<|TLS sidecar configuration.
-|xref:type-Sidecar-{context}[`Sidecar`]
+|xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |====
 
 [id='type-TopicOperatorSpec-{context}']
@@ -454,7 +456,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata.
 |integer
 |tlsSidecar                      1.2+<.<|TLS sidecar configuration.
-|xref:type-Sidecar-{context}[`Sidecar`]
+|xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |====
@@ -499,7 +501,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#tolerations-v1-core[Toleration] array
 |tlsSidecar     1.2+<.<|TLS sidecar configuration.
-|xref:type-Sidecar-{context}[`Sidecar`]
+|xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |====
 
 [id='type-EntityTopicOperatorSpec-{context}']

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -354,6 +354,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -665,6 +676,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -913,6 +935,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -1259,6 +1292,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -358,6 +358,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -669,6 +680,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -917,6 +939,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:
@@ -1263,6 +1296,17 @@ spec:
                   properties:
                     image:
                       type: string
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
                     resources:
                       type: object
                       properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As part of adding log level to the TLS sidecar, this PR adds the CRD part of it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

