### PR TITLE
Fix ignored logging configuration in Entity Operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -82,7 +82,7 @@ public class EntityTopicOperator extends AbstractModel {
 
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-topic-operator-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/entity-topic-operator/custom-config/";
+        this.logAndMetricsConfigMountPath = "/opt/topic-operator/custom-config/";
         this.validLoggerFields = getDefaultLogConfig();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -74,7 +74,7 @@ public class EntityUserOperator extends AbstractModel {
 
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-user-operator-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/entity-user-operator/custom-config/";
+        this.logAndMetricsConfigMountPath = "/opt/user-operator/custom-config/";
         this.validLoggerFields = getDefaultLogConfig();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -169,7 +169,7 @@ public class EntityTopicOperatorTest {
         assertEquals(new Integer(EntityTopicOperator.HEALTHCHECK_PORT), container.getPorts().get(0).getContainerPort());
         assertEquals(EntityTopicOperator.HEALTHCHECK_PORT_NAME, container.getPorts().get(0).getName());
         assertEquals("TCP", container.getPorts().get(0).getProtocol());
-        assertEquals(map("entity-topic-operator-metrics-and-logging", "/opt/entity-topic-operator/custom-config/",
+        assertEquals(map("entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
                 EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
                 EntityOperatorTest.volumeMounts(container.getVolumeMounts()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -159,7 +159,7 @@ public class EntityUserOperatorTest {
         assertEquals(new Integer(EntityUserOperator.HEALTHCHECK_PORT), container.getPorts().get(0).getContainerPort());
         assertEquals(EntityUserOperator.HEALTHCHECK_PORT_NAME, container.getPorts().get(0).getName());
         assertEquals("TCP", container.getPorts().get(0).getProtocol());
-        assertEquals("/opt/entity-user-operator/custom-config/", container.getVolumeMounts().get(0).getMountPath());
+        assertEquals("/opt/user-operator/custom-config/", container.getVolumeMounts().get(0).getMountPath());
         assertEquals("entity-user-operator-metrics-and-logging", container.getVolumeMounts().get(0).getName());
     }
 }

--- a/user-operator/Dockerfile
+++ b/user-operator/Dockerfile
@@ -3,8 +3,10 @@ FROM strimzi/java-base:latest
 ARG strimzi_version=1.0-SNAPSHOT
 ENV STRIMZI_VERSION ${strimzi_version}
 
+COPY ./scripts/ /bin
+
 ADD target/user-operator-${strimzi_version}.jar /
 
 USER 1001
 
-CMD /bin/launch_java.sh /user-operator-${STRIMZI_VERSION}.jar
+CMD /bin/user_operator_run.sh /user-operator-${STRIMZI_VERSION}.jar

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -f /opt/user-operator/custom-config/log4j2.properties ];
+then
+    export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/user-operator/custom-config/log4j2.properties"
+fi
+
+exec /bin/launch_java.sh $1


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When UO and TO are deployed as EO, their logging configuration currently doesn't work:
* The TO expects the Log4j properties file in path `/opt/topic-operator/custom-config/` but the CO mounts it into `/opt/entity-topic-operator/custom-config/`. This has to be fixed in the CO to use the same path every time.
* The UO doesn't seem to have any support for pointing Log4j to the properties file with configuration because it is just using the JAR on top of the Java base image. I added custom startup script to do this in the same way as TO does it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
