### PR TITLE
Removed EO Deployment generation

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -59,11 +59,11 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
      */
     public Future<Void> rollingUpdate(String namespace, String name, long operationTimeoutMs) {
         return getAsync(namespace, name)
-                .compose(deployment -> killPod(namespace, name))
+                .compose(deployment -> deletePod(namespace, name))
                 .compose(ignored -> readiness(namespace, name, 1_000, operationTimeoutMs));
     }
 
-    public Future<ReconcileResult<Pod>> killPod(String namespace, String name) {
+    public Future<ReconcileResult<Pod>> deletePod(String namespace, String name) {
         Labels labels = Labels.fromMap(null).withName(name);
         String podName = podOperations.list(namespace, labels).get(0).getMetadata().getName();
         return podOperations.reconcile(namespace, podName, null);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
@@ -46,11 +46,6 @@ public class DeploymentOperatorTest extends
 
     @Override
     protected DeploymentOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new DeploymentOperator(vertx, mockClient) {
-            @Override
-            protected void setGeneration(Deployment desired, int nextGeneration) {
-
-            }
-        };
+        return new DeploymentOperator(vertx, mockClient);
     }
 }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

This PR is related to #1067.
While working on that, it turned out that the generation on the EO Deployment was just added for forcing a rolling update (at k8s level) on certificate renewal (a change on the Deployment was needed to force k8s to start the rolling update).
Because we are going to add a CA certificate specific annotation for covering this scenario, this generation annotation isn't needed anymore.
For the time being, I added killing EO Deployment pod for forcing a rolling update on certificates renewal.

This PR is just a temporary workaround until the above CA certificate specific annotation mechanism will be in place.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

