### PR TITLE
Use italic monospace for variables in code samples throughout the documentation.

### DIFF
--- a/documentation/book/assembly-kafka-connect-bootstrap-servers.adoc
+++ b/documentation/book/assembly-kafka-connect-bootstrap-servers.adoc
@@ -13,9 +13,9 @@
 
 Kafka Connect cluster always works together with a Kafka cluster.
 The Kafka cluster is specified in the form of a list of bootstrap servers.
-On {ProductPlatformName}, the list must ideally contain the Kafka cluster bootstrap service which is named `_<cluster-name>_-kafka-bootstrap` and a port of 9092 for plain traffic or 9093 for encrypted traffic.
+On {ProductPlatformName}, the list must ideally contain the Kafka cluster bootstrap service which is named `_cluster-name_-kafka-bootstrap` and a port of 9092 for plain traffic or 9093 for encrypted traffic.
 
-The list of bootstrap servers can be configured in the `bootstrapServers` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`. The servers should be a comma-separated list containing one or more Kafka brokers or a service pointing to Kafka brokers specified as a `<hostname>:<port>` pairs.
+The list of bootstrap servers can be configured in the `bootstrapServers` property in `KafkaConnect.spec` and `KafkaConnectS2I.spec`. The servers should be a comma-separated list containing one or more Kafka brokers or a service pointing to Kafka brokers specified as a `_hostname_:_port_` pairs.
 
 When using Kafka Connect with a Kafka cluster not managed by {ProductName}, you can specify the bootstrap servers list according to the configuration of a given cluster.
 

--- a/documentation/book/con-certificates.adoc
+++ b/documentation/book/con-certificates.adoc
@@ -11,19 +11,19 @@ The CAs themselves use self-signed certificates.
 
 All of the generated certificates are saved as `Secrets` in the {ProductPlatformName} cluster, named as follows:
 
-`_<cluster-name>_-cluster-ca`::
+`_cluster-name_-cluster-ca`::
 Contains the private and public keys of the cluster CA which is used for signing server certificates for the Kafka and {ProductName} components (Kafka brokers, Zookeeper nodes, and so on).
-`_<cluster-name>_-cluster-ca-cert`::
+`_cluster-name_-cluster-ca-cert`::
 Contains only the public key of the cluster CA which is used by Kafka clients to verify the identity of the Kafka brokers they are connecting to (TLS server authentication).
-`_<cluster-name>_-clients-ca`::
+`_cluster-name_-clients-ca`::
 Contains private and public keys of the clients CA which is used for TLS client authentication of Kafka clients when connecting to Kafka brokers.
-`_<cluster-name>_-clients-ca-cert`::
+`_cluster-name_-clients-ca-cert`::
 Contains only the public key of the client CA which is used by the Kafka brokers to verify the identity of Kafka clients when TLS client authentication is used.
-`_<cluster-name>_-kafka-brokers`::
+`_cluster-name_-kafka-brokers`::
 Contains all Kafka broker private and public keys (certificates signed with the cluster CA).
-`_<cluster-name>_-zookeeper-nodes`::
+`_cluster-name_-zookeeper-nodes`::
 Contains all Zookeeper node private and public keys (certificates signed with the cluster CA).
-`_<cluster-name>_-topic-operator-certs`::
+`_cluster-name_-topic-operator-certs`::
 Contains the private and public keys (certificates signed with the cluster CA) used for encrypting communication between the Topic Operator and Kafka or Zookeeper.
 
 All keys are 2048 bits in size and are valid for 365 days from initial generation.

--- a/documentation/book/con-cluster-operator-rbac.adoc
+++ b/documentation/book/con-cluster-operator-rbac.adoc
@@ -24,11 +24,11 @@ Because the Cluster Operator must be able to create the `ClusterRoleBindings`, a
 
 When the Cluster Operator deploys resources for a desired `Kafka` resource it also creates `ServiceAccounts`, `RoleBindings`, and `ClusterRoleBindings`, as follows:
 
-* The Kafka broker pods use a `ServiceAccount` called `_<cluster-name>_-kafka`
-  - When the rack feature is used, the `strimzi-_<cluster-name>_-kafka-init` `ClusterRoleBinding` is used to grant this `ServiceAccount` access to the nodes within the cluster via a `ClusterRole` called `strimzi-kafka-broker`
+* The Kafka broker pods use a `ServiceAccount` called `_cluster-name_-kafka`
+  - When the rack feature is used, the `strimzi-_cluster-name_-kafka-init` `ClusterRoleBinding` is used to grant this `ServiceAccount` access to the nodes within the cluster via a `ClusterRole` called `strimzi-kafka-broker`
   - When the rack feature is not used no binding is created.
 * The Zookeeper pods use the default `ServiceAccount`, as they do not need access to the {ProductPlatformName} resources.
-* The Topic Operator pod uses a `ServiceAccount` called `_<cluster-name>_-topic-operator`
+* The Topic Operator pod uses a `ServiceAccount` called `_cluster-name_-topic-operator`
     - The Topic Operator produces {ProductPlatformName} events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-topic-operator` which grants this access via the `strimzi-topic-operator-role-binding` `RoleBinding`.
 
 The pods for `KafkaConnect` and `KafkaConnectS2I` resources use the default `ServiceAccount`, as they do not require access to the {ProductPlatformName} resources.

--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -37,39 +37,39 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 . Find the hostname of the bootstrap loadbalancer.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
+kubectl get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
-oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
+oc get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
 +
 If no hostname was found (nothing was returned by the command), use the loadbalancer IP address.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
+kubectl get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
-oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
+oc get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
 +
 Use the hostname or IP address together with port 9094 in your Kafka client as the _bootstrap_ address.
 
@@ -78,13 +78,13 @@ Use the hostname or IP address together with port 9094 in your Kafka client as t
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+kubectl get secret _cluster-name_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc extract`:
 +
 [source,shell,subs=+quotes]
-oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
+oc extract secret/_cluster-name_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
 +
 Use the extracted certificate in your Kafka client to configure TLS connection.
 If you enabled any authentication, you will also need to configure SASL or TLS authentication.

--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -37,26 +37,26 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 . Find the port number of the bootstrap service.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
+kubectl get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
-oc get service _<cluster-name>_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
+oc get service _cluster-name_-kafka-external-bootstrap -o=jsonpath='{.spec.ports[0].nodePort}{"\n"}'
 +
 The port should be used in the Kafka _bootstrap_ address.
 
@@ -65,13 +65,13 @@ The port should be used in the Kafka _bootstrap_ address.
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
+kubectl get node _node-name_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc get`:
 +
 [source,shell,subs=+quotes]
-oc get node _<node-name>_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
+oc get node _node-name_ -o=jsonpath='{range .status.addresses[*]}{.type}{"\t"}{.address}{"\n"}'
 +
 If several different addresses are returned, select the address type you want based on the following order:
 +
@@ -88,13 +88,13 @@ Use the address with the port found in the previous step in the Kafka _bootstrap
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl get`:
 [source,shell,subs=+quotes]
-kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+kubectl get secret _cluster-name_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc extract`:
 +
 [source,shell,subs=+quotes]
-oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
+oc extract secret/_cluster-name_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
 +
 Use the extracted certificate in your Kafka client to configure TLS connection.
 If you enabled any authentication, you will also need to configure SASL or TLS authentication.

--- a/documentation/book/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/book/proc-accessing-kafka-using-routes.adoc
@@ -35,19 +35,19 @@ spec:
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 . Find the address of the bootstrap `Route`.
 +
 [source,shell]
-oc get routes _<cluster-name>_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
+oc get routes _cluster-name_-kafka-bootstrap -o=jsonpath='{.status.ingress[0].host}{"\n"}'
 +
 Use the address together with port 443 in your Kafka client as the _bootstrap_ address.
 
 . Extract the public certificate of the broker certification authority
 +
 [source,shell]
-oc extract secret/_<cluster-name>_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
+oc extract secret/_cluster-name_-cluster-ca-cert --keys=ca.crt --to=- > ca.crt
 +
 Use the extracted certificate in your Kafka client to configure TLS connection.
 If you enabled any authentication, you will also need to configure SASL or TLS authentication.

--- a/documentation/book/proc-changing-a-topic.adoc
+++ b/documentation/book/proc-changing-a-topic.adoc
@@ -43,13 +43,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 
 .Additional resources

--- a/documentation/book/proc-changing-kafka-user.adoc
+++ b/documentation/book/proc-changing-kafka-user.adoc
@@ -55,12 +55,12 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 endif::Kubernetes[]
 +
 On {OpenShiftName} this can be done using `oc apply`:
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 +
 . Use the updated credentials from the `my-user` secret in your application.
 

--- a/documentation/book/proc-configuring-clients-to-trust-cluster-ca.adoc
+++ b/documentation/book/proc-configuring-clients-to-trust-cluster-ca.adoc
@@ -3,25 +3,25 @@
 // assembly-security.adoc
 
 [id='configuring-clients-to-trust-cluster-ca-{context}']
-= Configuring clients to trust the cluster CA 
+= Configuring clients to trust the cluster CA
 
 If a Kafka client wants to connect to the `tls` listener on port 9093 or the `external` listener on port 9094, it needs to trust the cluster CA certificate.
 
 .Procedure
 
-. The cluster CA certificate can be extracted from the generated `_<cluster-name>_-cluster-ca-cert` `Secret`.
+. The cluster CA certificate can be extracted from the generated `_cluster-name_-cluster-ca-cert` `Secret`.
 ifdef::Kubernetes[]
 +
 On {KubernetesName}, the certificate can be extracted with the following command:
 +
 [source,shell,subs="+quotes"]
-kubectl get secret _<cluster-name>_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+kubectl get secret _cluster-name_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 endif::Kubernetes[]
 +
 On {OpenShiftName}, the certificate can be extracted with the following command:
 +
 [source,shell,subs="+quotes"]
-oc extract secret/_<cluster-name>_-cluster-ca-cert --keys ca.crt
+oc extract secret/_cluster-name_-cluster-ca-cert --keys ca.crt
 
 . The Kafka client has to be configured to trust certificates signed by this CA.
 For the Java-based Kafka Producer, Consumer, and Streams APIs, you can do this by importing the CA certificate into the JVM's truststore using the following `keytool` command:
@@ -31,7 +31,6 @@ keytool -keystore client.truststore.jks -alias CARoot -import -file ca.crt
 
 . In order to configure the Kafka client, following properties should be specified:
 
-* `security.protocol: SSL` when using TLS for encryption (with or without TLS authentication), or `security.protocol: SASL_SSL` when using SCRAM-SHA authentication over TLS. 
+* `security.protocol: SSL` when using TLS for encryption (with or without TLS authentication), or `security.protocol: SASL_SSL` when using SCRAM-SHA authentication over TLS.
 * `ssl.truststore.location`: the truststore location where the certificates were imported.
 * `ssl.truststore.password`: the password for accessing the truststore. This property can be omitted if it is not needed by the truststore.
-

--- a/documentation/book/proc-configuring-container-images.adoc
+++ b/documentation/book/proc-configuring-container-images.adoc
@@ -35,10 +35,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-healthchecks.adoc
+++ b/documentation/book/proc-configuring-healthchecks.adoc
@@ -40,10 +40,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-init-container-image.adoc
+++ b/documentation/book/proc-configuring-init-container-image.adoc
@@ -43,10 +43,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-jvm-options.adoc
+++ b/documentation/book/proc-configuring-jvm-options.adoc
@@ -37,10 +37,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-broker-replicas.adoc
+++ b/documentation/book/proc-configuring-kafka-broker-replicas.adoc
@@ -37,10 +37,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-brokers.adoc
+++ b/documentation/book/proc-configuring-kafka-brokers.adoc
@@ -37,10 +37,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-authentication-scram-sha-512.adoc
@@ -19,15 +19,15 @@ If such a `Secret` does not exist yet, prepare a file with the password and crea
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl create`:
 [source,shell,subs=+quotes]
-echo -n '_<password>_' > _<my-password.txt>_
-kubectl create secret generic _<my-secret>_ --from-file=_<my-password.txt>_
+echo -n '_password_' > _my-password.txt_
+kubectl create secret generic _my-secret_ --from-file=_my-password.txt_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc create`:
 +
 [source,shell,subs=+quotes]
-echo -n '1f2d1e2e67df' > _<my-password.txt>_
-oc create secret generic _<my-secret>_ --from-file=_<my-password.txt>_
+echo -n '1f2d1e2e67df' > _my-password.txt_
+oc create secret generic _my-secret_ --from-file=_my-password.txt_
 . Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` resource.
 For example:
 +
@@ -41,10 +41,10 @@ spec:
   # ...
   authentication:
     type: scram-sha-512
-    username: _<my-username>_
+    username: _my-username_
     passwordSecret:
-      secretName: _<my-secret>_
-      password: _<my-password.txt>_
+      secretName: _my-secret_
+      password: _my-password.txt_
   # ...
 ----
 +
@@ -53,10 +53,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect-authentication-tls.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-authentication-tls.adoc
@@ -18,13 +18,13 @@ If such a `Secret` does not exist yet, prepare the keys in a file and create the
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl create`:
 [source,shell,subs=+quotes]
-kubectl create secret generic _<my-secret>_ --from-file=_<my-public.crt>_ --from-file=_<my-private.key>_
+kubectl create secret generic _my-secret_ --from-file=_my-public.crt_ --from-file=_my-private.key_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc create`:
 +
 [source,shell,subs=+quotes]
-oc create secret generic _<my-secret>_ --from-file=_<my-public.crt>_ --from-file=_<my-private.key>_
+oc create secret generic _my-secret_ --from-file=_my-public.crt_ --from-file=_my-private.key_
 . Edit the `authentication` property in the `KafkaConnect` or `KafkaConnectS2I` resource.
 For example:
 +
@@ -50,10 +50,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect-bootstrap-servers.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-bootstrap-servers.adoc
@@ -32,10 +32,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect-replicas.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-replicas.adoc
@@ -34,10 +34,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect-tls.adoc
+++ b/documentation/book/proc-configuring-kafka-connect-tls.adoc
@@ -18,13 +18,13 @@ If such secret does not exist yet, prepare the certificate in a file and create 
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl create`:
 [source,shell,subs=+quotes]
-kubectl create secret generic _<my-secret>_ --from-file=_<my-file.crt>_
+kubectl create secret generic _my-secret_ --from-file=_my-file.crt_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc create`:
 +
 [source,shell,subs=+quotes]
-oc create secret generic _<my-secret>_ --from-file=_<my-file.crt>_
+oc create secret generic _my-secret_ --from-file=_my-file.crt_
 . Edit the `tls` property in the `KafkaConnect` or `KafkaConnectS2I` resource.
 For example:
 +
@@ -48,10 +48,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-connect.adoc
+++ b/documentation/book/proc-configuring-kafka-connect.adoc
@@ -47,10 +47,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-entity-operator.adoc
+++ b/documentation/book/proc-configuring-kafka-entity-operator.adoc
@@ -40,10 +40,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-kafka-listeners.adoc
+++ b/documentation/book/proc-configuring-kafka-listeners.adoc
@@ -35,13 +35,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 * For more information about the schema, see xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-configuring-kafka-rack-awareness.adoc
+++ b/documentation/book/proc-configuring-kafka-rack-awareness.adoc
@@ -42,13 +42,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional Resources
 * For information about Configuring init container image for Kafka rack awareness, see xref:assembly-configuring-container-images-deployment-configuration-kafka[].

--- a/documentation/book/proc-configuring-metrics.adoc
+++ b/documentation/book/proc-configuring-metrics.adoc
@@ -36,10 +36,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-resource-limits-and-requests.adoc
+++ b/documentation/book/proc-configuring-resource-limits-and-requests.adoc
@@ -39,13 +39,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 * For more information about the schema, see xref:type-Resources-reference[`Resources` schema reference].

--- a/documentation/book/proc-configuring-tls-sidecar.adoc
+++ b/documentation/book/proc-configuring-tls-sidecar.adoc
@@ -42,10 +42,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-zookeeper-nodes.adoc
+++ b/documentation/book/proc-configuring-zookeeper-nodes.adoc
@@ -35,10 +35,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-configuring-zookeeper-replicas.adoc
+++ b/documentation/book/proc-configuring-zookeeper-replicas.adoc
@@ -35,10 +35,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-creating-a-topic.adoc
+++ b/documentation/book/proc-creating-a-topic.adoc
@@ -40,13 +40,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 * For more information about the schema for `KafkaTopics`, see xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].

--- a/documentation/book/proc-creating-kafka-user-scram-sha.adoc
+++ b/documentation/book/proc-creating-kafka-user-scram-sha.adoc
@@ -52,13 +52,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 . Use the credentials from the secret `my-user` in your application
 

--- a/documentation/book/proc-creating-kafka-user-tls.adoc
+++ b/documentation/book/proc-creating-kafka-user-tls.adoc
@@ -52,13 +52,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 . Use the credentials from the secret `my-user` in your application
 

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -19,7 +19,7 @@ The following procedure describes the process for creating such a custom image.
 ----
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/
+COPY ./_my-plugins_/ /opt/kafka/plugins/
 USER {DockerImageUser}
 ----
 

--- a/documentation/book/proc-dedicated-nodes.adoc
+++ b/documentation/book/proc-dedicated-nodes.adoc
@@ -19,26 +19,26 @@
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl taint`:
 [source,shell,subs=+quotes]
-kubectl taint node _<your-node>_ dedicated=Kafka:NoSchedule
+kubectl taint node _your-node_ dedicated=Kafka:NoSchedule
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc adm taint`:
 +
 [source,shell,subs=+quotes]
-oc adm taint node _<your-node>_ dedicated=Kafka:NoSchedule
+oc adm taint node _your-node_ dedicated=Kafka:NoSchedule
 +
 . Additionally, add a label to the selected nodes as well.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl label`:
 [source,shell,subs=+quotes]
-kubectl label node _<your-node>_ dedicated=Kafka
+kubectl label node _your-node_ dedicated=Kafka
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc label`:
 +
 [source,shell,subs=+quotes]
-oc label node _<your-node>_ dedicated=Kafka
+oc label node _your-node_ dedicated=Kafka
 +
 . Edit the `affinity` and `tolerations` properties in the resource specifying the cluster deployment.
 For example:
@@ -74,10 +74,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-deleting-a-topic.adoc
+++ b/documentation/book/proc-deleting-a-topic.adoc
@@ -21,13 +21,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl`:
 +
 [source,shell,subs=+quotes]
-kubectl delete kafkatopic _<your-topic-name>_
+kubectl delete kafkatopic _your-topic-name_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc`:
 +
 [source,shell,subs=+quotes]
-oc delete kafkatopic _<your-topic-name>_
+oc delete kafkatopic _your-topic-name_
 +
 NOTE: Whether the topic can actually be deleted depends on the value of the `delete.topic.enable` Kafka broker configuration, specified in the `Kafka.spec.kafka.config` property.
 

--- a/documentation/book/proc-deleting-kafka-user.adoc
+++ b/documentation/book/proc-deleting-kafka-user.adoc
@@ -21,13 +21,13 @@ ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl`:
 +
 [source,shell,subs=+quotes]
-kubectl delete kafkauser _<your-user-name>_
+kubectl delete kafkauser _your-user-name_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc`:
 +
 [source,shell,subs=+quotes]
-oc delete kafkauser _<your-user-name>_
+oc delete kafkauser _your-user-name_
 +
 
 .Additional resources

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
@@ -11,7 +11,7 @@
 +
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-operator/*RoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure
@@ -37,32 +37,32 @@ spec:
 ----
 
 . For all namespaces or projects which should be watched by the Cluster Operator, install the `RoleBindings`.
-Replace the `_<my-namespace>_` or `_<my-project>_` with the {Namespace} used in the previous step.
+Replace the `_my-namespace_` or `_my-project_` with the {Namespace} used in the previous step.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f examples/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _<my-namespace>_
-kubectl apply -f examples/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _<my-namespace>_
-kubectl apply -f examples/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _<my-namespace>_
+kubectl apply -f examples/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _my-namespace_
+kubectl apply -f examples/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _my-namespace_
+kubectl apply -f examples/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _my-namespace_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f examples/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _<my-project>_
-oc apply -f examples/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _<my-project>_
-oc apply -f examples/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _<my-project>_
+oc apply -f examples/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _my-project_
+oc apply -f examples/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _my-project_
+oc apply -f examples/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _my-project_
 
 . Deploy the Cluster Operator
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f examples/install/cluster-operator -n _<my-namespace>_
+kubectl apply -f examples/install/cluster-operator -n _my-namespace_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f examples/install/cluster-operator -n _<my-project>_
+oc apply -f examples/install/cluster-operator -n _my-project_

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
@@ -11,7 +11,7 @@
 +
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-operator/*RoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure
@@ -20,5 +20,5 @@ sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-
 +
 [source]
 ----
-kubectl apply -f examples/install/cluster-operator -n _<my-namespace>_
+kubectl apply -f examples/install/cluster-operator -n _my-namespace_
 ----

--- a/documentation/book/proc-deploying-cluster-operator-openshift.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-openshift.adoc
@@ -12,7 +12,7 @@
 +
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _<my-project>_/' examples/install/cluster-operator/*RoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-project_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure
@@ -21,6 +21,6 @@ sed -i 's/namespace: .\*/namespace: _<my-project>_/' examples/install/cluster-op
 +
 [source]
 ----
-oc apply -f examples/install/cluster-operator -n _<my-project>_
-oc apply -f examples/templates/cluster-operator -n _<my-project>_
+oc apply -f examples/install/cluster-operator -n _my-project_
+oc apply -f examples/templates/cluster-operator -n _my-project_
 ----

--- a/documentation/book/proc-deploying-example-clients.adoc
+++ b/documentation/book/proc-deploying-example-clients.adoc
@@ -13,7 +13,7 @@
 . Deploy the producer.
 +
 [source,subs="+quotes,attributes"]
-oc run kafka-producer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-producer.sh --broker-list __<cluster-name>__-kafka-bootstrap:9092 --topic _<my-topic>_
+oc run kafka-producer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
 
 . Type your message into the console where the producer is running.
 
@@ -22,6 +22,6 @@ oc run kafka-producer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-co
 . Deploy the consumer.
 +
 [source,subs="+quotes,attributes"]
-oc run kafka-consumer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-consumer.sh --bootstrap-server __<cluster-name>__-kafka-bootstrap:9092 --topic _<my-topic>_ --from-beginning
+oc run kafka-consumer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning
 
 . Confirm that you see the incoming messages in the consumer console.

--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -4,7 +4,7 @@
 // assembly-deploying-the-topic-operator.adoc
 
 [id='deploying-the-topic-operator-standalone-{context}']
-= Deploying the standalone Topic Operator 
+= Deploying the standalone Topic Operator
 
 Deploying the Topic Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
 For instance is can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
@@ -17,8 +17,8 @@ For instance is can operate _with_ any Kafka cluster, not necessarily one deploy
 
 . Edit the `examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml` resource. You will need to change the following
 +
-.. The `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of bootstrap brokers in your Kafka cluster, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs.
-.. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
+.. The `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of bootstrap brokers in your Kafka cluster, given as a comma-separated list of `_hostname_:‍_port_` pairs.
+.. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaTopic` resources.
 
 . Deploy the Cluster Operator.
@@ -35,7 +35,7 @@ On {OpenShiftName} this can be done using `oc apply`:
 [source,shell]
 oc apply -f examples/install/topic-operator
 
-. Verify that the Topic Operator has been deployed successfully. 
+. Verify that the Topic Operator has been deployed successfully.
 ifdef::Kubernetes[]
 +
 On {KubernetesName} this can be done using `kubectl describe`:
@@ -48,7 +48,7 @@ On {OpenShiftName} this can be done using `oc describe`:
 +
 [source,shell]
 oc describe deployment strimzi-topic-operator
-+ 
++
 The Topic Operator is deployed once the `Replicas:` entry shows `1 available`.
 +
 NOTE: This could take some time if you have a slow connection to the {ProductPlatformName} and the images have not been downloaded before.

--- a/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
@@ -21,13 +21,13 @@ Edit the `Kafka` resource ensuring it has a `Kafka.spec.entityOperator` object t
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 

--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -18,7 +18,7 @@ For instance it can operate _with_ any Kafka cluster, not only the one deployed 
 +
 .. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} `Secret` which should contain the Certificate Authority for signing new user certificates for TLS Client Authentication.
 The `Secret` should contain the public key of the Certificate Authority under the key `clients-ca.crt` and the private key under `clients-ca.key`.
-.. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_<hostname>_:‍_<port>_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
+.. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
 
 . Deploy the Cluster Operator.
@@ -48,7 +48,7 @@ On {OpenShiftName} this can be done using `oc describe`:
 +
 [source,shell]
 oc describe deployment strimzi-user-operator
-+ 
++
 The User Operator is deployed once the `Replicas:` entry shows `1 available`.
 +
 NOTE: This could take some time if you have a slow connection to the {ProductPlatformName} and the images have not been downloaded before.

--- a/documentation/book/proc-deploying-the-user-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-using-the-cluster-operator.adoc
@@ -19,13 +19,13 @@
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -37,13 +37,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 * For more information about the supported authentication mechanisms, see xref:ref-kafka-authentication-{context}[authentication reference].

--- a/documentation/book/proc-kafka-authorization.adoc
+++ b/documentation/book/proc-kafka-authorization.adoc
@@ -34,13 +34,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 * For more information about the supported authorization methods, see xref:ref-kafka-authorization-{context}[authorization reference].

--- a/documentation/book/proc-kafka-external-logging.adoc
+++ b/documentation/book/proc-kafka-external-logging.adoc
@@ -28,10 +28,10 @@ Remember to place your custom ConfigMap under `log4j.properties` eventually `log
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-kafka-inline-logging.adoc
+++ b/documentation/book/proc-kafka-inline-logging.adoc
@@ -18,7 +18,7 @@ spec:
     logging:
       type: inline
       loggers:
-       _<logger.name>_: "INFO"
+       _logger.name_: "INFO"
     # ...
 ----
 +
@@ -30,10 +30,10 @@ You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For 
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/book/proc-scheduling-based-on-other-pods.adoc
@@ -45,10 +45,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-scheduling-deplyoment-to-node-using-node-affinity.adoc
+++ b/documentation/book/proc-scheduling-deplyoment-to-node-using-node-affinity.adoc
@@ -17,13 +17,13 @@
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl label`:
 [source,shell,subs=+quotes]
-kubectl label node _<your-node>_ node-type=fast-network
+kubectl label node _your-node_ node-type=fast-network
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc label`:
 +
 [source,shell,subs=+quotes]
-oc label node _<your-node>_ node-type=fast-network
+oc label node _your-node_ node-type=fast-network
 +
 Alternatively, some of the existing labels might be reused.
 . Edit the `affinity` property in the resource specifying the cluster deployment.
@@ -55,10 +55,10 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_

--- a/documentation/book/proc-topic-operator-with-resource-requests-limits.adoc
+++ b/documentation/book/proc-topic-operator-with-resource-requests-limits.adoc
@@ -34,13 +34,13 @@ spec:
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
 On {OpenShiftName} this can be done using `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _<your-file>_
+oc apply -f _your-file_
 
 .Additional resources
 

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -30,8 +30,8 @@ with Kafka Connect plugins:
 +
 [source,subs="+quotes"]
 ----
-$ tree ./_<my-plugins>_/
-./_<my-plugins>_/
+$ tree ./_my-plugins_/
+./_my-plugins_/
 ├── debezium-connector-mongodb
 │   ├── bson-3.4.2.jar
 │   ├── CHANGELOG.md
@@ -69,7 +69,7 @@ $ tree ./_<my-plugins>_/
 . Start a new image build using the prepared directory:
 +
 [source,subs="+quotes"]
-oc start-build _<my-connect-cluster-connect>_ --from-dir ./_<my-plugins>_/
+oc start-build _my-connect-cluster-connect_ --from-dir ./_my-plugins_/
 +
 NOTE: The name of the build will be changed according to the cluster name of the deployed Kafka Connect cluster.
 

--- a/documentation/book/ref-document-conventions.adoc
+++ b/documentation/book/ref-document-conventions.adoc
@@ -7,11 +7,11 @@
 
 .Replaceables
 
-In this document, replaceable text is styled in monospace and surrounded by angle brackets.
+In this document, replaceable text is styled in monospace and italics.
 
-For example, in the following code, you will want to replace `_<my-namespace>_` with the name of your namespace:
+For example, in the following code, you will want to replace `_my-namespace_` with the name of your namespace:
 
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _<my-namespace>_/' examples/install/cluster-operator/*ClusterRoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*ClusterRoleBinding*.yaml
 ----

--- a/documentation/book/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-cluster-resources.adoc
@@ -7,32 +7,32 @@
 
 The following resources will created by the Cluster Operator in the {ProductPlatformName} cluster:
 
-`_<cluster-name>_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods.
-`_<cluster-name>_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
-`_<cluster-name>_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients.
-`_<cluster-name>_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled.
-`_<cluster-name>_-kafka-_<pod-id>_`:: Service used to route traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled.
-`_<cluster-name>_-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled and set to type `route`.
-`_<cluster-name>_-kafka-_<pod-id>_`:: Route for traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled and set to type `route`.
-`_<cluster-name>_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
-`_<cluster-name>_-kafka-brokers`:: Secret with Kafka broker keys.
-`_<cluster-name>_-kafka`:: Service account used by the Kafka brokers.
-`strimzi-_<namespace-name>_-_<cluster-name>_-kafka-init`:: Cluster role binding used by the Kafka brokers.
-`_<cluster-name>_-zookeeper`:: StatefulSet which is in charge of managing the Zookeeper node pods.
-`_<cluster-name>_-zookeeper-nodes`:: Service needed to have DNS resolve the Zookeeper pods IP addresses directly.
-`_<cluster-name>_-zookeeper-client`:: Service used by Kafka brokers to connect to Zookeeper nodes as clients.
-`_<cluster-name>_-zookeeper-config`:: ConfigMap which contains the Zookeeper ancillary configuration and is mounted as a volume by the Zookeeper node pods.
-`_<cluster-name>_-zookeeper-nodes`:: Secret with Zookeeper node keys.
-`_<cluster-name>_-entity-operator`:: Deployment with Topic and User Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
-`_<cluster-name>_-entity-topic-operator-config`:: Configmap with ancillary configuration for Topic Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
-`_<cluster-name>_-entity-user-operator-config`:: Configmap with ancillary configuration for User Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
-`_<cluster-name>_-entity-operator-certs`:: Secret with Entitiy operators keys for communication with Kafka and Zookeeper. This resource will be created only if Cluster Operator deployed Entity Operator.
-`_<cluster-name>_-entity-operator`:: Service account used by the Entity Operator.
-`strimzi-_<cluster-name>_-topic-operator`:: Role binding used by the Entity Operator.
-`strimzi-_<cluster-name>_-user-operator`:: Role binding used by the Entity Operator.
-`_<cluster-name>_-cluster-ca`:: Secret with the Cluster CA used to encrypt the cluster communication.
-`_<cluster-name>_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
-`_<cluster-name>_-clients-ca`::  Secret with the Clients CA used to encrypt the communication between Kafka brokers and Kafka clients.
-`_<cluster-name>_-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka brokers.
-`data-_<cluster-name>_-kafka-_<idx>_`:: Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `<idx>`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
-`data-_<cluster-name>_-zookeeper-_<idx>_`:: Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `<idx>`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
+`_cluster-name_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods.
+`_cluster-name_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
+`_cluster-name_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients.
+`_cluster-name_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled.
+`_cluster-name_-kafka-_pod-id_`:: Service used to route traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled.
+`_cluster-name_-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside of the {ProductPlatformName} cluster. This resource will be created only when external listener is enabled and set to type `route`.
+`_cluster-name_-kafka-_pod-id_`:: Route for traffic from outside of the {ProductPlatformName} cluster to individual pods. This resource will be created only when external listener is enabled and set to type `route`.
+`_cluster-name_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
+`_cluster-name_-kafka-brokers`:: Secret with Kafka broker keys.
+`_cluster-name_-kafka`:: Service account used by the Kafka brokers.
+`strimzi-_namespace-name_-_cluster-name_-kafka-init`:: Cluster role binding used by the Kafka brokers.
+`_cluster-name_-zookeeper`:: StatefulSet which is in charge of managing the Zookeeper node pods.
+`_cluster-name_-zookeeper-nodes`:: Service needed to have DNS resolve the Zookeeper pods IP addresses directly.
+`_cluster-name_-zookeeper-client`:: Service used by Kafka brokers to connect to Zookeeper nodes as clients.
+`_cluster-name_-zookeeper-config`:: ConfigMap which contains the Zookeeper ancillary configuration and is mounted as a volume by the Zookeeper node pods.
+`_cluster-name_-zookeeper-nodes`:: Secret with Zookeeper node keys.
+`_cluster-name_-entity-operator`:: Deployment with Topic and User Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
+`_cluster-name_-entity-topic-operator-config`:: Configmap with ancillary configuration for Topic Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
+`_cluster-name_-entity-user-operator-config`:: Configmap with ancillary configuration for User Operators. This resource will be created only if Cluster Operator deployed Entity Operator.
+`_cluster-name_-entity-operator-certs`:: Secret with Entitiy operators keys for communication with Kafka and Zookeeper. This resource will be created only if Cluster Operator deployed Entity Operator.
+`_cluster-name_-entity-operator`:: Service account used by the Entity Operator.
+`strimzi-_cluster-name_-topic-operator`:: Role binding used by the Entity Operator.
+`strimzi-_cluster-name_-user-operator`:: Role binding used by the Entity Operator.
+`_cluster-name_-cluster-ca`:: Secret with the Cluster CA used to encrypt the cluster communication.
+`_cluster-name_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
+`_cluster-name_-clients-ca`::  Secret with the Clients CA used to encrypt the communication between Kafka brokers and Kafka clients.
+`_cluster-name_-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka brokers.
+`data-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
+`data-_cluster-name_-zookeeper-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.

--- a/documentation/book/ref-list-of-kafka-connect-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-connect-resources.adoc
@@ -7,6 +7,6 @@
 
 The following resources will created by the Cluster Operator in the {ProductPlatformName} cluster:
 
-_<connect-cluster-name>_-connect:: Deployment which is in charge to create the Kafka Connect worker node pods.
-_<connect-cluster-name>_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
-_<connect-cluster-name>_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.
+_connect-cluster-name_-connect:: Deployment which is in charge to create the Kafka Connect worker node pods.
+_connect-cluster-name_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
+_connect-cluster-name_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.

--- a/documentation/book/ref-list-of-kafka-connect-s2i-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-connect-s2i-resources.adoc
@@ -7,9 +7,9 @@
 
 The following resources will created by the Cluster Operator in the {ProductPlatformName} cluster:
 
-_<connect-cluster-name>_-connect-source:: ImageStream which is used as the base image for the newly-built Docker images.
-_<connect-cluster-name>_-connect:: BuildConfig which is responsible for building the new Kafka Connect Docker images.
-_<connect-cluster-name>_-connect:: ImageStream where the newly built Docker images will be pushed.
-_<connect-cluster-name>_-connect:: DeploymentConfig which is in charge of creating the Kafka Connect worker node pods.
-_<connect-cluster-name>_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
-_<connect-cluster-name>_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.
+_connect-cluster-name_-connect-source:: ImageStream which is used as the base image for the newly-built Docker images.
+_connect-cluster-name_-connect:: BuildConfig which is responsible for building the new Kafka Connect Docker images.
+_connect-cluster-name_-connect:: ImageStream where the newly built Docker images will be pushed.
+_connect-cluster-name_-connect:: DeploymentConfig which is in charge of creating the Kafka Connect worker node pods.
+_connect-cluster-name_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
+_connect-cluster-name_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.

--- a/documentation/book/ref-storage-persistent.adoc
+++ b/documentation/book/ref-storage-persistent.adoc
@@ -72,8 +72,8 @@ storage:
 
 When the persistent storage is used, it will create Persistent Volume Claims with the following names:
 
-`data-_<cluster-name>_-kafka-_<idx>_`::
-Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `[idx]`.
+`data-_cluster-name_-kafka-_idx_`::
+Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`.
 
-`data-_<cluster-name>_-zookeeper-_<idx>_`::
-Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `[idx]`.
+`data-_cluster-name_-zookeeper-_idx_`::
+Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `_idx_`.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This pull request changes the style that is applied to replaceable text in code samples throughout the documentation. It changes <_replaceable-text_> (in angled brackets) to _replaceable-text_ (no angled brackets) in multiple content files. The existing use of monospace for code samples is retained.

This change makes it easier for users to adapt pasted code samples to suit their own environment. It's also the recommended style for variables in the _IBM Style Guide_.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ y ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

