### PR TITLE
fix link rendering

### DIFF
--- a/documentation/book/proc-kafka-inline-logging.adoc
+++ b/documentation/book/proc-kafka-inline-logging.adoc
@@ -23,7 +23,7 @@ spec:
 ----
 +
 In the above example, the log level is set to INFO.
-You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information about the log levels, see link: https://logging.apache.org/log4j/2.x/manual/customloglevels.html[log4j manual^].
+You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information about the log levels, see link:https://logging.apache.org/log4j/2.x/manual/customloglevels.html[log4j manual^].
 
 . Create or update the Kafka resource in {ProductPlatformName}.
 +


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

We had a link rendering with the link: text because of a 'space' this removes the space.

### Checklist
