### PR TITLE
Add example CRs with metrics and the Grafana dashbaords to the releas…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RELEASE_VERSION ?= latest
 CHART_PATH ?= ./helm-charts/strimzi-kafka-operator/
 CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
 
-SUBDIRS=docker-images test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init helm-charts examples
+SUBDIRS=docker-images test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init helm-charts examples metrics
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -1,9 +1,11 @@
 PROJECT_NAME=metrics
 RELEASE_VERSION ?= latest
-RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
+RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/examples/$(PROJECT_NAME)
 
 release:
 	mkdir -p $(RELEASE_PATH)
-	cp -r ./* $(RELEASE_PATH)/
+	mkdir -p $(RELEASE_PATH)/grafana-dashboards
+	cp -r ./examples/kafka/* $(RELEASE_PATH)/
+	cp -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
 
 .PHONY: all build clean docker_build docker_push docker_tag


### PR DESCRIPTION
…e artifcacts

### Type of change

- Enhancement / new feature

### Description

The metrics examples and Grafana Dashboards are currently hidden in the `metrics/examles` dir. This PR takes the example CRs and the dashboards and adds them to the release files, so that they are released as well.