### PR TITLE
Fixed wrong Javadoc about generate Secrets methods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -233,8 +233,10 @@ public class EntityOperator extends AbstractModel {
     }
 
     /**
-     * Generate the Secret containing CA self-signed certificates for internal communication
-     * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
+     * Generate the Secret containing the Entity Operator certificate signed by the cluster CA certificate used for TLS based
+     * internal communication with Kafka and Zookeeper.
+     * It also contains the related Entity Operator private key.
+     *
      * @return The generated Secret
      */
     public Secret generateSecret(ClusterCa clusterCa) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -569,7 +569,7 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Generate the Secret containing the Kafka brokers certificates signed by the cluster CA certificate used for TLS based
-     * internal communication with Zookeeper as well.
+     * internal communication with Zookeeper.
      * It also contains the related Kafka brokers private keys.
      *
      * @return The generated Secret

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -568,9 +568,9 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generate the Secret containing CA self-signed certificate for TLS communication.
-     * It also contains the private key-certificate (signed by cluster CA) for each brokers as well as for communicating
-     * with Zookeeper as well
+     * Generate the Secret containing the Kafka brokers certificates signed by the cluster CA certificate used for TLS based
+     * internal communication with Zookeeper as well.
+     * It also contains the related Kafka brokers private keys.
      *
      * @return The generated Secret
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -312,9 +312,10 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     /**
-     * Generate the Secret containing CA self-signed certificate for internal communication.
-     * It also contains the private key-certificate (signed by internal CA) for each brokers for communicating
-     * internally within the cluster
+     * Generate the Secret containing the Zookeeper nodes certificates signed by the cluster CA certificate used for TLS based
+     * internal communication with Kafka as well.
+     * It also contains the related Zookeeper nodes private keys.
+     *
      * @return The generated Secret
      */
     public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -313,7 +313,7 @@ public class ZookeeperCluster extends AbstractModel {
 
     /**
      * Generate the Secret containing the Zookeeper nodes certificates signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka as well.
+     * internal communication with Kafka.
      * It also contains the related Zookeeper nodes private keys.
      *
      * @return The generated Secret


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR fixes old Javadoc related to methods for Secrets with certificates generation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

