### PR TITLE
Fix StrimziUpdateST

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -38,6 +38,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
@@ -1125,8 +1126,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             String podAnnotation = ca instanceof ClientsCa ?
                     Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION :
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION;
-            final int podCaCertGeneration =
-                    Integer.parseInt(pod.getMetadata().getAnnotations().get(podAnnotation));
+            String generation = Util.annotations(pod).get(podAnnotation);
+            final int podCaCertGeneration = generation != null ?
+                    Integer.parseInt(generation) : Ca.INIT_GENERATION;
             return caCertGeneration == podCaCertGeneration;
         }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -11,6 +11,7 @@ import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.certs.Subject;
+import io.strimzi.operator.common.Util;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,7 +84,7 @@ public abstract class Ca {
     public static final String ANNO_STRIMZI_IO_CA_CERT_GENERATION = "strimzi.io/ca-cert-generation";
     public static final String ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION = "strimzi.io/cluster-ca-cert-generation";
     public static final String ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION = "strimzi.io/clients-ca-cert-generation";
-    private static final int INIT_GENERATION = 0;
+    public static final int INIT_GENERATION = 0;
 
     /**
      * Set the {@code strimzi.io/force-renew} annotation on the given {@code caCert} if the given {@code caKey} has
@@ -314,7 +315,7 @@ public abstract class Ca {
         // cluster CA certificate generation annotation handling
         int caCertGeneration = INIT_GENERATION;
         if (caCertSecret != null && caCertSecret.getData().get(CA_CRT) != null) {
-            String caCertGenerationAnnotation = caCertSecret.getMetadata().getAnnotations().get(ANNO_STRIMZI_IO_CA_CERT_GENERATION);
+            String caCertGenerationAnnotation = Util.annotations(caCertSecret).get(ANNO_STRIMZI_IO_CA_CERT_GENERATION);
             if (caCertGenerationAnnotation != null) {
                 caCertGeneration = Integer.parseInt(caCertGenerationAnnotation);
                 if (caRenewed) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -11,11 +12,19 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Map;
 import java.util.function.BooleanSupplier;
+
+import static java.util.Collections.emptyMap;
 
 public class Util {
 
     private static final Logger LOGGER = LogManager.getLogger(Util.class);
+
+    public static Map<String, String> annotations(HasMetadata resource) {
+        Map<String, String> annotations = resource.getMetadata().getAnnotations();
+        return annotations != null ? annotations : emptyMap();
+    }
 
     /**
      * Returns a future that completes when the given {@code ready} indicates readiness.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `StrimziUpgradeST` reveals a couple of NPEs in the CA-related code when the Secrets were generated by an old version of Strimzi (and so lack the generation annotations). 

This PR adds an `annotations()` method. Another PR will refactor existing call sites where we get the annotations and have to do a null check.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

