### PR TITLE
Adding two single/simple/demo node deployments for persistent/ephemeral

### DIFF
--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -1,0 +1,28 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 1
+    listeners:
+      plain: {}
+      tls: {}
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

It's adding simple installs for both storage types, but just using one node for each, Apache Zookeeper and Apache Kafka.

Especially with demos this is handy