### PR TITLE
Enable link even on section headings which are not in the TOC

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -7,6 +7,7 @@
 :numbered:
 :sectanchors!:
 :sectnums:
+:sectlinks:
 :source-highlighter: highlightjs
 :toc: left
 :linkattrs:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Currently, when you want to share a link to the documentation, you can do so easily only for the section titles which are in the TOC. This PR enabled that all headings in the text will be rendered as links and will allow you to click on them and _copy-paste_ the link. This should allow us to share more precisely the different docu sections.