### PR TITLE
Fix Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
         <maven.failsafe.version>2.20.1</maven.failsafe.version>
         <maven.assembly.version>3.1.0</maven.assembly.version>
         <maven.shade.version>3.1.0</maven.shade.version>
+        <maven.javadoc.version>3.0.1</maven.javadoc.version>
+        <maven.source.version>3.0.1</maven.source.version>
+        <maven.dependency.version>3.0.2</maven.dependency.version>
+        <maven.gpg.version>1.6</maven.gpg.version>
+        <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+        <findbugs.version>3.0.5</findbugs.version>
+        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
 
@@ -270,7 +277,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven.checkstyle.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
@@ -371,7 +378,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <version>${findbugs.version}</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.
@@ -404,7 +411,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>${maven.dependency.version}</version>
                 <executions>
                     <execution>
                         <id>analyze</id>
@@ -428,6 +435,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -440,6 +448,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -459,6 +468,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.version}</version>
                         <configuration>
                             <!--suppress UnresolvedMavenProperty -->
                             <argLine>${surefireArgLine}</argLine>
@@ -483,7 +493,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>${maven.gpg.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -497,7 +507,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>${sonatype.nexus.staging}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We should be using fixed (configured) versions of all dependencies including Maven plugins. It would be also good to have them all in one place. This PR defines all plugin versions through properties in the `pom.xml` file.