### PR TITLE
Make it clear which image is using which directory to store plugins

### DIFF
--- a/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
+++ b/documentation/book/assembly-using-kafka-connect-with-plugins.adoc
@@ -11,9 +11,8 @@
 
 {ProductName} container images for Kafka Connect contain, by default, only the `FileStreamSinkConnector` and `FileStreamSourceConnector` connectors which are part of Apache Kafka.
 
-To facilitate deployment with 3rd party connectors, Kafka Connect is configured to automatically load all plugins or connectors that are present in the `/opt/kafka/plugins` directory during startup.
-
-There are two ways of adding custom plugins into this directory:
+To facilitate deployment with 3rd party connectors, you have to add the connector plugins to the Kafka Connect container image.
+There are two ways how to do that:
 
 * Using a custom Docker image
 * Using the {OpenShiftName} build system with the {ProductName} S2I

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -10,7 +10,7 @@
 The `{DockerKafkaConnect}` image is configured to automatically load all plugins or connectors that are present in the `/opt/kafka/plugins` directory during startup.
 This image can be used as a base image for building a new custom image with additional plugins.
 
-The following procedure describes the process for creating such a custom image and adding the connector plugins to the the `/opt/kafka/plugins` director.
+The following procedure describes the process for creating such a custom image and adding the connector plugins to the the `/opt/kafka/plugins` directory.
 
 .Procedure
 

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -5,11 +5,12 @@
 [id='creating-new-image-from-base-{context}']
 = Create a new image based on our base image
 
-{ProductName} provides its own Docker image for running Kafka Connect, which can be found on {DockerRepository} as
+{ProductName} provides its own container image for running Kafka Connect, which can be found on {DockerRepository} as
 `{DockerKafkaConnect}`.
+The `{DockerKafkaConnect}` image is configured to automatically load all plugins or connectors that are present in the `/opt/kafka/plugins` directory during startup.
 This image can be used as a base image for building a new custom image with additional plugins.
 
-The following procedure describes the process for creating such a custom image.
+The following procedure describes the process for creating such a custom image and adding the connector plugins to the the `/opt/kafka/plugins` director.
 
 .Procedure
 

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -7,14 +7,13 @@
 = Using {OpenShiftName} builds and S2I to create new images
 
 {OpenShiftName} supports link:https://docs.openshift.org/3.9/dev_guide/builds/index.html[builds^], which can be used together with the link:https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)^] framework to create new container images.
-An {OpenShiftName} build takes a builder image with S2I support together with source code and binaries provided by the user and uses them to build a new container image.
+An {OpenShiftName} build takes a builder image with S2I support together with the connector plugin binaries provided by the user and uses them to build a new container image.
 The newly created container image is stored in {OpenShiftName}'s local container image repository and can be used in deployments.
-{ProductName} provides a Kafka Connect builder image, which can be found on {DockerRepository} as `{DockerKafkaConnectS2I}` with this S2I support.
-It takes user-provided binaries (with plugins and connectors) and creates a new Kafka Connect image.
-This enhanced Kafka Connect image can be used with the Kafka Connect deployment.
 
-The S2I deployment provided as an {OpenShiftName} template. It can be deployed from the template using the command-line
-or the {OpenShiftName} console.
+{ProductName} provides a Kafka Connect builder image, which can be found on {DockerRepository} as `{DockerKafkaConnectS2I}` with this S2I support.
+The S2I image takes user-provided binaries (with plugins and connectors), places them in the `/tmp/kafka-plugins` directory, and creates a new Kafka Connect image with them.
+This enhanced Kafka Connect image can be used with the Kafka Connect deployment.
+When Kafka Connect is started using the new image, it will automatically load all plugins or connectors from the `/tmp/kafka-plugins`` directory.
 
 .Procedure
 

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -13,7 +13,7 @@ The newly created container image is stored in {OpenShiftName}'s local container
 {ProductName} provides a Kafka Connect builder image, which can be found on {DockerRepository} as `{DockerKafkaConnectS2I}` with this S2I support.
 The S2I image takes user-provided binaries (with plugins and connectors), places them in the `/tmp/kafka-plugins` directory, and creates a new Kafka Connect image with them.
 This enhanced Kafka Connect image can be used with the Kafka Connect deployment.
-When Kafka Connect is started using the new image, it will automatically load all plugins or connectors from the `/tmp/kafka-plugins`` directory.
+When Kafka Connect is started using the new image, it will automatically load all plugins or connectors from the `/tmp/kafka-plugins` directory.
 
 .Procedure
 

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -11,9 +11,9 @@ An {OpenShiftName} build takes a builder image with S2I support together with th
 The newly created container image is stored in {OpenShiftName}'s local container image repository and can be used in deployments.
 
 {ProductName} provides a Kafka Connect builder image, which can be found on {DockerRepository} as `{DockerKafkaConnectS2I}` with this S2I support.
-The S2I image takes user-provided binaries (with plugins and connectors), places them in the `/tmp/kafka-plugins` directory, and creates a new Kafka Connect image with them.
+The S2I image takes user-provided binaries (with plugins and connectors), places them in the `/tmp/kafka-plugins/s2i` directory, and creates a new Kafka Connect image with them.
 This enhanced Kafka Connect image can be used with the Kafka Connect deployment.
-When Kafka Connect is started using the new image, it will automatically load all plugins or connectors from the `/tmp/kafka-plugins` directory.
+When Kafka Connect is started using the new image, it will automatically load all plugins or connectors from the `/tmp/kafka-plugins/s2i` directory.
 
 .Procedure
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation currently provides wrong / confusing information about the path from which Kafka Connect deployments load the connector plugins. This PR tries to fix that.

There are bigger changes planned for the Kafka Connect section, but these will take more time. This should at least solve the bug.