### PR TITLE
ST: Mirror Maker

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -559,8 +559,8 @@ public class KafkaST extends AbstractST {
         boolean consumerSuccess = false;
         while (m.find()) {
             String json = m.group();
-            String name2 = getValueFromJson(json, "$.name");
-            if ("records_consumed".equals(name2)) {
+            String name = getValueFromJson(json, "$.name");
+            if ("records_consumed".equals(name)) {
                 assertEquals(String.valueOf(messagesCount), getValueFromJson(json, "$.count"));
                 consumerSuccess = true;
             }
@@ -729,7 +729,7 @@ public class KafkaST extends AbstractST {
         }
 
         if (tlsListener) {
-            String clusterCaSecretName = CLUSTER_NAME + "-cluster-ca-cert";
+            String clusterCaSecretName = clusterCaCertSecretName(CLUSTER_NAME);
             String clusterCaSecretVolumeName = "ca-cert";
             String caSecretMountPoint = "/opt/kafka/cluster-ca";
             cb.addNewVolumeMount()
@@ -1101,12 +1101,12 @@ public class KafkaST extends AbstractST {
         // Initialize CertSecretSource with certificate and secret names for consumer
         CertSecretSource certSecretSource = new CertSecretSource();
         certSecretSource.setCertificate("ca.crt");
-        certSecretSource.setSecretName(kafkaSourceName + "-cluster-ca-cert");
+        certSecretSource.setSecretName(clusterCaCertSecretName(kafkaSourceName));
 
         // Initialize CertSecretSource with certificate and secret names for producer
         CertSecretSource certSecretTarget = new CertSecretSource();
         certSecretTarget.setCertificate("ca.crt");
-        certSecretTarget.setSecretName(kafkaTargetName + "-cluster-ca-cert");
+        certSecretTarget.setSecretName(clusterCaCertSecretName(kafkaTargetName));
 
         // Deploy Mirror Maker with tls listener and mutual tls auth
         resources().kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, true)
@@ -1303,7 +1303,7 @@ public class KafkaST extends AbstractST {
         }
 
         if (tlsListener) {
-            String clusterCaSecretName = bootstrapServer + "-cluster-ca-cert";
+            String clusterCaSecretName = clusterCaCertSecretName(bootstrapServer);
             String clusterCaSecretVolumeName = "ca-cert";
             String caSecretMountPoint = "/opt/kafka/cluster-ca";
             cb.addNewVolumeMount()
@@ -1419,7 +1419,7 @@ public class KafkaST extends AbstractST {
         }
 
         if (tlsListener) {
-            String clusterCaSecretName = bootstrapServer + "-cluster-ca-cert";
+            String clusterCaSecretName = clusterCaCertSecretName(bootstrapServer);
             String clusterCaSecretVolumeName = "ca-cert";
             String caSecretMountPoint = "/opt/kafka/cluster-ca";
             cb.addNewVolumeMount()

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.KafkaListenerAuthenticationTls;
@@ -24,6 +25,7 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
+import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 import io.strimzi.test.ClusterOperator;
 import io.strimzi.test.JUnitGroup;
@@ -1016,116 +1018,236 @@ public class KafkaST extends AbstractST {
     @JUnitGroup(name = "regression")
     public void testMirrorMaker() {
         String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
-
-        resources().kafkaEphemeral(CLUSTER_NAME + "-source", 3).done();
-        resources().kafkaEphemeral(CLUSTER_NAME + "-target", 3).done();
-
-        String nameProducerSource = "send-messages-plain-anon-producer-source";
-        String nameConsumerSource = "send-messages-plain-anon-consumer-source";
-        String nametarget = "send-messages-plain-anon-target";
+        String nameProducerSource = "send-messages-producer-source";
+        String nameConsumerSource = "send-messages-consumer-source";
+        String nameConsumerTarget = "send-messages-consumer-target";
+        String kafkaSourceName = CLUSTER_NAME + "-source";
+        String kafkaTargetName = CLUSTER_NAME + "-target";
         int messagesCount = 20;
 
-        // TODO Try to create one Topic
-        resources().topic(CLUSTER_NAME + "-source", topicSourceName).done();
-//        resources().topic(CLUSTER_NAME + "-target", topicTargetName).done();
+        // Deploy source kafka
+        resources().kafkaEphemeral(kafkaSourceName, 3).done();
+        // Deploy target kafka
+        resources().kafkaEphemeral(kafkaTargetName, 3).done();
+        // Deploy Topic
+        resources().topic(kafkaSourceName, topicSourceName).done();
+        // Deploy Mirror Maker
+        resources().kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
-        resources().kafkaMirrorMaker(CLUSTER_NAME, "my-group", 1, false)
-            .editSpec()
-                .editConsumer()
-                .withBootstrapServers("my-cluster-source-kafka-bootstrap:9092")
-                .endConsumer()
-                .editProducer()
-                .withBootstrapServers("my-cluster-target-kafka-bootstrap:9092")
-                .endProducer()
-            .endSpec()
-            .done();
-//        kubeClient.searchInLog("deploy", "my-cluster-mirror-maker", stopwatch.runtime(SECONDS),  "\"Successfully joined group\"");
-
+        // Wait when Mirror Maker will join group
         waitFor("Mirror Maker will join group", 1_000, 120_000, () ->
-//            kubeClient.searchInLog("deploy", "my-cluster-mirror-maker", stopwatch.runtime(SECONDS),  "\"Resetting offset for partition\"").isEmpty()
             !kubeClient.searchInLog("deploy", "my-cluster-mirror-maker", stopwatch.runtime(SECONDS),  "\"Successfully joined group\"").isEmpty()
         );
 
-        waitForJobSuccess(sendRecordsToClusterJob(nameProducerSource, topicSourceName, messagesCount, null, false));
-        waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-source", nameConsumerSource, topicSourceName, messagesCount, null, false));
-
-
-        Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-target", nameConsumerSource + "-1", topicSourceName, messagesCount, null, false));
-
+        // Create job to send 20 records using Kafka producer for source cluster
+        waitForJobSuccess(sendRecordsToClusterJob(kafkaSourceName, nameProducerSource, topicSourceName, messagesCount, null, false));
+        // Create job to read 20 records using Kafka producer for source cluster
+        waitForJobSuccess(readMessagesFromClusterJob(kafkaSourceName, nameConsumerSource, topicSourceName, messagesCount, null, false));
+        // Create job to read 20 records using Kafka consumer for target cluster
+        Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(kafkaTargetName, nameConsumerTarget, topicSourceName, messagesCount, null, false));
+        // Check consumed messages in target cluster
         checkRecordsForConsumer(messagesCount, jobReadMessagesForTarget);
     }
 
     /**
-     * Test sending messages over tls transport using mutual tls auth
+     * Test mirroring messages by Mirror Maker over tls transport using mutual tls auth
      */
     @Test
     @JUnitGroup(name = "regression")
     public void testMirrorMakerTlsAuthenticated() {
         String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String nameProducerSource = "send-messages-plain-anon-producer-source";
-        String nameConsumerSource = "send-messages-plain-anon-consumer-source";
+        String nameProducerSource = "send-messages-producer-source";
+        String nameConsumerSource = "send-messages-consumer-source";
+        String nameConsumerTarget = "send-messages-consumer-target";
+        String kafkaUser = "my-user";
+        String kafkaSourceName = CLUSTER_NAME + "-source";
+        String kafkaTargetName = CLUSTER_NAME + "-target";
+        int messagesCount = 20;
 
         KafkaListenerAuthenticationTls auth = new KafkaListenerAuthenticationTls();
         KafkaListenerTls listenerTls = new KafkaListenerTls();
         listenerTls.setAuth(auth);
 
+        // Deploy source kafka with tls listener and mutual tls auth
         resources().kafka(resources().defaultKafka(CLUSTER_NAME + "-source", 3)
                 .editSpec()
-                .editKafka()
-                .withNewListeners()
-                .withTls(listenerTls)
-                .withNewTls()
-                .endTls()
-                .endListeners()
-                .endKafka()
+                    .editKafka()
+                        .withNewListeners()
+                            .withTls(listenerTls)
+                            .withNewTls()
+                            .endTls()
+                        .endListeners()
+                    .endKafka()
                 .endSpec().build()).done();
 
+        // Deploy target kafka with tls listener and mutual tls auth
         resources().kafka(resources().defaultKafka(CLUSTER_NAME + "-target", 3)
                 .editSpec()
-                .editKafka()
-                .withNewListeners()
-                .withTls(listenerTls)
-                .withNewTls()
-                .endTls()
-                .endListeners()
-                .endKafka()
+                    .editKafka()
+                        .withNewListeners()
+                            .withTls(listenerTls)
+                            .withNewTls()
+                            .endTls()
+                        .endListeners()
+                    .endKafka()
                 .endSpec().build()).done();
 
-        String kafkaUser = "my-user";
-        String name = "send-messages-tls-auth";
-        int messagesCount = 20;
+        // Deploy topic
+        resources().topic(kafkaSourceName, topicSourceName).done();
 
-        resources().topic(CLUSTER_NAME + "-source", topicSourceName).done();
-
+        // Create Kafka user
         KafkaUser user = resources().tlsUser(kafkaUser).done();
         waitTillSecretExists(kafkaUser);
 
-        resources().kafkaMirrorMaker(CLUSTER_NAME, "my-group", 1, false)
+        // Initialize CertSecretSource with certificate and secret names for consumer
+        CertSecretSource certSecretSource = new CertSecretSource();
+        certSecretSource.setCertificate("ca.crt");
+        certSecretSource.setSecretName(kafkaSourceName + "-cluster-ca-cert");
+
+        // Initialize CertSecretSource with certificate and secret names for producer
+        CertSecretSource certSecretTarget = new CertSecretSource();
+        certSecretTarget.setCertificate("ca.crt");
+        certSecretTarget.setSecretName(kafkaTargetName + "-cluster-ca-cert");
+
+        // Deploy Mirror Maker with tls listener and mutual tls auth
+        resources().kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, true)
                 .editSpec()
                 .editConsumer()
-                .withBootstrapServers("my-cluster-source-kafka-bootstrap:9093")
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretSource)
+                    .endTls()
                 .endConsumer()
                 .editProducer()
-                .withBootstrapServers("my-cluster-target-kafka-bootstrap:9093")
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
                 .endProducer()
                 .endSpec()
                 .done();
 
+        // Wait when Mirror Maker will join the group
         waitFor("Mirror Maker will join group", 1_000, 120_000, () ->
-//            kubeClient.searchInLog("deploy", "my-cluster-mirror-maker", stopwatch.runtime(SECONDS),  "\"Resetting offset for partition\"").isEmpty()
-                        !kubeClient.searchInLog("deploy", "my-cluster-mirror-maker", stopwatch.runtime(SECONDS),  "\"Successfully joined group\"").isEmpty()
+            !kubeClient.searchInLog("deploy", CLUSTER_NAME + "-mirror-maker", stopwatch.runtime(SECONDS),  "\"Successfully joined group\"").isEmpty()
         );
 
-        waitForJobSuccess(sendRecordsToClusterJob(nameProducerSource, topicSourceName, messagesCount, user, true));
-        waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-source", nameConsumerSource, topicSourceName, messagesCount, user, true));
-
-
-        Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-target", nameConsumerSource + "-1", topicSourceName, messagesCount, user, true));
-
+        // Create job to send 20 records using Kafka producer for source cluster
+        waitForJobSuccess(sendRecordsToClusterJob(kafkaSourceName, nameProducerSource, topicSourceName, messagesCount, user, true));
+        // Create job to read 20 records using Kafka producer for source cluster
+        waitForJobSuccess(readMessagesFromClusterJob(kafkaSourceName, nameConsumerSource, topicSourceName, messagesCount, user, true));
+        // Create job to read 20 records using Kafka consumer for target cluster
+        Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(kafkaTargetName, nameConsumerTarget, topicSourceName, messagesCount, user, true));
+        // Check consumed messages in target cluster
         checkRecordsForConsumer(messagesCount, jobReadMessagesForTarget);
     }
 
-    private PodSpecBuilder createPodSpecForProducer(ContainerBuilder cb, KafkaUser kafkaUser, boolean tlsListener) {
+    /**
+     * Test mirroring messages by Mirror Maker over tls transport using scram-sha auth
+     */
+    @Test
+    @JUnitGroup(name = "regression")
+    public void testMirrorMakerTlsScramSha() {
+        String kafkaUserSource = "my-user-source";
+        String kafkaUserTarget = "my-user-target";
+        String nameProducerSource = "send-messages-producer-source";
+        String nameConsumerSource = "read-messages-consumer-source";
+        String nameConsumerTarget = "read-messages-consumer-target";
+        String kafkaSourceName = CLUSTER_NAME + "-source";
+        String kafkaTargetName = CLUSTER_NAME + "-target";
+        String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
+        int messagesCount = 20;
+
+
+        // Deploy source kafka with tls listener and SCRAM-SHA authentication
+        resources().kafka(resources().defaultKafka(kafkaSourceName, 3)
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewTls().withAuth(new KafkaListenerAuthenticationScramSha512()).endTls()
+                        .endListeners()
+                    .endKafka()
+                .endSpec().build()).done();
+
+        // Deploy target kafka with tls listener and SCRAM-SHA authentication
+        resources().kafka(resources().defaultKafka(kafkaTargetName, 3)
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                          .withNewTls().withAuth(new KafkaListenerAuthenticationScramSha512()).endTls()
+                        .endListeners()
+                    .endKafka()
+                .endSpec().build()).done();
+
+        // Deploy topic
+        resources().topic(kafkaSourceName, topicName).done();
+
+        // Create Kafka user for source cluster
+        KafkaUser userSource = resources().scramShaUser(kafkaUserSource).done();
+        waitTillSecretExists(kafkaUserSource);
+
+        // Create Kafka user for target cluster
+        KafkaUser userTarget = resources().scramShaUser(kafkaUserTarget).done();
+        waitTillSecretExists(kafkaUserTarget);
+
+        // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec
+        PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
+        passwordSecretSource.setSecretName(kafkaUserSource);
+        passwordSecretSource.setPassword("password");
+
+        // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec
+        PasswordSecretSource passwordSecretTarget = new PasswordSecretSource();
+        passwordSecretTarget.setSecretName(kafkaUserTarget);
+        passwordSecretTarget.setPassword("password");
+
+        // Initialize CertSecretSource with certificate and secret names for consumer
+        CertSecretSource certSecretSource = new CertSecretSource();
+        certSecretSource.setCertificate("ca.crt");
+        certSecretSource.setSecretName(clusterCaCertSecretName(kafkaSourceName));
+
+        // Initialize CertSecretSource with certificate and secret names for producer
+        CertSecretSource certSecretTarget = new CertSecretSource();
+        certSecretTarget.setCertificate("ca.crt");
+        certSecretTarget.setSecretName(clusterCaCertSecretName(kafkaTargetName));
+
+        // Deploy Mirror Maker with TLS and ScramSha512
+        resources().kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, true)
+                .editSpec()
+                    .editConsumer()
+                        .withNewKafkaMirrorMakerAuthenticationScramSha512Authentication()
+                            .withUsername(kafkaUserSource)
+                            .withPasswordSecret(passwordSecretSource)
+                        .endKafkaMirrorMakerAuthenticationScramSha512Authentication()
+                        .withNewTls()
+                            .withTrustedCertificates(certSecretSource)
+                        .endTls()
+                    .endConsumer()
+                .editProducer()
+                    .withNewKafkaMirrorMakerAuthenticationScramSha512Authentication()
+                        .withUsername(kafkaUserTarget)
+                        .withPasswordSecret(passwordSecretTarget)
+                    .endKafkaMirrorMakerAuthenticationScramSha512Authentication()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
+                .endProducer()
+                .endSpec().done();
+
+        // Wait when Mirror Maker will join group
+        waitFor("Mirror Maker will join group", 1_000, 120_000, () ->
+            !kubeClient.searchInLog("deploy", CLUSTER_NAME + "-mirror-maker", stopwatch.runtime(SECONDS),  "\"Successfully joined group\"").isEmpty()
+        );
+
+        // Create job to send 20 records using Kafka producer for source cluster
+        waitForJobSuccess(sendRecordsToClusterJob(CLUSTER_NAME + "-source", nameProducerSource, topicName, messagesCount, userSource, true));
+        // Create job to read 20 records using Kafka consumer for source cluster
+        waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-source", nameConsumerSource, topicName, messagesCount, userSource, true));
+        // Create job to read 20 records using Kafka consumer for target cluster
+        Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-target", nameConsumerTarget, topicName, messagesCount, userTarget, true));
+        // Check consumed messages in target cluster
+        checkRecordsForConsumer(messagesCount, jobReadMessagesForTarget);
+    }
+
+
+    private PodSpecBuilder createPodSpecForProducer(ContainerBuilder cb, KafkaUser kafkaUser, boolean tlsListener, String bootstrapServer) {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder()
                 .withRestartPolicy("OnFailure");
 
@@ -1182,7 +1304,7 @@ public class KafkaST extends AbstractST {
         }
 
         if (tlsListener) {
-            String clusterCaSecretName = CLUSTER_NAME + "-cluster-ca-cert";
+            String clusterCaSecretName = bootstrapServer + "-cluster-ca-cert";
             String clusterCaSecretVolumeName = "ca-cert";
             String caSecretMountPoint = "/opt/kafka/cluster-ca";
             cb.addNewVolumeMount()
@@ -1207,9 +1329,9 @@ public class KafkaST extends AbstractST {
         return podSpecBuilder.withContainers(cb.build());
     }
 
-    private Job sendRecordsToClusterJob(String name, String topic, int messagesCount, KafkaUser kafkaUser, boolean tlsListener) {
+    private Job sendRecordsToClusterJob(String bootstrapServer, String name, String topic, int messagesCount, KafkaUser kafkaUser, boolean tlsListener) {
 
-        String connect = tlsListener ? CLUSTER_NAME + "-source" + "-kafka-bootstrap:9093" : CLUSTER_NAME + "-source" + "-kafka-bootstrap:9092";
+        String connect = tlsListener ? bootstrapServer + "-kafka-bootstrap:9093" : bootstrapServer + "-kafka-bootstrap:9092";
 
         ContainerBuilder cb = new ContainerBuilder()
             .withName("send-records")
@@ -1220,27 +1342,27 @@ public class KafkaST extends AbstractST {
                     "--max-messages " + messagesCount).endEnv()
             .withCommand("/opt/kafka/producer.sh");
 
-        PodSpec producerPodSpec = createPodSpecForProducer(cb, kafkaUser, tlsListener).build();
+        PodSpec producerPodSpec = createPodSpecForProducer(cb, kafkaUser, tlsListener, bootstrapServer).build();
 
         Job job = resources().deleteLater(namespacedClient().extensions().jobs().create(new JobBuilder()
             .withNewMetadata()
-            .withName(name)
+                .withName(name)
             .endMetadata()
             .withNewSpec()
-            .withNewTemplate()
-            .withNewMetadata()
-            .withName(name)
-            .addToLabels("job", name)
-            .endMetadata()
-            .withSpec(producerPodSpec)
-            .endTemplate()
+                .withNewTemplate()
+                    .withNewMetadata()
+                        .withName(name)
+                        .addToLabels("job", name)
+                    .endMetadata()
+                .withSpec(producerPodSpec)
+                .endTemplate()
             .endSpec()
             .build()));
         LOGGER.info("Created Job {}", job);
         return job;
     }
 
-    private PodSpecBuilder createPodSpecForConsumer(ContainerBuilder cb, KafkaUser kafkaUser, boolean tlsListener) {
+    private PodSpecBuilder createPodSpecForConsumer(ContainerBuilder cb, KafkaUser kafkaUser, boolean tlsListener, String bootstrapServer) {
 
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder()
                 .withRestartPolicy("OnFailure");
@@ -1298,7 +1420,7 @@ public class KafkaST extends AbstractST {
         }
 
         if (tlsListener) {
-            String clusterCaSecretName = CLUSTER_NAME + "-cluster-ca-cert";
+            String clusterCaSecretName = bootstrapServer + "-cluster-ca-cert";
             String clusterCaSecretVolumeName = "ca-cert";
             String caSecretMountPoint = "/opt/kafka/cluster-ca";
             cb.addNewVolumeMount()
@@ -1337,23 +1459,27 @@ public class KafkaST extends AbstractST {
                 .withCommand("/opt/kafka/consumer.sh");
 
 
-        PodSpec consumerPodSpec = createPodSpecForConsumer(cb, kafkaUser, tlsListener).build();
+        PodSpec consumerPodSpec = createPodSpecForConsumer(cb, kafkaUser, tlsListener, bootstrapServer).build();
 
         Job job = resources().deleteLater(namespacedClient().extensions().jobs().create(new JobBuilder()
                 .withNewMetadata()
-                .withName(name)
+                    .withName(name)
                 .endMetadata()
                 .withNewSpec()
-                .withNewTemplate()
-                .withNewMetadata()
-                .withName(name)
-                .addToLabels("job", name)
-                .endMetadata()
-                .withSpec(consumerPodSpec)
-                .endTemplate()
+                    .withNewTemplate()
+                        .withNewMetadata()
+                            .withName(name)
+                            .addToLabels("job", name)
+                        .endMetadata()
+                        .withSpec(consumerPodSpec)
+                    .endTemplate()
                 .endSpec()
                 .build()));
         LOGGER.info("Created Job {}", job);
         return job;
+    }
+
+    private String clusterCaCertSecretName(String cluster)  {
+        return cluster + "-cluster-ca-cert";
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -549,8 +549,7 @@ public class KafkaST extends AbstractST {
     }
 
     /**
-     * Greps logs from a pod which ran kafka-verifiable-producer.sh and
-     * kafka-verifiable-consumer.sh
+     * Greps logs from a pod which ran kafka-verifiable-consumer.sh
      */
     private void checkRecordsForConsumer(int messagesCount, Job job) {
         String podName = jobPodName(job);

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -308,20 +308,20 @@ public class Resources {
         });
     }
 
-    DoneableKafkaMirrorMaker kafkaMirrorMaker(String name, String groupId, int mirrorMakerReplicas, boolean tlsListener) {
-        return kafkaMirrorMaker(defaultMirrorMaker(name, groupId, mirrorMakerReplicas, tlsListener).build());
+    DoneableKafkaMirrorMaker kafkaMirrorMaker(String name, String sourceBootstrapServer, String targetBootstrapServer, String groupId, int mirrorMakerReplicas, boolean tlsListener) {
+        return kafkaMirrorMaker(defaultMirrorMaker(name, sourceBootstrapServer, targetBootstrapServer, groupId, mirrorMakerReplicas, tlsListener).build());
     }
 
-    private KafkaMirrorMakerBuilder defaultMirrorMaker(String name, String groupId, int mirrorMakerReplicas, boolean tlsListener) {
+    private KafkaMirrorMakerBuilder defaultMirrorMaker(String name, String sourceBootstrapServer, String targetBootstrapServer, String groupId, int mirrorMakerReplicas, boolean tlsListener) {
         return new KafkaMirrorMakerBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
                 .withNewConsumer()
-                    .withBootstrapServers(tlsListener ? name + "-kafka-bootstrap:9093" : name + "-kafka-bootstrap:9092")
+                    .withBootstrapServers(tlsListener ? sourceBootstrapServer + "-kafka-bootstrap:9093" : sourceBootstrapServer + "-kafka-bootstrap:9092")
                     .withGroupId(groupId)
                 .endConsumer()
                 .withNewProducer()
-                    .withBootstrapServers(tlsListener ? name + "-kafka-bootstrap:9093" : name + "-kafka-bootstrap:9092")
+                    .withBootstrapServers(tlsListener ? targetBootstrapServer + "-kafka-bootstrap:9093" : targetBootstrapServer + "-kafka-bootstrap:9092")
                 .endProducer()
             .withReplicas(mirrorMakerReplicas)
             .withWhitelist(".*")
@@ -344,8 +344,7 @@ public class Resources {
                     }
                 }
             );
-            return waitFor(deleteLater(
-                    k));
+            return waitFor(deleteLater(k));
         });
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -52,6 +52,8 @@ import java.util.stream.IntStream;
 public class Resources {
 
     private static final Logger LOGGER = LogManager.getLogger(Resources.class);
+    private static final long TIMEOUT_FOR_CREATION = 60_000;
+    private static final long TIMEOUT_INTERVAL_FOR_CREATION = 5_000;
 
     private final NamespacedKubernetesClient client;
 
@@ -215,7 +217,7 @@ public class Resources {
 
     DoneableKafka kafka(Kafka kafka) {
         return new DoneableKafka(kafka, k -> {
-            TestUtils.waitFor("Kafka creation", 60000, 5000,
+            TestUtils.waitFor("Kafka creation", TIMEOUT_FOR_CREATION, TIMEOUT_INTERVAL_FOR_CREATION,
                 () -> {
                     try {
                         kafka().inNamespace(client().getNamespace()).createOrReplace(k);
@@ -249,7 +251,7 @@ public class Resources {
 
     private DoneableKafkaConnect kafkaConnect(KafkaConnect kafkaConnect) {
         return new DoneableKafkaConnect(kafkaConnect, kC -> {
-            TestUtils.waitFor("KafkaConnect creation", 60000, 5000,
+            TestUtils.waitFor("KafkaConnect creation", TIMEOUT_FOR_CREATION, TIMEOUT_INTERVAL_FOR_CREATION,
                 () -> {
                     try {
                         kafkaConnect().inNamespace(client().getNamespace()).createOrReplace(kC);
@@ -289,7 +291,7 @@ public class Resources {
 
     private DoneableKafkaConnectS2I kafkaConnectS2I(KafkaConnectS2I kafkaConnectS2I) {
         return new DoneableKafkaConnectS2I(kafkaConnectS2I, kCS2I -> {
-            TestUtils.waitFor("KafkaConnectS2I creation", 60000, 5000,
+            TestUtils.waitFor("KafkaConnectS2I creation", TIMEOUT_FOR_CREATION, TIMEOUT_INTERVAL_FOR_CREATION,
                 () -> {
                     try {
                         kafkaConnectS2I().inNamespace(client().getNamespace()).createOrReplace(kCS2I);
@@ -330,7 +332,7 @@ public class Resources {
 
     private DoneableKafkaMirrorMaker kafkaMirrorMaker(KafkaMirrorMaker kafkaMirrorMaker) {
         return new DoneableKafkaMirrorMaker(kafkaMirrorMaker, k -> {
-            TestUtils.waitFor("Kafka Mirror Maker creation", 60000, 5000,
+            TestUtils.waitFor("Kafka Mirror Maker creation", TIMEOUT_FOR_CREATION, TIMEOUT_INTERVAL_FOR_CREATION,
                 () -> {
                     try {
                         kafkaMirrorMaker().inNamespace(client().getNamespace()).createOrReplace(k);


### PR DESCRIPTION
### Type of change
- System tests

### Description
This PR contains new system tests for Mirror Maker. Also this PR has methods to deploy Mirror Maker using `Resources` and fabric8.

Test cases:
case 1 
1.1 Test deploys 2 Kafka clusters (Source/Target) 
1.2 Test creates a topic
1.3 Test deploys Mirror Maker without tls and auth
1.4 Test creates jobs to send and read messages in the source cluster
1.5 Test creates job to read mirrored messages in the target cluster  
case 2
2.1 Test deploys 2 Kafka clusters (Source/Target) 
2.2 Test creates a topic
2.3 Test deploys Mirror Maker with tls
2.4 Test creates new user
2.5 Test creates jobs to send and read messages in the source cluster
2.5 Test creates job to read mirrored messages in the target cluster  
case 3
3.1 Test deploys 2 Kafka clusters (Source/Target) 
3.2 Test creates a topic
3.3 Test deploys Mirror Maker with tls and scram-sha-512 auth
3.4 Test creates new users
3.5 Test creates jobs to send and read messages in the source cluster
3.5 Test creates job to read mirrored messages in the target cluster  

### Checklist
- [ ] Write tests
- [ ] Execute system tests on local environment 
- [ ] Ckeck tests results in Jenkins
