### PR TITLE
Fix #1031

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -4,14 +4,8 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
-import io.strimzi.operator.common.operator.resource.PodOperator;
-import io.strimzi.operator.common.operator.resource.PvcOperator;
-import io.strimzi.operator.common.operator.resource.ReconcileResult;
-
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.extensions.DoneableStatefulSet;
@@ -20,12 +14,16 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.operator.common.operator.resource.PvcOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -278,9 +276,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         } else {
             log.debug("Patching {} {}/{}", resourceKind, namespace, name);
         }
-        StatefulSet ss = operation().inNamespace(namespace).withName(name).cascading(false).patch(desired);
-        log.debug("Patched {} {}/{}", resourceKind, namespace, name);
-        return Future.succeededFuture(ReconcileResult.patched(ss));
+        return super.internalPatch(namespace, name, current, desired, false);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -81,10 +81,10 @@ public class CertificateRenewalTest {
             }).collect(Collectors.toList());
         });
         ArgumentCaptor<Secret> c = ArgumentCaptor.forClass(Secret.class);
-        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
-        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
-        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaCertSecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
-        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop()));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaCertSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
+        when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
                 new ResourceOperatorSupplier(null, null, null,

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -88,6 +88,11 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-server-mock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>zjsonpatch</artifactId>
+            <version>${fabric8.zjsonpatch.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -20,6 +21,8 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiPredicate;
+
+import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
 
 /**
  * Abstract resource creation, for a generic resource type {@code R}.
@@ -96,7 +99,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
                         internalDelete(namespace, name).setHandler(future);
                     } else {
                         log.debug("{} {}/{} does not exist, noop", resourceKind, namespace, name);
-                        future.complete(ReconcileResult.noop());
+                        future.complete(ReconcileResult.noop(null));
                     }
                 }
 
@@ -127,13 +130,31 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
      * and completes the given future accordingly.
      */
     protected Future<ReconcileResult<T>> internalPatch(String namespace, String name, T current, T desired) {
+        return internalPatch(namespace, name, current, desired, true);
+    }
+
+    protected Future<ReconcileResult<T>> internalPatch(String namespace, String name, T current, T desired, boolean cascading) {
         try {
-            ReconcileResult.Patched<T> result = ReconcileResult.patched(operation().inNamespace(namespace).withName(name).cascading(true).patch(desired));
+            T result = operation().inNamespace(namespace).withName(name).cascading(cascading).patch(desired);
             log.debug("{} {} in namespace {} has been patched", resourceKind, name, namespace);
-            return Future.succeededFuture(result);
+            return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
         } catch (Exception e) {
             log.error("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
+        }
+    }
+
+    private boolean wasChanged(T oldVersion, T newVersion) {
+        if (oldVersion != null && newVersion != null) {
+            try {
+                Object x = oldVersion.getClass().getMethod("getSpec").invoke(oldVersion);
+                Object y = newVersion.getClass().getMethod("getSpec").invoke(newVersion);
+                return JsonDiff.asJson(patchMapper().valueToTree(x), patchMapper().valueToTree(y)).iterator().hasNext();
+            } catch (ReflectiveOperationException e) {
+                return true;
+            }
+        } else {
+            return true;
         }
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
@@ -45,7 +45,7 @@ public class ConfigMapOperator extends AbstractResourceOperator<KubernetesClient
                 // Checking some metadata. We cannot check entire metadata object because it contains
                 // timestamps which would cause restarting loop
                 log.debug("{} {} in namespace {} has not been patched because resources are equal", resourceKind, name, namespace);
-                return Future.succeededFuture(ReconcileResult.noop());
+                return Future.succeededFuture(ReconcileResult.noop(current));
             } else {
                 return super.internalPatch(namespace, name, current, desired);
             }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
@@ -13,8 +13,8 @@ public abstract class ReconcileResult<R> {
     };
 
     public static class Noop<R> extends ReconcileResult<R> {
-        private Noop() {
-            super(null);
+        private Noop(R resource) {
+            super(resource);
         }
 
         public String toString() {
@@ -22,7 +22,6 @@ public abstract class ReconcileResult<R> {
         }
     }
 
-    private static final ReconcileResult NOOP = new Noop();
 
     public static class Created<R> extends ReconcileResult<R> {
         private Created(R resource) {
@@ -61,8 +60,8 @@ public abstract class ReconcileResult<R> {
     }
 
     /** No action was performed. */
-    public static final <P> ReconcileResult<P> noop() {
-        return NOOP;
+    public static final <P> ReconcileResult<P> noop(P resource) {
+        return new Noop<>(resource);
     }
 
     private final R resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -32,6 +32,6 @@ public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesC
     @Override
     protected Future<ReconcileResult<ServiceAccount>> internalPatch(String namespace, String name, ServiceAccount current, ServiceAccount desired) {
         // Patching a SA causes new tokens to be created, which we should avoid
-        return Future.succeededFuture(ReconcileResult.noop());
+        return Future.succeededFuture(ReconcileResult.noop(current));
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -50,6 +50,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      *
      * @return  Future with reconciliation result
      */
+    @Override
     protected Future<ReconcileResult<Service>> internalPatch(String namespace, String name, Service current, Service desired) {
         try {
             if (current.getSpec() != null && desired.getSpec() != null
@@ -58,9 +59,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
                 patchNodePorts(current, desired);
             }
 
-            ReconcileResult.Patched<Service> result = ReconcileResult.patched(operation().inNamespace(namespace).withName(name).cascading(true).patch(desired));
-            log.debug("{} {} in namespace {} has been patched", resourceKind, name, namespace);
-            return Future.succeededFuture(result);
+            return super.internalPatch(namespace, name, current, desired);
         } catch (Exception e) {
             log.error("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -19,7 +19,6 @@ import io.vertx.ext.unit.TestContext;
 import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
@@ -91,8 +90,8 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
             if (!ar.succeeded()) {
                 ar.cause().printStackTrace();
             }
-            assertTrue(ar.succeeded());
-            assertTrue(ar.result().equals(ReconcileResult.noop()));
+            context.assertTrue(ar.succeeded());
+            context.assertTrue(ar.result() instanceof ReconcileResult.Noop);
             verify(mockResource).get();
             //verify(mockResource).patch(any());
             verify(mockResource, never()).create(any());

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
@@ -34,7 +34,7 @@ public class ScramShaCredentialsOperator {
                         credsManager.delete(username);
                         future.complete(ReconcileResult.deleted());
                     } else {
-                        future.complete(ReconcileResult.noop());
+                        future.complete(ReconcileResult.noop(null));
                     }
                 }
             },

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -8,14 +8,6 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.user.model.KafkaUserModel;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 import io.strimzi.operator.user.model.acl.SimpleAclRuleResource;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -28,6 +20,13 @@ import org.apache.logging.log4j.Logger;
 import scala.Tuple2;
 import scala.collection.Iterator;
 import scala.collection.JavaConversions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * SimlpeAclOperator is responsible for managing the authorization rules in Apache Kafka / Apache Zookeeper.
@@ -77,7 +76,7 @@ public class SimpleAclOperator {
                 if (desired == null || desired.isEmpty()) {
                     if (current.size() == 0)    {
                         log.debug("User {}: No expected Acl rules and no existing Acl rules -> NoOp", username);
-                        future.complete(ReconcileResult.noop());
+                        future.complete(ReconcileResult.noop(desired));
                     } else {
                         log.debug("User {}: No expected Acl rules, but {} existing Acl rules -> Deleting rules", username, current.size());
                         internalDelete(username, current).setHandler(future);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #1031 by using a diff between the desired resource and the resource returned from the patch to determine whether the patch was a noop or not.

In doing this I refactored StatefulSetOperator.internalPatch() slightly so it calls the superclass version.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

