### PR TITLE
Fixed wrong matchLabels for storage in doc

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
@@ -58,8 +58,7 @@ public class PersistentClaimStorage extends Storage {
     }
 
     @Description("Specifies a specific persistent volume to use. " +
-            "It contains a matchLabels field which defines an inner JSON object with " +
-            "key:value representing labels for selecting such a volume.")
+            "It contains key:value pairs representing labels for selecting such a volume.")
     public Map<String, String> getSelector() {
         return selector;
     }

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -116,7 +116,7 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |string
 |size         1.2+<.<|When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
 |string
-|selector     1.2+<.<|Specifies a specific persistent volume to use. It contains a matchLabels field which defines an inner JSON object with key:value representing labels for selecting such a volume.
+|selector     1.2+<.<|Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
 |map
 |deleteClaim  1.2+<.<|Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |boolean

--- a/documentation/book/ref-storage-persistent.adoc
+++ b/documentation/book/ref-storage-persistent.adoc
@@ -63,7 +63,7 @@ storage:
   size: 1Gi
   selector:
     matchLabels:
-      "hdd-type": "ssd"
+      hdd-type: ssd
   deleteClaim: true
 # ...
 ----

--- a/documentation/book/ref-storage-persistent.adoc
+++ b/documentation/book/ref-storage-persistent.adoc
@@ -20,7 +20,7 @@ The {ProductPlatformName} {K8SStorageClass} to use for dynamic volume provisioni
 
 `selector` (optional)::
 Allows selecting a specific persistent volume to use.
-It contains a `matchLabels` field which contains key:value pairs representing labels for selecting such a volume.
+It contains key:value pairs representing labels for selecting such a volume.
 
 `delete-claim` (optional)::
 Boolean value which specifies if the Persistent Volume Claim has to be deleted when the cluster is undeployed.
@@ -62,8 +62,7 @@ storage:
   type: persistent-claim
   size: 1Gi
   selector:
-    matchLabels:
-      hdd-type: ssd
+    hdd-type: ssd
   deleteClaim: true
 # ...
 ----


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This trivial PR fixes they way `matchLabels` is defined in the storage example.
It comes from the old way to use JSON for storage.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

