### PR TITLE
ST: Removing hard-code in log collector

### DIFF
--- a/api/src/test/java/io/strimzi/test/StrimziExtension.java
+++ b/api/src/test/java/io/strimzi/test/StrimziExtension.java
@@ -230,10 +230,10 @@ public class StrimziExtension implements AfterAllCallback, BeforeAllCallback, Af
 
         private void collectEvents() {
             LOGGER.info("Collecting events in namespace {}", namespace);
-            String events = kubeClient().exec("oc", "get", "events").out();
+            String events = kubeClient().getEvents();
 
             // Print events to console
-            LOGGER.info("Events for namspace {}{}{}", namespace, System.lineSeparator(), events);
+            LOGGER.info("Events for namespace {}{}{}", namespace, System.lineSeparator(), events);
 
             // Write events to file
             writeFile(logDir + "/" + "events-in-namespace" + kubeClient().namespace() + ".log", events);

--- a/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -105,6 +105,11 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     }
 
     @Override
+    public String getEvents() {
+        return Exec.exec(namespacedCommand("get", "events")).out();
+    }
+
+    @Override
     public K create(File... files) {
         try (Context context = defaultContext()) {
             KubeClusterException error = execRecursive(CREATE, files, Comparator.comparing(File::getName));

--- a/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
+++ b/api/src/test/java/io/strimzi/test/k8s/KubeClient.java
@@ -159,6 +159,12 @@ public interface KubeClient<K extends KubeClient<K>> {
      */
     String get(String resource, String resourceName);
 
+    /**
+     * Get a list of events in a given namespace
+     * @return List of events
+     */
+    String getEvents();
+
     K waitForResourceDeletion(String resourceType, String resourceName);
 
     List<String> list(String resourceType);


### PR DESCRIPTION

### Type of change
- Bugfix

### Description
Fixed issue #1099 with a hard-coded client in log collector. These changes are necessary because of using minikube on the Travis side. Also was added a method to get events in kube client.

### Checklist
- [ ] Make sure all tests pass

