### PR TITLE
Enable metrics even when the metrics object in CRD is empty (but exists)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -270,7 +270,7 @@ public class KafkaCluster extends AbstractModel {
         result.setJvmOptions(kafkaClusterSpec.getJvmOptions());
         result.setConfiguration(new KafkaConfiguration(kafkaClusterSpec.getConfig().entrySet()));
         Map<String, Object> metrics = kafkaClusterSpec.getMetrics();
-        if (metrics != null && !metrics.isEmpty()) {
+        if (metrics != null) {
             result.setMetricsEnabled(true);
             result.setMetricsConfig(metrics.entrySet());
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -145,7 +145,7 @@ public class KafkaConnectCluster extends AbstractModel {
             }
 
             Map<String, Object> metrics = spec.getMetrics();
-            if (metrics != null && !metrics.isEmpty()) {
+            if (metrics != null) {
                 kafkaConnect.setMetricsEnabled(true);
                 kafkaConnect.setMetricsConfig(metrics.entrySet());
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -173,7 +173,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
             kafkaMirrorMakerCluster.setLogging(kafkaMirrorMaker.getSpec().getLogging());
 
             Map<String, Object> metrics = kafkaMirrorMaker.getSpec().getMetrics();
-            if (metrics != null && !metrics.isEmpty()) {
+            if (metrics != null) {
                 kafkaMirrorMakerCluster.setMetricsEnabled(true);
                 kafkaMirrorMakerCluster.setMetricsConfig(metrics.entrySet());
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -172,7 +172,7 @@ public class ZookeeperCluster extends AbstractModel {
         Logging logging = zookeeperClusterSpec.getLogging();
         zk.setLogging(logging == null ? new InlineLogging() : logging);
         Map<String, Object> metrics = zookeeperClusterSpec.getMetrics();
-        if (metrics != null && !metrics.isEmpty()) {
+        if (metrics != null) {
             zk.setMetricsEnabled(true);
             zk.setMetricsConfig(metrics.entrySet());
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the 'metrics' property is set to empty object, we should start the Prometheus export with the default settings. This is useful for those who do not want to change any of the defaults. This was also the original implementation and it is how it is described in the docs. This PR restores this functionality which was changed probably during the move to the CRDs.