### PR TITLE
User maintenance time windows configuration

### DIFF
--- a/api/src/test/java/io/strimzi/test/CronTest.java
+++ b/api/src/test/java/io/strimzi/test/CronTest.java
@@ -60,8 +60,22 @@ public class CronTest {
         // the pod is running on a "Pacific/Easter" timezone data center, so cron expression needs the right timezone for evaluation
         cronExpression.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Rome")));
 
-        // it's really 20:00 in "Pacific/Easter" but 14:00 for "user"
+        // it's really 08:00 in "Pacific/Easter" but 14:00 for "user"
         Date d = Date.from(LocalDateTime.of(2018, 11, 26, 8, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+    }
+
+    @Test
+    public void testUtcTimeZone() throws ParseException {
+        // the "user" writes the cron expression in UTC timezone, but let's imagine he is in Europe/Rome timezone
+        // every second, every minute, hour 15 to 16 every day --> from 15:00 to 15:59
+        CronExpression cronExpression = new CronExpression("* * 14-15 * * ?");
+
+        // the pod is running on a "Pacific/Easter" timezone data center, so cron expression needs the right timezone for evaluation
+        cronExpression.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+        // it's really 09:00 in "Pacific/Easter" but 15:00 for "user" so 14:00 in UTC
+        Date d = Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant());
         assertTrue(cronExpression.isSatisfiedBy(d));
     }
 }

--- a/api/src/test/java/io/strimzi/test/CronTest.java
+++ b/api/src/test/java/io/strimzi/test/CronTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test;
+
+import org.apache.logging.log4j.core.util.CronExpression;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CronTest {
+
+    @Test
+    public void testHoursRangeEveryDay() throws ParseException {
+        // every second, every minute, hour 14 to 15 every day --> from 14:00 to 15:59
+        CronExpression cronExpression = new CronExpression("* * 14-15 * * ?");
+
+        Date d = Date.from(LocalDateTime.of(2018, 11, 26, 13, 59, 0).atZone(ZoneId.systemDefault()).toInstant());
+        assertFalse(cronExpression.isSatisfiedBy(d));
+        d = Date.from(LocalDateTime.of(2018, 11, 26, 14, 00, 0).atZone(ZoneId.systemDefault()).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+        d = Date.from(LocalDateTime.of(2018, 11, 26, 15, 59, 0).atZone(ZoneId.systemDefault()).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+        d = Date.from(LocalDateTime.of(2018, 11, 26, 16, 00, 1).atZone(ZoneId.systemDefault()).toInstant());
+        assertFalse(cronExpression.isSatisfiedBy(d));
+    }
+
+    @Test
+    public void testHoursRangeOnWeekend() throws ParseException {
+        // every second, every minute, hour 14 to 15 on days of the week 1 and 7 --> from 14:00 to 15:59, on Saturday (7) and Sunday (1)
+        CronExpression cronExpression = new CronExpression("* * 14-15 ? * 1,7");
+
+        // Saturday November 24th, 2018
+        Date d = Date.from(LocalDateTime.of(2018, 11, 24, 14, 00, 0).atZone(ZoneId.systemDefault()).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+        // Sunday November 25th, 2018
+        d = Date.from(LocalDateTime.of(2018, 11, 25, 14, 00, 0).atZone(ZoneId.systemDefault()).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+        // the working day Monday to Friday, November 26th to November 30th, 2018
+        for (int day = 26; day <= 30; day++) {
+            d = Date.from(LocalDateTime.of(2018, 11, day, 14, 00, 0).atZone(ZoneId.systemDefault()).toInstant());
+            assertFalse(cronExpression.isSatisfiedBy(d));
+        }
+    }
+
+    @Test
+    public void testUserTimeZoneVsPodTimeZone() throws ParseException {
+        // the "user" writes the cron expression in his timezone
+        // every second, every minute, hour 14 to 15 every day --> from 14:00 to 15:59
+        CronExpression cronExpression = new CronExpression("* * 14-15 * * ?");
+
+        // the pod is running on a "Pacific/Easter" timezone data center, so cron expression needs the right timezone for evaluation
+        cronExpression.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Rome")));
+
+        // it's really 20:00 in "Pacific/Easter" but 14:00 for "user"
+        Date d = Date.from(LocalDateTime.of(2018, 11, 26, 8, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant());
+        assertTrue(cronExpression.isSatisfiedBy(d));
+    }
+}

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>certificate-manager</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -200,21 +200,21 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private final Kafka kafkaAssembly;
         private final Reconciliation reconciliation;
 
-        ClusterCa clusterCa; /* test */
-        private ClientsCa clientsCa;
+        /* test */ ClusterCa clusterCa;
+        /* test */ ClientsCa clientsCa;
 
         private ZookeeperCluster zkCluster;
         private Service zkService;
         private Service zkHeadlessService;
         private ConfigMap zkMetricsAndLogsConfigMap;
-        ReconcileResult<StatefulSet> zkDiffs; /* test */
+        /* test */ ReconcileResult<StatefulSet> zkDiffs;
         private boolean zkAncillaryCmChange;
 
         private KafkaCluster kafkaCluster = null;
         private Service kafkaService;
         private Service kafkaHeadlessService;
         private ConfigMap kafkaMetricsAndLogsConfigMap;
-        private ReconcileResult<StatefulSet> kafkaDiffs;
+        /* test */ ReconcileResult<StatefulSet> kafkaDiffs;
         private String kafkaExternalBootstrapDnsName = null;
         private SortedMap<Integer, String> kafkaExternalAddresses = new TreeMap<>();
         private SortedMap<Integer, String> kafkaExternalDnsNames = new TreeMap<>();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -224,8 +224,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Deployment toDeployment = null;
         private ConfigMap toMetricsAndLogsConfigMap = null;
 
-        private EntityOperator entityOperator;
-        private Deployment eoDeployment = null;
+        /* test */ EntityOperator entityOperator;
+        /* test */ Deployment eoDeployment = null;
         private ConfigMap topicOperatorMetricsAndLogsConfigMap = null;
         private ConfigMap userOperatorMetricsAndLogsConfigMap;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -220,8 +220,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private SortedMap<Integer, String> kafkaExternalDnsNames = new TreeMap<>();
         private boolean kafkaAncillaryCmChange;
 
-        private TopicOperator topicOperator;
-        private Deployment toDeployment = null;
+        /* test */ TopicOperator topicOperator;
+        /* test */ Deployment toDeployment = null;
         private ConfigMap toMetricsAndLogsConfigMap = null;
 
         /* test */ EntityOperator entityOperator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -119,7 +119,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
@@ -135,7 +135,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
@@ -151,7 +151,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
@@ -167,7 +167,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
@@ -183,7 +183,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testZkRollingUpdate(null,
+        doZkRollingUpdate(null,
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
@@ -199,7 +199,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testZkRollingUpdate(Arrays.asList("* * 8-10 * * ?", "* * 14-15 * * ?"),
+        doZkRollingUpdate(Arrays.asList("* * 8-10 * * ?", "* * 14-15 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
@@ -215,7 +215,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testKafkaRollingUpdate(null,
+        doKafkaRollingUpdate(null,
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
@@ -231,7 +231,7 @@ public class MaintenanceTimeWindowsTest {
 
         Async async = context.async();
 
-        testZkRollingUpdate(Collections.singletonList("* * 14-15 * * ?"),
+        doZkRollingUpdate(Collections.singletonList("* * 14-15 * * ?"),
             () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant()),
             r -> {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
@@ -247,8 +247,8 @@ public class MaintenanceTimeWindowsTest {
         return pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION);
     }
 
-    private void testZkRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
-                                    Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+    private void doZkRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
+                                   Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
 
         this.init(maintenanceTimeWindows);
 
@@ -272,8 +272,8 @@ public class MaintenanceTimeWindowsTest {
         this.reconciliationState.zkRollingUpdate(dateSupplier).setHandler(handler);
     }
 
-    private void testKafkaRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
-                                     Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+    private void doKafkaRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
+                                      Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
 
         this.init(maintenanceTimeWindows);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -184,12 +184,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         testZkRollingUpdate(null,
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                });
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
 
         async.await();
     }
@@ -200,12 +200,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         testZkRollingUpdate(Arrays.asList("* * 8-10 * * ?", "* * 14-15 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                });
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
 
         async.await();
     }
@@ -216,12 +216,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         testKafkaRollingUpdate(null,
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                });
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
 
         async.await();
     }
@@ -232,12 +232,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         testZkRollingUpdate(Collections.singletonList("* * 14-15 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                });
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("Pacific/Easter")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
 
         async.await();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaAssemblyList;
+import io.strimzi.api.kafka.model.DoneableKafka;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.ClientsCa;
+import io.strimzi.operator.cluster.model.ClusterCa;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.ResourceType;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+
+@RunWith(VertxUnitRunner.class)
+public class MaintenanceTimeWindowsTest {
+
+    private static final String NAMESPACE = "test-maintenance-time-windows";
+    private static final String NAME = "my-kafka";
+
+    private Vertx vertx;
+    private Kafka kafka;
+    private KubernetesClient mockClient;
+    private KafkaAssemblyOperator.ReconciliationState reconciliationState;
+
+    private Secret clusterCaSecret;
+    private Secret clientsCaSecret;
+
+    private void init(List<String> maintenanceTimeWindows) {
+        this.vertx = Vertx.vertx();
+
+        // setting up the Kafka CRD and a related Kafka cluster resource
+        CustomResourceDefinition kafkaAssemblyCrd = Crds.kafka();
+
+        this.kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(1)
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(1)
+                    .endZookeeper()
+                    .withMaintenanceTimeWindows(maintenanceTimeWindows)
+                .endSpec()
+                .build();
+
+        // setting up a mock Kubernetes client with the above environment
+        this.mockClient = new MockKube()
+                .withCustomResourceDefinition(kafkaAssemblyCrd, Kafka.class, KafkaAssemblyList.class, DoneableKafka.class)
+                .withInitialInstances(Collections.singleton(this.kafka))
+                .end()
+                .build();
+
+        this.clusterCaSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaResources.clusterCaCertificateSecretName(NAME))
+                    .withAnnotations(Collections.singletonMap(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"))
+                .endMetadata()
+                .build();
+        this.clientsCaSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(KafkaResources.clientsCaCertificateSecretName(NAME))
+                    .withAnnotations(Collections.singletonMap(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"))
+                .endMetadata()
+                .build();
+        this.mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clusterCaCertificateSecretName(NAME)).create(this.clusterCaSecret);
+        this.mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaCertificateSecretName(NAME)).create(this.clientsCaSecret);
+
+        // creating the Kafka operator
+        ResourceOperatorSupplier ros =
+                new ResourceOperatorSupplier(this.vertx, this.mockClient, false, 60_000L);
+
+        KafkaAssemblyOperator kao = new KafkaAssemblyOperator(this.vertx, false, 2_000, null, ros);
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
+
+        this.reconciliationState = kao.new ReconciliationState(reconciliation, kafka);
+    }
+
+
+    @Test
+    public void testZkRollingUpdateMaintenanceSatisfied(TestContext context) {
+
+        Async async = context.async();
+
+        testZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
+
+        async.await();
+    }
+
+    @Test
+    public void testZkRollingUpdateMaintenanceNotSatisfied(TestContext context) {
+
+        Async async = context.async();
+
+        testZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceSatisfied(TestContext context) {
+
+        Async async = context.async();
+
+        testKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceNotSatisfied(TestContext context) {
+
+        Async async = context.async();
+
+        testKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            });
+
+        async.await();
+    }
+
+    private String getClusterCaGenerationPod(String podName) {
+        Pod pod = this.mockClient.pods().inNamespace(NAMESPACE).withName(podName).get();
+        return pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION);
+    }
+
+    private void testZkRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
+                                    Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+
+        this.init(maintenanceTimeWindows);
+
+        StatefulSet zkSS = ZookeeperCluster.fromCrd(this.kafka).generateStatefulSet(false);
+        zkSS.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0");
+        this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(NAME)).create(zkSS);
+
+        this.reconciliationState.zkDiffs = ReconcileResult.created(zkSS);
+        this.reconciliationState.clusterCa = new ClusterCa(null, null, this.clusterCaSecret, null) {
+
+            @Override
+            public boolean certRenewed() {
+                return true;
+            }
+        };
+
+        StatefulSet z = this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(NAME)).get();
+        z.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "1");
+        this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(NAME)).patch(z);
+
+        this.reconciliationState.zkRollingUpdate(dateSupplier).setHandler(handler);
+    }
+
+    private void testKafkaRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
+                                     Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+
+        this.init(maintenanceTimeWindows);
+
+        StatefulSet kafkaSS = KafkaCluster.fromCrd(this.kafka).generateStatefulSet(false);
+        kafkaSS.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0");
+        kafkaSS.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+        this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaStatefulSetName(NAME)).create(kafkaSS);
+
+        this.reconciliationState.kafkaDiffs = ReconcileResult.created(kafkaSS);
+        this.reconciliationState.clusterCa = new ClusterCa(null, null, this.clusterCaSecret, null) {
+
+            @Override
+            public boolean certRenewed() {
+                return true;
+            }
+        };
+        this.reconciliationState.clientsCa = new ClientsCa(null, null, this.clientsCaSecret, null, null, 0, 0, true) {
+
+            @Override
+            public boolean certRenewed() {
+                return false;
+            }
+        };
+
+        StatefulSet k = this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaStatefulSetName(NAME)).get();
+        k.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "1");
+        k.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
+        this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaStatefulSetName(NAME)).patch(k);
+
+        this.reconciliationState.kafkaRollingUpdate(dateSupplier).setHandler(handler);
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
@@ -110,6 +110,8 @@ public class MockKube {
     private final Map<String, NetworkPolicy> policyDb = db(emptySet(), NetworkPolicy.class, DoneableNetworkPolicy.class);
     private final Map<String, Route> routeDb = db(emptySet(), Route.class, DoneableRoute.class);
 
+    private Map<String, List<String>> podsForDeployments = new HashMap<>();
+
     public MockKube withInitialCms(Set<ConfigMap> initialCms) {
         this.cmDb.putAll(db(initialCms, ConfigMap.class, DoneableConfigMap.class));
         return this;
@@ -181,7 +183,7 @@ public class MockKube {
         MixedOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> mockSvc = buildServices();
         MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods = buildPods();
         MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> mockSs = buildStatefulSets(mockPods);
-        MixedOperation<Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>> mockDep = buildDeployments();
+        MixedOperation<Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>> mockDep = buildDeployments(mockPods);
         MixedOperation<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>> mockSecrets = buildSecrets();
         MixedOperation<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> mockServiceAccounts = buildServiceAccount();
         MixedOperation<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> mockNetworkPolicy = buildNetworkPolicy();
@@ -253,16 +255,70 @@ public class MockKube {
         }
     }
 
-    private MixedOperation<Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>> buildDeployments() {
+    private MixedOperation<Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>> buildDeployments(MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods) {
         return new AbstractMockBuilder<Deployment, DeploymentList, DoneableDeployment, ScalableResource<Deployment, DoneableDeployment>>(
             Deployment.class, DeploymentList.class, DoneableDeployment.class, castClass(ScalableResource.class), depDb) {
             @Override
             protected void nameScopedMocks(ScalableResource<Deployment, DoneableDeployment> resource, String resourceName) {
                 mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
+                mockWatch(resourceName, resource);
+                //mockCreate(resourceName, resource);
+                when(resource.create(any())).thenAnswer(invocation -> {
+                    checkNotExists(resourceName);
+                    Deployment deployment = invocation.getArgument(0);
+                    LOGGER.debug("create {} {} -> {}", resourceType, resourceName, deployment);
+                    depDb.put(resourceName, copyResource(deployment));
+                    for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
+                        String uuid = UUID.randomUUID().toString();
+                        String podName = deployment.getMetadata().getName() + "-" + uuid;
+                        LOGGER.debug("create Pod {} because it's in Deployment {}", podName, resourceName);
+                        Pod pod = new PodBuilder()
+                                .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
+                                    .withUid(uuid)
+                                    .withNamespace(deployment.getMetadata().getNamespace())
+                                    .withName(podName)
+                                .endMetadata()
+                                .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
+                                .build();
+                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podName).create(pod);
+                        podsForDeployments.computeIfAbsent(deployment.getMetadata().getName(), s -> new ArrayList<>());
+                        podsForDeployments.get(deployment.getMetadata().getName()).add(podName);
+                    }
+                    return deployment;
+                });
                 mockCascading(resource);
-                mockPatch(resourceName, resource);
+                //mockPatch(resourceName, resource);
                 mockDelete(resourceName, resource);
+                when(resource.patch(any())).thenAnswer(invocation -> {
+                    Deployment deployment = invocation.getArgument(0);
+                    LOGGER.debug("patched {} {} -> {}", resourceType, resourceName, deployment);
+                    depDb.put(resourceName, copyResource(deployment));
+                    List<String> newPodNames = new ArrayList<>();
+                    for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
+                        // create a "new" Pod
+                        String uuid = UUID.randomUUID().toString();
+                        String newPodName = deployment.getMetadata().getName() + "-" + uuid;
+
+                        Pod newPod = new PodBuilder()
+                                .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
+                                    .withUid(uuid)
+                                    .withNamespace(deployment.getMetadata().getNamespace())
+                                    .withName(newPodName)
+                                .endMetadata()
+                                .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
+                                .build();
+                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(newPodName).create(newPod);
+                        newPodNames.add(newPodName);
+
+                        // delete one "old" Pod
+                        String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).get(i);
+                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
+                        podsForDeployments.get(deployment.getMetadata().getName()).remove(i);
+                    }
+                    podsForDeployments.get(deployment.getMetadata().getName()).addAll(newPodNames);
+
+                    return deployment;
+                });
             }
         }.build();
     }
@@ -405,7 +461,7 @@ public class MockKube {
                                 .withNewMetadataLike(templateMeta)
                                 .withUid(UUID.randomUUID().toString())
                                 .withNamespace(podNamespace)
-                                .withNamespace(podName)
+                                .withName(podName)
                                 .endMetadata()
                                 .withNewSpecLike(statefulSet.getSpec().getTemplate().getSpec()).endSpec()
                                 .done();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java
@@ -310,10 +310,9 @@ public class MockKube {
                         mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(newPodName).create(newPod);
                         newPodNames.add(newPodName);
 
-                        // delete one "old" Pod
-                        String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).get(i);
+                        // delete the first one "old" Pod
+                        String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
                         mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
-                        podsForDeployments.get(deployment.getMetadata().getName()).remove(i);
                     }
                     podsForDeployments.get(deployment.getMetadata().getName()).addAll(newPodNames);
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <mockito.version>2.12.0</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
+        <quartz.version>2.2.1</quartz.version>
 
         <jupiter.version>5.3.1</jupiter.version>
         <junit.platform.version>1.3.1</junit.platform.version>
@@ -227,6 +228,11 @@
                 <groupId>io.strimzi</groupId>
                 <artifactId>certificate-manager</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz</artifactId>
+                <version>${quartz.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR addresses #1109 adding the user configuration for maintenance time windows to describe when operations which start a rolling update (i.e. certificate renewal) can take place.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

