### PR TITLE
Docs fix sed on macos2

### DIFF
--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
@@ -16,7 +16,7 @@ On Linux, use:
 sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 +
-On MacOS use:
+On MacOS, use:
 +
 [source, subs="+quotes"]
 ----

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc
@@ -9,9 +9,18 @@
 
 * Edit the installation files according to the {Namespace} the Cluster Operator is going to be installed in.
 +
+On Linux, use:
++
 [source, subs="+quotes"]
 ----
 sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
+----
++
+On MacOS use:
++
+[source, subs="+quotes"]
+----
+sed -i '' 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
@@ -16,7 +16,7 @@ On Linux, use:
 sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 +
-On MacOS use:
+On MacOS, use:
 +
 [source, subs="+quotes"]
 ----

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes.adoc
@@ -9,9 +9,18 @@
 
 * Modify the installation files according to the namespace the Cluster Operator is going to be installed in.
 +
+On Linux, use:
++
 [source, subs="+quotes"]
 ----
 sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
+----
++
+On MacOS use:
++
+[source, subs="+quotes"]
+----
+sed -i '' 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure

--- a/documentation/book/proc-deploying-cluster-operator-openshift.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-openshift.adoc
@@ -10,9 +10,18 @@
 * A user with `cluster-admin` role needs to be used, for example, `system:admin`.
 * Modify the installation files according to the namespace the Cluster Operator is going to be installed in.
 +
+On Linux, use:
++
 [source, subs="+quotes"]
 ----
 sed -i 's/namespace: .\*/namespace: _my-project_/' examples/install/cluster-operator/*RoleBinding*.yaml
+----
++
+On MacOS use:
++
+[source, subs="+quotes"]
+----
+sed -i '' 's/namespace: .\*/namespace: _my-project_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 
 .Procedure

--- a/documentation/book/proc-deploying-cluster-operator-openshift.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-openshift.adoc
@@ -17,7 +17,7 @@ On Linux, use:
 sed -i 's/namespace: .\*/namespace: _my-project_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----
 +
-On MacOS use:
+On MacOS, use:
 +
 [source, subs="+quotes"]
 ----

--- a/documentation/book/ref-document-conventions.adoc
+++ b/documentation/book/ref-document-conventions.adoc
@@ -13,5 +13,5 @@ For example, in the following code, you will want to replace `_my-namespace_` wi
 
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*ClusterRoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' examples/install/cluster-operator/*RoleBinding*.yaml
 ----


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The `sed` command used in the installation guides does not work with BSD version of `sed`. This PR splits the command into two: Linux and MacOS version to make this work even for MacOS users. I cannot add any Windows version since I have no Windows and have no clue what is the sed alternative there.

It also fixes the name of the files being replaced in the example in Document Conventions to not confuse the users.