### PR TITLE
Edits to Kafka Cluster section to emphasise the cluster name

### DIFF
--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -9,11 +9,11 @@
 [id='kafka-cluster-{context}']
 = Kafka cluster
 
-You can use {ProductName} to deploy ephemeral and persistent Kafka clusters to {ProductPlatformName}.
+You can use {ProductName} to deploy an ephemeral or persistent Kafka cluster to {ProductPlatformName}. When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
 
-Ephemeral:: An ephemeral Kafka cluster is only suitable for development and testing purposes, not for production. This deployment uses `emptyDir` volumes for storing broker information (for Zookeeper) and topics or partitions (for Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
+Ephemeral cluster:: In general, an ephemeral (that is, temporary) Kafka cluster is suitable for development and testing purposes, not for production. This deployment uses `emptyDir` volumes for storing broker information (for Zookeeper) and topics or partitions (for Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
 
-Persistent:: A persistent Kafka cluster uses `PersistentVolumes` to store Zookeeper and Kafka data. The `PersistentVolume` is
+Persistent cluster:: A persistent Kafka cluster uses `PersistentVolumes` to store Zookeeper and Kafka data. The `PersistentVolume` is
 acquired using a `PersistentVolumeClaim` to make it independent of the actual type of the `PersistentVolume`. For example, it can use
 ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
@@ -23,7 +23,7 @@ Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML fil
 * `kafka-ephemeral.yaml` deploys an ephemeral cluster, named `my-cluster` by default.
 * `kafka-persistent.yaml` deploys a persistent cluster, named `my-cluster` by default.
 
-To rename the cluster before deployment, edit the `Kafka.metadata.name` resource in the relevant YAML file.
+The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed. To change the cluster name before you deploy the cluster, edit the `Kafka.metadata.name` property of the resource in the relevant YAML file.
 
 [source,yaml,subs=+quotes]
 ----
@@ -33,8 +33,6 @@ metadata:
   name: my-cluster
 # ...
 ----
-
-NOTE: When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
 
 ifdef::Kubernetes[]
 include::proc-deploying-kafka-cluster-kubernetes.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -9,16 +9,32 @@
 [id='kafka-cluster-{context}']
 = Kafka cluster
 
-You can use {ProductName} to deploy ephemeral and persistent Kafka clusters.
+You can use {ProductName} to deploy ephemeral and persistent Kafka clusters to {ProductPlatformName}.
 
-Ephemeral:: An ephemeral Kafka cluster is only suitable for development and testing purposes, not for production. This deployment uses `emptyDir` volumes for storing broker information (Zookeeper) and topics or partitions (Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
+Ephemeral:: An ephemeral Kafka cluster is only suitable for development and testing purposes, not for production. This deployment uses `emptyDir` volumes for storing broker information (for Zookeeper) and topics or partitions (for Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
 
 Persistent:: A persistent Kafka cluster uses `PersistentVolumes` to store Zookeeper and Kafka data. The `PersistentVolume` is
 acquired using a `PersistentVolumeClaim` to make it independent of the actual type of the `PersistentVolume`. For example, it can use
 ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
 
-When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
+{ProductName} includes two templates for deploying a Kafka cluster:
+
+* `kafka-ephemeral.yaml` deploys an ephemeral cluster, named `my-cluster` by default.
+* `kafka-persistent.yaml` deploys a persistent cluster, named `my-cluster` by default.
+
+To rename the cluster before deployment, edit the `Kafka.metadata.name` resource in the relevant YAML file.
+
+[source,yaml,subs=+quotes]
+----
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+# ...
+----
+
+NOTE: When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
 
 ifdef::Kubernetes[]
 include::proc-deploying-kafka-cluster-kubernetes.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -9,17 +9,16 @@
 [id='kafka-cluster-{context}']
 = Kafka cluster
 
-When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
+You can use {ProductName} to deploy ephemeral and persistent Kafka clusters.
 
-{ProductName} provides two options for Kafka cluster deployment:
+Ephemeral:: An ephemeral Kafka cluster is only suitable for development and testing purposes, not for production. This deployment uses `emptyDir` volumes for storing broker information (Zookeeper) and topics or partitions (Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
 
-Ephemeral:: is suitable only for development and testing purposes and not for production. This deployment uses `emptyDir` volumes for storing broker information (Zookeeper) and topics or partitions
-(Kafka). Using an `emptyDir` volume means that its content is strictly related to the pod life cycle and is deleted when the pod goes down.
-
-Persistent:: uses `PersistentVolumes` to store Zookeeper and Kafka data. The `PersistentVolume` is
+Persistent:: A persistent Kafka cluster uses `PersistentVolumes` to store Zookeeper and Kafka data. The `PersistentVolume` is
 acquired using a `PersistentVolumeClaim` to make it independent of the actual type of the `PersistentVolume`. For example, it can use
 ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
+
+When installing Kafka, {ProductName} also installs a Zookeeper cluster and adds the necessary configuration to connect Kafka with Zookeeper.
 
 ifdef::Kubernetes[]
 include::proc-deploying-kafka-cluster-kubernetes.adoc[leveloffset=+1]

--- a/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
@@ -29,4 +29,4 @@ kubectl apply -f examples/kafka/kafka-persistent.yaml
 
 .Additional resources
 * For more information on deploying the Cluster Operator, see xref:cluster-operator-str[].
-* For more information on the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[]
+* For more information on the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[].

--- a/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
@@ -9,11 +9,11 @@ The following procedure describes how to deploy an ephemeral or persistent Kafka
 
 .Prerequisites
 
-* You must have deployed the Cluster Operator before you can deploy a cluster.
+* The Cluster Operator is deployed.
 
 .Procedure
 
-. If you plan to use the cluster for development or testing purposes, create and deploy an ephemeral cluster using `kubectl apply`.
+. If you plan to use the cluster for development or testing purposes, you can create and deploy an ephemeral cluster using `kubectl apply`.
 +
 [source,shell]
 ----

--- a/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-kubernetes.adoc
@@ -5,20 +5,22 @@
 [id='deploying-kafka-cluster-kubernetes-{context}']
 = Deploying the Kafka cluster to {KubernetesName}
 
+The following procedure describes how to deploy an ephemeral or persistent Kafka cluster to {KubernetesName} on the command line.
+
 .Prerequisites
 
-* Before deploying a Kafka cluster, the Cluster Operator must be deployed.
+* You must have deployed the Cluster Operator before you can deploy a cluster.
 
 .Procedure
 
-. If you are planning to use the Kafka broker for development or testing, create an ephemeral cluster
+. If you plan to use the cluster for development or testing purposes, create and deploy an ephemeral cluster using `kubectl apply`.
 +
 [source,shell]
 ----
 kubectl apply -f examples/kafka/kafka-ephemeral.yaml
 ----
 
-. If you are planning to use the Kafka cluster in production, create a persistent cluster
+. If you plan to use the cluster in production, create and deploy a persistent cluster using `kubectl apply`.
 +
 [source,shell]
 ----
@@ -26,5 +28,5 @@ kubectl apply -f examples/kafka/kafka-persistent.yaml
 ----
 
 .Additional resources
-* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[]
-* For more information about the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[]
+* For more information on deploying the Cluster Operator, see xref:cluster-operator-str[].
+* For more information on the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[]

--- a/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
@@ -5,22 +5,29 @@
 [id='deploying-kafka-cluster-openshift-{context}']
 = Deploying the Kafka cluster to {OpenShiftName}
 
-{OpenShiftName} provides a template for deploying the Kafka cluster either in the {OpenShiftName} console or on the command-line.
+{ProductName} includes two templates for deploying a Kafka cluster to {OpenShiftName}:
+
+* `kafka-ephemeral.yaml` deploys an ephemeral cluster named `my-cluster` by default.
+* `kafka-persistent.yaml` deploys a persistent cluster named `my-cluster` by default.
+
+To rename the cluster before deployment, edit the `Kafka.metadata.name` resource in the relevant YAML file.
+
+The following procedure describes how to deploy both types of clusters on the command line. You can also deploy clusters in the {OpenShiftName} console. 
 
 .Prerequisites
 
-* Before deploying a Kafka cluster, the Cluster Operator must be deployed.
+* You must have deployed the Cluster Operator before you can deploy a cluster.
 
 .Procedure
 
-. If you are planning to use the Kafka cluster for development or testing, create an ephemeral cluster
+. If you plan to use the cluster for development or testing purposes, create and deploy an ephemeral cluster using `oc apply`.
 +
 [source,shell]
 ----
 oc apply -f examples/kafka/kafka-ephemeral.yaml
 ----
 
-. If you are planning to use the Kafka cluster in production, create a persistent cluster
+. If you plan to use the cluster in production, create and deploy a persistent cluster using `oc apply`.
 +
 [source,shell]
 ----
@@ -28,5 +35,5 @@ oc apply -f examples/kafka/kafka-persistent.yaml
 ----
 
 .Additional resources
-* For more information about deploying the Cluster Operator, see xref:cluster-operator-str[]
-For more information about the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[]
+* For more information on deploying the Cluster Operator, see xref:cluster-operator-str[].
+For more information on the different configuration options supported by the `Kafka` resource, see xref:assembly-deployment-configuration-kafka-str[].

--- a/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
@@ -9,7 +9,7 @@ The following procedure describes how to deploy an ephemeral or persistent Kafka
 
 .Prerequisites
 
-* You must have deployed the Cluster Operator before you can deploy a cluster.
+* The Cluster Operator is deployed.
 
 .Procedure
 

--- a/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
+++ b/documentation/book/proc-deploying-kafka-cluster-openshift.adoc
@@ -5,14 +5,7 @@
 [id='deploying-kafka-cluster-openshift-{context}']
 = Deploying the Kafka cluster to {OpenShiftName}
 
-{ProductName} includes two templates for deploying a Kafka cluster to {OpenShiftName}:
-
-* `kafka-ephemeral.yaml` deploys an ephemeral cluster named `my-cluster` by default.
-* `kafka-persistent.yaml` deploys a persistent cluster named `my-cluster` by default.
-
-To rename the cluster before deployment, edit the `Kafka.metadata.name` resource in the relevant YAML file.
-
-The following procedure describes how to deploy both types of clusters on the command line. You can also deploy clusters in the {OpenShiftName} console. 
+The following procedure describes how to deploy an ephemeral or persistent Kafka cluster to {OpenShiftName} on the command line. You can also deploy clusters in the {OpenShiftName} console. 
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

- General style edits to the content and organisation of the Kafka Cluster assembly.
- Makes it clear that two YAML files are provided for deploying ephemeral and persistent clusters.
- Makes it clear that the cluster will be named `my-cluster` unless you rename it in the YAML file. Adds a code block to help.
- General style edits to both procedures (deploying cluster to K8 and OS).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ y] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

