### PR TITLE
Run operators and Kafka Init under the strimzi user and not under roo…

### DIFF
--- a/cluster-operator/Dockerfile
+++ b/cluster-operator/Dockerfile
@@ -5,4 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/cluster-operator-${strimzi_version}.jar /
 
+USER strimzi:strimzi
+
 CMD /bin/launch_java.sh /cluster-operator-${STRIMZI_VERSION}.jar

--- a/docker-images/java-base/Dockerfile
+++ b/docker-images/java-base/Dockerfile
@@ -5,5 +5,9 @@ RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java
 
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
+
 # Copy scripts for starting Java apps
 COPY scripts/* /bin/

--- a/kafka-init/Dockerfile
+++ b/kafka-init/Dockerfile
@@ -5,4 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/kafka-init-${strimzi_version}.jar /
 
+USER strimzi:strimzi
+
 CMD /bin/launch_java.sh /kafka-init-${STRIMZI_VERSION}.jar

--- a/topic-operator/Dockerfile
+++ b/topic-operator/Dockerfile
@@ -7,4 +7,6 @@ COPY ./scripts/ /bin
 
 ADD target/topic-operator-${strimzi_version}.jar /
 
+USER strimzi:strimzi
+
 CMD /bin/topic_operator_run.sh /topic-operator-${STRIMZI_VERSION}.jar

--- a/user-operator/Dockerfile
+++ b/user-operator/Dockerfile
@@ -5,4 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/user-operator-${strimzi_version}.jar /
 
+USER strimzi:strimzi
+
 CMD /bin/launch_java.sh /user-operator-${STRIMZI_VERSION}.jar


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It turns out all our operators and the kafka-init image are running under root on Kubernetes. This might not be always secure. This PR adds the user strimzi to their images and runs the containers by default under this user.

This PR fixes #1018.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
