### PR TITLE
Fixed the context in two xrefs

### DIFF
--- a/documentation/book/proc-creating-a-topic.adoc
+++ b/documentation/book/proc-creating-a-topic.adoc
@@ -52,4 +52,4 @@ oc apply -f _your-file_
 * For more information about the schema for `KafkaTopics`, see xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].
 * For more information about deploying a Kafka cluster using the Cluster Operator, see xref:cluster-operator-str[].
 * For more information about deploying the Topic Operator using the Cluster Operator, see xref:deploying-the-topic-operator-using-the-cluster-operator-str[].
-* For more information about deploying the standalone Topic Operator, see xref:deploying-the-topic-operator-standalone-deploying[].
+* For more information about deploying the standalone Topic Operator, see xref:deploying-the-topic-operator-standalone-str[].

--- a/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
@@ -6,8 +6,8 @@
 [id='deploying-the-topic-operator-using-the-cluster-operator-{context}']
 = Deploying the Topic Operator using the Cluster Operator
 
-This procedure describes how to deploy the Topic Operator using the Cluster Operator. 
-If you want to use the Topic Operator with a Kafka cluster that is not managed by {ProductName}, you must deploy the Topic Operator as a standalone component. For more information, see xref:deploying-the-topic-operator-standalone-deploying[].
+This procedure describes how to deploy the Topic Operator using the Cluster Operator.
+If you want to use the Topic Operator with a Kafka cluster that is not managed by {ProductName}, you must deploy the Topic Operator as a standalone component. For more information, see xref:deploying-the-topic-operator-standalone-str[].
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixed build errors. Unknown ID or title "deploying-the-topic-operator-standalone-deploying", used as an internal cross reference

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

