### PR TITLE
Fixed wrong comment indentation

### DIFF
--- a/documentation/book/assembly-kafka-mirror-maker-replicas.adoc
+++ b/documentation/book/assembly-kafka-mirror-maker-replicas.adoc
@@ -1,4 +1,4 @@
-    // This assembly is included in the following assemblies:
+// This assembly is included in the following assemblies:
 //
 // assembly-deployment-configuration-kafka-mirror-maker.adoc
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The wrong indentation messed the documentation up. This PR fixes it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

