### PR TITLE
 Reconcile certificates when SANs change

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -105,18 +105,39 @@ public class ClusterCa extends Ca {
 
     public Map<String, CertAndKey> generateBrokerCerts(Kafka kafka, String externalBootstrapAddress, Map<Integer, String> externalAddresses) throws IOException {
         String cluster = kafka.getMetadata().getName();
-
+        String namespace = kafka.getMetadata().getNamespace();
         Function<Integer, Subject> subjectFn = i -> {
+            Map<String, String> sbjAltNames = new HashMap<>();
+            sbjAltNames.put("DNS.1", KafkaCluster.serviceName(cluster));
+            sbjAltNames.put("DNS.2", String.format("%s.%s", KafkaCluster.serviceName(cluster), namespace));
+            sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", KafkaCluster.kafkaPodName(cluster, i), KafkaCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            int nextDnsId = 5;
+            int nextIpId = 1;
+            if (externalBootstrapAddress != null)   {
+                String sna = !ipv4Address.matcher(externalBootstrapAddress).matches() ?
+                        String.format("DNS.%d", nextDnsId++) :
+                        String.format("IP.%d", nextIpId++);
+
+                sbjAltNames.put(sna, externalBootstrapAddress);
+            }
+
+            if (externalAddresses.get(i) != null)   {
+                String sna = !ipv4Address.matcher(externalAddresses.get(i)).matches() ?
+                        String.format("DNS.%d", nextDnsId) :
+                        String.format("IP.%d", nextIpId);
+
+                sbjAltNames.put(sna, externalAddresses.get(i));
+            }
+
             Subject subject = new Subject();
             subject.setOrganizationName("io.strimzi");
             subject.setCommonName(KafkaCluster.kafkaClusterName(cluster));
-            subject.setSubjectAltNames(generateSbjAltNames(kafka, externalBootstrapAddress, externalAddresses, i));
+            subject.setSubjectAltNames(sbjAltNames);
 
             return subject;
         };
-
         log.debug("{}: Reconciling kafka broker certificates", this);
-
         return maybeCopyOrGenerateCerts(
             kafka.getSpec().getKafka().getReplicas(),
             subjectFn,
@@ -124,33 +145,4 @@ public class ClusterCa extends Ca {
             podNum -> KafkaCluster.kafkaPodName(cluster, podNum));
     }
 
-    private Map<String, String> generateSbjAltNames(Kafka kafka, String externalBootstrapAddress, Map<Integer, String> externalAddresses, Integer podNumber)    {
-        String cluster = kafka.getMetadata().getName();
-        String namespace = kafka.getMetadata().getNamespace();
-
-        Map<String, String> sbjAltNames = new HashMap<>();
-        sbjAltNames.put("DNS.1", KafkaCluster.serviceName(cluster));
-        sbjAltNames.put("DNS.2", String.format("%s.%s", KafkaCluster.serviceName(cluster), namespace));
-        sbjAltNames.put("DNS.3", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-        sbjAltNames.put("DNS.4", String.format("%s.%s.%s.svc.%s", KafkaCluster.kafkaPodName(cluster, podNumber), KafkaCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-        int nextDnsId = 5;
-        int nextIpId = 1;
-        if (externalBootstrapAddress != null)   {
-            String sna = !ipv4Address.matcher(externalBootstrapAddress).matches() ?
-                    String.format("DNS.%d", nextDnsId++) :
-                    String.format("IP.%d", nextIpId++);
-
-            sbjAltNames.put(sna, externalBootstrapAddress);
-        }
-
-        if (externalAddresses.get(podNumber) != null)   {
-            String sna = !ipv4Address.matcher(externalAddresses.get(podNumber)).matches() ?
-                    String.format("DNS.%d", nextDnsId) :
-                    String.format("IP.%d", nextIpId);
-
-            sbjAltNames.put(sna, externalAddresses.get(podNumber));
-        }
-
-        return sbjAltNames;
-    }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -248,7 +248,7 @@ public abstract class Ca {
                     .map(item -> (String) item.get(1))
                     .collect(Collectors.toList());
         } catch (CertificateException e) {
-            log.error("Failed to parse existing certificate", e);
+            log.debug("Failed to parse existing certificate", e);
         }
 
         return subjectAltNames;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -239,15 +239,14 @@ public abstract class Ca {
         List<String> subjectAltNames = null;
 
         try {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            ByteArrayInputStream inStream = new ByteArrayInputStream(certificate);
-            X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
+            X509Certificate cert = x509Certificate("Parsing certificate SANs", certificate);
             Collection<List<?>> altNames = cert.getSubjectAlternativeNames();
             subjectAltNames = altNames.stream()
                     .filter(name -> name.get(1) instanceof String)
                     .map(item -> (String) item.get(1))
                     .collect(Collectors.toList());
-        } catch (CertificateException e) {
+        } catch (CertificateException|RuntimeException e) {
+            // TODO: We should mock the certificates properly so that this doesn't fail in tests (not now => long term :-o)
             log.debug("Failed to parse existing certificate", e);
         }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -245,7 +245,7 @@ public abstract class Ca {
                     .filter(name -> name.get(1) instanceof String)
                     .map(item -> (String) item.get(1))
                     .collect(Collectors.toList());
-        } catch (CertificateException|RuntimeException e) {
+        } catch (CertificateException | RuntimeException e) {
             // TODO: We should mock the certificates properly so that this doesn't fail in tests (not now => long term :-o)
             log.debug("Failed to parse existing certificate", e);
         }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, we do not regenerate the certificates for brokers when the SANs change. This means that for example when external access is not enabled from the start or when it is changed, the hostname verification in clients will not work anymore.

This PR adds a check to `maybeCopyOrGenerateCerts` to verify whether the SANs are still valid and regenerate the key if the changed. Since currently a change of the address means in 99% of cases external address changed and that also means that rolling update is needed anyway, we do not have to anything special for that.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
