### PR TITLE
Added k8s revision annotation before patching

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -14,6 +14,8 @@ import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
+import java.util.HashMap;
+
 /**
  * Operations for {@code Deployment}s.
  */
@@ -69,5 +71,20 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
                     .endTemplate()
                 .endSpec()
             .build();
+    }
+
+    @Override
+    protected Future<ReconcileResult<Deployment>> internalPatch(String namespace, String name, Deployment current, Deployment desired, boolean cascading) {
+        if (current.getMetadata().getAnnotations() != null) {
+            String k8sRev = current.getMetadata().getAnnotations().get("deployment.kubernetes.io/revision");
+            if (k8sRev != null) {
+                if (desired.getMetadata().getAnnotations() == null) {
+                    desired.getMetadata().setAnnotations(new HashMap<>(1));
+                }
+                desired.getMetadata().getAnnotations().put("deployment.kubernetes.io/revision", k8sRev);
+            }
+        }
+
+        return super.internalPatch(namespace, name, current, desired, cascading);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #1061 which also drives to have PATCH and not NOOP as result of a reconcile on EO Deployment when nothing changes (i.e. every reconciles). This also determines a problem on doing the rolling update for EO when certs are renewed.
This PR just copies the missing annotation from `current` to `desired` Deployment avoiding to add a new DeploymentDiff class (as we have for StatefulSet).
After discussing with @tombentley it seems to be the best way due to the fact that the fabric8 library doesn't provide a way for doing the patch passing a JSON diff and moving the decision of what needs to be considered a difference or not at application level. We want to open an issue for that on the fabric8 project.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

