### PR TITLE
Fix the titles for two different chapters which used the same title

### DIFF
--- a/documentation/book/assembly-kafka-broker-replicas.adoc
+++ b/documentation/book/assembly-kafka-broker-replicas.adoc
@@ -8,7 +8,7 @@
 
 [id='assembly-kafka-broker-replicas-{context}']
 
-= Replicas
+= Kafka broker replicas
 
 A Kafka cluster can run with many brokers.
 You can configure the number of brokers used for the Kafka cluster in `Kafka.spec.kafka.replicas`.

--- a/documentation/book/assembly-zookeeper-replicas.adoc
+++ b/documentation/book/assembly-zookeeper-replicas.adoc
@@ -8,7 +8,7 @@
 
 [id='assembly-zookeeper-replicas-{context}']
 
-= Replicas
+= Zookeeper replicas
 
 Zookeeper clusters or ensembles usually run with an odd number of nodes and always requires the majority of the nodes to be available in order to maintain a quorum.
 Maintaining a quorum is important because when the Zookeeper cluster loses a quorum, it will stop responding to clients.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

We have two different chapters in our documentation which are both titled just _Replicas_. This looks really strange and confusing, because they are were close to each other in the ToC (3.1.2 and 3.1.6). This PR renames them to make them more distinguishable. There are other chapters called _Replicas_ as well, but I think there it is OK because they are in placed in different parent sections. So I haven't changed those.