### PR TITLE
Fix wrong title in Deploying Kafka Mirror Maker to Kubernetes procedure

### DIFF
--- a/documentation/book/proc-deploying-kafka-mirror-maker-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-mirror-maker-kubernetes.adoc
@@ -3,7 +3,7 @@
 // assembly-kafka-mirror-maker.adoc
 
 [id='deploying-kafka-mirror-maker-kubernetes-{context}']
-= Deploying Kafka Connect to {KubernetesName}
+= Deploying Kafka Mirror Maker to {KubernetesName}
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes the incorrect title in the _Deploying Kafka Mirror Maker to Kubernetes_ procedure which refers to Connect instead of MIrror Maker.

