### PR TITLE
MAke it possible to specify directly the truststore and keystore in TO

### DIFF
--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -6,21 +6,21 @@ then
 fi
 
 if [ "$STRIMZI_TLS_ENABLED" = "true" ]; then
+    if [ -z "$STRIMZI_TRUSTSTORE_LOCATION" ] && [ -z "$STRIMZI_KEYSTORE_LOCATION" ]; then
+        # Generate temporary keystore password
+        export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 
-    # Generate temporary keystore password
-    export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
+        mkdir -p /tmp/topic-operator
 
-    mkdir -p /tmp/topic-operator
+        # Import certificates into keystore and truststore
+        /bin/tls_prepare_certificates.sh
 
-    # Import certificates into keystore and truststore
-    /bin/tls_prepare_certificates.sh
+        export STRIMZI_TRUSTSTORE_LOCATION=/tmp/topic-operator/replication.truststore.p12
+        export STRIMZI_TRUSTSTORE_PASSWORD=$CERTS_STORE_PASSWORD
 
-    export STRIMZI_TRUSTSTORE_LOCATION=/tmp/topic-operator/replication.truststore.p12
-    export STRIMZI_TRUSTSTORE_PASSWORD=$CERTS_STORE_PASSWORD
-
-    export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
-    export STRIMZI_KEYSTORE_PASSWORD=$CERTS_STORE_PASSWORD
-
+        export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
+        export STRIMZI_KEYSTORE_PASSWORD=$CERTS_STORE_PASSWORD
+    fi
 fi
 
 exec /bin/launch_java.sh $1


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

In the [documentation](http://strimzi.io/docs/master/full.html#topic-operator-environment-deploying), we suggest users to configure the JKS keystore and truststore path in environment variables. However, we always override these with our internal handling for the TO embedded into the entity operator.

This PR makes sure that when the path to the truststore and keystore is set, we do not call the creation of keystore and truststore from X509 files.

This should resolve #1058

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging