### PR TITLE
Build source and javadoc jars for all modules and fix the Javadoc errors

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -258,30 +258,6 @@
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -71,7 +71,6 @@ public class SecretCertProvider {
      * @param cert certificate to store
      * @param labels Labels to add to the Secret
      * @return the Secret
-     * @throws IOException
      */
     public Secret createSecret(String namespace, String name, String keyKey, String certKey, byte[] key, byte[] cert, Map<String, String> labels, OwnerReference ownerReference) {
         Map<String, String> data = new HashMap<>();
@@ -92,7 +91,6 @@ public class SecretCertProvider {
      * @param data Map with secret data / files
      * @param labels Labels to add to the Secret
      * @return the Secret
-     * @throws IOException
      */
     public Secret createSecret(String namespace, String name, Map<String, String> data, Map<String, String> labels, OwnerReference ownerReference) {
         Secret secret = new SecretBuilder()
@@ -117,7 +115,6 @@ public class SecretCertProvider {
      * @param key private key to store
      * @param cert certificate to store
      * @return the Secret
-     * @throws IOException
      */
     public Secret addSecret(Secret secret, String keyKey, String certKey, byte[] key, byte[] cert) {
         Base64.Encoder encoder = Base64.getEncoder();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -406,7 +406,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generates service for pod {@pod}. This service is used for exposing it externally.
+     * Generates service for pod. This service is used for exposing it externally.
      *
      * @param pod   Number of the pod for which this service should be generated
      * @return The generated Service
@@ -427,7 +427,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generates route for pod {@pod}. This route is used for exposing it externally using OpenShift Routes.
+     * Generates route for pod. This route is used for exposing it externally using OpenShift Routes.
      *
      * @param pod   Number of the pod for which this route should be generated
      * @return The generated Route

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -131,7 +131,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * Reconciliation works by getting the assembly resource (e.g. {@code KafkaAssembly}) in the given namespace with the given name and
      * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
      * <ul>
-     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, T) created or updated} if ConfigMap is without same-named resources</li>
+     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created or updated} if ConfigMap is without same-named resources</li>
      * <li>An assembly will be {@linkplain #delete(Reconciliation) deleted} if resources without same-named ConfigMap</li>
      * </ul>
      */
@@ -193,7 +193,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * Reconciliation works by getting the assembly ConfigMaps in the given namespace with the given selector and
      * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
      * <ul>
-     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, T) created} for all ConfigMaps without same-named resources</li>
+     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created} for all ConfigMaps without same-named resources</li>
      * <li>An assembly will be {@linkplain #delete(Reconciliation) deleted} for all resources without same-named ConfigMaps</li>
      * </ul>
      *

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -119,7 +119,7 @@ public class Labels {
      *
      * @param stringLabels  String with labels
      * @return  Labels object with parsed labels
-     * @throws IllegalArgumentException|
+     * @throws IllegalArgumentException
      */
     public static Labels fromString(String stringLabels) throws IllegalArgumentException {
         Map<String, String> labels = new HashMap<>();

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -53,12 +53,12 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
     /**
      * Asynchronously scale up the resource given by {@code namespace} and {@code name} to have the scale given by
      * {@code scaleTo}, returning a future for the outcome.
-     * If the resource does not exist, or has a current scale >= the given {@code scaleTo}, then complete successfully.
+     * If the resource does not exist, or has a current scale &gt;= the given {@code scaleTo}, then complete successfully.
      * @param namespace The namespace of the resource to scale.
      * @param name The name of the resource to scale.
      * @param scaleTo The desired scale.
      * @return A future whose value is the scale after the operation.
-     * If the scale was initially > the given {@code scaleTo} then this value will be the original scale,
+     * If the scale was initially &gt; the given {@code scaleTo} then this value will be the original scale,
      * The value will be null if the resource didn't exist (hence no scaling occurred).
      */
     public Future<Integer> scaleUp(String namespace, String name, int scaleTo) {
@@ -89,12 +89,12 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
     /**
      * Asynchronously scale down the resource given by {@code namespace} and {@code name} to have the scale given by
      * {@code scaleTo}, returning a future for the outcome.
-     * If the resource does not exists, is has a current scale <= the given {@code scaleTo} then complete successfully.
+     * If the resource does not exists, is has a current scale &lt;= the given {@code scaleTo} then complete successfully.
      * @param namespace The namespace of the resource to scale.
      * @param name The name of the resource to scale.
      * @param scaleTo The desired scale.
      * @return A future whose value is the scale after the operation.
-     * If the scale was initially < the given {@code scaleTo} then this value will be the original scale,
+     * If the scale was initially &lt; the given {@code scaleTo} then this value will be the original scale,
      * The value will be null if the resource didn't exist (hence no scaling occurred).
      */
     public Future<Integer> scaleDown(String namespace, String name, int scaleTo) {

--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -139,7 +139,6 @@ public final class TestUtils {
      * @param cls The class relative to which the resource will be loaded.
      * @param resourceName The name of the resource
      * @return The resource content
-     * @throws IOException
      */
     public static String readResource(Class<?> cls, String resourceName) {
         try {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * Represents the difference between two topics.
  * {@code TopicDiff}s are {@linkplain #diff(Topic, Topic) computed} from a source topic to a target topic
  * with the invariant that:
- * <pre></pre><code>
+ * <pre><code>
  *     TopicDiff.diff(topicA, topicB).apply(topicA).equals(topicB)
  * </code></pre>
  */

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
@@ -40,7 +40,7 @@ public class ScramShaCredentials {
 
     /**
      * Create or update the SCRAM-SHA credentials for the given user.
-     * @param iterations If <= 0 the default number of iterations will be used.
+     * @param iterations If &lt;= 0 the default number of iterations will be used.
      */
     public void createOrUpdate(String username, String password, int iterations) {
         if (0 < iterations && iterations < mechanism.minIterations()) {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

To be able to upload all JARs to Maven repositories, we will need to have source and javadocs JARs. This PR starts building Javadoc and source JARs for all modules. This will also help to detect Javadoc errors early.

Enabling Javadoc JAR building raised a lot of existing errors. Tis PR solves the errors. 

_There is still like million warnings about missing param and return fields. I didn't fixed these. But we should be more careful and try to do the Javadoc comments properly when we use them! :-/_