### PR TITLE
Use numeric UIDs in Dockerfiles

### DIFF
--- a/cluster-operator/Dockerfile
+++ b/cluster-operator/Dockerfile
@@ -5,6 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/cluster-operator-${strimzi_version}.jar /
 
-USER strimzi:strimzi
+USER 1001
 
 CMD /bin/launch_java.sh /cluster-operator-${STRIMZI_VERSION}.jar

--- a/docker-images/entity-operator-stunnel/Dockerfile
+++ b/docker-images/entity-operator-stunnel/Dockerfile
@@ -3,6 +3,6 @@ FROM strimzi/stunnel-base:latest
 # copy scripts for starting Stunnel
 COPY ./scripts/ $STUNNEL_HOME
 
-USER stunnel:stunnel
+USER 1001
 
 CMD ["/opt/stunnel/stunnel_run.sh"]

--- a/docker-images/kafka-connect/Dockerfile
+++ b/docker-images/kafka-connect/Dockerfile
@@ -5,6 +5,6 @@ EXPOSE 8083 9404
 # copy scripts for starting Kafka Connect
 COPY ./scripts/ $KAFKA_HOME
 
-USER kafka:kafka
+USER 1001
 
 CMD ["/opt/kafka/kafka_connect_run.sh"]

--- a/docker-images/kafka-mirror-maker/Dockerfile
+++ b/docker-images/kafka-mirror-maker/Dockerfile
@@ -3,6 +3,6 @@ FROM strimzi/kafka-base:latest
 # copy scripts for starting Mirror Maker
 COPY ./scripts/ $KAFKA_HOME
 
-USER kafka:kafka
+USER 1001
 
 CMD ["/opt/kafka/kafka_mirror_maker_run.sh"]

--- a/docker-images/kafka-stunnel/Dockerfile
+++ b/docker-images/kafka-stunnel/Dockerfile
@@ -3,6 +3,6 @@ FROM strimzi/stunnel-base:latest
 # copy scripts for starting Stunnel
 COPY ./scripts/ $STUNNEL_HOME
 
-USER stunnel:stunnel
+USER 1001
 
 CMD ["/opt/stunnel/stunnel_run.sh"]

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -6,6 +6,6 @@ EXPOSE 9091 9092 9404
 # copy scripts for starting Kafka
 COPY ./scripts/ $KAFKA_HOME
 
-USER kafka:kafka
+USER 1001
 
 CMD ["/opt/kafka/kafka_run.sh"]

--- a/docker-images/test-client/Dockerfile
+++ b/docker-images/test-client/Dockerfile
@@ -3,5 +3,5 @@ FROM strimzi/kafka-base:latest
 # copy scripts for starting Kafka
 COPY ./scripts/ $KAFKA_HOME
 
-USER kafka:kafka
+USER 1001
 

--- a/docker-images/zookeeper-stunnel/Dockerfile
+++ b/docker-images/zookeeper-stunnel/Dockerfile
@@ -6,6 +6,6 @@ EXPOSE 2181 2888 3888
 # copy scripts for starting Stunnel
 COPY ./scripts/ $STUNNEL_HOME
 
-USER stunnel:stunnel
+USER 1001
 
 CMD ["/opt/stunnel/stunnel_run.sh"]

--- a/docker-images/zookeeper/Dockerfile
+++ b/docker-images/zookeeper/Dockerfile
@@ -6,6 +6,6 @@ EXPOSE 9404
 # copy scripts for starting Zookeeper
 COPY ./scripts/ $KAFKA_HOME
 
-USER kafka:kafka
+USER 1001
 
 CMD ["/opt/kafka/zookeeper_run.sh"]

--- a/kafka-init/Dockerfile
+++ b/kafka-init/Dockerfile
@@ -5,6 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/kafka-init-${strimzi_version}.jar /
 
-USER strimzi:strimzi
+USER 1001
 
 CMD /bin/launch_java.sh /kafka-init-${STRIMZI_VERSION}.jar

--- a/topic-operator/Dockerfile
+++ b/topic-operator/Dockerfile
@@ -7,6 +7,6 @@ COPY ./scripts/ /bin
 
 ADD target/topic-operator-${strimzi_version}.jar /
 
-USER strimzi:strimzi
+USER 1001
 
 CMD /bin/topic_operator_run.sh /topic-operator-${STRIMZI_VERSION}.jar

--- a/user-operator/Dockerfile
+++ b/user-operator/Dockerfile
@@ -5,6 +5,6 @@ ENV STRIMZI_VERSION ${strimzi_version}
 
 ADD target/user-operator-${strimzi_version}.jar /
 
-USER strimzi:strimzi
+USER 1001
 
 CMD /bin/launch_java.sh /user-operator-${STRIMZI_VERSION}.jar


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When running on a kubernetes cluster with a PodSecurityPolicy that enforces MustRunAsNonRoot the following occurs:

```
7s          31s          3       my-cluster-zookeeper-0.15636beefb990d54                     Pod           spec.containers{zookeeper}                  Warning   Failed                  kubelet, minikube        Error: container has runAsNonRoot and image has non-numeric user (kafka), cannot verify user is non-root
7s          22s          3       my-cluster-zookeeper-0.15636bf10d25ff00                     Pod           spec.containers{tls-sidecar}                Warning   Failed                  kubelet, minikube        Error: container has runAsNonRoot and image has non-numeric user (stunnel), cannot verify user is non-root
```

This changes the Dockerfiles to use numeric UIDs which can be verified.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

