### PR TITLE
@JsonAnyGetter and @JsonAnySetter

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -11,6 +13,8 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 @Description("Configuration of how TLS certificates are used within the cluster." +
         "This applies to certificates used for both internal communication within the cluster and to certificates " +
@@ -26,9 +30,10 @@ public class CertificateAuthority implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    int validityDays;
-    boolean generateCertificateAuthority = true;
-    int renewalDays;
+    private int validityDays;
+    private boolean generateCertificateAuthority = true;
+    private int renewalDays;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The number of days generated certificates should be valid for. Default is 365.")
     @Minimum(1)
@@ -63,5 +68,15 @@ public class CertificateAuthority implements Serializable {
 
     public void setRenewalDays(int renewalDays) {
         this.renewalDays = renewalDays;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -11,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -30,6 +33,7 @@ public class JvmOptions implements Serializable {
     private String xms;
     private Boolean server;
     private Map<String, String> xx;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @JsonProperty("-Xmx")
     @Pattern("[0-9]+[mMgG]?")
@@ -71,6 +75,16 @@ public class JvmOptions implements Serializable {
 
     public void setXx(Map<String, String> xx) {
         this.xx = xx;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
     }
 
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -48,6 +50,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     private JvmOptions jvmOptions;
     private Logging logging;
     private Map<String, Object> metrics = new HashMap<>(0);
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The number of pods in the `Deployment`.")
     @Minimum(1)
@@ -163,5 +166,15 @@ public class KafkaMirrorMakerSpec implements Serializable {
 
     public void setResources(Resources resources) {
         this.resources = resources;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
@@ -4,12 +4,16 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Describes the logging configuration
@@ -26,7 +30,19 @@ public abstract class Logging implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
     @Description("Logging type, must be either 'inline' or 'external'.")
     public abstract String getType();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
 }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
@@ -4,10 +4,15 @@
  */
 package io.strimzi.api.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.vertx.core.cli.annotations.DefaultValue;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Representation of a TLS sidecar container configuration
@@ -22,6 +27,7 @@ public class TlsSidecar extends Sidecar {
     private static final long serialVersionUID = 1L;
 
     private TlsSidecarLogLevel logLevel = TlsSidecarLogLevel.NOTICE;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The log level for the TLS sidecar." +
             "Default value is `notice`.")
@@ -33,5 +39,15 @@ public class TlsSidecar extends Sidecar {
 
     public void setLogLevel(TlsSidecarLogLevel logLevel) {
         this.logLevel = logLevel;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
     }
 }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.crdgenerator;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -33,7 +31,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
@@ -46,6 +43,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static io.strimzi.crdgenerator.Property.hasAnyGetterAndAnySetter;
 import static io.strimzi.crdgenerator.Property.properties;
 import static io.strimzi.crdgenerator.Property.sortedProperties;
 import static io.strimzi.crdgenerator.Property.subtypes;
@@ -295,34 +293,11 @@ public class CrdGenerator {
             checkForBuilderClass(crdClass, crdClass.getName() + "FluentImpl");
         }
         if (!Modifier.isAbstract(crdClass.getModifiers())) {
-            checkForAnyGetterSetter(crdClass);
+            hasAnyGetterAndAnySetter(crdClass);
         } else {
             for (Class c : subtypes(crdClass)) {
-                checkForAnyGetterSetter(c);
+                hasAnyGetterAndAnySetter(c);
             }
-        }
-
-    }
-
-    private void checkForAnyGetterSetter(Class<?> crdClass) {
-        boolean anyGetter = false;
-        boolean anySetter = false;
-        for (Method method : crdClass.getMethods()) {
-            if (method.isAnnotationPresent(JsonAnySetter.class)) {
-                anySetter = true;
-            }
-            if (method.isAnnotationPresent(JsonAnyGetter.class)) {
-                anyGetter = true;
-            }
-            if (anyGetter && anySetter) {
-                break;
-            }
-        }
-        if (!anySetter) {
-            err(crdClass + " lacks @JsonAnySetter");
-        }
-        if (!anyGetter) {
-            err(crdClass + " lacks @JsonAnyGetter");
         }
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

All CRD objects should support unknown properties (which helps with adding properties without incrementing the CRD version all the time). Adding `@JsonAnySetter` and `@JsonAnyGetter` methods means Jackson can round-trip unknown properties, rather than throwing an exception.

This PR adds a check to the `CrdGenerator` that all encountered classes do have such methods, and adds them to those classes which previously lacked them.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

