### PR TITLE
Added CRD short names for Kafka, Kafka Connect and Kafka Connect S2I

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -76,6 +76,7 @@ public class Crds {
             listKind = Kafka.RESOURCE_LIST_KIND;
             group = Kafka.RESOURCE_GROUP;
             version = Kafka.VERSION;
+            shortNames = Kafka.RESOURCE_SHORTNAMES;
         } else if (cls.equals(KafkaConnect.class)) {
             kind = KafkaConnect.RESOURCE_KIND;
             crdApiVersion = KafkaConnect.CRD_API_VERSION;
@@ -84,6 +85,7 @@ public class Crds {
             listKind = KafkaConnect.RESOURCE_LIST_KIND;
             group = KafkaConnect.RESOURCE_GROUP;
             version = KafkaConnect.VERSION;
+            shortNames = KafkaConnect.RESOURCE_SHORTNAMES;
         } else if (cls.equals(KafkaConnectS2I.class)) {
             kind = KafkaConnectS2I.RESOURCE_KIND;
             crdApiVersion = KafkaConnectS2I.CRD_API_VERSION;
@@ -92,6 +94,7 @@ public class Crds {
             listKind = KafkaConnectS2I.RESOURCE_LIST_KIND;
             group = KafkaConnectS2I.RESOURCE_GROUP;
             version = KafkaConnectS2I.VERSION;
+            shortNames = KafkaConnectS2I.RESOURCE_SHORTNAMES;
         } else if (cls.equals(KafkaTopic.class)) {
             kind = KafkaTopic.RESOURCE_KIND;
             crdApiVersion = KafkaTopic.CRD_API_VERSION;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -23,7 +23,10 @@ import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.Inline;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 /**
  * A description of a Kafka assembly, as exposed by the Strimzi Kafka CRD.
@@ -36,7 +39,8 @@ import java.util.Map;
         spec = @Crd.Spec(
                 names = @Crd.Spec.Names(
                         kind = Kafka.RESOURCE_KIND,
-                        plural = Kafka.RESOURCE_PLURAL
+                        plural = Kafka.RESOURCE_PLURAL,
+                        shortNames = {Kafka.SHORT_NAME}
                 ),
                 group = Kafka.RESOURCE_GROUP,
                 scope = "Namespaced",
@@ -63,6 +67,8 @@ public class Kafka extends CustomResource {
     public static final String RESOURCE_SINGULAR = "kafka";
     public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
+    public static final String SHORT_NAME = "k";
+    public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -23,7 +23,10 @@ import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.Inline;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 @JsonDeserialize(
         using = JsonDeserializer.None.class
@@ -33,7 +36,8 @@ import java.util.Map;
         spec = @Crd.Spec(
                 names = @Crd.Spec.Names(
                         kind = KafkaConnect.RESOURCE_KIND,
-                        plural = KafkaConnect.RESOURCE_PLURAL
+                        plural = KafkaConnect.RESOURCE_PLURAL,
+                        shortNames = {KafkaConnect.SHORT_NAME}
                 ),
                 group = KafkaConnect.RESOURCE_GROUP,
                 scope = "Namespaced",
@@ -60,6 +64,8 @@ public class KafkaConnect extends CustomResource {
     public static final String RESOURCE_SINGULAR = "kafkaconnect";
     public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
+    public static final String SHORT_NAME = "kc";
+    public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
 
     private String apiVersion;
     private KafkaConnectSpec spec;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -23,7 +23,10 @@ import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.Inline;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 @JsonDeserialize(
         using = JsonDeserializer.None.class
@@ -33,7 +36,8 @@ import java.util.Map;
         spec = @Crd.Spec(
                 names = @Crd.Spec.Names(
                         kind = KafkaConnectS2I.RESOURCE_KIND,
-                        plural = KafkaConnectS2I.RESOURCE_PLURAL
+                        plural = KafkaConnectS2I.RESOURCE_PLURAL,
+                        shortNames = {KafkaConnectS2I.SHORT_NAME}
                 ),
                 group = KafkaConnectS2I.RESOURCE_GROUP,
                 scope = "Namespaced",
@@ -60,6 +64,8 @@ public class KafkaConnectS2I extends CustomResource {
     public static final String RESOURCE_SINGULAR = "kafkaconnects2i";
     public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
     public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
+    public static final String SHORT_NAME = "kcs2i";
+    public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
 
     private String apiVersion;
     private ObjectMeta metadata;

--- a/examples/install/cluster-operator/040-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/040-Crd-kafka.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: KafkaList
     singular: kafka
     plural: kafkas
+    shortNames:
+    - k
   validation:
     openAPIV3Schema:
       properties:

--- a/examples/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: KafkaConnectList
     singular: kafkaconnect
     plural: kafkaconnects
+    shortNames:
+    - kc
   validation:
     openAPIV3Schema:
       properties:

--- a/examples/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: KafkaConnectS2IList
     singular: kafkaconnects2i
     plural: kafkaconnects2is
+    shortNames:
+    - kcs2i
   validation:
     openAPIV3Schema:
       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -18,6 +18,8 @@ spec:
     listKind: KafkaList
     singular: kafka
     plural: kafkas
+    shortNames:
+    - k
   validation:
     openAPIV3Schema:
       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -18,6 +18,8 @@ spec:
     listKind: KafkaConnectList
     singular: kafkaconnect
     plural: kafkaconnects
+    shortNames:
+    - kc
   validation:
     openAPIV3Schema:
       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -18,6 +18,8 @@ spec:
     listKind: KafkaConnectS2IList
     singular: kafkaconnects2i
     plural: kafkaconnects2is
+    shortNames:
+    - kcs2i
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This minor PR adds the shor names `k`, `kc` and `kcs2i` for Kafka, Kafka Connect and Kafka Connect S2I resources (as we already have for topic, user and mirror maker with `kt`, `ku` and `kmm`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

