### PR TITLE
KafkaUser's now need to be labeled for the UO to see them

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -382,7 +382,7 @@ class KafkaST extends AbstractST {
                     .endKafka()
                 .endSpec().build()).done();
         resources().topic(CLUSTER_NAME, topicName).done();
-        KafkaUser user = resources().tlsUser(kafkaUser).done();
+        KafkaUser user = resources().tlsUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
 
         // Create ping job
@@ -417,7 +417,7 @@ class KafkaST extends AbstractST {
                     .endKafka()
                 .endSpec().build()).done();
         resources().topic(CLUSTER_NAME, topicName).done();
-        KafkaUser user = resources().scramShaUser(kafkaUser).done();
+        KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
         String brokerPodLog = podLog(CLUSTER_NAME + "-kafka-0", "kafka");
         Pattern p = Pattern.compile("^.*" + Pattern.quote(kafkaUser) + ".*$", Pattern.MULTILINE);
@@ -473,7 +473,7 @@ class KafkaST extends AbstractST {
                     .endKafka()
                 .endSpec().build()).done();
         resources().topic(CLUSTER_NAME, topicName).done();
-        KafkaUser user = resources().scramShaUser(kafkaUser).done();
+        KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
 
         // Create ping job
@@ -782,7 +782,7 @@ class KafkaST extends AbstractST {
         resources().topic(kafkaSourceName, topicSourceName).done();
 
         // Create Kafka user
-        KafkaUser user = resources().tlsUser(kafkaUser).done();
+        KafkaUser user = resources().tlsUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
 
         // Initialize CertSecretSource with certificate and secret names for consumer
@@ -869,11 +869,11 @@ class KafkaST extends AbstractST {
         resources().topic(kafkaSourceName, topicName).done();
 
         // Create Kafka user for source cluster
-        KafkaUser userSource = resources().scramShaUser(kafkaUserSource).done();
+        KafkaUser userSource = resources().scramShaUser(CLUSTER_NAME, kafkaUserSource).done();
         waitTillSecretExists(kafkaUserSource);
 
         // Create Kafka user for target cluster
-        KafkaUser userTarget = resources().scramShaUser(kafkaUserTarget).done();
+        KafkaUser userTarget = resources().scramShaUser(CLUSTER_NAME, kafkaUserTarget).done();
         waitTillSecretExists(kafkaUserTarget);
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -485,11 +485,12 @@ public class Resources {
         });
     }
 
-    DoneableKafkaUser tlsUser(String name) {
+    DoneableKafkaUser tlsUser(String clusterName, String name) {
         return user(new KafkaUserBuilder().withMetadata(
                 new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(client().getNamespace())
+                        .addToLabels("strimzi.io/cluster", clusterName)
                         .build())
                 .withNewSpec()
                     .withNewKafkaUserTlsClientAuthenticationAuthentication()
@@ -498,11 +499,12 @@ public class Resources {
                 .build());
     }
 
-    DoneableKafkaUser scramShaUser(String name) {
+    DoneableKafkaUser scramShaUser(String clusterName, String name) {
         return user(new KafkaUserBuilder().withMetadata(
                 new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(client().getNamespace())
+                        .addToLabels("strimzi.io/cluster", clusterName)
                         .build())
                 .withNewSpec()
                     .withNewKafkaUserScramSha512ClientAuthenticationAuthentication()

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -168,7 +168,7 @@ class SecurityST extends AbstractST {
     public void testAutoRenewCaCertsTriggeredByAnno() throws InterruptedException {
         createCluster();
         String userName = "alice";
-        resources().tlsUser(userName).done();
+        resources().tlsUser(CLUSTER_NAME, userName).done();
         waitFor("", 1_000, 60_000, () -> {
             return client.secrets().inNamespace(NAMESPACE).withName("alice").get() != null;
         },
@@ -223,7 +223,7 @@ class SecurityST extends AbstractST {
         AvailabilityVerifier.Result result = mp.stop(30_000);
         LOGGER.info("Producer/consumer stats during cert renewal {}", result);
     }
-
+    
     private AvailabilityVerifier waitForInitialAvailability(String userName) {
         AvailabilityVerifier mp = new AvailabilityVerifier(client, NAMESPACE, CLUSTER_NAME, userName);
         mp.start();
@@ -291,7 +291,7 @@ class SecurityST extends AbstractST {
         // 2. Now create a cluster
         createCluster();
         String userName = "alice";
-        resources().tlsUser(userName).done();
+        resources().tlsUser(CLUSTER_NAME, userName).done();
 
         AvailabilityVerifier mp = waitForInitialAvailability(userName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -48,7 +48,7 @@ class UserST extends AbstractST {
                 .endKafka()
             .endSpec().build()).done();
 
-        KafkaUser user = resources().tlsUser(kafkaUser).done();
+        KafkaUser user = resources().tlsUser(CLUSTER_NAME, kafkaUser).done();
         kubeClient.waitForResourceCreation("secret", kafkaUser);
 
         String kafkaUserSecret = kubeClient.getResourceAsJson("secret", kafkaUser);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Recent change to the UO to make it require the cluster label broke ST which created users without the lable. This PR fixes those ST.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

