### PR TITLE
Removed image tag from kafka mirror maker YAMLs

### DIFF
--- a/examples/kafka-mirror-maker/kafka-mirror-maker-tls.yaml
+++ b/examples/kafka-mirror-maker/kafka-mirror-maker-tls.yaml
@@ -3,7 +3,6 @@ kind: KafkaMirrorMaker
 metadata:
   name: my-mirror-maker
 spec:
-  image: strimzi/kafka-mirror-maker:latest
   replicas: 1
   consumer:
     bootstrapServers: my-source-cluster-kafka-bootstrap:9093

--- a/examples/kafka-mirror-maker/kafka-mirror-maker.yaml
+++ b/examples/kafka-mirror-maker/kafka-mirror-maker.yaml
@@ -3,7 +3,6 @@ kind: KafkaMirrorMaker
 metadata:
   name: my-mirror-maker
 spec:
-  image: strimzi/kafka-mirror-maker:latest
   replicas: 1
   consumer:
     bootstrapServers: my-source-cluster-kafka-bootstrap:9092

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -43,6 +43,8 @@ spec:
               value: "{{ default .Values.kafkaConnect.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.kafkaConnect.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE
               value: "{{ default .Values.kafkaConnects2i.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaConnects2i.image.name }}:{{ default .Values.kafkaConnects2i.image.tag .Values.imageTagOverride }}"
+            - name: STRIMZI_DEFAULT_KAFKA_MIRRORMAKER_IMAGE
+              value: "{{ default .Values.kafkaMirrorMaker.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.kafkaMirrorMaker.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: "{{ default .Values.topicOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.topicOperator.image.name }}:{{ default .Values.topicOperator.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
@@ -57,8 +59,6 @@ spec:
               value: "{{ default .Values.tlsSidecarEntityOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.tlsSidecarEntityOperator.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
-            - name: STRIMZI_DEFAULT_KAFKA_MIRRORMAKER_IMAGE
-              value: "{{ default .Values.kafkaMirrorMaker.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.kafkaMirrorMaker.image.tag .Values.imageTagOverride }}"          
           livenessProbe:
             httpGet:
               path: /healthy

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -33,6 +33,8 @@ spec:
           value: strimzi/kafka-connect:latest
         - name: STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE
           value: strimzi/kafka-connect-s2i:latest
+        - name: STRIMZI_DEFAULT_KAFKA_MIRRORMAKER_IMAGE
+          value: strimzi/kafka-mirror-maker:latest
         - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
           value: strimzi/topic-operator:latest
         - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
@@ -47,8 +49,6 @@ spec:
           value: strimzi/entity-operator-stunnel:latest
         - name: STRIMZI_LOG_LEVEL
           value: INFO
-        - name: STRIMZI_DEFAULT_KAFKA_MIRRORMAKER_IMAGE
-          value: strimzi/kafka-mirror-maker:latest
         livenessProbe:
           httpGet:
             path: /healthy


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the `image' tag from Kafka Mirror Maker YAMLs files in order to rely on default image set in the CO deployment (as for all the other images).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

