### PR TITLE
Manual rolling update annotaion fix

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -59,7 +59,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
 
-import static io.strimzi.operator.cluster.ClusterOperator.STRIMZI_CLUSTER_OPERATOR_DOMAIN;
+import static io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator.STRIMZI_OPERATOR_DOMAIN;
 
 /**
  * <p>Assembly operator for a "Kafka" assembly, which manages:</p>
@@ -85,7 +85,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private final RoleBindingOperator roleBindingOperator;
     private final ClusterRoleBindingOperator clusterRoleBindingOperator;
 
-    public static final String ANNOTATION_MANUAL_RESTART = STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/manual-rolling-update";
+    public static final String ANNOTATION_MANUAL_RESTART = STRIMZI_OPERATOR_DOMAIN + "/manual-rolling-update";
 
     /**
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -30,9 +30,9 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
             R extends ScalableResource<T, D>>
         extends AbstractReadyResourceOperator<C, T, L, D, R> {
 
-    public static final String STRIMZI_CLUSTER_OPERATOR_DOMAIN = "operator.strimzi.io";
-    public static final String ANNOTATION_GENERATION = STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/generation";
-    public static final String ANNOTATION_MANUAL_DELETE_POD_AND_PVC = STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/delete-pod-and-pvc";
+    public static final String STRIMZI_OPERATOR_DOMAIN = "operator.strimzi.io";
+    public static final String ANNOTATION_GENERATION = STRIMZI_OPERATOR_DOMAIN + "/generation";
+    public static final String ANNOTATION_MANUAL_DELETE_POD_AND_PVC = STRIMZI_OPERATOR_DOMAIN + "/delete-pod-and-pvc";
 
     private final Logger log = LogManager.getLogger(getClass());
 


### PR DESCRIPTION
### Type of change
- Bugfix
- Refactoring


### Description

There was a field `STRIMZI_CLUSTER_OPERATOR_DOMAIN` with two different values. Refactoring.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

