### PR TITLE
Factor out useful naming-related functions into API

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -101,30 +101,30 @@ public class KafkaResources {
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The name of the corresponding bootstrap {@code Service}.
      */
-    public static String internalBootstrapServiceName(String clusterName) {
+    public static String bootstrapServiceName(String clusterName) {
         return clusterName + "-kafka-bootstrap";
     }
 
     /**
-     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
+     * Returns the address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
      * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The socket address of the corresponding bootstrap {@code Service}.
-     * @see #internalTlsBootstrapConnection(String)
+     * @return The address of the corresponding bootstrap {@code Service}.
+     * @see #tlsBootstrapConnection(String)
      */
-    public static String internalPlainBootstrapConnection(String clusterName) {
-        return internalBootstrapServiceName(clusterName) + ":9092";
+    public static String plainBootstrapConnection(String clusterName) {
+        return bootstrapServiceName(clusterName) + ":9092";
     }
 
     /**
-     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
+     * Returns the address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
      * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The socket address of the corresponding bootstrap {@code Service}.
-     * @see #internalPlainBootstrapConnection(String)
+     * @return The address of the corresponding bootstrap {@code Service}.
+     * @see #plainBootstrapConnection(String)
      */
-    public static String internalTlsBootstrapConnection(String clusterName) {
-        return internalBootstrapServiceName(clusterName) + ":9093";
+    public static String tlsBootstrapConnection(String clusterName) {
+        return bootstrapServiceName(clusterName) + ":9093";
     }
 
     /**
@@ -136,10 +136,6 @@ public class KafkaResources {
         return clusterName + "-kafka-brokers";
     }
 
-    public static String brokerConnection(String clusterName) {
-        return brokersServiceName(clusterName) + ":9092";
-    }
-
     /**
      * Returns the name of the external bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * This {@code Service} will only exist if {@code Kafka.spec.kafka.listeners.external} is configured for a
@@ -149,22 +145,6 @@ public class KafkaResources {
      */
     public static String externalBootstrapServiceName(String clusterName) {
         return clusterName + "-kafka-external-bootstrap";
-    }
-
-    /**
-     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
-     * of the external bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
-     * This {@code Service} will only exist if {@code Kafka.spec.kafka.listeners.external} is configured for a
-     * loadbalancer or NodePort in the {@code Kafka} resource with the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The socket address of the corresponding bootstrap {@code Service}.
-     */
-    public static String externalBootstrapConnection(String clusterName) {
-        return externalBootstrapServiceName(clusterName) + ":9094";
-    }
-
-    public static String externalServiceName(String cluster, int pod) {
-        return cluster + "-kafka-" + pod;
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
+ * {@code Kafka} cluster.
+ */
+public class KafkaResources {
+    private KafkaResources() { }
+
+    /**
+     * Returns the name of the Zookeeper {@code StatefulSet} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Zookeeper {@code StatefulSet}.
+     */
+    public static String zookeeperStatefulSetName(String clusterName) {
+        return clusterName + "-zookeeper";
+    }
+
+    /**
+     * Returns the name of the Zookeeper {@code Pod} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @param podNum The number of the Zookeeper pod
+     * @return The name of the corresponding Zookeeper {@code Pod}.
+     */
+    public static String zookeeperPodName(String clusterName, int podNum) {
+        return zookeeperStatefulSetName(clusterName) + "-" + podNum;
+    }
+
+    /**
+     * Returns the name of the Kafka {@code StatefulSet} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Kafka {@code StatefulSet}.
+     */
+    public static String kafkaStatefulSetName(String clusterName) {
+        return clusterName + "-kafka";
+    }
+
+    /**
+     * Returns the name of the Kafka {@code Pod} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @param podNum The number of the Kafka pod
+     * @return The name of the corresponding Kafka {@code Pod}.
+     */
+    public static String kafkaPodName(String clusterName, int podNum) {
+        return kafkaStatefulSetName(clusterName) + "-" + podNum;
+    }
+
+    /**
+     * Returns the name of the Entity Operator {@code Deployment} for a {@code Kafka} cluster of the given name.
+     * This {@code Deployment} will only exist if {@code Kafka.spec.entityOperator} is configured in the
+     * {@code Kafka} resource with the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Entity Operator {@code Deployment}.
+     */
+    public static String entityOperatorDeploymentName(String clusterName) {
+        return clusterName + "-entity-operator";
+    }
+
+    /**
+     * Returns the name of the Cluster CA certificate {@code Secret} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Cluster CA certificate {@code Secret}.
+     */
+    public static String clusterCaCertificateSecretName(String clusterName) {
+        return clusterName + "-cluster-ca-cert";
+    }
+
+    /**
+     * Returns the name of the Cluster CA key {@code Secret} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Cluster CA key {@code Secret}.
+     */
+    public static String clusterCaKeySecretName(String clusterName) {
+        return clusterName + "-cluster-ca";
+    }
+
+    /**
+     * Returns the name of the Clients CA certificate {@code Secret} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Clients CA certificate {@code Secret}.
+     */
+    public static String clientsCaCertificateSecretName(String clusterName) {
+        return clusterName + "-clients-ca-cert";
+    }
+
+    /**
+     * Returns the name of the Clients CA key {@code Secret} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Clients CA key {@code Secret}.
+     */
+    public static String clientsCaKeySecretName(String clusterName) {
+        return clusterName + "-clients-ca";
+    }
+
+    /**
+     * Returns the name of the internal bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding bootstrap {@code Service}.
+     */
+    public static String internalBootstrapServiceName(String clusterName) {
+        return clusterName + "-kafka-bootstrap";
+    }
+
+    /**
+     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
+     * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The socket address of the corresponding bootstrap {@code Service}.
+     * @see #internalTlsBootstrapConnection(String)
+     */
+    public static String internalPlainBootstrapConnection(String clusterName) {
+        return internalBootstrapServiceName(clusterName) + ":9092";
+    }
+
+    /**
+     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
+     * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The socket address of the corresponding bootstrap {@code Service}.
+     * @see #internalPlainBootstrapConnection(String)
+     */
+    public static String internalTlsBootstrapConnection(String clusterName) {
+        return internalBootstrapServiceName(clusterName) + ":9093";
+    }
+
+    /**
+     * Returns the name of the (headless) brokers {@code Service} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding brokers {@code Service}.
+     */
+    public static String brokersServiceName(String clusterName) {
+        return clusterName + "-kafka-brokers";
+    }
+
+    public static String brokerConnection(String clusterName) {
+        return brokersServiceName(clusterName) + ":9092";
+    }
+
+    /**
+     * Returns the name of the external bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
+     * This {@code Service} will only exist if {@code Kafka.spec.kafka.listeners.external} is configured for a
+     * loadbalancer or NodePort in the {@code Kafka} resource with the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding bootstrap {@code Service}.
+     */
+    public static String externalBootstrapServiceName(String clusterName) {
+        return clusterName + "-kafka-external-bootstrap";
+    }
+
+    /**
+     * Returns the socket address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
+     * of the external bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
+     * This {@code Service} will only exist if {@code Kafka.spec.kafka.listeners.external} is configured for a
+     * loadbalancer or NodePort in the {@code Kafka} resource with the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The socket address of the corresponding bootstrap {@code Service}.
+     */
+    public static String externalBootstrapConnection(String clusterName) {
+        return externalBootstrapServiceName(clusterName) + ":9094";
+    }
+
+    public static String externalServiceName(String cluster, int pod) {
+        return cluster + "-kafka-" + pod;
+    }
+
+    /**
+     * Returns the name of the Kafka metrics and log {@code ConfigMap} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Kafka metrics and log {@code ConfigMap}.
+     */
+    public static String kafkaMetricsAndLogConfigMapName(String clusterName) {
+        return clusterName + "-kafka-config";
+    }
+
+    /**
+     * Returns the name of the Zookeeper metrics and log {@code ConfigMap} for a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Zookeeper metrics and log {@code ConfigMap}.
+     */
+    public static String zookeeperMetricsAndLogConfigMapName(String clusterName) {
+        return clusterName + "-zookeeper-config";
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -110,9 +110,9 @@ public class KafkaResources {
      * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The address of the corresponding bootstrap {@code Service}.
-     * @see #tlsBootstrapConnection(String)
+     * @see #tlsBootstrapAddress(String)
      */
-    public static String plainBootstrapConnection(String clusterName) {
+    public static String plainBootstrapAddress(String clusterName) {
         return bootstrapServiceName(clusterName) + ":9092";
     }
 
@@ -121,9 +121,9 @@ public class KafkaResources {
      * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The address of the corresponding bootstrap {@code Service}.
-     * @see #plainBootstrapConnection(String)
+     * @see #plainBootstrapAddress(String)
      */
-    public static String tlsBootstrapConnection(String clusterName) {
+    public static String tlsBootstrapAddress(String clusterName) {
         return bootstrapServiceName(clusterName) + ":9093";
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -54,6 +54,7 @@ import io.strimzi.api.kafka.model.CpuMemory;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.JvmOptions;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
@@ -1086,11 +1087,11 @@ public abstract class AbstractModel {
     }
 
     public static String clusterCaCertSecretName(String cluster)  {
-        return cluster + "-cluster-ca-cert";
+        return KafkaResources.clusterCaCertificateSecretName(cluster);
     }
 
     public static String clusterCaKeySecretName(String cluster)  {
-        return cluster + "-cluster-ca";
+        return KafkaResources.clusterCaKeySecretName(cluster);
     }
 
     protected static Map<String, String> mergeAnnotations(Map<String, String> internal, Map<String, String> template) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
@@ -89,7 +90,7 @@ public class EntityOperator extends AbstractModel {
     }
 
     public static String entityOperatorName(String cluster) {
-        return cluster + NAME_SUFFIX;
+        return KafkaResources.entityOperatorDeploymentName(cluster);
     }
 
     protected static String defaultZookeeperConnect(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -194,7 +194,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String serviceName(String cluster) {
-        return KafkaResources.internalBootstrapServiceName(cluster);
+        return KafkaResources.bootstrapServiceName(cluster);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -43,6 +43,7 @@ import io.strimzi.api.kafka.model.KafkaListenerExternalLoadBalancer;
 import io.strimzi.api.kafka.model.KafkaListenerExternalNodePort;
 import io.strimzi.api.kafka.model.KafkaListenerExternalRoute;
 import io.strimzi.api.kafka.model.KafkaListeners;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Rack;
@@ -117,15 +118,9 @@ public class KafkaCluster extends AbstractModel {
     protected static final String TLS_SIDECAR_CLUSTER_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
 
     private static final String NAME_SUFFIX = "-kafka";
-    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-bootstrap";
-    private static final String HEADLESS_SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-brokers";
 
     // Suffixes for secrets with certificates
     private static final String SECRET_BROKERS_SUFFIX = NAME_SUFFIX + "-brokers";
-    private static final String SECRET_CLIENTS_CA_KEY_SUFFIX = "-clients-ca";
-    private static final String SECRET_CLIENTS_CA_SUFFIX = "-clients-ca-cert";
-
-    protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 
     // Kafka configuration
     private String zookeeperConnect;
@@ -191,15 +186,15 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String kafkaClusterName(String cluster) {
-        return cluster + KafkaCluster.NAME_SUFFIX;
+        return KafkaResources.kafkaStatefulSetName(cluster);
     }
 
     public static String metricAndLogConfigsName(String cluster) {
-        return cluster + KafkaCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
+        return KafkaResources.kafkaMetricsAndLogConfigMapName(cluster);
     }
 
     public static String serviceName(String cluster) {
-        return cluster + KafkaCluster.SERVICE_NAME_SUFFIX;
+        return KafkaResources.internalBootstrapServiceName(cluster);
     }
 
     /**
@@ -209,7 +204,7 @@ public class KafkaCluster extends AbstractModel {
      * @return
      */
     public static String externalBootstrapServiceName(String cluster) {
-        return kafkaClusterName(cluster) + "-external-bootstrap";
+        return KafkaResources.externalBootstrapServiceName(cluster);
     }
 
     /**
@@ -224,7 +219,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String headlessServiceName(String cluster) {
-        return cluster + KafkaCluster.HEADLESS_SERVICE_NAME_SUFFIX;
+        return KafkaResources.brokersServiceName(cluster);
     }
 
     public static String kafkaPodName(String cluster, int pod) {
@@ -232,7 +227,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String clientsCaKeySecretName(String cluster) {
-        return cluster + KafkaCluster.SECRET_CLIENTS_CA_KEY_SUFFIX;
+        return KafkaResources.clientsCaKeySecretName(cluster);
     }
 
     public static String brokersSecretName(String cluster) {
@@ -240,7 +235,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     public static String clientsCaCertSecretName(String cluster) {
-        return cluster + KafkaCluster.SECRET_CLIENTS_CA_SUFFIX;
+        return KafkaResources.clientsCaCertificateSecretName(cluster);
     }
 
     public static KafkaCluster fromCrd(Kafka kafkaAssembly) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
@@ -83,11 +84,11 @@ public class ZookeeperCluster extends AbstractModel {
     public static final String ENV_VAR_TLS_SIDECAR_LOG_LEVEL = "TLS_SIDECAR_LOG_LEVEL";
 
     public static String zookeeperClusterName(String cluster) {
-        return cluster + ZookeeperCluster.NAME_SUFFIX;
+        return KafkaResources.zookeeperStatefulSetName(cluster);
     }
 
     public static String zookeeperMetricAndLogConfigsName(String cluster) {
-        return cluster + ZookeeperCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
+        return KafkaResources.zookeeperMetricsAndLogConfigMapName(cluster);
     }
 
     public static String logConfigsName(String cluster) {
@@ -103,7 +104,7 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     public static String zookeeperPodName(String cluster, int pod) {
-        return zookeeperClusterName(cluster) + "-" + pod;
+        return KafkaResources.zookeeperPodName(cluster, pod);
     }
 
     public static String getPersistentVolumeClaimName(String clusterName, int podId) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -105,7 +105,7 @@ public class AbstractST {
     }
 
     static String kafkaServiceName(String clusterName) {
-        return KafkaResources.internalBootstrapServiceName(clusterName);
+        return KafkaResources.bootstrapServiceName(clusterName);
     }
 
     static String kafkaHeadlessServiceName(String clusterName) {
@@ -226,7 +226,7 @@ public class AbstractST {
     public void sendMessages(String podName, String clusterName, String topic, int messagesCount) {
         LOGGER.info("Sending messages");
         String command = "sh bin/kafka-verifiable-producer.sh --broker-list " +
-                KafkaResources.internalPlainBootstrapConnection(clusterName) + " --topic " + topic + " --max-messages " + messagesCount + "";
+                KafkaResources.plainBootstrapConnection(clusterName) + " --topic " + topic + " --max-messages " + messagesCount + "";
 
         LOGGER.info("Command for kafka-verifiable-producer.sh {}", command);
 
@@ -237,7 +237,7 @@ public class AbstractST {
         LOGGER.info("Consuming messages");
         String output = kubeClient.execInPod(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
                 "bin/kafka-verifiable-consumer.sh --broker-list " +
-                        KafkaResources.internalPlainBootstrapConnection(clusterName) + " --topic " + topic + " --group-id " + groupID + " & sleep "
+                        KafkaResources.plainBootstrapConnection(clusterName) + " --topic " + topic + " --group-id " + groupID + " & sleep "
                         + timeout + "; kill %1").out();
         output = "[" + output.replaceAll("\n", ",") + "]";
         LOGGER.info("Output for kafka-verifiable-consumer.sh {}", output);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -24,6 +24,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClient;
@@ -92,7 +93,7 @@ public class AbstractST {
     }
 
     static String kafkaClusterName(String clusterName) {
-        return clusterName + "-kafka";
+        return KafkaResources.kafkaStatefulSetName(clusterName);
     }
 
     static String kafkaConnectName(String clusterName) {
@@ -100,27 +101,27 @@ public class AbstractST {
     }
 
     static String kafkaPodName(String clusterName, int podId) {
-        return kafkaClusterName(clusterName) + "-" + podId;
+        return KafkaResources.kafkaPodName(clusterName, podId);
     }
 
     static String kafkaServiceName(String clusterName) {
-        return kafkaClusterName(clusterName) + "-bootstrap";
+        return KafkaResources.internalBootstrapServiceName(clusterName);
     }
 
     static String kafkaHeadlessServiceName(String clusterName) {
-        return kafkaClusterName(clusterName) + "-brokers";
+        return KafkaResources.brokersServiceName(clusterName);
     }
 
     static String kafkaMetricsConfigName(String clusterName) {
-        return kafkaClusterName(clusterName) + "-config";
+        return KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName);
     }
 
     static String zookeeperClusterName(String clusterName) {
-        return clusterName + "-zookeeper";
+        return KafkaResources.zookeeperStatefulSetName(clusterName);
     }
 
     static String zookeeperPodName(String clusterName, int podId) {
-        return zookeeperClusterName(clusterName) + "-" + podId;
+        return KafkaResources.zookeeperPodName(clusterName, podId);
     }
 
     static String zookeeperServiceName(String clusterName) {
@@ -132,7 +133,7 @@ public class AbstractST {
     }
 
     static String zookeeperMetricsConfigName(String clusterName) {
-        return zookeeperClusterName(clusterName) + "-config";
+        return KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName);
     }
 
     static String zookeeperPVCName(String clusterName, int podId) {
@@ -140,7 +141,7 @@ public class AbstractST {
     }
 
     static String entityOperatorDeploymentName(String clusterName) {
-        return clusterName + "-entity-operator";
+        return KafkaResources.entityOperatorDeploymentName(clusterName);
     }
 
     private <T extends CustomResource, L extends CustomResourceList<T>, D extends Doneable<T>>
@@ -225,7 +226,7 @@ public class AbstractST {
     public void sendMessages(String podName, String clusterName, String topic, int messagesCount) {
         LOGGER.info("Sending messages");
         String command = "sh bin/kafka-verifiable-producer.sh --broker-list " +
-                clusterName + "-kafka-bootstrap:9092 --topic " + topic + " --max-messages " + messagesCount + "";
+                KafkaResources.internalPlainBootstrapConnection(clusterName) + " --topic " + topic + " --max-messages " + messagesCount + "";
 
         LOGGER.info("Command for kafka-verifiable-producer.sh {}", command);
 
@@ -235,8 +236,8 @@ public class AbstractST {
     public String consumeMessages(String clusterName, String topic, int groupID, int timeout, int kafkaPodID) {
         LOGGER.info("Consuming messages");
         String output = kubeClient.execInPod(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
-                "bin/kafka-verifiable-consumer.sh --broker-list " + clusterName +
-                        "-kafka-bootstrap:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
+                "bin/kafka-verifiable-consumer.sh --broker-list " +
+                        KafkaResources.internalPlainBootstrapConnection(clusterName) + " --topic " + topic + " --group-id " + groupID + " & sleep "
                         + timeout + "; kill %1").out();
         output = "[" + output.replaceAll("\n", ",") + "]";
         LOGGER.info("Output for kafka-verifiable-consumer.sh {}", output);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -226,7 +226,7 @@ public class AbstractST {
     public void sendMessages(String podName, String clusterName, String topic, int messagesCount) {
         LOGGER.info("Sending messages");
         String command = "sh bin/kafka-verifiable-producer.sh --broker-list " +
-                KafkaResources.plainBootstrapConnection(clusterName) + " --topic " + topic + " --max-messages " + messagesCount + "";
+                KafkaResources.plainBootstrapAddress(clusterName) + " --topic " + topic + " --max-messages " + messagesCount + "";
 
         LOGGER.info("Command for kafka-verifiable-producer.sh {}", command);
 
@@ -237,7 +237,7 @@ public class AbstractST {
         LOGGER.info("Consuming messages");
         String output = kubeClient.execInPod(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
                 "bin/kafka-verifiable-consumer.sh --broker-list " +
-                        KafkaResources.plainBootstrapConnection(clusterName) + " --topic " + topic + " --group-id " + groupID + " & sleep "
+                        KafkaResources.plainBootstrapAddress(clusterName) + " --topic " + topic + " --group-id " + groupID + " & sleep "
                         + timeout + "; kill %1").out();
         output = "[" + output.replaceAll("\n", ",") + "]";
         LOGGER.info("Output for kafka-verifiable-consumer.sh {}", output);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest;
 
 import io.fabric8.kubernetes.api.model.Event;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.test.ClusterOperator;
 import io.strimzi.test.JUnitGroup;
 import io.strimzi.test.Namespace;
@@ -47,7 +48,7 @@ public class ConnectST extends AbstractST {
 
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka-bootstrap:9092";
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.internalPlainBootstrapConnection(KAFKA_CLUSTER_NAME);
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.key.converter.schemas.enable=false\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -48,7 +48,7 @@ public class ConnectST extends AbstractST {
 
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.plainBootstrapConnection(KAFKA_CLUSTER_NAME);
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.plainBootstrapAddress(KAFKA_CLUSTER_NAME);
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.key.converter.schemas.enable=false\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -48,7 +48,7 @@ public class ConnectST extends AbstractST {
 
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
-    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.internalPlainBootstrapConnection(KAFKA_CLUSTER_NAME);
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.plainBootstrapConnection(KAFKA_CLUSTER_NAME);
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.key.converter.schemas.enable=false\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -644,7 +644,7 @@ public class KafkaST extends AbstractST {
      */
     private Job pingJob(String name, String topic, int messagesCount, KafkaUser kafkaUser, boolean tlsListener) {
 
-        String connect = tlsListener ? KafkaResources.tlsBootstrapConnection(CLUSTER_NAME) : KafkaResources.plainBootstrapConnection(CLUSTER_NAME);
+        String connect = tlsListener ? KafkaResources.tlsBootstrapAddress(CLUSTER_NAME) : KafkaResources.plainBootstrapAddress(CLUSTER_NAME);
         ContainerBuilder cb = new ContainerBuilder()
                 .withName("ping")
                 .withImage(TestUtils.changeOrgAndTag("strimzi/test-client:latest"))

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -644,7 +644,7 @@ public class KafkaST extends AbstractST {
      */
     private Job pingJob(String name, String topic, int messagesCount, KafkaUser kafkaUser, boolean tlsListener) {
 
-        String connect = tlsListener ? KafkaResources.internalTlsBootstrapConnection(CLUSTER_NAME) : KafkaResources.internalPlainBootstrapConnection(CLUSTER_NAME);
+        String connect = tlsListener ? KafkaResources.tlsBootstrapConnection(CLUSTER_NAME) : KafkaResources.plainBootstrapConnection(CLUSTER_NAME);
         ContainerBuilder cb = new ContainerBuilder()
                 .withName("ping")
                 .withImage(TestUtils.changeOrgAndTag("strimzi/test-client:latest"))

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.KafkaListenerAuthenticationTls;
 import io.strimzi.api.kafka.model.KafkaListenerPlain;
 import io.strimzi.api.kafka.model.KafkaListenerTls;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
@@ -643,7 +644,7 @@ public class KafkaST extends AbstractST {
      */
     private Job pingJob(String name, String topic, int messagesCount, KafkaUser kafkaUser, boolean tlsListener) {
 
-        String connect = tlsListener ? CLUSTER_NAME + "-kafka-bootstrap:9093" : CLUSTER_NAME + "-kafka-bootstrap:9092";
+        String connect = tlsListener ? KafkaResources.internalTlsBootstrapConnection(CLUSTER_NAME) : KafkaResources.internalPlainBootstrapConnection(CLUSTER_NAME);
         ContainerBuilder cb = new ContainerBuilder()
                 .withName("ping")
                 .withImage(TestUtils.changeOrgAndTag("strimzi/test-client:latest"))

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -245,7 +245,7 @@ public class Resources {
         return new KafkaConnectBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
-                .withBootstrapServers(KafkaResources.plainBootstrapConnection(name))
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
                 .withReplicas(kafkaConnectReplicas)
             .endSpec();
     }
@@ -285,7 +285,7 @@ public class Resources {
         return new KafkaConnectS2IBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
-                .withBootstrapServers(KafkaResources.plainBootstrapConnection(name))
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
                 .withReplicas(kafkaConnectS2IReplicas)
             .endSpec();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -245,7 +245,7 @@ public class Resources {
         return new KafkaConnectBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
-                .withBootstrapServers(KafkaResources.internalPlainBootstrapConnection(name))
+                .withBootstrapServers(KafkaResources.plainBootstrapConnection(name))
                 .withReplicas(kafkaConnectReplicas)
             .endSpec();
     }
@@ -285,7 +285,7 @@ public class Resources {
         return new KafkaConnectS2IBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
-                .withBootstrapServers(KafkaResources.internalPlainBootstrapConnection(name))
+                .withBootstrapServers(KafkaResources.plainBootstrapConnection(name))
                 .withReplicas(kafkaConnectS2IReplicas)
             .endSpec();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -50,10 +50,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static io.strimzi.api.kafka.model.KafkaResources.entityOperatorDeploymentName;
-import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
-import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
-
 public class Resources {
 
     private static final Logger LOGGER = LogManager.getLogger(Resources.class);
@@ -359,9 +355,9 @@ public class Resources {
         String name = kafka.getMetadata().getName();
         LOGGER.info("Waiting for Kafka {}", name);
         String namespace = kafka.getMetadata().getNamespace();
-        waitForStatefulSet(namespace, zookeeperStatefulSetName(name));
-        waitForStatefulSet(namespace, kafkaStatefulSetName(name));
-        waitForDeployment(namespace, entityOperatorDeploymentName(name));
+        waitForStatefulSet(namespace, KafkaResources.zookeeperStatefulSetName(name));
+        waitForStatefulSet(namespace, KafkaResources.kafkaStatefulSetName(name));
+        waitForDeployment(namespace, KafkaResources.entityOperatorDeploymentName(name));
         return kafka;
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

Factor-out some common methods encapsulating the naming of resources for a `Kafka` cluster into the API module. I've not included certain namings (such as for the Zookeeper services) on purpose if clients shouldn't be accessing those things anyway, but this can be discussed.

For the time being I've not inlined the existing utility functions (such as in `KafkaCluster`). We can do this later. I've also not bitten off a `KafkaConnectResources` etc. Again, that can be a later PR.

Since this is in the API module we should pay particular attention to the names of these new methods.

### Checklist

- [x] Make sure all tests pass
- [ ] Update CHANGELOG.md

