### PR TITLE
Removed useless part for rolling EO on cluster CA cert renewal

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1107,17 +1107,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 eoDeployment.getSpec().getTemplate().getMetadata().getAnnotations()
                         .put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(getCaCertGeneration(this.clusterCa)));
             }
-
-            return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment)
-                    .compose(reconcileResult -> {
-                        if (this.entityOperator != null && this.clusterCa.certRenewed() && reconcileResult instanceof ReconcileResult.Noop<?>) {
-                            // roll the EO if the cluster CA was renewed and reconcile hasn't rolled it
-                            log.debug("{}: Restarting Entity Operator due to Cluster CA renewal", reconciliation);
-                            return deploymentOperations.rollingUpdate(namespace, EntityOperator.entityOperatorName(name), operationTimeoutMs);
-                        } else {
-                            return Future.succeededFuture();
-                        }
-                    }));
+            return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment));
         }
 
         Future<ReconciliationState> entityOperatorSecret() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1000,16 +1000,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> topicOperatorDeployment() {
-            return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment)
-                .compose(reconcileResult -> {
-                    if (this.topicOperator != null && this.clusterCa.certRenewed()  && reconcileResult instanceof ReconcileResult.Noop<?>) {
-                        // roll the TO if the cluster CA was renewed and reconcile hasn't rolled it
-                        log.debug("{}: Restarting Topic Operator due to Cluster CA renewal", reconciliation);
-                        return deploymentOperations.rollingUpdate(namespace, TopicOperator.topicOperatorName(name), operationTimeoutMs);
-                    } else {
-                        return Future.succeededFuture();
-                    }
-                }));
+            if (this.toDeployment != null) {
+                toDeployment.getSpec().getTemplate().getMetadata().getAnnotations()
+                        .put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(getCaCertGeneration(this.clusterCa)));
+            }
+            return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment));
         }
 
         Future<ReconciliationState> topicOperatorSecret() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Due to the usage of cluster CA certificate generation annotation on the related `Secret` and the EO pod, this PR removes a useless piece of code to check if a cluster CA renewal happens and forcing an EO rolling update.
Because the cluster CA certificate generation annotation is set as an annotation to the EO pod as well, it determines a change in the `Deployment` so the rolling update runs out of the box.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

