### PR TITLE
Topic operator does not print InvalidReplicationFactorException

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -12,6 +12,7 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -194,6 +195,8 @@ public class TopicOperator {
                     handler.handle(ar);
                     if (ar.cause() instanceof TopicExistsException) {
                         // TODO reconcile
+                    } else if (ar.cause() instanceof InvalidReplicationFactorException) {
+                        // error message is printed in the `reconcile` method
                     } else {
                         throw new OperatorException(involvedObject, ar.cause());
                     }


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
When creating a topic and using `replicas` greater than Kafka brokers count is used the stacktrace is not printed.

https://github.com/strimzi/strimzi-kafka-operator/issues/990
### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

