### PR TITLE
Set 'type' of external listener as required

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -39,6 +39,7 @@ public abstract class KafkaListenerExternal implements Serializable {
             "* `loadbalancer` type uses LoadBalancer type services to expose Kafka." +
             "* `nodeport` type uses NodePort type services to expose Kafka.")
     @JsonIgnore
+    @JsonProperty(required = true)
     public abstract String getType();
 
     @Description("Authentication configuration for Kafka brokers")


### PR DESCRIPTION
### Type of change
- Bugfix


### Description
The issue is descibed in https://github.com/strimzi/strimzi-kafka-operator/issues/872

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

