### PR TITLE
Add metrics port to Network Policies

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -832,6 +832,8 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public NetworkPolicy generateNetworkPolicy() {
+        List<NetworkPolicyIngressRule> rules = new ArrayList<>(5);
+
         // Restrict access to 9091 / replication port
         NetworkPolicyPort replicationPort = new NetworkPolicyPort();
         replicationPort.setPort(new IntOrString(REPLICATION_PORT));
@@ -855,30 +857,56 @@ public class KafkaCluster extends AbstractModel {
                 .withFrom(kafkaClusterPeer, entityOperatorPeer)
                 .build();
 
+        rules.add(replicationRule);
+
         // Free access to 9092, 9093 and 9094 ports
-        NetworkPolicyPort plainPort = new NetworkPolicyPort();
-        plainPort.setPort(new IntOrString(CLIENT_PORT));
+        if (listeners != null && listeners.getPlain() != null) {
+            NetworkPolicyPort plainPort = new NetworkPolicyPort();
+            plainPort.setPort(new IntOrString(CLIENT_PORT));
 
-        NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
-                .withPorts(plainPort)
-                .withFrom()
-                .build();
+            NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
+                    .withPorts(plainPort)
+                    .withFrom()
+                    .build();
 
-        NetworkPolicyPort tlsPort = new NetworkPolicyPort();
-        tlsPort.setPort(new IntOrString(CLIENT_TLS_PORT));
+            rules.add(plainRule);
+        }
 
-        NetworkPolicyIngressRule tlsRule = new NetworkPolicyIngressRuleBuilder()
-                .withPorts(tlsPort)
-                .withFrom()
-                .build();
+        if (listeners != null && listeners.getTls() != null) {
+            NetworkPolicyPort tlsPort = new NetworkPolicyPort();
+            tlsPort.setPort(new IntOrString(CLIENT_TLS_PORT));
 
-        NetworkPolicyPort externalPort = new NetworkPolicyPort();
-        externalPort.setPort(new IntOrString(EXTERNAL_PORT));
+            NetworkPolicyIngressRule tlsRule = new NetworkPolicyIngressRuleBuilder()
+                    .withPorts(tlsPort)
+                    .withFrom()
+                    .build();
 
-        NetworkPolicyIngressRule externalRule = new NetworkPolicyIngressRuleBuilder()
-                .withPorts(externalPort)
-                .withFrom()
-                .build();
+            rules.add(tlsRule);
+        }
+
+        if (isExposed()) {
+            NetworkPolicyPort externalPort = new NetworkPolicyPort();
+            externalPort.setPort(new IntOrString(EXTERNAL_PORT));
+
+            NetworkPolicyIngressRule externalRule = new NetworkPolicyIngressRuleBuilder()
+                    .withPorts(externalPort)
+                    .withFrom()
+                    .build();
+
+            rules.add(externalRule);
+        }
+
+        if (isMetricsEnabled) {
+            NetworkPolicyPort metricsPort = new NetworkPolicyPort();
+            metricsPort.setPort(new IntOrString(METRICS_PORT));
+
+            NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
+                    .withPorts(metricsPort)
+                    .withFrom()
+                    .build();
+
+            rules.add(metricsRule);
+        }
 
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
                 .withNewMetadata()
@@ -889,7 +917,7 @@ public class KafkaCluster extends AbstractModel {
                 .endMetadata()
                 .withNewSpec()
                     .withPodSelector(labelSelector)
-                    .withIngress(replicationRule, plainRule, tlsRule, externalRule)
+                    .withIngress(rules)
                 .endSpec()
                 .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -860,40 +860,42 @@ public class KafkaCluster extends AbstractModel {
         rules.add(replicationRule);
 
         // Free access to 9092, 9093 and 9094 ports
-        if (listeners != null && listeners.getPlain() != null) {
-            NetworkPolicyPort plainPort = new NetworkPolicyPort();
-            plainPort.setPort(new IntOrString(CLIENT_PORT));
+        if (listeners != null) {
+            if (listeners.getPlain() != null) {
+                NetworkPolicyPort plainPort = new NetworkPolicyPort();
+                plainPort.setPort(new IntOrString(CLIENT_PORT));
 
-            NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
-                    .withPorts(plainPort)
-                    .withFrom()
-                    .build();
+                NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
+                        .withPorts(plainPort)
+                        .withFrom()
+                        .build();
 
-            rules.add(plainRule);
-        }
+                rules.add(plainRule);
+            }
 
-        if (listeners != null && listeners.getTls() != null) {
-            NetworkPolicyPort tlsPort = new NetworkPolicyPort();
-            tlsPort.setPort(new IntOrString(CLIENT_TLS_PORT));
+            if (listeners.getTls() != null) {
+                NetworkPolicyPort tlsPort = new NetworkPolicyPort();
+                tlsPort.setPort(new IntOrString(CLIENT_TLS_PORT));
 
-            NetworkPolicyIngressRule tlsRule = new NetworkPolicyIngressRuleBuilder()
-                    .withPorts(tlsPort)
-                    .withFrom()
-                    .build();
+                NetworkPolicyIngressRule tlsRule = new NetworkPolicyIngressRuleBuilder()
+                        .withPorts(tlsPort)
+                        .withFrom()
+                        .build();
 
-            rules.add(tlsRule);
-        }
+                rules.add(tlsRule);
+            }
 
-        if (isExposed()) {
-            NetworkPolicyPort externalPort = new NetworkPolicyPort();
-            externalPort.setPort(new IntOrString(EXTERNAL_PORT));
+            if (isExposed()) {
+                NetworkPolicyPort externalPort = new NetworkPolicyPort();
+                externalPort.setPort(new IntOrString(EXTERNAL_PORT));
 
-            NetworkPolicyIngressRule externalRule = new NetworkPolicyIngressRuleBuilder()
-                    .withPorts(externalPort)
-                    .withFrom()
-                    .build();
+                NetworkPolicyIngressRule externalRule = new NetworkPolicyIngressRuleBuilder()
+                        .withPorts(externalPort)
+                        .withFrom()
+                        .build();
 
-            rules.add(externalRule);
+                rules.add(externalRule);
+            }
         }
 
         if (isMetricsEnabled) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -199,6 +199,8 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     public NetworkPolicy generateNetworkPolicy() {
+        List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
+
         NetworkPolicyPort port1 = new NetworkPolicyPort();
         port1.setPort(new IntOrString(CLIENT_PORT));
 
@@ -234,6 +236,20 @@ public class ZookeeperCluster extends AbstractModel {
                 .withFrom(kafkaClusterPeer, zookeeperClusterPeer, entityOperatorPeer)
                 .build();
 
+        rules.add(networkPolicyIngressRule);
+
+        if (isMetricsEnabled) {
+            NetworkPolicyPort metricsPort = new NetworkPolicyPort();
+            metricsPort.setPort(new IntOrString(METRICS_PORT));
+
+            NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
+                    .withPorts(metricsPort)
+                    .withFrom()
+                    .build();
+
+            rules.add(metricsRule);
+        }
+
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
                 .withNewMetadata()
                     .withName(policyName(cluster))
@@ -243,7 +259,7 @@ public class ZookeeperCluster extends AbstractModel {
                 .endMetadata()
                 .withNewSpec()
                     .withPodSelector(labelSelector2)
-                    .withIngress(networkPolicyIngressRule)
+                    .withIngress(rules)
                 .endSpec()
                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The network policies currently handle only the Kafka and Zookeeper ports. But they forget to open the 9404 port for metrics. This can cause problems in some environments. This PR also changes how the rules are added to the Network Policy to reference only ports which are actually used.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
