### PR TITLE
Make sure Mirror Maker examples are packaged with the examples during…

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,6 +8,7 @@ release:
 	cp -r ./templates $(RELEASE_PATH)/
 	cp -r ./kafka $(RELEASE_PATH)/
 	cp -r ./kafka-connect $(RELEASE_PATH)/
+	cp -r ./kafka-mirror-maker $(RELEASE_PATH)/
 	cp -r ./user $(RELEASE_PATH)/
 	cp -r ./topic $(RELEASE_PATH)/
 


### PR DESCRIPTION
… release

### Type of change

- Bugfix

### Description

Kafka Mirror Maker examples are not packaged because they are not in Makefile. This PR fixes that.