### PR TITLE
WIP: Scale-up zookeeper using algorithm

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -33,6 +33,9 @@
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]KafkaConnectCluster.java"/>
 
+    <suppress checks="ClassFanOutComplexity"
+              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]resource[/\\]StatefulSetOperator.java"/>
+
     <!-- topic operator -->
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="io[/\\]strimzi[/\\]operator[/\\]topic[/\\]TopicOperator.java"/>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -131,8 +131,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.zkNodesSecret())
                 .compose(state -> state.zkNetPolicy())
                 .compose(state -> state.zkStatefulSet())
-                .compose(state -> state.zkRollingUpdate())
                 .compose(state -> state.zkScaleUp())
+                .compose(state -> state.zkRollingUpdate())
                 .compose(state -> state.zkServiceEndpointReadiness())
                 .compose(state -> state.zkHeadlessServiceEndpointReadiness())
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -126,7 +126,7 @@ public abstract class Ca {
         }
     }
 
-    private static CertAndKey asCertAndKey(Secret secret, String key, String cert) {
+    public static CertAndKey asCertAndKey(Secret secret, String key, String cert) {
         Base64.Decoder decoder = Base64.getDecoder();
         return secret == null ? null : new CertAndKey(
                 decoder.decode(secret.getData().get(key)),


### PR DESCRIPTION
### Type of change
 Enhancement / new feature

### Description
Implemented scaling up the zookeeper cluster using the algorithm described [here](https://gist.github.com/miketheman/6057930). It uses a dirty hack to get the trusted certs.

Currently, the `maybeRollingUpdate` restarts the leader pod as the last one even when the desired change does not update pods count.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

