### PR TITLE
Added user defined configuration handling for Mirror Maker consumer and producer

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
@@ -28,7 +28,7 @@ public class KafkaMirrorMakerClientSpec implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String bootstrapServers;
-    protected Map<String, Object> config;
+    protected Map<String, Object> config = new HashMap<>(0);
     private KafkaMirrorMakerTls tls;
     private KafkaMirrorMakerAuthentication authentication;
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -31,7 +31,6 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
 
     @Override
     @Description("The mirror maker consumer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -25,7 +25,6 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
 
     @Override
     @Description("The mirror maker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
         return config;
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.out.yaml
@@ -13,6 +13,10 @@ spec:
     numStreams: 2
     groupId: "my-source-group-id"
     bootstrapServers: "my-source-kafka:9092"
+    config:
+      foo: "bar"
   producer:
     bootstrapServers: "my-target-kafka:9092"
+    config:
+      foo: "buz"
   metrics: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker.yaml
@@ -10,5 +10,9 @@ spec:
     numStreams: 2
     groupId: my-source-group-id
     bootstrapServers: my-source-kafka:9092
+    config:
+      foo: bar
   producer:
     bootstrapServers: my-target-kafka:9092
+    config:
+      foo: buz

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -59,6 +59,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER = "KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER = "KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_GROUPID_CONSUMER = "KAFKA_MIRRORMAKER_GROUPID_CONSUMER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_CONSUMER = "KAFKA_MIRRORMAKER_CONFIGURATION_CONSUMER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER = "KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER";
 
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_PRODUCER = "KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER = "KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER";
@@ -321,6 +323,10 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_CONSUMER,
+                new KafkaMirrorMakerConsumerConfiguration(consumer.getConfig().entrySet()).getConfiguration()));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER,
+                new KafkaMirrorMakerProducerConfiguration(producer.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_CONSUMER, consumer.getBootstrapServers()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_PRODUCER, producer.getBootstrapServers()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Class for handling Kafka Mirror Maker consumer configuration passed by the user
+ */
+public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration {
+
+    private static final List<String> FORBIDDEN_OPTIONS;
+    private static final Properties DEFAULTS;
+
+    static {
+        FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
+
+        DEFAULTS = new Properties();
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public KafkaMirrorMakerConsumerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
+        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Class for handling Kafka Mirror Maker producer configuration passed by the user
+ */
+public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration {
+
+    private static final List<String> FORBIDDEN_OPTIONS;
+    private static final Properties DEFAULTS;
+
+    static {
+        FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
+
+        DEFAULTS = new Properties();
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public KafkaMirrorMakerProducerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
+        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+    }
+}


### PR DESCRIPTION
producer

### Type of change

- Bugfix

### Description

This PR fixes #934.
It adds the support for user-defined configuration (consumer and producer) to the Kafka Mirror Maker operator.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

