### PR TITLE
Add possibility to auto-create cluster roles from the CO

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -39,6 +39,7 @@
     <suppress checks="ClassFanOutComplexity"
               files="io[/\\]strimzi[/\\]operator[/\\]topic[/\\]MockAdminClient.java"/>
 
-
+    <suppress checks="ClassDataAbstractionCoupling"
+              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]Main.java"/>
 
 </suppressions>

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -15,13 +15,13 @@ make docker_build
 if [ ! -e  documentation/book/appendix_crds.adoc ] ; then
   exit 1
 fi
-CHANGED_DERIVED=$(git diff --name-status -- examples/ helm-charts/ documentation/book/appendix_crds.adoc)
+CHANGED_DERIVED=$(git diff --name-status -- examples/ helm-charts/ documentation/book/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles)
 if [ -n "$CHANGED_DERIVED" ] ; then
   echo "ERROR: Uncommitted changes in derived resources:"
   echo "$CHANGED_DERIVED"
   echo "Run the following to add up-to-date resources:"
   echo "  mvn clean verify -DskipTests -DskipITs \\"
-  echo "    && git add examples/ helm-charts/ documentation/book/appendix_crds.adoc"
+  echo "    && git add examples/ helm-charts/ documentation/book/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles"
   echo "    && git commit -m 'Update derived resources'"
   exit 1
 fi

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ RELEASE_VERSION ?= latest
 CHART_PATH ?= ./helm-charts/strimzi-kafka-operator/
 CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
 
-SUBDIRS=docker-images test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init helm-charts examples metrics
+SUBDIRS=docker-images helm-charts test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init examples metrics
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
-$(DOCKER_TARGETS): $(SUBDIRS)
+$(DOCKER_TARGETS): helm_examples $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 
 next_version:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -21,13 +21,16 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
+    public static final String STRIMZI_CREATE_CLUSTER_ROLES = "STRIMZI_CREATE_CLUSTER_ROLES";
 
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
+    public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
 
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;
     private final long operationTimeoutMs;
+    private final boolean createClusterRoles;
 
     /**
      * Constructor
@@ -36,10 +39,11 @@ public class ClusterOperatorConfig {
      * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
      * @param operationTimeoutMs    timeout for internal operations specified in milliseconds
      */
-    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs) {
+    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs, boolean createClusterRoles) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
+        this.createClusterRoles = createClusterRoles;
     }
 
     /**
@@ -70,7 +74,13 @@ public class ClusterOperatorConfig {
             operationTimeout = Long.parseLong(operationTimeoutEnvVar);
         }
 
-        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout);
+        boolean createClusterRoles = DEFAULT_CREATE_CLUSTER_ROLES;
+        String createClusterRolesEnvVar = map.get(ClusterOperatorConfig.STRIMZI_CREATE_CLUSTER_ROLES);
+        if (createClusterRolesEnvVar != null) {
+            createClusterRoles = Boolean.parseBoolean(createClusterRolesEnvVar);
+        }
+
+        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles);
     }
 
 
@@ -95,11 +105,20 @@ public class ClusterOperatorConfig {
         return operationTimeoutMs;
     }
 
+    /**
+     * @return  Indicates whether Cluster Roles should be created
+     */
+    public boolean isCreateClusterRoles() {
+        return createClusterRoles;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +
                 "namespaces=" + namespaces +
                 ",reconciliationIntervalMs=" + reconciliationIntervalMs +
+                ",operationTimeoutMs=" + operationTimeoutMs +
+                ",createClusterRoles=" + createClusterRoles +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -72,7 +72,7 @@ public class Main {
         Vertx vertx = Vertx.vertx();
         KubernetesClient client = new DefaultKubernetesClient();
 
-        createClusterRoles(vertx, config, client).setHandler(crs -> {
+        maybeCreateClusterRoles(vertx, config, client).setHandler(crs -> {
             if (crs.succeeded())    {
                 isOnOpenShift(vertx, client).setHandler(os -> {
                     if (os.succeeded()) {
@@ -210,7 +210,7 @@ public class Main {
         }
     }
 
-    private static Future<Void> createClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
+    private static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
         if (config.isCreateClusterRoles()) {
             List<Future> futures = new ArrayList<>();
             ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,217 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-namespaced
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  - kafkamirrormakers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - extensions
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  - deploymentconfigs/status
+  - deploymentconfigs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - builds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+  - update
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  - imagestreams/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update

--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-global
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete

--- a/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -48,7 +48,7 @@ public class ClusterOperatorConfigTest {
     @Test
     public void testReconciliationInterval() {
 
-        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000);
+        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(60_000, config.getReconciliationIntervalMs());

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -6,6 +6,7 @@ CHART_NAME=strimzi-kafka-operator
 CHART_PATH=./$(CHART_NAME)/
 CHART_RENDERED_TEMPLATES_TMP=../target/charts
 CHART_RENDERED_TEMPLATES_EXAMPLES=../examples/install/cluster-operator/
+CHART_RENDERED_TEMPLATES_CLUSTERROLES=../cluster-operator/src/main/resources/cluster-roles/
 
 helm_clean:
 	rm -rf $(CHART_RENDERED_TEMPLATES_TMP)
@@ -35,6 +36,12 @@ helm_examples: helm_clean helm_template
 	| grep -v 'CustomResourceDefinition$$' \
 	| sed -E 's/([^ ]*) ([a-zA-Z0-9]*)$$/\1/' \
 	| xargs -IFILE cp FILE $(CHART_RENDERED_TEMPLATES_EXAMPLES)
+	# Copying rendered template files to: $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
+	mkdir -p $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
+	# Find rendered resources which are not CustomResourceDefinition and move them
+	find $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*ClusterRole-*.yaml' -printf "%p " -exec yq r {} kind \; \
+	| sed -E 's/([^ ]*) ([a-zA-Z0-9]*)$$/\1/' \
+	| xargs -IFILE cp FILE $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
 
 helm_pkg: helm_lint helm_examples
 	# Copying unarchived Helm Chart to release directory

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
@@ -4,9 +4,10 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -24,13 +25,9 @@ public class ClusterRoleOperator extends WorkaroundRbacOperator<ClusterRoleOpera
     }
 
     public static class ClusterRole {
-        private final String name;
         private final String resource;
 
-        public ClusterRole(
-                String name,
-                String yaml) {
-            this.name = name;
+        public ClusterRole(String yaml) {
             this.resource = convertYamlToJson(yaml);
         }
 
@@ -40,7 +37,7 @@ public class ClusterRoleOperator extends WorkaroundRbacOperator<ClusterRoleOpera
                 Object obj = yamlReader.readValue(yaml, Object.class);
                 ObjectMapper jsonWriter = new ObjectMapper();
                 return jsonWriter.writeValueAsString(obj);
-            } catch (Exception e)   {
+            } catch (IOException e)   {
                 throw new RuntimeException(e);
             }
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * This class is a temporary work-around for the fact that Fabric8 doesn't
+ * yet support an API for manipulating Kubernetes ClusterRoles
+ * @deprecated This can be removed once support for ClusterRoles and ClusterRoleBindings is in Fabric8.
+ */
+@Deprecated
+public class ClusterRoleOperator extends WorkaroundRbacOperator<ClusterRoleOperator.ClusterRole> {
+
+    public ClusterRoleOperator(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "rbac.authorization.k8s.io", "v1beta1", "clusterroles");
+    }
+
+    public static class ClusterRole {
+        private final String name;
+        private final String resource;
+
+        public ClusterRole(
+                String name,
+                String yaml) {
+            this.name = name;
+            this.resource = convertYamlToJson(yaml);
+        }
+
+        private String convertYamlToJson(String yaml) {
+            try {
+                ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+                Object obj = yamlReader.readValue(yaml, Object.class);
+                ObjectMapper jsonWriter = new ObjectMapper();
+                return jsonWriter.writeValueAsString(obj);
+            } catch (Exception e)   {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public String toString() {
+            return resource;
+        }
+    }
+
+    private String urlWithoutName() {
+        return baseUrl + "apis/" + group + "/" + apiVersion + "/" + plural;
+    }
+
+    private String urlWithName(String name) {
+        return urlWithoutName() + "/" + name;
+    }
+
+    public Future<Void> reconcile(String name, ClusterRole resource) {
+        return doReconcile(urlWithoutName(), urlWithName(name), resource);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

To make it easier to work with Operator Lifecycle Manager we might need to create Cluster Roles on the fly from the cluster operator. This PR adds this option. It is disabled by default and has no impact on anyone not using Strimzi without OLM.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
