### PR TITLE
The Spec section of CR should not be null

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -112,6 +112,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     @Override
     public Future<Void> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
         Future<Void> chainFuture = Future.future();
+        if (kafkaAssembly.getSpec() == null) {
+            log.error("{} spec cannot be null", kafkaAssembly.getMetadata().getName());
+            return Future.failedFuture("Spec cannot be null");
+        }
         new ReconciliationState(reconciliation, kafkaAssembly)
                 .reconcileClusterCa()
                 // Roll everything so the new CA is added to the trust store.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -73,6 +73,10 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
         KafkaConnectCluster connect;
+        if (kafkaConnect.getSpec() == null) {
+            log.error("{} spec cannot be null", kafkaConnect.getMetadata().getName());
+            return Future.failedFuture("Spec cannot be null");
+        }
         try {
             connect = KafkaConnectCluster.fromCrd(kafkaConnect);
         } catch (Exception e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -82,6 +82,10 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
     @Override
     public Future<Void> createOrUpdate(Reconciliation reconciliation, KafkaConnectS2I kafkaConnectS2I) {
         String namespace = reconciliation.namespace();
+        if (kafkaConnectS2I.getSpec() == null) {
+            log.error("{} spec cannot be null", kafkaConnectS2I.getMetadata().getName());
+            return Future.failedFuture("Spec cannot be null");
+        }
         if (isOpenShift) {
             KafkaConnectS2ICluster connect;
             try {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -74,6 +74,10 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
         KafkaMirrorMakerCluster mirror;
+        if (assemblyResource.getSpec() == null) {
+            log.error("{} spec cannot be null", assemblyResource.getMetadata().getName());
+            return Future.failedFuture("Spec cannot be null");
+        }
         try {
             mirror = KafkaMirrorMakerCluster.fromCrd(assemblyResource);
         } catch (Exception e) {


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
All operators should check for the spec for being a null to avoid NPEs. The Spec section is not required.
https://github.com/strimzi/strimzi-kafka-operator/issues/778

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

