### PR TITLE
Fix #872

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
@@ -4,9 +4,9 @@
  */
 package io.strimzi.api.kafka.model;
 
-import io.strimzi.crdgenerator.annotations.Description;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
 /**
@@ -18,6 +18,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type"})
 public class AclRuleClusterResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
@@ -4,9 +4,9 @@
  */
 package io.strimzi.api.kafka.model;
 
-import io.strimzi.crdgenerator.annotations.Description;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.vertx.core.cli.annotations.DefaultValue;
 
@@ -19,6 +19,7 @@ import io.vertx.core.cli.annotations.DefaultValue;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "name", "patternType"})
 public class AclRuleGroupResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
@@ -4,23 +4,23 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  * A representation of a single ACL rule for SimpleAclAuthorizer
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = AclRuleTopicResource.TYPE_TOPIC, value = AclRuleTopicResource.class),
         @JsonSubTypes.Type(name = AclRuleGroupResource.TYPE_GROUP, value = AclRuleGroupResource.class),
@@ -34,7 +34,6 @@ public abstract class AclRuleResource implements Serializable {
 
     @Description("Resource type. " +
             "The available resource types are `topic`, `group` and `cluster`.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
@@ -4,9 +4,9 @@
  */
 package io.strimzi.api.kafka.model;
 
-import io.strimzi.crdgenerator.annotations.Description;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.vertx.core.cli.annotations.DefaultValue;
 
@@ -19,6 +19,7 @@ import io.vertx.core.cli.annotations.DefaultValue;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "name", "patternType"})
 public class AclRuleTopicResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -16,6 +17,7 @@ import io.sundr.builder.annotations.Buildable;
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
+@JsonPropertyOrder({"type", "name"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExternalLogging extends Logging {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -19,6 +20,7 @@ import java.util.Map;
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
+@JsonPropertyOrder({"type", "loggers"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class InlineLogging extends Logging {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -4,23 +4,23 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  * Configures the broker authorization
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaAuthorizationSimple.TYPE_SIMPLE, value = KafkaAuthorizationSimple.class),
 })
@@ -33,7 +33,6 @@ public abstract class KafkaAuthorization implements Serializable {
     @Description("Authorization type. " +
             "Currently the only supported type is `simple`. " +
             "`simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -4,13 +4,13 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
+import io.sundr.builder.annotations.Buildable;
 
 import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import io.sundr.builder.annotations.Buildable;
 
 /**
  * Configures the broker authorization
@@ -21,6 +21,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "superUsers"})
 public class KafkaAuthorizationSimple extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -19,7 +18,9 @@ import java.util.Map;
 /**
  * Configures the Kafka Connect authentication
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaConnectAuthenticationTls.TYPE_TLS, value = KafkaConnectAuthenticationTls.class),
         @JsonSubTypes.Type(name = KafkaConnectAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaConnectAuthenticationScramSha512.class),
@@ -35,7 +36,6 @@ public abstract class KafkaConnectAuthentication implements Serializable {
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
             "`tls` type is supported only over TLS connections.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerAuthentication.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -20,7 +19,9 @@ import java.util.Map;
 /**
  * Configures listener authentication.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaListenerAuthenticationTls.TYPE_TLS, value = KafkaListenerAuthenticationTls.class),
         @JsonSubTypes.Type(name = KafkaListenerAuthenticationScramSha512.SCRAM_SHA_512, value = KafkaListenerAuthenticationScramSha512.class),
@@ -40,7 +41,6 @@ public abstract class KafkaListenerAuthentication implements Serializable {
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
             "`tls` type is supported only on TLS listeners.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -4,24 +4,22 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  * Configures the external listener which exposes Kafka outside of Kubernetes / OpenShift
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, visible = false, property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaListenerExternalRoute.TYPE_ROUTE, value = KafkaListenerExternalRoute.class),
         @JsonSubTypes.Type(name = KafkaListenerExternalLoadBalancer.TYPE_LOADBALANCER, value = KafkaListenerExternalLoadBalancer.class),
@@ -38,7 +36,6 @@ public abstract class KafkaListenerExternal implements Serializable {
             "* `route` type uses OpenShift Routes to expose Kafka." +
             "* `loadbalancer` type uses LoadBalancer type services to expose Kafka." +
             "* `nodeport` type uses NodePort type services to expose Kafka.")
-    @JsonIgnore
     public abstract String getType();
 
     @Description("Authentication configuration for Kafka brokers")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -19,7 +19,9 @@ import java.util.Map;
 /**
  * Configures the external listener which exposes Kafka outside of Kubernetes / OpenShift
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, visible = false, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaListenerExternalRoute.TYPE_ROUTE, value = KafkaListenerExternalRoute.class),
         @JsonSubTypes.Type(name = KafkaListenerExternalLoadBalancer.TYPE_LOADBALANCER, value = KafkaListenerExternalLoadBalancer.class),

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,6 +20,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "authentication"})
 public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,6 +20,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "authentication"})
 public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi.api.kafka.model;
 
-import io.strimzi.crdgenerator.annotations.Description;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
 /**
@@ -19,6 +19,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "authentication"})
 public class KafkaListenerExternalRoute extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthentication.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -19,7 +18,9 @@ import java.util.Map;
 /**
  * Configures the Kafka Mirror Maker authentication
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaMirrorMakerAuthenticationTls.TYPE_TLS, value = KafkaMirrorMakerAuthenticationTls.class),
         @JsonSubTypes.Type(name = KafkaMirrorMakerAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaMirrorMakerAuthenticationScramSha512.class),
@@ -35,7 +36,6 @@ public abstract class KafkaMirrorMakerAuthentication implements Serializable {
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "The `tls` type uses TLS Client Authentication. " +
             "The `tls` type is supported only over TLS connections.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -16,7 +15,9 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaUserTlsClientAuthentication.TYPE_TLS, value = KafkaUserTlsClientAuthentication.class),
         @JsonSubTypes.Type(name = KafkaUserScramSha512ClientAuthentication.TYPE_SCRAM_SHA_512, value = KafkaUserScramSha512ClientAuthentication.class),
@@ -28,7 +29,6 @@ public abstract class KafkaUserAuthentication implements Serializable {
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
@@ -4,20 +4,20 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaUserAuthorizationSimple.TYPE_SIMPLE, value = KafkaUserAuthorizationSimple.class),
 })
@@ -30,7 +30,6 @@ public abstract class KafkaUserAuthorization implements Serializable {
     @Description("Authorization type. " +
             "Currently the only supported type is `simple`. " +
             "`simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer` class for authorization.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorizationSimple.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi.api.kafka.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.strimzi.crdgenerator.annotations.Description;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
 import java.util.List;
@@ -21,6 +21,7 @@ import java.util.List;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "acls"})
 public class KafkaUserAuthorizationSimple extends KafkaUserAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.api.kafka.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -15,7 +14,9 @@ import java.io.Serializable;
 /**
  * Describes the logging configuration
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(name = InlineLogging.TYPE_INLINE, value = InlineLogging.class),
         @JsonSubTypes.Type(name = ExternalLogging.TYPE_EXTERNAL, value = ExternalLogging.class),
@@ -26,7 +27,6 @@ public abstract class Logging implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Description("Logging type, must be either 'inline' or 'external'.")
-    @JsonIgnore
     public abstract String getType();
 }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 
@@ -19,6 +20,7 @@ import java.util.Map;
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
+@JsonPropertyOrder({"type", "size", "storageClass", "selector", "deleteClaim"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PersistentClaimStorage extends Storage {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -21,6 +20,7 @@ import java.util.Map;
  */
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "type"
 )
 @JsonSubTypes({
@@ -37,7 +37,6 @@ public abstract class Storage implements Serializable {
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Storage type, must be either 'ephemeral' or 'persistent-claim'.")
-    @JsonIgnore
     public abstract String getType();
 
     @JsonAnyGetter

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -206,10 +206,10 @@ It must have the value `route` for the type `KafkaListenerExternalRoute`.
 [options="header"]
 |====
 |Field                  |Description
-|authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
-|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
 |type            1.2+<.<|Must be `route`.
 |string
+|authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
 |====
 
 [id='type-KafkaListenerExternalLoadBalancer-{context}']
@@ -223,12 +223,12 @@ It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBal
 [options="header"]
 |====
 |Field                  |Description
+|type            1.2+<.<|Must be `loadbalancer`.
+|string
 |authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
 |tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
-|type            1.2+<.<|Must be `loadbalancer`.
-|string
 |====
 
 [id='type-KafkaListenerExternalNodePort-{context}']
@@ -242,12 +242,12 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 [options="header"]
 |====
 |Field                  |Description
+|type            1.2+<.<|Must be `nodeport`.
+|string
 |authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
 |tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
-|type            1.2+<.<|Must be `nodeport`.
-|string
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -110,15 +110,15 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 [options="header"]
 |====
 |Field               |Description
-|class        1.2+<.<|The storage class to use for dynamic volume allocation.
+|type         1.2+<.<|Must be `persistent-claim`.
 |string
-|deleteClaim  1.2+<.<|Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
-|boolean
-|selector     1.2+<.<|Specifies a specific persistent volume to use. It contains a matchLabels field which defines an inner JSON object with key:value representing labels for selecting such a volume.
-|map
 |size         1.2+<.<|When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
 |string
-|type         1.2+<.<|Must be `persistent-claim`.
+|selector     1.2+<.<|Specifies a specific persistent volume to use. It contains a matchLabels field which defines an inner JSON object with key:value representing labels for selecting such a volume.
+|map
+|deleteClaim  1.2+<.<|Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
+|boolean
+|class        1.2+<.<|The storage class to use for dynamic volume allocation.
 |string
 |====
 
@@ -261,10 +261,10 @@ It must have the value `simple` for the type `KafkaAuthorizationSimple`.
 [options="header"]
 |====
 |Field              |Description
-|superUsers  1.2+<.<|List of super users. Should contain list of user principals which should get unlimited access rights.
-|string array
 |type        1.2+<.<|Must be `simple`.
 |string
+|superUsers  1.2+<.<|List of super users. Should contain list of user principals which should get unlimited access rights.
+|string array
 |====
 
 [id='type-Rack-{context}']
@@ -353,10 +353,10 @@ It must have the value `inline` for the type `InlineLogging`.
 [options="header"]
 |====
 |Field           |Description
-|loggers  1.2+<.<|A Map from logger name to logger level.
-|map
 |type     1.2+<.<|Must be `inline`.
 |string
+|loggers  1.2+<.<|A Map from logger name to logger level.
+|map
 |====
 
 [id='type-ExternalLogging-{context}']
@@ -370,9 +370,9 @@ It must have the value `external` for the type `ExternalLogging`.
 [options="header"]
 |====
 |Field        |Description
-|name  1.2+<.<|The name of the `ConfigMap` from which to get the logging configuration.
-|string
 |type  1.2+<.<|Must be `external`.
+|string
+|name  1.2+<.<|The name of the `ConfigMap` from which to get the logging configuration.
 |string
 |====
 
@@ -859,10 +859,10 @@ It must have the value `simple` for the type `KafkaUserAuthorizationSimple`.
 [options="header"]
 |====
 |Field        |Description
-|acls  1.2+<.<|List of ACL rules which should be applied to this user.
-|xref:type-AclRule-{context}[`AclRule`] array
 |type  1.2+<.<|Must be `simple`.
 |string
+|acls  1.2+<.<|List of ACL rules which should be applied to this user.
+|xref:type-AclRule-{context}[`AclRule`] array
 |====
 
 [id='type-AclRule-{context}']
@@ -895,12 +895,12 @@ It must have the value `topic` for the type `AclRuleTopicResource`.
 [options="header"]
 |====
 |Field               |Description
+|type         1.2+<.<|Must be `topic`.
+|string
 |name         1.2+<.<|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
 |string
 |patternType  1.2+<.<|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
 |string (one of [prefix, literal])
-|type         1.2+<.<|Must be `topic`.
-|string
 |====
 
 [id='type-AclRuleGroupResource-{context}']
@@ -914,12 +914,12 @@ It must have the value `group` for the type `AclRuleGroupResource`.
 [options="header"]
 |====
 |Field               |Description
+|type         1.2+<.<|Must be `group`.
+|string
 |name         1.2+<.<|Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
 |string
 |patternType  1.2+<.<|Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full topic name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`.
 |string (one of [prefix, literal])
-|type         1.2+<.<|Must be `group`.
-|string
 |====
 
 [id='type-AclRuleClusterResource-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -47,6 +47,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                  required:
+                  - type
                 listeners:
                   type: object
                   properties:
@@ -58,6 +63,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                     tls:
                       type: object
                       properties:
@@ -66,6 +76,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                     external:
                       type: object
                       properties:
@@ -74,6 +89,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                         tls:
                           type: boolean
                         type:
@@ -93,6 +113,10 @@ spec:
                         type: string
                     type:
                       type: string
+                      enum:
+                      - simple
+                  required:
+                  - type
                 config:
                   type: object
                 rack:
@@ -363,6 +387,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
                 tlsSidecar:
                   type: object
                   properties:
@@ -425,6 +454,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                  required:
+                  - type
                 config:
                   type: object
                 affinity:
@@ -685,6 +719,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
                 tlsSidecar:
                   type: object
                   properties:
@@ -990,6 +1029,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
             clientsCa:
               type: object
               properties:
@@ -1061,6 +1105,11 @@ spec:
                           type: string
                         type:
                           type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
                 userOperator:
                   type: object
                   properties:
@@ -1104,6 +1153,11 @@ spec:
                           type: string
                         type:
                           type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
                 affinity:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -78,6 +78,12 @@ spec:
                           type: boolean
                         type:
                           type: string
+                          enum:
+                          - route
+                          - loadbalancer
+                          - nodeport
+                      required:
+                      - type
                 authorization:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -265,6 +265,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             metrics:
               type: object
             authentication:
@@ -295,8 +300,13 @@ spec:
                   - secretName
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
                 username:
                   type: string
+              required:
+              - type
             bootstrapServers:
               type: string
             config:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -271,8 +271,13 @@ spec:
                   - secretName
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
                 username:
                   type: string
+              required:
+              - type
             bootstrapServers:
               type: string
             config:
@@ -288,6 +293,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             resources:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -31,6 +31,11 @@ spec:
               properties:
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+              required:
+              - type
             authorization:
               type: object
               properties:
@@ -67,6 +72,12 @@ spec:
                             - prefix
                           type:
                             type: string
+                            enum:
+                            - topic
+                            - group
+                            - cluster
+                        required:
+                        - type
                       type:
                         type: string
                         enum:
@@ -77,7 +88,10 @@ spec:
                     - resource
                 type:
                   type: string
+                  enum:
+                  - simple
               required:
               - acls
+              - type
           required:
           - authentication

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -71,8 +71,13 @@ spec:
                       - secretName
                     type:
                       type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
                     username:
                       type: string
+                  required:
+                  - type
                 config:
                   type: object
                 tls:
@@ -128,8 +133,13 @@ spec:
                       - secretName
                     type:
                       type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
                     username:
                       type: string
+                  required:
+                  - type
                 config:
                   type: object
                 tls:
@@ -389,6 +399,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             metrics:
               type: object
           required:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -43,6 +43,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                  required:
+                  - type
                 listeners:
                   type: object
                   properties:
@@ -54,6 +59,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                     tls:
                       type: object
                       properties:
@@ -62,6 +72,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                     external:
                       type: object
                       properties:
@@ -70,6 +85,11 @@ spec:
                           properties:
                             type:
                               type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
                         tls:
                           type: boolean
                         type:
@@ -89,6 +109,10 @@ spec:
                         type: string
                     type:
                       type: string
+                      enum:
+                      - simple
+                  required:
+                  - type
                 config:
                   type: object
                 rack:
@@ -359,6 +383,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
                 tlsSidecar:
                   type: object
                   properties:
@@ -421,6 +450,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                  required:
+                  - type
                 config:
                   type: object
                 affinity:
@@ -681,6 +715,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
                 tlsSidecar:
                   type: object
                   properties:
@@ -986,6 +1025,11 @@ spec:
                       type: string
                     type:
                       type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
             clientsCa:
               type: object
               properties:
@@ -1057,6 +1101,11 @@ spec:
                           type: string
                         type:
                           type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
                 userOperator:
                   type: object
                   properties:
@@ -1100,6 +1149,11 @@ spec:
                           type: string
                         type:
                           type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
                 affinity:
                   type: object
                   properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -74,6 +74,12 @@ spec:
                           type: boolean
                         type:
                           type: string
+                          enum:
+                          - route
+                          - loadbalancer
+                          - nodeport
+                      required:
+                      - type
                 authorization:
                   type: object
                   properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -261,6 +261,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             metrics:
               type: object
             authentication:
@@ -291,8 +296,13 @@ spec:
                   - secretName
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
                 username:
                   type: string
+              required:
+              - type
             bootstrapServers:
               type: string
             config:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -267,8 +267,13 @@ spec:
                   - secretName
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
                 username:
                   type: string
+              required:
+              - type
             bootstrapServers:
               type: string
             config:
@@ -284,6 +289,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             resources:
               type: object
               properties:

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -27,6 +27,11 @@ spec:
               properties:
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+              required:
+              - type
             authorization:
               type: object
               properties:
@@ -63,6 +68,12 @@ spec:
                             - prefix
                           type:
                             type: string
+                            enum:
+                            - topic
+                            - group
+                            - cluster
+                        required:
+                        - type
                       type:
                         type: string
                         enum:
@@ -73,7 +84,10 @@ spec:
                     - resource
                 type:
                   type: string
+                  enum:
+                  - simple
               required:
               - acls
+              - type
           required:
           - authentication

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -67,8 +67,13 @@ spec:
                       - secretName
                     type:
                       type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
                     username:
                       type: string
+                  required:
+                  - type
                 config:
                   type: object
                 tls:
@@ -124,8 +129,13 @@ spec:
                       - secretName
                     type:
                       type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
                     username:
                       type: string
+                  required:
+                  - type
                 config:
                   type: object
                 tls:
@@ -385,6 +395,11 @@ spec:
                   type: string
                 type:
                   type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
             metrics:
               type: object
           required:

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -27,6 +27,11 @@ spec:
               properties:
                 type:
                   type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+              required:
+              - type
             authorization:
               type: object
               properties:
@@ -63,6 +68,12 @@ spec:
                             - prefix
                           type:
                             type: string
+                            enum:
+                            - topic
+                            - group
+                            - cluster
+                        required:
+                        - type
                       type:
                         type: string
                         enum:
@@ -73,7 +84,10 @@ spec:
                     - resource
                 type:
                   type: string
+                  enum:
+                  - simple
               required:
               - acls
+              - type
           required:
           - authentication


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This fixes #872 by removing the `@JsonIgnore` annotation. But it's a bit more complicated than that because we need to ensure the `type` property is included exactly once, which is what the other annotation changes are for.

We probably need to make the same changes for other classes which use this same pattern for the discriminator for inheritance in the api classes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

