### PR TITLE
Fix storage issues - the init container is still needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -91,6 +91,7 @@ public abstract class AbstractModel {
 
     private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
     protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
+    private static final Long VOLUME_MOUNT_HACK_USERID = 1001L;
     private static final Long VOLUME_MOUNT_HACK_GROUPID = 0L;
 
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.yml";
@@ -769,7 +770,7 @@ public abstract class AbstractModel {
         // there is an hack on volume mounting which needs an "init-container"
         if (this.storage instanceof PersistentClaimStorage && !isOpenShift) {
             String chown = String.format("chown -R %d:%d %s",
-                    AbstractModel.VOLUME_MOUNT_HACK_GROUPID,
+                    AbstractModel.VOLUME_MOUNT_HACK_USERID,
                     AbstractModel.VOLUME_MOUNT_HACK_GROUPID,
                     volumeMounts.get(0).getMountPath());
             Container initContainer = new ContainerBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -509,9 +509,11 @@ public class KafkaCluster extends AbstractModel {
         return createStatefulSet(
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
+                getVolumeMounts(),
                 getMergedAffinity(),
                 getInitContainers(),
-                getContainers());
+                getContainers(),
+                isOpenShift);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -277,9 +277,11 @@ public class ZookeeperCluster extends AbstractModel {
         return createStatefulSet(
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
+                getVolumeMounts(),
                 getMergedAffinity(),
                 getInitContainers(),
-                getContainers());
+                getContainers(),
+                isOpenShift);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The removal of the init container for storage ownership rights manipulation in PR #1017 seemed to be premature. This PR reverts that change.

