### PR TITLE
Added IP address for external bootstrap service and pods to the SAN list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.8.0
+
+* Support for TLS hostname verification when connecting through IP address from outside of the Kafka cluster 
+
 ## 0.7.0
 
 * Exposing Kafka to the outside using:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #873.
I tested it on the same AKS (Azure Container Service) platform where I noticed the bug.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

