### PR TITLE
Using group 0 for users in our Docker images

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -24,8 +23,6 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
-import io.fabric8.kubernetes.api.model.PodSecurityContext;
-import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -88,10 +85,6 @@ public abstract class AbstractModel {
 
     protected static final int CERTS_EXPIRATION_DAYS = 365;
     protected static final String DEFAULT_JVM_XMS = "128M";
-
-    private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
-    protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
-    private static final Long VOLUME_MOUNT_HACK_GROUPID = 1001L;
 
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.yml";
     public static final String ANCILLARY_CM_KEY_LOG_CONFIG = "log4j.properties";
@@ -751,11 +744,9 @@ public abstract class AbstractModel {
     protected StatefulSet createStatefulSet(
             List<Volume> volumes,
             List<PersistentVolumeClaim> volumeClaims,
-            List<VolumeMount> volumeMounts,
             Affinity affinity,
             List<Container> initContainers,
-            List<Container> containers,
-            boolean isOpenShift) {
+            List<Container> containers) {
 
         Map<String, String> annotations = new HashMap<>();
 
@@ -763,31 +754,7 @@ public abstract class AbstractModel {
                 String.valueOf(storage instanceof PersistentClaimStorage
                         && ((PersistentClaimStorage) storage).isDeleteClaim()));
 
-
         List<Container> initContainersInternal = new ArrayList<>();
-        PodSecurityContext securityContext = null;
-        // if a persistent volume claim is requested and the running cluster is a Kubernetes one
-        // there is an hack on volume mounting which needs an "init-container"
-        if (this.storage instanceof PersistentClaimStorage && !isOpenShift) {
-
-            String chown = String.format("chown -R %d:%d %s",
-                    AbstractModel.VOLUME_MOUNT_HACK_GROUPID,
-                    AbstractModel.VOLUME_MOUNT_HACK_GROUPID,
-                    volumeMounts.get(0).getMountPath());
-
-            Container initContainer = new ContainerBuilder()
-                    .withName(AbstractModel.VOLUME_MOUNT_HACK_NAME)
-                    .withImage(AbstractModel.VOLUME_MOUNT_HACK_IMAGE)
-                    .withVolumeMounts(volumeMounts.get(0))
-                    .withCommand("sh", "-c", chown)
-                    .build();
-
-            initContainersInternal.add(initContainer);
-
-            securityContext = new PodSecurityContextBuilder()
-                    .withFsGroup(AbstractModel.VOLUME_MOUNT_HACK_GROUPID)
-                    .build();
-        }
         // add all the other init containers provided by the specific model implementation
         if (initContainers != null) {
             initContainersInternal.addAll(initContainers);
@@ -815,7 +782,6 @@ public abstract class AbstractModel {
                         .withNewSpec()
                             .withServiceAccountName(getServiceAccountName())
                             .withAffinity(affinity)
-                            .withSecurityContext(securityContext)
                             .withInitContainers(initContainersInternal)
                             .withContainers(containers)
                             .withVolumes(volumes)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -516,11 +516,9 @@ public class KafkaCluster extends AbstractModel {
         return createStatefulSet(
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
-                getVolumeMounts(),
                 getMergedAffinity(),
                 getInitContainers(),
-                getContainers(),
-                isOpenShift);
+                getContainers());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -277,11 +277,9 @@ public class ZookeeperCluster extends AbstractModel {
         return createStatefulSet(
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
-                getVolumeMounts(),
                 getMergedAffinity(),
                 getInitContainers(),
-                getContainers(),
-                isOpenShift);
+                getContainers());
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -23,7 +23,6 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaListenerAuthenticationTls;
-import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
@@ -250,25 +249,6 @@ public class KafkaClusterTest {
         assertEquals(KafkaCluster.BROKER_CERTS_VOLUME, containers.get(1).getVolumeMounts().get(0).getName());
         assertEquals(KafkaCluster.TLS_SIDECAR_KAFKA_CERTS_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(0).getMountPath());
         assertEquals(KafkaCluster.TLS_SIDECAR_CLUSTER_CA_CERTS_VOLUME_MOUNT, containers.get(1).getVolumeMounts().get(1).getMountPath());
-
-        if (cm.getSpec().getKafka().getStorage() != null) {
-
-            io.strimzi.api.kafka.model.Storage storage = cm.getSpec().getKafka().getStorage();
-
-            if (storage instanceof PersistentClaimStorage && !isOpenShift) {
-
-                PodSpec podSpec = ss.getSpec().getTemplate().getSpec();
-
-                // check that pod spec contains the volume hack container for Kubernetes
-                List<Container> initContainers = podSpec.getInitContainers();
-                assertNotNull(initContainers);
-                assertTrue(initContainers.size() > 0);
-
-                boolean isVolumeHack =
-                        initContainers.stream().anyMatch(container -> container.getName().equals(AbstractModel.VOLUME_MOUNT_HACK_NAME));
-                assertTrue(isVolumeHack);
-            }
-        }
 
         if (cm.getSpec().getKafka().getRack() != null) {
 

--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install java-1.8.0-openjdk-headless gettext nmap-ncat openssl && yum 
 ENV KAFKA_HOME=/opt/kafka
 
 # Add kafka group / user
-RUN groupadd -r -g 1001 kafka && useradd -r -m -u 1001 -g kafka kafka
+RUN useradd -r -m -u 1001 -g 0 kafka
 
 # Set Scala and Kafka version
 ENV SCALA_VERSION=2.12

--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -5,7 +5,8 @@ RUN yum -y install java-1.8.0-openjdk-headless gettext nmap-ncat openssl && yum 
 # set Kafka home folder
 ENV KAFKA_HOME=/opt/kafka
 
-# Add kafka group / user
+# Add kafka user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
 RUN useradd -r -m -u 1001 -g 0 kafka
 
 # Set Scala and Kafka version

--- a/docker-images/stunnel-base/Dockerfile
+++ b/docker-images/stunnel-base/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install stunnel && yum clean all -y
 ENV STUNNEL_HOME=/opt/stunnel
 
 # Add stunnel group / user
-RUN groupadd -r -g 1001 stunnel && useradd -r -m -u 1001 -g stunnel stunnel
+RUN useradd -r -m -u 1001 -g 0 stunnel
 
 RUN mkdir $STUNNEL_HOME && mkdir -p -m g+rw /usr/local/var/run/
 

--- a/docker-images/stunnel-base/Dockerfile
+++ b/docker-images/stunnel-base/Dockerfile
@@ -5,7 +5,8 @@ RUN yum -y install stunnel && yum clean all -y
 # set Stunnel home folder
 ENV STUNNEL_HOME=/opt/stunnel
 
-# Add stunnel group / user
+# Add stunnel user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
 RUN useradd -r -m -u 1001 -g 0 stunnel
 
 RUN mkdir $STUNNEL_HOME && mkdir -p -m g+rw /usr/local/var/run/


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Using our own group in our Docker images seems to cause a lot of problems. Among them is the fact that we need to modify the storage permissions to match this group. This is for example problem on OpenShift when the storage is not run user the `Restricted` policy but uses for example the `Anyuid` policy.

Using the group 0 which is used as a default group to mount the volumes should help with this issue. As a member of tis group should be able to read them without doing anything special under Kubernetes or on OpenShift with different SCC policies.

This should fix the issue #1009.

### Checklist

- [X] Make sure all tests pass
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

