### PR TITLE
Fix the run command which cannot be executed twice because the pods s…

### DIFF
--- a/documentation/book/proc-deploying-example-clients.adoc
+++ b/documentation/book/proc-deploying-example-clients.adoc
@@ -13,12 +13,12 @@
 . Deploy the producer.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl run`:
+On {KubernetesName}, use `kubectl run`:
 [source,shell,subs="+quotes,attributes"]
 kubectl run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc run`:
+On {OpenShiftName}, use `oc run`:
 +
 [source,shell,subs="+quotes,attributes"]
 oc run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
@@ -30,12 +30,12 @@ oc run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin
 . Deploy the consumer.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl run`:
+On {KubernetesName}, use `kubectl run`:
 [source,shell,subs="+quotes,attributes"]
 kubectl run kafka-consumer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc run`:
+On {OpenShiftName}, use `oc run`:
 +
 [source,shell,subs="+quotes,attributes"]
 oc run kafka-consumer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning

--- a/documentation/book/proc-deploying-example-clients.adoc
+++ b/documentation/book/proc-deploying-example-clients.adoc
@@ -12,8 +12,16 @@
 
 . Deploy the producer.
 +
-[source,subs="+quotes,attributes"]
-oc run kafka-producer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl run`:
+[source,shell,subs="+quotes,attributes"]
+kubectl run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc run`:
++
+[source,shell,subs="+quotes,attributes"]
+oc run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
 
 . Type your message into the console where the producer is running.
 
@@ -21,7 +29,15 @@ oc run kafka-producer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-co
 
 . Deploy the consumer.
 +
-[source,subs="+quotes,attributes"]
-oc run kafka-consumer -ti --image={DockerKafka} --restart=Never \-- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl run`:
+[source,shell,subs="+quotes,attributes"]
+kubectl run kafka-consumer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc run`:
++
+[source,shell,subs="+quotes,attributes"]
+oc run kafka-consumer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_ --from-beginning
 
 . Confirm that you see the incoming messages in the consumer console.


### PR DESCRIPTION
…tayes there

### Type of change

- Bugfix
- Documentation

### Description

The procedure _Deploying example clients_ has several issues:
* There seems to be some incorrect escape before `--` which renders into the command.
* There are no Kubernetes versions of these commands
* The commands cannto be run repeatedly because the pod stays there after the user terminates the producer.

All three issues should be solved by this PR: The last one should be solved by adding `--rm=true` to the run command.