### PR TITLE
Generate single file installation files which can be put on the relea…

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -151,7 +151,7 @@ The release process should normally look like this:
 6. Create the tag and push it to GitHub. Tag name determines the tag of the resulting Docker images. Therefore the Git 
 tag name has to be the same as the `RELEASE_VERSION`,
 7. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. 
-Attach the TAR.GZ/ZIP archives and the Helm Chart to the release
+Attach the TAR.GZ/ZIP archives, YAML files (for installation from URL) and the Helm Chart to the release
 8. On the `master` git branch
   * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. 
   For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_TARGETS=docker_build docker_push docker_tag
 all: $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): $(SUBDIRS)
-release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_pkg release_helm_repo docu_clean
+release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 
 next_version:
 	echo $(shell echo $(NEXT_VERSION) | tr a-z A-Z) > release.version
@@ -50,6 +50,11 @@ release_helm_repo:
 	echo "Updating Helm Repository index.yaml"
 	helm repo index ./ --url https://github.com/strimzi/strimzi-kafka-operator/releases/download/$(RELEASE_VERSION)/ --merge ./helm-charts/index.yaml
 	mv ./index.yaml ./helm-charts/index.yaml
+
+release_single_file:
+	find ./strimzi-$(RELEASE_VERSION)/examples/install/cluster-operator/ -type f -exec cat {} \; -exec printf "\n---\n" \; > strimzi-cluster-operator-$(RELEASE_VERSION).yaml
+	find ./strimzi-$(RELEASE_VERSION)/examples/install/topic-operator/ -type f -exec cat {} \; -exec printf "\n---\n" \; > strimzi-topic-operator-$(RELEASE_VERSION).yaml
+	find ./strimzi-$(RELEASE_VERSION)/examples/install/user-operator/ -type f -exec cat {} \; -exec printf "\n---\n" \; > strimzi-user-operator-$(RELEASE_VERSION).yaml
 
 helm_pkg:
 	# Copying unarchived Helm Chart to release directory


### PR DESCRIPTION
…se website and linked - Closes #935

### Type of change

- Enhancement / new feature

### Description

This PR add single file installation files to our releases. Having them attached tot he GitHub release will make it easier to use the release remotely (e.g. `kubectl apply -f https://... `) which cannot be done today with he directory. This should address the #935.
