### PR TITLE
Fix bootstrap address in the kafka templates

### DIFF
--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -14,7 +14,7 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:9092' as bootstrap server in your application"
+message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-kafka-bootstrap:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -10,7 +10,7 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:9092' as bootstrap server in your application."
+message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-kafka-bootstrap:9092' as bootstrap server in your application."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka templates currently contain incorrect messages which use `<cluster-name>:9092` as the bootstrap address. This PR fixes that by adding the right suffix for bootstrap services.