### PR TITLE
Add docs for adding users as Strimzi admins

### DIFF
--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 fatal=0
+GREP=grep
+
+if [ $(uname -s) = "Darwin" ]; then
+  GREP=ggrep
+fi
 
 function grep_check {
   local pattern=$1
   local description=$2
   local opts=${3:--i -E -r -n}
   local fatalness=${4:-1}
-  x=$(grep $opts "$pattern" documentation/book/)
+  x=$($GREP $opts "$pattern" documentation/book/)
   if [ -n "$x" ]; then
     echo "$description:"
     echo "$x"

--- a/HACKING.md
+++ b/HACKING.md
@@ -36,8 +36,8 @@ In order to use `make` these all need to be available in your `$PATH`.
 
 The `make` build is using GNU versions of `find` and `sed` utilities and is not compatible with the BSD versions available on Mac OS. 
 When using Mac OS, you have to install the GNU versions of `find` and `sed`.
-When using `brew`, you can do `brew install gnu-sed findutils`.
-This command will install the GNU versions as `gsed` and `gfind` and our `make` build will automatically pick them up and use them.   
+When using `brew`, you can do `brew install gnu-sed findutils grep coreutils`.
+This command will install the GNU versions as `gcp`, `ggrep`, `gsed` and `gfind` and our `make` build will automatically pick them up and use them.   
 
 ## Docker images
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ release_single_file:
 helm_pkg:
 	# Copying unarchived Helm Chart to release directory
 	mkdir -p strimzi-$(RELEASE_VERSION)/charts/
-	cp -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)
+	$(CP) -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)
 	# Packaging helm chart with semantic version: $(CHART_SEMANTIC_RELEASE_VERSION)
 	helm package --version $(CHART_SEMANTIC_RELEASE_VERSION) --app-version $(CHART_SEMANTIC_RELEASE_VERSION) --destination ./ $(CHART_PATH)
 	mv strimzi-kafka-operator-$(CHART_SEMANTIC_RELEASE_VERSION).tgz strimzi-kafka-operator-helm-chart-$(CHART_SEMANTIC_RELEASE_VERSION).tgz
@@ -70,14 +70,14 @@ helm_pkg:
 
 docu_html: docu_htmlclean docu_check
 	mkdir -p documentation/html
-	cp -vrL documentation/book/images documentation/html/images
+	$(CP) -vrL documentation/book/images documentation/html/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/book/master.adoc -o documentation/html/index.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
 
 
 docu_htmlnoheader: docu_htmlnoheaderclean docu_check
 	mkdir -p documentation/htmlnoheader
-	cp -vrL documentation/book/images documentation/htmlnoheader/images
+	$(CP) -vrL documentation/book/images documentation/htmlnoheader/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/book/master.adoc -o documentation/htmlnoheader/master.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing.html
 
@@ -92,8 +92,8 @@ pushtonexus:
 
 release_docu: docu_html docu_htmlnoheader
 	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	cp -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
-	cp -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/
+	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/
 
 docu_clean: docu_htmlclean docu_htmlnoheaderclean
 

--- a/Makefile.os
+++ b/Makefile.os
@@ -1,8 +1,12 @@
 FIND = find
 SED = sed
+GREP = grep
+CP = cp
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	FIND = gfind
 	SED = gsed
+	GREP = ggrep
+	CP = gcp
 endif

--- a/documentation/book/assembly-getting-started-strimzi-admin.adoc
+++ b/documentation/book/assembly-getting-started-strimzi-admin.adoc
@@ -1,0 +1,13 @@
+// This assembly is included in the following assemblies:
+//
+// getting-started.adoc
+
+[id='assembly-getting-started-strimzi-admin-{context}']
+= Strimzi Administrator
+
+{ProductName} adds several custom resources.
+By default, only {ProductPlatformName} cluster administrators users will have the rights to create, edit and delete these resources.
+To allow also other users to manage the {ProductName} resources, they have to be granted these permissions.
+
+include::proc-adding-users-the-strimzi-admin-role.adoc[leveloffset=+1]
+

--- a/documentation/book/assembly-getting-started-strimzi-admin.adoc
+++ b/documentation/book/assembly-getting-started-strimzi-admin.adoc
@@ -3,11 +3,11 @@
 // getting-started.adoc
 
 [id='assembly-getting-started-strimzi-admin-{context}']
-= Strimzi Administrator
+= Strimzi Administrators
 
-{ProductName} adds several custom resources.
-By default, only {ProductPlatformName} cluster administrators users will have the rights to create, edit and delete these resources.
-To allow also other users to manage the {ProductName} resources, they have to be granted these permissions.
+{ProductName} includes several custom resources.
+By default, permission to create, edit, and delete these resources is limited to {ProductPlatformName} cluster administrators.
+If you want to allow non-cluster administators to manage {ProductName} resources, you must assign them the Strimzi Administrator role.
 
-include::proc-adding-users-the-strimzi-admin-role.adoc[leveloffset=+1]
+include::proc-designating-strimzi-administrators.adoc[leveloffset=+1]
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -47,3 +47,5 @@ include::proc-deploying-example-clients.adoc[leveloffset=+1]
 include::assembly-getting-started-topic-operator.adoc[leveloffset=+1]
 
 include::assembly-getting-started-user-operator.adoc[leveloffset=+1]
+
+include::assembly-getting-started-strimzi-admin.adoc[leveloffset=+1]

--- a/documentation/book/proc-adding-users-the-strimzi-admin-role.adoc
+++ b/documentation/book/proc-adding-users-the-strimzi-admin-role.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// assembly-getting-started-strimzi-admin.adoc
+
+[id='proc-adding-users-the-strimzi-admin-role-{context}']
+= Deploying the User Operator using the Cluster Operator
+
+.Prerequisites
+
+* {ProductName} `CustomResourceDefinitions` installed
+
+.Procedure
+
+. Create the `strimzi-admin` cluster role in {ProductPlatformName}.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f install/strimzi-admin
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f install/strimzi-admin
+
+. Assign the `strimzi-admin` cluster role to an existing {ProductPlatformName} user(s).
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl create`:
+[source,shell,subs=+quotes]
+kubectl create clusterrolebinding strimzi-admin --clusterrole=strimzi-admin --user=_user1_ --user=_user2_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc adm`:
++
+[source,shell,subs=+quotes]
+oc adm policy add-cluster-role-to-user strimzi-admin _user1_ _user2_

--- a/documentation/book/proc-designating-strimzi-administrators.adoc
+++ b/documentation/book/proc-designating-strimzi-administrators.adoc
@@ -3,36 +3,36 @@
 // assembly-getting-started-strimzi-admin.adoc
 
 [id='proc-adding-users-the-strimzi-admin-role-{context}']
-= Deploying the User Operator using the Cluster Operator
+= Designating Strimzi Administrators
 
 .Prerequisites
 
-* {ProductName} `CustomResourceDefinitions` installed
+* {ProductName} `CustomResourceDefinitions` are installed.
 
 .Procedure
 
 . Create the `strimzi-admin` cluster role in {ProductPlatformName}.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName}, use `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f install/strimzi-admin
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName}, use `oc apply`:
 +
 [source,shell,subs=+quotes]
 oc apply -f install/strimzi-admin
 
-. Assign the `strimzi-admin` cluster role to an existing {ProductPlatformName} user(s).
+. Assign the `strimzi-admin` `ClusterRole` to one or more existing users in the {ProductPlatformName} cluster.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl create`:
+On {KubernetesName}, use `kubectl create`:
 [source,shell,subs=+quotes]
 kubectl create clusterrolebinding strimzi-admin --clusterrole=strimzi-admin --user=_user1_ --user=_user2_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc adm`:
+On {OpenShiftName}, use `oc adm`:
 +
 [source,shell,subs=+quotes]
 oc adm policy add-cluster-role-to-user strimzi-admin _user1_ _user2_

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,11 +5,11 @@ RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
 
 release:
 	mkdir -p $(RELEASE_PATH)
-	cp -r ./templates $(RELEASE_PATH)/
-	cp -r ./kafka $(RELEASE_PATH)/
-	cp -r ./kafka-connect $(RELEASE_PATH)/
-	cp -r ./kafka-mirror-maker $(RELEASE_PATH)/
-	cp -r ./user $(RELEASE_PATH)/
-	cp -r ./topic $(RELEASE_PATH)/
+	$(CP) -r ./templates $(RELEASE_PATH)/
+	$(CP) -r ./kafka $(RELEASE_PATH)/
+	$(CP) -r ./kafka-connect $(RELEASE_PATH)/
+	$(CP) -r ./kafka-mirror-maker $(RELEASE_PATH)/
+	$(CP) -r ./user $(RELEASE_PATH)/
+	$(CP) -r ./topic $(RELEASE_PATH)/
 
 .PHONY: all build clean docker_build docker_push docker_tag

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -38,18 +38,18 @@ helm_install: helm_clean helm_template
 	$(FIND) $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -printf "%p " -exec yq r {} kind \; \
 	| grep -v 'CustomResourceDefinition$$' \
 	| $(SED) -E 's/([^ ]*) ([a-zA-Z0-9]*)$$/\1/' \
-	| xargs -IFILE cp FILE $(CHART_RENDERED_TEMPLATES_INSTALL)
+	| xargs -IFILE $(CP) FILE $(CHART_RENDERED_TEMPLATES_INSTALL)
 	# Copying rendered template files to: $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
 	mkdir -p $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
 	# Find rendered resources which are not CustomResourceDefinition and move them
 	$(FIND) $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*ClusterRole-*.yaml' -printf "%p " -exec yq r {} kind \; \
 	| $(SED) -E 's/([^ ]*) ([a-zA-Z0-9]*)$$/\1/' \
-	| xargs -IFILE cp FILE $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
+	| xargs -IFILE $(CP) FILE $(CHART_RENDERED_TEMPLATES_CLUSTERROLES)
 
 helm_pkg: helm_lint helm_install
 	# Copying unarchived Helm Chart to release directory
 	mkdir -p strimzi-$(RELEASE_VERSION)/charts/
-	cp -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)
+	$(CP) -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)
 	# Packaging helm chart with semantic version: $(CHART_SEMANTIC_RELEASE_VERSION)
 	helm package --version $(CHART_SEMANTIC_RELEASE_VERSION) --app-version $(CHART_SEMANTIC_RELEASE_VERSION) --destination ./ $(CHART_PATH)
 	rm -rf strimzi-$(RELEASE_VERSION)

--- a/install/Makefile
+++ b/install/Makefile
@@ -5,8 +5,8 @@ RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
 
 release:
 	mkdir -p $(RELEASE_PATH)
-	cp -r ./cluster-operator $(RELEASE_PATH)/
-	cp -r ./user-operator $(RELEASE_PATH)/
-	cp -r ./topic-operator $(RELEASE_PATH)/
+	$(CP) -r ./cluster-operator $(RELEASE_PATH)/
+	$(CP) -r ./user-operator $(RELEASE_PATH)/
+	$(CP) -r ./topic-operator $(RELEASE_PATH)/
 
 .PHONY: all build clean docker_build docker_push docker_tag

--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-admin
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  - kafkamirrormakers
+  - kafkausers
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -5,7 +5,7 @@ RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/examples/$(PROJECT_NAME)
 release:
 	mkdir -p $(RELEASE_PATH)
 	mkdir -p $(RELEASE_PATH)/grafana-dashboards
-	cp -r ./examples/kafka/* $(RELEASE_PATH)/
-	cp -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
+	$(CP) -r ./examples/kafka/* $(RELEASE_PATH)/
+	$(CP) -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
 
 .PHONY: all build clean docker_build docker_push docker_tag


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

Currently, after Strimzi is installed, only cluster admins can create the Strimzi objects. This PR adds a new chapter to the docs which describes how to add the `strimzi-admin` role to users. It also adds the file with he role to `install/strimzi-admin`.

In addition to that, it also fixes several more issues related to MacOS in the build - mainly around `grep` and `cp` commands.