### PR TITLE
Fix exposing using routes by setting the external addresses

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -901,6 +901,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaStatefulSet() {
+            kafkaCluster.setExternalAddresses(kafkaExternalAddresses);
             StatefulSet kafkaSs = kafkaCluster.generateStatefulSet(isOpenShift);
             kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations()
                     .put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(getCaCertGeneration(this.clusterCa)));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Exposing KAfka using routes doesn't work anymore, because we do not set the external addresses anymore. Instead the CO loops Kafka infinitely when exposing using routes is enabled. This PR attempts to fix this.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
