### PR TITLE
Fixed pipe escaping

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -71,7 +71,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     }
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions." +
-            "Mirroring two topics named A and B can be achieved by using the whitelist `'A|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'`. " +
+            "Mirroring two topics named A and B can be achieved by using the whitelist `'A\\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. " +
             "Multiple regular expressions separated by commas can be specified as well.")
     @JsonProperty(required = true)
     public String getWhitelist() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -71,7 +71,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     }
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions." +
-            "Mirroring two topics named A and B can be achieved by using the whitelist `'A\\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. " +
+            "Mirroring two topics named A and B can be achieved by using the whitelist `'A|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. " +
             "Multiple regular expressions separated by commas can be specified as well.")
     @JsonProperty(required = true)
     public String getWhitelist() {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -184,6 +184,7 @@ public class DocGenerator {
         if (!doc.trim().matches(".*[.!?]$")) {
             doc = doc + ".";
         }
+        doc = doc.replaceAll("[|]", "\\\\|");
         return doc;
     }
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -961,7 +961,7 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 |integer
 |image        1.2+<.<|The docker image for the pods.
 |string
-|whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions.Mirroring two topics named A and B can be achieved by using the whitelist `'A|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'`. Multiple regular expressions separated by commas can be specified as well.
+|whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions.Mirroring two topics named A and B can be achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. Multiple regular expressions separated by commas can be specified as well.
 |string
 |consumer     1.2+<.<|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Missing pipe escape messed up the reference documentation for the `KafkaMirrorMaker` resource.
This PR fixes that.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

