### PR TITLE
Fixed permission denied setting the LOG_DIR

### DIFF
--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
@@ -44,6 +44,10 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
+# We don't need LOG_DIR because we write no log files, but setting it to a
+# directory avoids trying to create it (and logging a permission denied error)
+export LOG_DIR="$KAFKA_HOME"
+
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then
   export KAFKA_OPTS="-javaagent:/opt/prometheus/jmx_prometheus_javaagent.jar=9404:$KAFKA_HOME/custom-config/metrics-config.yml"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The current mirror maker shows this message in the log "mkdir: cannot create directory '/opt/kafka/bin/../logs': Permission denied".
This PR fixes this one setting the not used `LOG_DIR` but avoid its creation with related permission denied error.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

