### PR TITLE
Fix wrong place to log rolling pod finished

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -147,9 +147,12 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
                 Future del = podOperations.waitFor(namespace, name, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                     // predicate - changed generation means pod has been updated
                     String newUid = getPodUid(podOperations.get(namespace, podName));
-                    return !deleted.result().equals(newUid);
+                    boolean done = !deleted.result().equals(newUid);
+                    if (done) {
+                        log.debug("Rolling pod {} finished", podName);
+                    }
+                    return done;
                 });
-                log.debug("Rolling pod {} finished", podName);
                 return del;
             });
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This trivial PR fixes a wrong place where rolling pod ended is logged. With the current log, it shows that the deletion takes 0 ms.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

