### PR TITLE
Ensure stunnel refreshes endpoint IPs

### DIFF
--- a/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
@@ -18,6 +18,7 @@ cert = ${EO_CERTS_KEYS}/entity-operator.crt
 key = ${EO_CERTS_KEYS}/entity-operator.key
 accept = 127.0.0.1:2181
 connect = ${STRIMZI_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+delay = yes
 verify = 2
 
 EOF

--- a/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
@@ -20,6 +20,7 @@ cert = ${KAFKA_CERTS_KEYS}/${CURRENT}.crt
 key = ${KAFKA_CERTS_KEYS}/${CURRENT}.key
 accept = 127.0.0.1:2181
 connect = ${KAFKA_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
+delay = yes
 verify = 2
 
 EOF

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
@@ -9,7 +9,7 @@ cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
 echo "pid = /usr/local/var/run/stunnel.pid"
 echo "foreground = yes"
 echo "debug = $TLS_SIDECAR_LOG_LEVEL"
- 
+
 declare -a PORTS=("2888" "3888")
 
 CURRENT=${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1))
@@ -32,6 +32,7 @@ do
 			key = ${NODE_CERTS_KEYS}/${CURRENT}.key
 			accept = 127.0.0.1:$(expr $port \* 10 + $NODE - 1)
 			connect = ${PEER}.${BASE_FQDN}:$port
+			delay = yes
 			verify = 2
 
 			EOF


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

While testing zookeeper recovery in a 3 node cluster running on AWS (deleting one of the pods when cluster is up and running) I found that for the new pod (e.g. `my-cluster-zookeeper-0`), zookeeper wasn't allowing `bin/zkClient.sh` to connect: `Unable to read additional data from server sessionid 0x0, likely server has closed socket, closing socket connection and attempting reconnect`.
And in the zookeeper logs the corresponding message `WARN Exception causing close of session 0x0: ZooKeeperServer not running (org.apache.zookeeper.server.NIOServerCnxn) [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:21810]`

Plus every minute messages about leader election failure:
`INFO Have smaller server identifier, so dropping the connection: (2, 1) (org.apache.zookeeper.server.quorum.QuorumCnxManager) [QuorumPeer[myid=1]/0:0:0:0:0:0:0:0:21810]`
`INFO Have smaller server identifier, so dropping the connection: (3, 1) (org.apache.zookeeper.server.quorum.QuorumCnxManager) [QuorumPeer[myid=1]/0:0:0:0:0:0:0:0:21810]`
`INFO Notification time out: 60000 (org.apache.zookeeper.server.quorum.FastLeaderElection) [QuorumPeer[myid=1]/0:0:0:0:0:0:0:0:21810]`

The underlying issue is not in the pod that gets restarted, but the stunnel connections which become invalid in the other nodes.

Reloading stunnel config in all other zookeeper pods (e.g. `for i in {1..2}; do kubectl exec my-cluster-zookeeper-$i -c tls-sidecar -- kill -HUP 1; done`) fixes the issue as the DNS entries were refreshed.

It is possible to make stunnel not to cache the IP addresses leaving that job to the local library via the option `delay = yes`. 

Refs:
- https://www.stunnel.org/static/stunnel.html#delay-yes-no
- https://www.stunnel.org/pipermail/stunnel-users/2014-January/004504.html

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

