### PR TITLE
Update strimzi

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -31,6 +31,16 @@ public interface CertManager {
     void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException;
 
     /**
+     * Renew a new self-signed certificate, keeping the existing private key
+     * @param keyFile path to the file containing the existing private key
+     * @param certFile path to the file which will contain the new self signed certificate
+     * @param sbj subject information
+     * @param days certificate duration
+     * @throws IOException
+     */
+    void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException;
+
+    /**
      * Generate a certificate sign request
      *
      * @param keyFile path to the file which will contain the private key

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -43,11 +43,19 @@ public class ClusterCa extends Ca {
                      int validityDays,
                      int renewalDays,
                      boolean generateCa) {
-        super(certManager, "cluster-ca", AbstractModel.getClusterCaName(clusterName), clusterCaCert,
+        super(certManager, "cluster-ca",
+                forceRenewal(clusterCaKey),
+                AbstractModel.getClusterCaName(clusterName), clusterCaCert,
                 AbstractModel.getClusterCaKeyName(clusterName),
                 adapt060ClusterCaSecret(clusterCaKey),
                 validityDays, renewalDays, generateCa);
         this.clusterName = clusterName;
+    }
+
+    private static boolean forceRenewal(Secret clientsCaKey) {
+        return clientsCaKey != null
+                && clientsCaKey.getData() != null
+                && clientsCaKey.getData().containsKey("cluster-ca.key");
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -44,10 +44,27 @@ public class ClusterCa extends Ca {
                      int renewalDays,
                      boolean generateCa) {
         super(certManager, "cluster-ca", AbstractModel.getClusterCaName(clusterName), clusterCaCert,
-                AbstractModel.getClusterCaKeyName(clusterName), clusterCaKey,
+                AbstractModel.getClusterCaKeyName(clusterName),
+                adapt060ClusterCaSecret(clusterCaKey),
                 validityDays, renewalDays, generateCa);
         this.clusterName = clusterName;
     }
+
+    /**
+     * In Strimzi 0.6.0 the Secrets and keys used a different convention.
+     * Here we adapt the keys in the {@code *-cluster-ca} Secret to match what
+     * 0.7.0 expects.
+     */
+    public static Secret adapt060ClusterCaSecret(Secret clusterCaKey) {
+        if (clusterCaKey != null && clusterCaKey.getData() != null) {
+            String key = clusterCaKey.getData().get("cluster-ca.key");
+            if (key != null) {
+                clusterCaKey.getData().put("ca.key", key);
+            }
+        }
+        return clusterCaKey;
+    }
+
 
     @Override
     public String toString() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -241,20 +241,16 @@ public class CertificateRenewalTest {
         ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
         assertEquals(2, c.getAllValues().size());
         Map<String, String> certData = c.getAllValues().get(0).getData();
-        assertEquals(2, certData.size());
+        assertEquals(1, certData.size());
         String newCrt = certData.remove(CA_CRT);
         assertNotNull(newCrt);
-        String oldKey = certData.keySet().iterator().next();
-        String oldCrt = certData.get(oldKey);
-        assertNotNull(oldCrt);
-        assertNotEquals(newCrt, oldCrt);
-        assertEquals(initialCert, oldCrt);
+        assertNotEquals(initialCert, newCrt);
 
         Map<String, String> keyData = c.getAllValues().get(1).getData();
         assertEquals(singleton(CA_KEY), keyData.keySet());
         String newKey = keyData.remove(CA_KEY);
         assertNotNull(newKey);
-        assertNotEquals(initialKey, newKey);
+        assertEquals(initialKey, newKey);
     }
 
     @Test

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -22,7 +22,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -374,15 +373,9 @@ public abstract class Ca {
 
     private Map<String, String>[] createOrRenewCert(X509Certificate currentCert) throws IOException {
         log.debug("Generating new certificate {} to be stored in {}", CA_CRT, caCertSecretName);
-        CertAndKey ca = generateCa(commonName);
+        CertAndKey ca = currentCert == null ? generateCa(commonName) : renewCa(commonName);
         Map<String, String> certData = new HashMap<>();
         Map<String, String> keyData = new HashMap<>();
-        if (currentCert != null) {
-            // Add the current certificate as an old certificate (with date in UTC)
-            String notAfterDate = DATE_TIME_FORMATTER.format(currentCert.getNotAfter().toInstant().atZone(ZoneId.of("Z")));
-            // TODO factor out this naming scheme
-            certData.put("ca-" + notAfterDate + ".crt", caCertSecret.getData().get(CA_CRT));
-        }
         // Add the generated certificate as the current certificate
         certData.put(CA_CRT, ca.certAsBase64String());
         keyData.put(CA_KEY, ca.keyAsBase64String());
@@ -468,6 +461,31 @@ public abstract class Ca {
 
                 certManager.generateSelfSignedCert(keyFile, certFile, sbj, validityDays);
                 return new CertAndKey(Files.readAllBytes(keyFile.toPath()), Files.readAllBytes(certFile.toPath()));
+            } finally {
+                delete(certFile);
+            }
+        } finally {
+            delete(keyFile);
+        }
+    }
+
+    private CertAndKey renewCa(String commonName) throws IOException {
+        log.debug("Renewing CA with cn={}, org={}", commonName, IO_STRIMZI);
+
+        Base64.Decoder decoder = Base64.getDecoder();
+        byte[] bytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
+        File keyFile = File.createTempFile("ererver", "dffbvd");
+        try {
+            Files.write(keyFile.toPath(), bytes);
+            File certFile = File.createTempFile("tls", commonName + "-cert");
+            try {
+
+                Subject sbj = new Subject();
+                sbj.setOrganizationName(IO_STRIMZI);
+                sbj.setCommonName(commonName);
+
+                certManager.renewSelfSignedCert(keyFile, certFile, sbj, validityDays);
+                return new CertAndKey(bytes, Files.readAllBytes(certFile.toPath()));
             } finally {
                 delete(certFile);
             }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -83,6 +83,7 @@ public abstract class Ca {
     protected final int validityDays;
     protected final int renewalDays;
     private final boolean generateCa;
+    private final boolean forceRenewal;
     protected String caCertSecretName;
     private Secret caCertSecret;
     protected String caKeySecretName;
@@ -91,9 +92,11 @@ public abstract class Ca {
     private boolean certsRemoved;
 
     public Ca(CertManager certManager, String commonName,
+              boolean forceRenewal,
               String caCertSecretName, Secret caCertSecret,
               String caKeySecretName, Secret caKeySecret,
               int validityDays, int renewalDays, boolean generateCa) {
+        this.forceRenewal = forceRenewal;
         this.commonName = commonName;
         this.caCertSecret = caCertSecret;
         this.caCertSecretName = caCertSecretName;
@@ -271,7 +274,8 @@ public abstract class Ca {
             keyData = caKeySecret != null ? singletonMap(CA_KEY, caKeySecret.getData().get(CA_KEY)) : emptyMap();
             certsRemoved = false;
         } else {
-            if (caCertSecret == null
+            if (forceRenewal
+                    || caCertSecret == null
                     || caCertSecret.getData().get(CA_CRT) == null
                     || caKeySecret == null
                     || caKeySecret.getData().get(CA_KEY) == null

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -11,9 +11,17 @@ public class ClientsCa extends Ca {
     public ClientsCa(CertManager certManager, String caCertSecretName, Secret clientsCaCert,
                      String caSecretKeyName, Secret clientsCaKey,
                      int validityDays, int renewalDays, boolean generateCa) {
-        super(certManager, "clients-ca", caCertSecretName, clientsCaCert,
+        super(certManager, "clients-ca",
+                forceRenewal(clientsCaKey),
+                caCertSecretName, clientsCaCert,
                 caSecretKeyName, adapt060ClientsCaSecret(clientsCaKey),
                 validityDays, renewalDays, generateCa);
+    }
+
+    private static boolean forceRenewal(Secret clientsCaKey) {
+        return clientsCaKey != null
+                && clientsCaKey.getData() != null
+                && clientsCaKey.getData().containsKey("clients-ca.key");
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -12,8 +12,23 @@ public class ClientsCa extends Ca {
                      String caSecretKeyName, Secret clientsCaKey,
                      int validityDays, int renewalDays, boolean generateCa) {
         super(certManager, "clients-ca", caCertSecretName, clientsCaCert,
-                caSecretKeyName, clientsCaKey,
+                caSecretKeyName, adapt060ClientsCaSecret(clientsCaKey),
                 validityDays, renewalDays, generateCa);
+    }
+
+    /**
+     * In Strimzi 0.6.0 the Secrets and keys used a different convention.
+     * Here we adapt the keys in the {@code *-clients-ca} Secret to match what
+     * 0.7.0 expects.
+     */
+    public static Secret adapt060ClientsCaSecret(Secret clientsCaKey) {
+        if (clientsCaKey != null && clientsCaKey.getData() != null) {
+            String key = clientsCaKey.getData().get("clients-ca.key");
+            if (key != null) {
+                clientsCaKey.getData().put("ca.key", key);
+            }
+        }
+        return clientsCaKey;
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -166,6 +166,20 @@ public class MockCertManager implements CertManager {
     }
 
     /**
+     * Renew a new self-signed certificate, keeping the existing private key
+     *
+     * @param keyFile  path to the file containing the existing private key
+     * @param certFile path to the file which will contain the new self signed certificate
+     * @param sbj      subject information
+     * @param days     certificate duration
+     * @throws IOException
+     */
+    @Override
+    public void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
+        // TODO
+    }
+
+    /**
      * Generate a certificate sign request
      *
      * @param keyFile path to the file which will contain the private key


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes strimzi update and changes CA certificate renewal to retain the existing key, generating only a new CA certificate. This is necessary because `stunnel` doesn't support having multiple CAs. That in turn means we can't do a rolling update to update the stunnel trust in the new CA cert without breaking ZK quorum, which basically breaks the cluster. 

By using the existing CA private key it means that old client certs will be trusted by stunnels using either new or old CA certs, which means the rolling update does not break the quorum, and in turns strimzi update from 0.6.0 -> HEAD is possible.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

