### PR TITLE
Fix ACL Username handling for SCRAM users - Closes #825

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -330,11 +330,7 @@ public class KafkaUserModel {
      * @return
      */
     public boolean isTlsUser()  {
-        if (authentication instanceof KafkaUserTlsClientAuthentication) {
-            return true;
-        }
-
-        return false;
+        return authentication instanceof KafkaUserTlsClientAuthentication;
     }
 
     /**
@@ -343,10 +339,6 @@ public class KafkaUserModel {
      * @return
      */
     public boolean isScramUser()  {
-        if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
-            return true;
-        }
-
-        return false;
+        return authentication instanceof KafkaUserScramSha512ClientAuthentication;
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -237,8 +237,17 @@ public class KafkaUserModel {
      *
      * @return
      */
-    public static String getUserName(String username)    {
+    public static String getTlsUserName(String username)    {
         return "CN=" + username;
+    }
+
+    /**
+     * Generates the name of the User secret based on the username
+     *
+     * @return
+     */
+    public static String getScramUserName(String username)    {
+        return username;
     }
 
     /**
@@ -247,7 +256,13 @@ public class KafkaUserModel {
      * @return
      */
     public String getUserName()    {
-        return getUserName(name);
+        if (isTlsUser()) {
+            return getTlsUserName(name);
+        } else if (isScramUser()) {
+            return getScramUserName(name);
+        } else {
+            throw new RuntimeException("At least one authentication mechanism has to be selected");
+        }
     }
 
     public String getName() {
@@ -307,5 +322,31 @@ public class KafkaUserModel {
         }
 
         this.simpleAclRules = simpleAclRules;
+    }
+
+    /**
+     * Returns true if the user is using TLS authentication
+     *
+     * @return
+     */
+    public boolean isTlsUser()  {
+        if (authentication instanceof KafkaUserTlsClientAuthentication) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the user is using SCRAM-SHA-512 authentication
+     *
+     * @return
+     */
+    public boolean isScramUser()  {
+        if (authentication instanceof KafkaUserScramSha512ClientAuthentication) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -176,6 +176,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testGetUsername()    {
-        assertEquals("CN=my-user", KafkaUserModel.getUserName("my-user"));
+        assertEquals("CN=my-user", KafkaUserModel.getTlsUserName("my-user"));
+        assertEquals("my-user", KafkaUserModel.getScramUserName("my-user"));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -106,16 +106,18 @@ public class KafkaUserOperatorTest {
             context.assertEquals("key file", new String(Base64.getDecoder().decode(captured.getData().get("user.key"))));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
+            context.assertEquals(2, capturedAcls.size());
             Set<SimpleAclRule> aclRules = capturedAcls.get(0);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(1));
 
             async.complete();
         });
@@ -170,16 +172,18 @@ public class KafkaUserOperatorTest {
             context.assertEquals(userCert.getData().get("user.key"), captured.getData().get("user.key"));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
+            context.assertEquals(2, capturedAcls.size());
             Set<SimpleAclRule> aclRules = capturedAcls.get(0);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(1));
 
             async.complete();
         });
@@ -236,14 +240,15 @@ public class KafkaUserOperatorTest {
             context.assertNull(captured);
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
-            Set<SimpleAclRule> aclRules = capturedAcls.get(0);
-            context.assertNull(aclRules);
+            context.assertEquals(2, capturedAcls.size());
+            context.assertNull(capturedAcls.get(0));
+            context.assertNull(capturedAcls.get(1));
 
             async.complete();
         });
@@ -334,8 +339,9 @@ public class KafkaUserOperatorTest {
             context.assertEquals(ResourceUtils.NAMESPACE, capturedNamespaces.get(0));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             async.complete();
         });
@@ -396,16 +402,18 @@ public class KafkaUserOperatorTest {
             context.assertEquals("key file", new String(Base64.getDecoder().decode(captured.getData().get("user.key"))));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
+            context.assertEquals(2, capturedAcls.size());
             Set<SimpleAclRule> aclRules = capturedAcls.get(0);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(1));
 
             async.complete();
         });
@@ -466,16 +474,18 @@ public class KafkaUserOperatorTest {
             context.assertEquals(userCert.getData().get("user.key"), captured.getData().get("user.key"));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
+            context.assertEquals(2, capturedAcls.size());
             Set<SimpleAclRule> aclRules = capturedAcls.get(0);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(1));
 
             async.complete();
         });
@@ -520,8 +530,9 @@ public class KafkaUserOperatorTest {
             context.assertEquals(ResourceUtils.NAMESPACE, capturedNamespaces.get(0));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             async.complete();
         });
@@ -653,16 +664,18 @@ public class KafkaUserOperatorTest {
             context.assertTrue(new String(Base64.getDecoder().decode(captured.getData().get(KafkaUserModel.KEY_PASSWORD))).matches("[a-zA-Z0-9]{12}"));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
-            Set<SimpleAclRule> aclRules = capturedAcls.get(0);
+            context.assertEquals(2, capturedAcls.size());
+            Set<SimpleAclRule> aclRules = capturedAcls.get(1);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(0));
 
             async.complete();
         });
@@ -721,16 +734,18 @@ public class KafkaUserOperatorTest {
             context.assertEquals(password, scramPasswordCaptor.getValue());
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
             List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            context.assertEquals(1, capturedAcls.size());
-            Set<SimpleAclRule> aclRules = capturedAcls.get(0);
+            context.assertEquals(2, capturedAcls.size());
+            Set<SimpleAclRule> aclRules = capturedAcls.get(1);
 
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user).size(), aclRules.size());
             context.assertEquals(ResourceUtils.createExpectedSimpleAclRules(user), aclRules);
+            context.assertNull(capturedAcls.get(0));
 
             async.complete();
         });
@@ -775,10 +790,11 @@ public class KafkaUserOperatorTest {
             context.assertEquals(ResourceUtils.NAMESPACE, capturedNamespaces.get(0));
 
             List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            context.assertEquals(1, capturedAclNames.size());
-            context.assertEquals(KafkaUserModel.getUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(2, capturedAclNames.size());
+            context.assertEquals(KafkaUserModel.getTlsUserName(ResourceUtils.NAME), capturedAclNames.get(0));
+            context.assertEquals(KafkaUserModel.getScramUserName(ResourceUtils.NAME), capturedAclNames.get(1));
 
-            context.assertEquals(singletonList("CN=" + ResourceUtils.NAME), scramUserCaptor.getAllValues());
+            context.assertEquals(singletonList(ResourceUtils.NAME), scramUserCaptor.getAllValues());
             context.assertEquals(singletonList(null), scramPasswordCaptor.getAllValues());
 
             async.complete();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, the ACL names generated for SCRAM users have the names of the TLS users and therefore ACLs don't work with SCRAM. This PR should fix that as well as the issue #825 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

