### PR TITLE
Fix the Connect REST API URL in templates - Closes #968

### DIFF
--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -11,7 +11,7 @@ metadata:
     tags: "messaging"
     iconClass: "fa fa-exchange"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Kafka Connect S2I cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:8083' to access Kafka Connect REST API."
+message: "Kafka Connect S2I cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-connect-api:8083' to access Kafka Connect REST API."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -10,7 +10,7 @@ metadata:
     tags: "messaging"
     iconClass: "fa fa-exchange"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Kafka Connect cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:8083' to access Kafka Connect REST API."
+message: "Kafka Connect cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-connect-api:8083' to access Kafka Connect REST API."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka Connect templates contain invalid URL for the REST API. This PR should fix it (issue #968)