### PR TITLE
Fix documentation issues when Kubernetes sections are disabled

### DIFF
--- a/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
@@ -39,4 +39,7 @@ oc annotate pod _cluster-name_-kafka-_index_ operator.strimzi.io/delete-pod-and-
 .Additional resources
 
 * For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
-* For more information about deploying the Kafka cluster, see xref:deploying-kafka-cluster-openshift-str[] and xref:deploying-kafka-cluster-kubernetes-str[].
+* For more information about deploying the Kafka cluster on {OpenShiftName}, see xref:deploying-kafka-cluster-openshift-str[].
+ifdef::Kubernetes[]
+* For more information about deploying the Kafka cluster on {KubernetesName}, see xref:deploying-kafka-cluster-kubernetes-str[].
+endif::Kubernetes[]

--- a/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
@@ -39,4 +39,7 @@ oc annotate pod _cluster-name_-zookeeper-_index_ operator.strimzi.io/delete-pod-
 .Additional resources
 
 * For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
-* For more information about deploying the Zookeeper cluster, see xref:deploying-kafka-cluster-openshift-str[] and xref:deploying-kafka-cluster-kubernetes-str[].
+* For more information about deploying the Zookeeper cluster on {OpenShiftName}, see xref:deploying-kafka-cluster-openshift-str[].
+ifdef::Kubernetes[]
+* For more information about deploying the Zookeeper cluster on {KubernetesName}, see xref:deploying-kafka-cluster-kubernetes-str[].
+endif::Kubernetes[]

--- a/documentation/book/proc-manual-rolling-update-kafka.adoc
+++ b/documentation/book/proc-manual-rolling-update-kafka.adoc
@@ -38,4 +38,8 @@ Once the rolling update of all the pods is complete, the annotation is removed f
 .Additional resources
 
 * For more information about deploying the Cluster Operator, see xref:cluster-operator-str[].
-* For more information about deploying the Kafka cluster, see xref:deploying-kafka-cluster-openshift-str[] and xref:deploying-kafka-cluster-kubernetes-str[].
+* For more information about deploying the Kafka cluster on {OpenShiftName}, see xref:deploying-kafka-cluster-openshift-str[].
+ifdef::Kubernetes[]
+* For more information about deploying the Kafka cluster on {KubernetesName}, see xref:deploying-kafka-cluster-kubernetes-str[].
+endif::Kubernetes[]
+

--- a/documentation/book/snip-reassign-partitions.adoc
+++ b/documentation/book/snip-reassign-partitions.adoc
@@ -156,8 +156,6 @@ oc rsh -c kafka my-cluster-kafka-0 \
   --reassignment-json-file /tmp/reassignment.json \
   --verify
 ----
-ifdef::Kubernetes[]
-
 
 . The reassignment has finished when the `--verify` command reports each of  the partitions being moved as completed successfully. 
 This final `--verify` will also have the effect of removing any reassignment throttles.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Fix the documentation issues when the `Kubernetes` section enabled is disabled. The problems are caused by:
* One `ifdef::Kubernetes[]` secton being not closed
* ID of section being included only within `ifdef::Kubernetes[]` being referenced without `ifdef::Kubernetes[]` 