### PR TITLE
Moved Clients CA create/renew as the same Cluster CA

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1077,7 +1077,7 @@ public abstract class AbstractModel {
         return ANCILLARY_CM_KEY_LOG_CONFIG;
     }
 
-    public static String clusterCaSecretName(String cluster)  {
+    public static String clusterCaCertSecretName(String cluster)  {
         return cluster + "-cluster-ca-cert";
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1077,11 +1077,11 @@ public abstract class AbstractModel {
         return ANCILLARY_CM_KEY_LOG_CONFIG;
     }
 
-    public static String getClusterCaName(String cluster)  {
+    public static String clusterCaSecretName(String cluster)  {
         return cluster + "-cluster-ca-cert";
     }
 
-    public static String getClusterCaKeyName(String cluster)  {
+    public static String clusterCaKeySecretName(String cluster)  {
         return cluster + "-cluster-ca";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -44,9 +44,9 @@ public class ClusterCa extends Ca {
                      int renewalDays,
                      boolean generateCa) {
         super(certManager, "cluster-ca",
-                AbstractModel.getClusterCaName(clusterName),
+                AbstractModel.clusterCaSecretName(clusterName),
                 forceRenewal(clusterCaCert, clusterCaKey, "cluster-ca.key"),
-                AbstractModel.getClusterCaKeyName(clusterName),
+                AbstractModel.clusterCaKeySecretName(clusterName),
                 adapt060ClusterCaSecret(clusterCaKey),
                 validityDays, renewalDays, generateCa);
         this.clusterName = clusterName;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -44,7 +44,7 @@ public class ClusterCa extends Ca {
                      int renewalDays,
                      boolean generateCa) {
         super(certManager, "cluster-ca",
-                AbstractModel.clusterCaSecretName(clusterName),
+                AbstractModel.clusterCaCertSecretName(clusterName),
                 forceRenewal(clusterCaCert, clusterCaKey, "cluster-ca.key"),
                 AbstractModel.clusterCaKeySecretName(clusterName),
                 adapt060ClusterCaSecret(clusterCaKey),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -212,7 +212,7 @@ public class EntityOperator extends AbstractModel {
             volumeList.addAll(userOperator.getVolumes());
         }
         volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.secretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.getClusterCaName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -212,7 +212,7 @@ public class EntityOperator extends AbstractModel {
             volumeList.addAll(userOperator.getVolumes());
         }
         volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.secretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -190,8 +190,8 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_WATCHED_NAMESPACE, watchedNamespace));
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCASecretName(cluster)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsPublicKeyName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.getClientsCaKeyName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.getClientsCaName(cluster)));
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -191,7 +191,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCaKeySecretName(cluster)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsCaSecretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsCaCertSecretName(cluster)));
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -190,8 +190,8 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_WATCHED_NAMESPACE, watchedNamespace));
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.getClientsCaKeyName(cluster)));
-        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.getClientsCaName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCaKeySecretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsCaSecretName(cluster)));
         return varList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -228,7 +228,7 @@ public class KafkaCluster extends AbstractModel {
         return cluster + KafkaCluster.SECRET_BROKERS_SUFFIX;
     }
 
-    public static String clientsCaSecretName(String cluster) {
+    public static String clientsCaCertSecretName(String cluster) {
         return cluster + KafkaCluster.SECRET_CLIENTS_CA_SUFFIX;
     }
 
@@ -566,9 +566,9 @@ public class KafkaCluster extends AbstractModel {
         if (rack != null || isExposedWithNodePort()) {
             volumeList.add(createEmptyDirVolume(INIT_VOLUME_NAME));
         }
-        volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         volumeList.add(createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.clientsCaSecretName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.clientsCaCertSecretName(cluster), isOpenShift));
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         return volumeList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -220,7 +220,7 @@ public class KafkaCluster extends AbstractModel {
         return kafkaClusterName(cluster) + "-" + pod;
     }
 
-    public static String getClientsCaKeyName(String cluster) {
+    public static String clientsCaKeySecretName(String cluster) {
         return cluster + KafkaCluster.SECRET_CLIENTS_CA_KEY_SUFFIX;
     }
 
@@ -228,7 +228,7 @@ public class KafkaCluster extends AbstractModel {
         return cluster + KafkaCluster.SECRET_BROKERS_SUFFIX;
     }
 
-    public static String getClientsCaName(String cluster) {
+    public static String clientsCaSecretName(String cluster) {
         return cluster + KafkaCluster.SECRET_CLIENTS_CA_SUFFIX;
     }
 
@@ -566,9 +566,9 @@ public class KafkaCluster extends AbstractModel {
         if (rack != null || isExposedWithNodePort()) {
             volumeList.add(createEmptyDirVolume(INIT_VOLUME_NAME));
         }
-        volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.getClusterCaName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
         volumeList.add(createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.getClientsCaName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.clientsCaSecretName(cluster), isOpenShift));
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         return volumeList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -121,9 +121,8 @@ public class KafkaCluster extends AbstractModel {
 
     // Suffixes for secrets with certificates
     private static final String SECRET_BROKERS_SUFFIX = NAME_SUFFIX + "-brokers";
-    private static final String SECRET_CLUSTER_PUBLIC_KEY_SUFFIX = "-cert";
-    private static final String SECRET_CLIENTS_CA_SUFFIX = "-clients-ca";
-    private static final String SECRET_CLIENTS_PUBLIC_KEY_SUFFIX = "-clients-ca-cert";
+    private static final String SECRET_CLIENTS_CA_KEY_SUFFIX = "-clients-ca";
+    private static final String SECRET_CLIENTS_CA_SUFFIX = "-clients-ca-cert";
 
     protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
@@ -221,20 +220,16 @@ public class KafkaCluster extends AbstractModel {
         return kafkaClusterName(cluster) + "-" + pod;
     }
 
-    public static String clientsCASecretName(String cluster) {
-        return cluster + KafkaCluster.SECRET_CLIENTS_CA_SUFFIX;
+    public static String getClientsCaKeyName(String cluster) {
+        return cluster + KafkaCluster.SECRET_CLIENTS_CA_KEY_SUFFIX;
     }
 
     public static String brokersSecretName(String cluster) {
         return cluster + KafkaCluster.SECRET_BROKERS_SUFFIX;
     }
 
-    public static String clientsPublicKeyName(String cluster) {
-        return cluster + KafkaCluster.SECRET_CLIENTS_PUBLIC_KEY_SUFFIX;
-    }
-
-    public static String clusterPublicKeyName(String cluster) {
-        return getClusterCaName(cluster);
+    public static String getClientsCaName(String cluster) {
+        return cluster + KafkaCluster.SECRET_CLIENTS_CA_SUFFIX;
     }
 
     public static KafkaCluster fromCrd(Kafka kafkaAssembly) {
@@ -303,12 +298,10 @@ public class KafkaCluster extends AbstractModel {
      * Manage certificates generation based on those already present in the Secrets
      * @param clusterCa The certificates
      */
-    public void generateCertificates(Kafka kafka, ClusterCa clusterCa, ClientsCa clientsCa, String externalBootstrapDnsName, Map<Integer, String> externalDnsNames) {
+    public void generateCertificates(Kafka kafka, ClusterCa clusterCa, String externalBootstrapDnsName, Map<Integer, String> externalDnsNames) {
         log.debug("Generating certificates");
 
         try {
-            clientsCa.createOrRenew(kafka.getMetadata().getNamespace(), kafka.getMetadata().getName(),
-                    labels.toMap(), createOwnerReference());
             brokerCerts = clusterCa.generateBrokerCerts(kafka, externalBootstrapDnsName, externalDnsNames);
         } catch (IOException e) {
             log.warn("Error while generating certificates", e);
@@ -575,7 +568,7 @@ public class KafkaCluster extends AbstractModel {
         }
         volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.getClusterCaName(cluster), isOpenShift));
         volumeList.add(createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.clientsPublicKeyName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaCluster.getClientsCaName(cluster), isOpenShift));
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
 
         return volumeList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -344,7 +344,7 @@ public class TopicOperator extends AbstractModel {
         List<Volume> volumeList = new ArrayList<>();
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TopicOperator.secretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.getClusterCaName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -344,7 +344,7 @@ public class TopicOperator extends AbstractModel {
         List<Volume> volumeList = new ArrayList<>();
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TopicOperator.secretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -391,7 +391,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -391,7 +391,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));
-        volumeList.add(createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.getClusterCaName(cluster), isOpenShift));
+        volumeList.add(createSecretVolume(TLS_SIDECAR_CLUSTER_CA_VOLUME_NAME, AbstractModel.clusterCaSecretName(cluster), isOpenShift));
         return volumeList;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -941,18 +941,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return getReconciliationStateOfConfigMap(kafkaCluster, kafkaMetricsAndLogsConfigMap, this::withKafkaAncillaryCmChanged);
         }
 
-        Future<ReconciliationState> kafkaClientsCaKeySecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaKeySecretName(name), clientsCa.caKeySecret()));
-        }
-
-        Future<ReconciliationState> kafkaClientsCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaCertSecretName(name), clientsCa.caCertSecret()));
-        }
-
-        Future<ReconciliationState> kafkaClusterCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterCaCertSecretName(name), clusterCa.caCertSecret()));
-        }
-
         Future<ReconciliationState> kafkaBrokersSecret() {
             return withVoid(secretOperations.reconcile(namespace, KafkaCluster.brokersSecretName(name), kafkaCluster.generateBrokersSecret()));
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -117,7 +117,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return Future.failedFuture("Spec cannot be null");
         }
         new ReconciliationState(reconciliation, kafkaAssembly)
-                .reconcileClusterCa()
+                .reconcileCas()
                 // Roll everything so the new CA is added to the trust store.
                 .compose(state -> state.rollingUpdateForNewCaCert())
 
@@ -154,9 +154,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.kafkaReplicaRoutesReady())
                 .compose(state -> state.kafkaGenerateCertificates())
                 .compose(state -> state.kafkaAncillaryCm())
-                .compose(state -> state.kafkaClientsCaKeySecret())
-                .compose(state -> state.kafkaClientsCaSecret())
-                .compose(state -> state.kafkaClusterCaSecret())
                 .compose(state -> state.kafkaBrokersSecret())
                 .compose(state -> state.kafkaNetPolicy())
                 .compose(state -> state.kafkaStatefulSet())
@@ -234,24 +231,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         /**
          * Asynchronously reconciles the cluster and clients CA secrets.
-         * The cluster CA secret has to have the name determined by {@link AbstractModel#getClusterCaName(String)}.
-         * The clients CA secret has to have the name determined by {@link KafkaCluster#getClientsCaName(String)}.
+         * The cluster CA secret has to have the name determined by {@link AbstractModel#clusterCaSecretName(String)}.
+         * The clients CA secret has to have the name determined by {@link KafkaCluster#clientsCaSecretName(String)}.
          * Within both the secrets the current certificate is stored under the key {@code ca.crt}
          * and the current key is stored under the key {@code ca.key}.
          * Old certificates which are still within their validity are stored under keys named like {@code ca-<not-after-date>.crt}, where
          * {@code <not-after-date>} is the ISO 8601-formatted date of the certificates "notAfter" attribute.
          * Likewise, the corresponding keys are stored under keys named like {@code ca-<not-after-date>.key}.
          */
-        Future<ReconciliationState>  reconcileClusterCa() {
+        Future<ReconciliationState> reconcileCas() {
             Labels caLabels = Labels.userLabels(kafkaAssembly.getMetadata().getLabels()).withKind(reconciliation.type().toString()).withCluster(reconciliation.name());
             Future<ReconciliationState> result = Future.future();
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        String clusterCaCertName = AbstractModel.getClusterCaName(name);
-                        String clusterCaKeyName = AbstractModel.getClusterCaKeyName(name);
-                        String clientsCaCertName = KafkaCluster.getClientsCaName(name);
-                        String clientsCaKeyName = KafkaCluster.getClientsCaKeyName(name);
+                        String clusterCaCertName = AbstractModel.clusterCaSecretName(name);
+                        String clusterCaKeyName = AbstractModel.clusterCaKeySecretName(name);
+                        String clientsCaCertName = KafkaCluster.clientsCaSecretName(name);
+                        String clientsCaKeyName = KafkaCluster.clientsCaKeySecretName(name);
                         Secret clusterCaCertSecret = null;
                         Secret clusterCaKeySecret = null;
                         Secret clientsCaCertSecret = null;
@@ -948,15 +945,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaClientsCaKeySecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.getClientsCaKeyName(name), clientsCa.caKeySecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaKeySecretName(name), clientsCa.caKeySecret()));
         }
 
         Future<ReconciliationState> kafkaClientsCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.getClientsCaName(name), clientsCa.caCertSecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaSecretName(name), clientsCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaClusterCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.getClusterCaName(name), clusterCa.caCertSecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterCaSecretName(name), clusterCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaBrokersSecret() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -231,13 +231,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         /**
          * Asynchronously reconciles the cluster and clients CA secrets.
-         * The cluster CA secret has to have the name determined by {@link AbstractModel#clusterCaSecretName(String)}.
-         * The clients CA secret has to have the name determined by {@link KafkaCluster#clientsCaSecretName(String)}.
+         * The cluster CA secret has to have the name determined by {@link AbstractModel#clusterCaCertSecretName(String)}.
+         * The clients CA secret has to have the name determined by {@link KafkaCluster#clientsCaCertSecretName(String)}.
          * Within both the secrets the current certificate is stored under the key {@code ca.crt}
          * and the current key is stored under the key {@code ca.key}.
-         * Old certificates which are still within their validity are stored under keys named like {@code ca-<not-after-date>.crt}, where
-         * {@code <not-after-date>} is the ISO 8601-formatted date of the certificates "notAfter" attribute.
-         * Likewise, the corresponding keys are stored under keys named like {@code ca-<not-after-date>.key}.
          */
         Future<ReconciliationState> reconcileCas() {
             Labels caLabels = Labels.userLabels(kafkaAssembly.getMetadata().getLabels()).withKind(reconciliation.type().toString()).withCluster(reconciliation.name());
@@ -245,9 +242,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        String clusterCaCertName = AbstractModel.clusterCaSecretName(name);
+                        String clusterCaCertName = AbstractModel.clusterCaCertSecretName(name);
                         String clusterCaKeyName = AbstractModel.clusterCaKeySecretName(name);
-                        String clientsCaCertName = KafkaCluster.clientsCaSecretName(name);
+                        String clientsCaCertName = KafkaCluster.clientsCaCertSecretName(name);
                         String clientsCaKeyName = KafkaCluster.clientsCaKeySecretName(name);
                         Secret clusterCaCertSecret = null;
                         Secret clusterCaKeySecret = null;
@@ -949,11 +946,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaClientsCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaSecretName(name), clientsCa.caCertSecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clientsCaCertSecretName(name), clientsCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaClusterCaSecret() {
-            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterCaSecretName(name), clusterCa.caCertSecret()));
+            return withVoid(secretOperations.reconcile(namespace, KafkaCluster.clusterCaCertSecretName(name), clusterCa.caCertSecret()));
         }
 
         Future<ReconciliationState> kafkaBrokersSecret() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -104,18 +104,20 @@ public class ResourceUtils {
                 .endSpec().build();
     }
 
-    public static List<Secret> createKafkaClusterInitialSecrets(String clusterCmNamespace, String clusterName) {
+    public static List<Secret> createKafkaClusterInitialSecrets(String clusterNamespace, String clusterName) {
         List<Secret> secrets = new ArrayList<>();
-        secrets.add(createInitialClusterCaCertSecret(clusterCmNamespace, clusterName,
-                MockCertManager.clusterCaCert()));
-        secrets.add(createInitialClusterCaKeySecret(clusterCmNamespace, clusterName,
-                MockCertManager.clusterCaKey()));
+        secrets.add(createInitialCaCertSecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert()));
+        secrets.add(createInitialCaKeySecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey()));
         return secrets;
     }
 
-    public static ClusterCa createInitialClusterCa(String clusterCmNamespace, String clusterName) {
-        Secret initialClusterCaCertSecret = createInitialClusterCaCertSecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaCert());
-        Secret initialClusterCaKeySecret = createInitialClusterCaKeySecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaKey());
+    public static ClusterCa createInitialClusterCa(String clusterNamespace, String clusterName) {
+        Secret initialClusterCaCertSecret = createInitialCaCertSecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert());
+        Secret initialClusterCaKeySecret = createInitialCaKeySecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey());
         return createInitialClusterCa(clusterName, initialClusterCaCertSecret, initialClusterCaKeySecret);
     }
 
@@ -123,9 +125,11 @@ public class ResourceUtils {
         return new ClusterCa(new MockCertManager(), clusterName, initialClusterCaCert, initialClusterCaKey);
     }
 
-    public static ClientsCa createInitialClientsCa(String clusterCmNamespace, String clusterName) {
-        Secret initialClusterCaCertSecret = createInitialClusterCaCertSecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaCert());
-        Secret initialClusterCaKeySecret = createInitialClusterCaKeySecret(clusterCmNamespace, clusterName, MockCertManager.clusterCaKey());
+    public static ClientsCa createInitialClientsCa(String clusterNamespace, String clusterName) {
+        Secret initialClusterCaCertSecret = createInitialCaCertSecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert());
+        Secret initialClusterCaKeySecret = createInitialCaKeySecret(clusterNamespace, clusterName,
+                AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey());
         return createInitialClientsCa(clusterName, initialClusterCaCertSecret, initialClusterCaKeySecret);
     }
 
@@ -138,35 +142,35 @@ public class ResourceUtils {
                 365, 30, true);
     }
 
-    public static Secret createInitialClusterCaCertSecret(String clusterCmNamespace, String clusterName, String caCert) {
+    public static Secret createInitialCaCertSecret(String clusterNamespace, String clusterName, String secretName, String caCert) {
         return new SecretBuilder()
-        .withNewMetadata()
-            .withName(AbstractModel.clusterCaSecretName(clusterName))
-            .withNamespace(clusterCmNamespace)
-            .withLabels(Labels.forCluster(clusterName).withKind("Kafka").toMap())
-        .endMetadata()
-        .addToData("ca.crt", caCert)
-        .build();
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(clusterNamespace)
+                    .withLabels(Labels.forCluster(clusterName).withKind(Kafka.RESOURCE_KIND).toMap())
+                .endMetadata()
+                .addToData("ca.crt", caCert)
+                .build();
     }
 
-    public static Secret createInitialClusterCaKeySecret(String clusterCmNamespace, String clusterName, String caKey) {
+    public static Secret createInitialCaKeySecret(String clusterNamespace, String clusterName, String secretName, String caKey) {
         return new SecretBuilder()
-        .withNewMetadata()
-            .withName(AbstractModel.clusterCaKeySecretName(clusterName))
-            .withNamespace(clusterCmNamespace)
-            .withLabels(Labels.forCluster(clusterName).withKind("Kafka").toMap())
-        .endMetadata()
-        .addToData("ca.key", caKey)
-        .build();
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(clusterNamespace)
+                    .withLabels(Labels.forCluster(clusterName).withKind(Kafka.RESOURCE_KIND).toMap())
+                .endMetadata()
+                .addToData("ca.key", caKey)
+                .build();
     }
 
     public static List<Secret> createKafkaClusterSecretsWithReplicas(String clusterCmNamespace, String clusterName, int kafkaReplicas, int zkReplicas) {
         List<Secret> secrets = new ArrayList<>();
 
-        secrets.add(createInitialClusterCaKeySecret(clusterCmNamespace, clusterName,
-                MockCertManager.clusterCaKey()));
-        secrets.add(createInitialClusterCaCertSecret(clusterCmNamespace, clusterName,
-                MockCertManager.clusterCaCert()));
+        secrets.add(createInitialCaKeySecret(clusterCmNamespace, clusterName,
+                AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey()));
+        secrets.add(createInitialCaCertSecret(clusterCmNamespace, clusterName,
+                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert()));
 
         secrets.add(
                 new SecretBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -131,9 +131,9 @@ public class ResourceUtils {
 
     public static ClientsCa createInitialClientsCa(String clusterName, Secret initialClientsCaCert, Secret initialClientsCaKey) {
         return new ClientsCa(new MockCertManager(),
-                KafkaCluster.clientsPublicKeyName(clusterName),
+                KafkaCluster.getClientsCaName(clusterName),
                 initialClientsCaCert,
-                KafkaCluster.clientsCASecretName(clusterName),
+                KafkaCluster.getClientsCaKeyName(clusterName),
                 initialClientsCaKey,
                 365, 30, true);
     }
@@ -171,7 +171,7 @@ public class ResourceUtils {
         secrets.add(
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.clientsCASecretName(clusterName))
+                        .withName(KafkaCluster.getClientsCaKeyName(clusterName))
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
@@ -183,7 +183,7 @@ public class ResourceUtils {
         secrets.add(
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.clientsPublicKeyName(clusterName))
+                        .withName(KafkaCluster.getClientsCaName(clusterName))
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
@@ -208,7 +208,7 @@ public class ResourceUtils {
 
         builder = new SecretBuilder()
                         .withNewMetadata()
-                            .withName(KafkaCluster.clusterPublicKeyName(clusterName))
+                            .withName(KafkaCluster.getClusterCaName(clusterName))
                             .withNamespace(clusterCmNamespace)
                             .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -131,9 +131,9 @@ public class ResourceUtils {
 
     public static ClientsCa createInitialClientsCa(String clusterName, Secret initialClientsCaCert, Secret initialClientsCaKey) {
         return new ClientsCa(new MockCertManager(),
-                KafkaCluster.getClientsCaName(clusterName),
+                KafkaCluster.clientsCaSecretName(clusterName),
                 initialClientsCaCert,
-                KafkaCluster.getClientsCaKeyName(clusterName),
+                KafkaCluster.clientsCaKeySecretName(clusterName),
                 initialClientsCaKey,
                 365, 30, true);
     }
@@ -141,7 +141,7 @@ public class ResourceUtils {
     public static Secret createInitialClusterCaCertSecret(String clusterCmNamespace, String clusterName, String caCert) {
         return new SecretBuilder()
         .withNewMetadata()
-            .withName(AbstractModel.getClusterCaName(clusterName))
+            .withName(AbstractModel.clusterCaSecretName(clusterName))
             .withNamespace(clusterCmNamespace)
             .withLabels(Labels.forCluster(clusterName).withKind("Kafka").toMap())
         .endMetadata()
@@ -152,7 +152,7 @@ public class ResourceUtils {
     public static Secret createInitialClusterCaKeySecret(String clusterCmNamespace, String clusterName, String caKey) {
         return new SecretBuilder()
         .withNewMetadata()
-            .withName(AbstractModel.getClusterCaKeyName(clusterName))
+            .withName(AbstractModel.clusterCaKeySecretName(clusterName))
             .withNamespace(clusterCmNamespace)
             .withLabels(Labels.forCluster(clusterName).withKind("Kafka").toMap())
         .endMetadata()
@@ -171,7 +171,7 @@ public class ResourceUtils {
         secrets.add(
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.getClientsCaKeyName(clusterName))
+                        .withName(KafkaCluster.clientsCaKeySecretName(clusterName))
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
@@ -183,7 +183,7 @@ public class ResourceUtils {
         secrets.add(
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.getClientsCaName(clusterName))
+                        .withName(KafkaCluster.clientsCaSecretName(clusterName))
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
@@ -208,7 +208,7 @@ public class ResourceUtils {
 
         builder = new SecretBuilder()
                         .withNewMetadata()
-                            .withName(KafkaCluster.getClusterCaName(clusterName))
+                            .withName(KafkaCluster.clusterCaSecretName(clusterName))
                             .withNamespace(clusterCmNamespace)
                             .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -107,7 +107,7 @@ public class ResourceUtils {
     public static List<Secret> createKafkaClusterInitialSecrets(String clusterNamespace, String clusterName) {
         List<Secret> secrets = new ArrayList<>();
         secrets.add(createInitialCaCertSecret(clusterNamespace, clusterName,
-                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert()));
+                AbstractModel.clusterCaCertSecretName(clusterName), MockCertManager.clusterCaCert()));
         secrets.add(createInitialCaKeySecret(clusterNamespace, clusterName,
                 AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey()));
         return secrets;
@@ -115,7 +115,7 @@ public class ResourceUtils {
 
     public static ClusterCa createInitialClusterCa(String clusterNamespace, String clusterName) {
         Secret initialClusterCaCertSecret = createInitialCaCertSecret(clusterNamespace, clusterName,
-                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert());
+                AbstractModel.clusterCaCertSecretName(clusterName), MockCertManager.clusterCaCert());
         Secret initialClusterCaKeySecret = createInitialCaKeySecret(clusterNamespace, clusterName,
                 AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey());
         return createInitialClusterCa(clusterName, initialClusterCaCertSecret, initialClusterCaKeySecret);
@@ -127,7 +127,7 @@ public class ResourceUtils {
 
     public static ClientsCa createInitialClientsCa(String clusterNamespace, String clusterName) {
         Secret initialClusterCaCertSecret = createInitialCaCertSecret(clusterNamespace, clusterName,
-                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert());
+                AbstractModel.clusterCaCertSecretName(clusterName), MockCertManager.clusterCaCert());
         Secret initialClusterCaKeySecret = createInitialCaKeySecret(clusterNamespace, clusterName,
                 AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey());
         return createInitialClientsCa(clusterName, initialClusterCaCertSecret, initialClusterCaKeySecret);
@@ -135,7 +135,7 @@ public class ResourceUtils {
 
     public static ClientsCa createInitialClientsCa(String clusterName, Secret initialClientsCaCert, Secret initialClientsCaKey) {
         return new ClientsCa(new MockCertManager(),
-                KafkaCluster.clientsCaSecretName(clusterName),
+                KafkaCluster.clientsCaCertSecretName(clusterName),
                 initialClientsCaCert,
                 KafkaCluster.clientsCaKeySecretName(clusterName),
                 initialClientsCaKey,
@@ -170,7 +170,7 @@ public class ResourceUtils {
         secrets.add(createInitialCaKeySecret(clusterCmNamespace, clusterName,
                 AbstractModel.clusterCaKeySecretName(clusterName), MockCertManager.clusterCaKey()));
         secrets.add(createInitialCaCertSecret(clusterCmNamespace, clusterName,
-                AbstractModel.clusterCaSecretName(clusterName), MockCertManager.clusterCaCert()));
+                AbstractModel.clusterCaCertSecretName(clusterName), MockCertManager.clusterCaCert()));
 
         secrets.add(
                 new SecretBuilder()
@@ -187,7 +187,7 @@ public class ResourceUtils {
         secrets.add(
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.clientsCaSecretName(clusterName))
+                        .withName(KafkaCluster.clientsCaCertSecretName(clusterName))
                         .withNamespace(clusterCmNamespace)
                         .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()
@@ -212,7 +212,7 @@ public class ResourceUtils {
 
         builder = new SecretBuilder()
                         .withNewMetadata()
-                            .withName(KafkaCluster.clusterCaSecretName(clusterName))
+                            .withName(KafkaCluster.clusterCaCertSecretName(clusterName))
                             .withNamespace(clusterCmNamespace)
                             .withLabels(Labels.forCluster(clusterName).toMap())
                         .endMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -70,8 +70,8 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(uoWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.getClientsCaKeyName(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.getClientsCaName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCaKeySecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaSecretName(cluster)).build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -71,7 +71,7 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCaKeySecretName(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaSecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaCertSecretName(cluster)).build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -70,8 +70,8 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(uoWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(uoReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCASecretName(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsPublicKeyName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.getClientsCaKeyName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.getClientsCaName(cluster)).build());
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -686,9 +686,7 @@ public class KafkaClusterTest {
         ClusterCa clusterCa = new ClusterCa(new OpenSslCertManager(), cluster, null, null);
         clusterCa.createOrRenew(namespace, cluster, emptyMap(), null);
 
-        ClientsCa clientsCa = new ClientsCa(new OpenSslCertManager(), KafkaCluster.getClusterCaKeyName(cluster), null, KafkaCluster.clientsCASecretName(cluster), null, 365, 30, true);
-
-        kc.generateCertificates(kafkaAssembly, clusterCa, clientsCa, externalBootstrapAddress, externalAddresses);
+        kc.generateCertificates(kafkaAssembly, clusterCa, externalBootstrapAddress, externalAddresses);
         return kc.generateBrokersSecret();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
@@ -46,11 +46,13 @@ class ResourceTester<R extends HasMetadata, M extends AbstractModel> implements 
         this.fromK8sResource = resource -> {
             return fromResource.apply(resource,
                     new ClusterCa(new MockCertManager(), resource.getMetadata().getName(),
-                            ResourceUtils.createInitialClusterCaCertSecret(resource.getMetadata().getNamespace(),
+                            ResourceUtils.createInitialCaCertSecret(resource.getMetadata().getNamespace(),
                                     resource.getMetadata().getName(),
+                                    AbstractModel.clusterCaSecretName(resource.getMetadata().getName()),
                                     MockCertManager.clusterCaCert()),
-                            ResourceUtils.createInitialClusterCaKeySecret(resource.getMetadata().getNamespace(),
+                            ResourceUtils.createInitialCaKeySecret(resource.getMetadata().getNamespace(),
                                     resource.getMetadata().getName(),
+                                    AbstractModel.clusterCaKeySecretName(resource.getMetadata().getName()),
                                     MockCertManager.clusterCaKey())));
         };
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
@@ -48,7 +48,7 @@ class ResourceTester<R extends HasMetadata, M extends AbstractModel> implements 
                     new ClusterCa(new MockCertManager(), resource.getMetadata().getName(),
                             ResourceUtils.createInitialCaCertSecret(resource.getMetadata().getNamespace(),
                                     resource.getMetadata().getName(),
-                                    AbstractModel.clusterCaSecretName(resource.getMetadata().getName()),
+                                    AbstractModel.clusterCaCertSecretName(resource.getMetadata().getName()),
                                     MockCertManager.clusterCaCert()),
                             ResourceUtils.createInitialCaKeySecret(resource.getMetadata().getNamespace(),
                                     resource.getMetadata().getName(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -81,9 +81,9 @@ public class CertificateRenewalTest {
             }).collect(Collectors.toList());
         });
         ArgumentCaptor<Secret> c = ArgumentCaptor.forClass(Secret.class);
-        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
         when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
-        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaCertSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
@@ -144,7 +144,7 @@ public class CertificateRenewalTest {
         String commonName = "cluster-ca";
         CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
         return ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME,
-                AbstractModel.clusterCaSecretName(NAME), result.certAsBase64String());
+                AbstractModel.clusterCaCertSecretName(NAME), result.certAsBase64String());
     }
 
     private Secret initialClusterCaKeySecret(CertificateAuthority certificateAuthority) throws IOException {
@@ -158,7 +158,7 @@ public class CertificateRenewalTest {
         String commonName = "clients-ca";
         CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
         return ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME,
-                KafkaCluster.clientsCaSecretName(NAME), result.certAsBase64String());
+                KafkaCluster.clientsCaCertSecretName(NAME), result.certAsBase64String());
     }
 
     private Secret initialClientsCaKeySecret(CertificateAuthority certificateAuthority) throws IOException {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -69,7 +69,7 @@ public class CertificateRenewalTest {
         secrets = new ArrayList();
     }
 
-    private ArgumentCaptor<Secret> reconcileCa(TestContext context, CertificateAuthority certificateAuthority) {
+    private ArgumentCaptor<Secret> reconcileCa(TestContext context, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
         SecretOperator secretOps = mock(SecretOperator.class);
 
         when(secretOps.list(eq(NAMESPACE), any())).thenAnswer(invocation -> {
@@ -98,7 +98,8 @@ public class CertificateRenewalTest {
                     .withNamespace(NAMESPACE)
                 .endMetadata()
                 .withNewSpec()
-                    .withClusterCa(certificateAuthority)
+                    .withClusterCa(clusterCa)
+                    .withClientsCa(clientsCa)
                 .endSpec()
             .build();
 
@@ -139,18 +140,32 @@ public class CertificateRenewalTest {
         }
     }
 
-    private Secret initialCaCertSecret(CertificateAuthority certificateAuthority) throws IOException {
+    private Secret initialClusterCaCertSecret(CertificateAuthority certificateAuthority) throws IOException {
         String commonName = "cluster-ca";
         CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
-        return ResourceUtils.createInitialClusterCaCertSecret(NAMESPACE, NAME,
-                result.certAsBase64String());
+        return ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME,
+                AbstractModel.clusterCaSecretName(NAME), result.certAsBase64String());
     }
 
-    private Secret initialCaKeySecret(CertificateAuthority certificateAuthority) throws IOException {
+    private Secret initialClusterCaKeySecret(CertificateAuthority certificateAuthority) throws IOException {
         String commonName = "cluster-ca";
         CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
-        return ResourceUtils.createInitialClusterCaKeySecret(NAMESPACE, NAME,
-                result.keyAsBase64String());
+        return ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME,
+                AbstractModel.clusterCaKeySecretName(NAME), result.keyAsBase64String());
+    }
+
+    private Secret initialClientsCaCertSecret(CertificateAuthority certificateAuthority) throws IOException {
+        String commonName = "clients-ca";
+        CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
+        return ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME,
+                KafkaCluster.clientsCaSecretName(NAME), result.certAsBase64String());
+    }
+
+    private Secret initialClientsCaKeySecret(CertificateAuthority certificateAuthority) throws IOException {
+        String commonName = "clients-ca";
+        CertAndKey result = generateCa(certManager, certificateAuthority, commonName);
+        return ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME,
+                KafkaCluster.clientsCaKeySecretName(NAME), result.keyAsBase64String());
     }
 
     @Test
@@ -161,11 +176,13 @@ public class CertificateRenewalTest {
                 .withGenerateCertificateAuthority(true)
                 .build();
         secrets.clear();
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(4, c.getAllValues().size());
 
         assertEquals(singleton(CA_CRT), c.getAllValues().get(0).getData().keySet());
         assertEquals(singleton(CA_KEY), c.getAllValues().get(1).getData().keySet());
+        assertEquals(singleton(CA_CRT), c.getAllValues().get(2).getData().keySet());
+        assertEquals(singleton(CA_KEY), c.getAllValues().get(3).getData().keySet());
     }
 
     @Test
@@ -176,10 +193,12 @@ public class CertificateRenewalTest {
                 .withGenerateCertificateAuthority(false)
                 .build();
         secrets.clear();
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(c.getAllValues().toString(), 4, c.getAllValues().size());
         assertTrue(c.getAllValues().get(0).getData().isEmpty());
         assertTrue(c.getAllValues().get(1).getData().isEmpty());
+        assertTrue(c.getAllValues().get(2).getData().isEmpty());
+        assertTrue(c.getAllValues().get(3).getData().isEmpty());
     }
 
     @Test
@@ -193,26 +212,37 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(generateCertificateAuthority)
                 .build();
-        Secret initialCaCertSecret = initialCaCertSecret(certificateAuthority);
-        Secret initialCaKeySecret = initialCaKeySecret(certificateAuthority);
-        Map<String, String> initialCertData = initialCaCertSecret.getData();
-        assertEquals(singleton(CA_CRT), initialCertData.keySet());
-        String initialCert = initialCertData.get(CA_CRT);
-        assertNotNull(initialCert);
-        Map<String, String> initialKeyData = initialCaKeySecret .getData();
-        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
-        String initialKey = initialKeyData.get(CA_KEY);
-        assertNotNull(initialKey);
+        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
+        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
+        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
+        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
-        secrets.add(initialCaCertSecret);
-        secrets.add(initialCaKeySecret);
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
+        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
+        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
+        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
+
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
 
         assertEquals(set(CA_CRT), c.getAllValues().get(0).getData().keySet());
-        assertEquals(initialCert, c.getAllValues().get(0).getData().get(CA_CRT));
+        assertEquals(initialClusterCaCertSecret.getData().get(CA_CRT), c.getAllValues().get(0).getData().get(CA_CRT));
 
         assertEquals(set(CA_KEY), c.getAllValues().get(1).getData().keySet());
-        assertEquals(initialKey, c.getAllValues().get(1).getData().get(CA_KEY));
+        assertEquals(initialClusterCaKeySecret.getData().get(CA_KEY), c.getAllValues().get(1).getData().get(CA_KEY));
+
+        assertEquals(set(CA_CRT), c.getAllValues().get(2).getData().keySet());
+        assertEquals(initialClientsCaCertSecret.getData().get(CA_CRT), c.getAllValues().get(2).getData().get(CA_CRT));
+
+        assertEquals(set(CA_KEY), c.getAllValues().get(3).getData().keySet());
+        assertEquals(initialClientsCaKeySecret.getData().get(CA_KEY), c.getAllValues().get(3).getData().get(CA_KEY));
     }
 
     @Test
@@ -227,33 +257,51 @@ public class CertificateRenewalTest {
                 .withRenewalDays(3)
                 .withGenerateCertificateAuthority(true)
                 .build();
-        Secret initialCaCertSecret = initialCaCertSecret(certificateAuthority);
-        Secret initialCaKeySecret = initialCaKeySecret(certificateAuthority);
-        Map<String, String> initialCertData = initialCaCertSecret.getData();
-        assertEquals(singleton(CA_CRT), initialCertData.keySet());
-        String initialCert = initialCertData.get(CA_CRT);
-        assertNotNull(initialCert);
-        Map<String, String> initialKeyData = initialCaKeySecret .getData();
-        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
-        String initialKey = initialKeyData.get(CA_KEY);
-        assertNotNull(initialKey);
+        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
+        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
+        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
+        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
-        secrets.add(initialCaCertSecret);
-        secrets.add(initialCaKeySecret);
+        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
+        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
+        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
+        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
 
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(4, c.getAllValues().size());
-        Map<String, String> certData = c.getAllValues().get(0).getData();
-        assertEquals(1, certData.size());
-        String newCrt = certData.remove(CA_CRT);
-        assertNotNull(newCrt);
-        assertNotEquals(initialCert, newCrt);
 
-        Map<String, String> keyData = c.getAllValues().get(1).getData();
-        assertEquals(singleton(CA_KEY), keyData.keySet());
-        String newKey = keyData.remove(CA_KEY);
-        assertNotNull(newKey);
-        assertEquals(initialKey, newKey);
+        Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
+        assertEquals(singleton(CA_CRT), clusterCaCertData.keySet());
+        String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
+        assertNotNull(newClusterCaCert);
+        assertNotEquals(initialClusterCaCertSecret.getData().get(CA_CRT), newClusterCaCert);
+
+        Map<String, String> clusterCaKeyData = c.getAllValues().get(1).getData();
+        assertEquals(singleton(CA_KEY), clusterCaKeyData.keySet());
+        String newClusterCaKey = clusterCaKeyData.remove(CA_KEY);
+        assertNotNull(newClusterCaKey);
+        assertEquals(initialClusterCaKeySecret.getData().get(CA_KEY), newClusterCaKey);
+
+        Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
+        assertEquals(singleton(CA_CRT), clientsCaCertData.keySet());
+        String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
+        assertNotNull(newClientsCaCert);
+        assertNotEquals(initialClientsCaCertSecret.getData().get(CA_CRT), newClientsCaCert);
+
+        Map<String, String> clientsCaKeyData = c.getAllValues().get(3).getData();
+        assertEquals(singleton(CA_KEY), clientsCaKeyData.keySet());
+        String newClientsCaKey = clientsCaKeyData.remove(CA_KEY);
+        assertNotNull(newClientsCaKey);
+        assertEquals(initialClientsCaKeySecret.getData().get(CA_KEY), newClientsCaKey);
     }
 
     @Test
@@ -263,26 +311,32 @@ public class CertificateRenewalTest {
                 .withRenewalDays(3)
                 .withGenerateCertificateAuthority(false)
                 .build();
-        Secret initialCaCertSecret = initialCaCertSecret(certificateAuthority);
-        Secret initialCaKeySecret = initialCaKeySecret(certificateAuthority);
-        Map<String, String> initialCertData = initialCaCertSecret.getData();
-        assertEquals(singleton(CA_CRT), initialCertData.keySet());
-        String initialCert = initialCertData.get(CA_CRT);
-        assertNotNull(initialCert);
-        Map<String, String> initialKeyData = initialCaKeySecret .getData();
-        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
-        String initialKey = initialKeyData.get(CA_KEY);
-        assertNotNull(initialKey);
+        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
+        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
+        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
+        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
-        secrets.add(initialCaCertSecret);
-        secrets.add(initialCaKeySecret);
+        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
+        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
+        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
+        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
+        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
 
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(4, c.getAllValues().size());
-        Map<String, String> certData = c.getAllValues().get(0).getData();
-        assertEquals(initialCertData, certData);
-        Map<String, String> keyData = c.getAllValues().get(1).getData();
-        assertEquals(initialKeyData, keyData);
+
+        assertEquals(initialClusterCaCertSecret.getData(), c.getAllValues().get(0).getData());
+        assertEquals(initialClusterCaKeySecret.getData(), c.getAllValues().get(1).getData());
+        assertEquals(initialClientsCaCertSecret.getData(), c.getAllValues().get(2).getData());
+        assertEquals(initialClientsCaKeySecret.getData(), c.getAllValues().get(3).getData());
     }
 
     @Test
@@ -292,28 +346,41 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(true)
                 .build();
-        Secret initialCaCertSecret = initialCaCertSecret(certificateAuthority);
-        Secret initialCaKeySecret = initialCaKeySecret(certificateAuthority);
-        Map<String, String> initialCertData = initialCaCertSecret.getData();
-        assertEquals(singleton(CA_CRT), initialCertData.keySet());
-        String initialCert = initialCertData.get(CA_CRT);
-        initialCertData.put("ca-2018-07-01T09-00-00.crt", "whatever");
-        assertNotNull(initialCert);
-        Map<String, String> initialKeyData = initialCaKeySecret .getData();
-        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
-        String initialKey = initialKeyData.get(CA_KEY);
-        assertNotNull(initialKey);
+        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
+        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
+        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
+        initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
+        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
+        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
-        secrets.add(initialCaCertSecret);
-        secrets.add(initialCaKeySecret);
+        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
+        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
+        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
+        initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
+        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
+        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
 
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(4, c.getAllValues().size());
-        Map<String, String> certData = c.getAllValues().get(0).getData();
-        assertEquals(certData.keySet().toString(), 1, certData.size());
-        assertEquals(initialCert, certData.get(CA_CRT));
-        Map<String, String> keyData = c.getAllValues().get(1).getData();
-        assertEquals(initialKey, keyData.get(CA_KEY));
+
+        Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
+        assertEquals(clusterCaCertData.keySet().toString(), 1, clusterCaCertData.size());
+        assertEquals(initialClusterCaCertSecret.getData().get(CA_CRT), clusterCaCertData.get(CA_CRT));
+        Map<String, String> clusterCaKeyData = c.getAllValues().get(1).getData();
+        assertEquals(initialClusterCaKeySecret.getData().get(CA_KEY), clusterCaKeyData.get(CA_KEY));
+
+        Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
+        assertEquals(clientsCaCertData.keySet().toString(), 1, clientsCaCertData.size());
+        assertEquals(initialClientsCaCertSecret.getData().get(CA_CRT), clientsCaCertData.get(CA_CRT));
+        Map<String, String> clientsCaKeyData = c.getAllValues().get(3).getData();
+        assertEquals(initialClientsCaKeySecret.getData().get(CA_KEY), clientsCaKeyData.get(CA_KEY));
     }
 
     @Test
@@ -323,24 +390,31 @@ public class CertificateRenewalTest {
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(false)
                 .build();
-        Secret initialCaCertSecret = initialCaCertSecret(certificateAuthority);
-        Secret initialCaKeySecret = initialCaKeySecret(certificateAuthority);
-        Map<String, String> initialCertData = initialCaCertSecret.getData();
-        assertEquals(singleton(CA_CRT), initialCertData.keySet());
-        String initialCert = initialCertData.get(CA_CRT);
-        initialCertData.put("cluster-ca-2018-07-01T09-00-00.crt", "whatever");
-        assertNotNull(initialCert);
-        Map<String, String> initialKeyData = initialCaKeySecret .getData();
-        assertEquals(singleton(CA_KEY), initialKeyData.keySet());
-        String initialKey = initialKeyData.get(CA_KEY);
-        assertNotNull(initialKey);
+        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
+        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
+        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
+        initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
+        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
+        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
-        secrets.add(initialCaCertSecret);
-        secrets.add(initialCaKeySecret);
+        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
+        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
+        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
+        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
+        initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
+        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
+        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
 
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority);
+        secrets.add(initialClusterCaCertSecret);
+        secrets.add(initialClusterCaKeySecret);
+        secrets.add(initialClientsCaCertSecret);
+        secrets.add(initialClientsCaKeySecret);
+
+        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertEquals(4, c.getAllValues().size());
-        Map<String, String> certData = c.getAllValues().get(0).getData();
-        assertEquals(initialCertData, certData);
+
+        assertEquals(initialClusterCaCertSecret.getData(), c.getAllValues().get(0).getData());
+        assertEquals(initialClientsCaCertSecret.getData(), c.getAllValues().get(2).getData());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -239,8 +239,8 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(CLUSTER_NAME)).get());
             assertResourceRequirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaSecretName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterCaSecretName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaCertSecretName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(TopicOperator.secretName(CLUSTER_NAME)).get());
@@ -319,8 +319,8 @@ public class KafkaAssemblyOperatorMockTest {
     public void testUpdateClusterWithoutKafkaSecrets(TestContext context) {
         updateClusterWithoutSecrets(context,
                 KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME),
-                KafkaCluster.clientsCaSecretName(CLUSTER_NAME),
-                KafkaCluster.clusterCaSecretName(CLUSTER_NAME),
+                KafkaCluster.clientsCaCertSecretName(CLUSTER_NAME),
+                KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME),
                 KafkaCluster.brokersSecretName(CLUSTER_NAME),
                 ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
                 TopicOperator.secretName(CLUSTER_NAME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -25,7 +25,6 @@ import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.ResourcesBuilder;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.TopicOperator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
@@ -239,12 +238,11 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaCluster.metricAndLogConfigsName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(CLUSTER_NAME)).get());
             assertResourceRequirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCASecretName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsPublicKeyName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterPublicKeyName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClientsCaKeyName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClientsCaName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClusterCaName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(AbstractModel.getClusterCaName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(TopicOperator.secretName(CLUSTER_NAME)).get());
             createAsync.complete();
         });
@@ -320,9 +318,9 @@ public class KafkaAssemblyOperatorMockTest {
     @Test
     public void testUpdateClusterWithoutKafkaSecrets(TestContext context) {
         updateClusterWithoutSecrets(context,
-                KafkaCluster.clientsCASecretName(CLUSTER_NAME),
-                KafkaCluster.clientsPublicKeyName(CLUSTER_NAME),
-                KafkaCluster.clusterPublicKeyName(CLUSTER_NAME),
+                KafkaCluster.getClientsCaKeyName(CLUSTER_NAME),
+                KafkaCluster.getClientsCaName(CLUSTER_NAME),
+                KafkaCluster.getClusterCaName(CLUSTER_NAME),
                 KafkaCluster.brokersSecretName(CLUSTER_NAME),
                 ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
                 TopicOperator.secretName(CLUSTER_NAME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -238,9 +238,9 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaCluster.metricAndLogConfigsName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(CLUSTER_NAME)).get());
             assertResourceRequirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClientsCaKeyName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClientsCaName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.getClusterCaName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaSecretName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterCaSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.secrets().inNamespace(NAMESPACE).withName(TopicOperator.secretName(CLUSTER_NAME)).get());
@@ -318,9 +318,9 @@ public class KafkaAssemblyOperatorMockTest {
     @Test
     public void testUpdateClusterWithoutKafkaSecrets(TestContext context) {
         updateClusterWithoutSecrets(context,
-                KafkaCluster.getClientsCaKeyName(CLUSTER_NAME),
-                KafkaCluster.getClientsCaName(CLUSTER_NAME),
-                KafkaCluster.getClusterCaName(CLUSTER_NAME),
+                KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME),
+                KafkaCluster.clientsCaSecretName(CLUSTER_NAME),
+                KafkaCluster.clusterCaSecretName(CLUSTER_NAME),
                 KafkaCluster.brokersSecretName(CLUSTER_NAME),
                 ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
                 TopicOperator.secretName(CLUSTER_NAME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -279,8 +279,8 @@ public class KafkaAssemblyOperatorTest {
 
     private void createCluster(TestContext context, Kafka clusterCm, List<Secret> secrets) {
         ClusterCa clusterCa = new ClusterCa(new MockCertManager(), clusterCm.getMetadata().getName(),
-                ModelUtils.findSecretWithName(secrets, AbstractModel.getClusterCaName(clusterCm.getMetadata().getName())),
-                ModelUtils.findSecretWithName(secrets, AbstractModel.getClusterCaKeyName(clusterCm.getMetadata().getName())));
+                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaSecretName(clusterCm.getMetadata().getName())),
+                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaKeySecretName(clusterCm.getMetadata().getName())));
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(clusterCm);
         TopicOperator topicOperator = TopicOperator.fromCrd(clusterCm);
@@ -319,10 +319,10 @@ public class KafkaAssemblyOperatorTest {
         when(mockPolicyOps.reconcile(anyString(), anyString(), policyCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         Set<String> expectedSecrets = set(
-                KafkaCluster.getClientsCaKeyName(clusterCmName),
-                KafkaCluster.getClientsCaName(clusterCmName),
-                KafkaCluster.getClusterCaName(clusterCmName),
-                KafkaCluster.getClusterCaKeyName(clusterCmName),
+                KafkaCluster.clientsCaKeySecretName(clusterCmName),
+                KafkaCluster.clientsCaSecretName(clusterCmName),
+                KafkaCluster.clusterCaSecretName(clusterCmName),
+                KafkaCluster.clusterCaKeySecretName(clusterCmName),
                 KafkaCluster.brokersSecretName(clusterCmName),
                 ZookeeperCluster.nodesSecretName(clusterCmName));
         expectedSecrets.addAll(secrets.stream().map(s -> s.getMetadata().getName()).collect(Collectors.toSet()));
@@ -805,16 +805,16 @@ public class KafkaAssemblyOperatorTest {
 
         // providing certificates Secrets for existing clusters
         List<Secret> fooSecrets = ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, "foo");
-        //ClusterCa fooCerts = ResourceUtils.createInitialClusterCa("foo", ModelUtils.findSecretWithName(fooSecrets, AbstractModel.getClusterCaName("foo")));
+        //ClusterCa fooCerts = ResourceUtils.createInitialClusterCa("foo", ModelUtils.findSecretWithName(fooSecrets, AbstractModel.clusterCaSecretName("foo")));
         List<Secret> barSecrets = ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, "bar",
                 bar.getSpec().getKafka().getReplicas(),
                 bar.getSpec().getZookeeper().getReplicas());
         ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaKeyName("bar")));
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
         ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.getClientsCaName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.getClientsCaKeyName("bar")));
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
@@ -822,10 +822,10 @@ public class KafkaAssemblyOperatorTest {
                 asList(KafkaCluster.fromCrd(bar).generateStatefulSet(openShift))
         );
 
-        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName()))))
+        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(foo.getMetadata().getName()))))
                 .thenReturn(
                         fooSecrets.get(0));
-        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
@@ -840,8 +840,8 @@ public class KafkaAssemblyOperatorTest {
                     barCluster.generateBrokersSecret(),
                     barClusterCa.caCertSecret()))
         );
-        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
-        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.getClusterCaName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -279,7 +279,7 @@ public class KafkaAssemblyOperatorTest {
 
     private void createCluster(TestContext context, Kafka clusterCm, List<Secret> secrets) {
         ClusterCa clusterCa = new ClusterCa(new MockCertManager(), clusterCm.getMetadata().getName(),
-                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaSecretName(clusterCm.getMetadata().getName())),
+                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaCertSecretName(clusterCm.getMetadata().getName())),
                 ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaKeySecretName(clusterCm.getMetadata().getName())));
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(clusterCm);
@@ -320,8 +320,8 @@ public class KafkaAssemblyOperatorTest {
 
         Set<String> expectedSecrets = set(
                 KafkaCluster.clientsCaKeySecretName(clusterCmName),
-                KafkaCluster.clientsCaSecretName(clusterCmName),
-                KafkaCluster.clusterCaSecretName(clusterCmName),
+                KafkaCluster.clientsCaCertSecretName(clusterCmName),
+                KafkaCluster.clusterCaCertSecretName(clusterCmName),
                 KafkaCluster.clusterCaKeySecretName(clusterCmName),
                 KafkaCluster.brokersSecretName(clusterCmName),
                 ZookeeperCluster.nodesSecretName(clusterCmName));
@@ -805,15 +805,15 @@ public class KafkaAssemblyOperatorTest {
 
         // providing certificates Secrets for existing clusters
         List<Secret> fooSecrets = ResourceUtils.createKafkaClusterInitialSecrets(clusterCmNamespace, "foo");
-        //ClusterCa fooCerts = ResourceUtils.createInitialClusterCa("foo", ModelUtils.findSecretWithName(fooSecrets, AbstractModel.clusterCaSecretName("foo")));
+        //ClusterCa fooCerts = ResourceUtils.createInitialClusterCa("foo", ModelUtils.findSecretWithName(fooSecrets, AbstractModel.clusterCaCertSecretName("foo")));
         List<Secret> barSecrets = ResourceUtils.createKafkaClusterSecretsWithReplicas(clusterCmNamespace, "bar",
                 bar.getSpec().getKafka().getReplicas(),
                 bar.getSpec().getZookeeper().getReplicas());
         ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
                 ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
         ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
                 ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
@@ -822,10 +822,10 @@ public class KafkaAssemblyOperatorTest {
                 asList(KafkaCluster.fromCrd(bar).generateStatefulSet(openShift))
         );
 
-        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(foo.getMetadata().getName()))))
+        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName()))))
                 .thenReturn(
                         fooSecrets.get(0));
-        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
@@ -840,8 +840,8 @@ public class KafkaAssemblyOperatorTest {
                     barCluster.generateBrokersSecret(),
                     barClusterCa.caCertSecret()))
         );
-        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
-        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
+        when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -319,9 +319,9 @@ public class KafkaAssemblyOperatorTest {
         when(mockPolicyOps.reconcile(anyString(), anyString(), policyCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         Set<String> expectedSecrets = set(
-                KafkaCluster.clientsCASecretName(clusterCmName),
-                KafkaCluster.clientsPublicKeyName(clusterCmName),
-                KafkaCluster.clusterPublicKeyName(clusterCmName),
+                KafkaCluster.getClientsCaKeyName(clusterCmName),
+                KafkaCluster.getClientsCaName(clusterCmName),
+                KafkaCluster.getClusterCaName(clusterCmName),
                 KafkaCluster.getClusterCaKeyName(clusterCmName),
                 KafkaCluster.brokersSecretName(clusterCmName),
                 ZookeeperCluster.nodesSecretName(clusterCmName));
@@ -813,8 +813,8 @@ public class KafkaAssemblyOperatorTest {
                 ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaName("bar")),
                 ModelUtils.findSecretWithName(barSecrets, AbstractModel.getClusterCaKeyName("bar")));
         ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsPublicKeyName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCASecretName("bar")));
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.getClientsCaName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.getClientsCaKeyName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);


### PR DESCRIPTION
Some minor naming refactoring for consistency

### Type of change

- Refactoring

### Description

This PR mainly moves the clients CA creation/renewal in the same position of the cluster CA because in any case we need it and it's not related to the Kafka cluster creation.
It also makes some naming refactoring for more consistency with the cluster CA naming.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

