### PR TITLE
Remove the unneeded KAFKA_ZOOKEEPER_CONNECT env var from Kafka container

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -764,7 +764,6 @@ public class KafkaCluster extends AbstractModel {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-        varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -116,8 +116,8 @@ public class KafkaSetOperatorTest {
     @Test
     public void testNeedsRollingUpdateEnvZkConnect() {
         String envVar = ENV_VAR_KAFKA_ZOOKEEPER_CONNECT;
-        a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
-                containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
+        a.getSpec().getTemplate().getSpec().getContainers().get(1).getEnv().add(new EnvVar(envVar,
+                containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(1)).get(envVar) + "-foo", null));
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `KAFKA_ZOOKEEPER_CONNECT` is not needed anymore in the Kafka container as now connects always to `localhost:2181`. This PR removes it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally