### PR TITLE
Fix wrong annotation in doc for manual pod deletion

### DIFF
--- a/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
@@ -27,12 +27,12 @@ For example, if the cluster is named _cluster-name_, the pods are named _cluster
 ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate pod _cluster-name_-kafka-_index_ cluster.operator.strimzi.io/delete-pod-and-pvc=true
+kubectl annotate pod _cluster-name_-kafka-_index_ operator.strimzi.io/delete-pod-and-pvc=true
 endif::Kubernetes[]
 +
 On {OpenShiftName} use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate pod _cluster-name_-kafka-_index_ cluster.operator.strimzi.io/delete-pod-and-pvc=true
+oc annotate pod _cluster-name_-kafka-_index_ operator.strimzi.io/delete-pod-and-pvc=true
 +
 . Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.
 

--- a/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
@@ -27,12 +27,12 @@ For example, if the cluster is named _cluster-name_, the pods are named _cluster
 ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate pod _cluster-name_-zookeeper-_index_ cluster.operator.strimzi.io/delete-pod-and-pvc=true
+kubectl annotate pod _cluster-name_-zookeeper-_index_ operator.strimzi.io/delete-pod-and-pvc=true
 endif::Kubernetes[]
 +
 On {OpenShiftName} use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate pod _cluster-name_-zookeeper-_index_ cluster.operator.strimzi.io/delete-pod-and-pvc=true
+oc annotate pod _cluster-name_-zookeeper-_index_ operator.strimzi.io/delete-pod-and-pvc=true
 +
 . Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The wrong annotation is reported in the documentation about manual pod deletion.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

