### PR TITLE
Manage SCRAM-SHA-512 credentials without starting new JVMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
         <fasterxml.jackson-annotations.version>2.9.5</fasterxml.jackson-annotations.version>
         <kafka.version>2.0.0</kafka.version>
+        <zkclient.version>0.11</zkclient.version>
         <scala-library.version>2.12.6</scala-library.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <mockito.version>2.12.0</mockito.version>
@@ -187,6 +188,11 @@
                         <artifactId>jline</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.101tec</groupId>
+                <artifactId>zkclient</artifactId>
+                <version>${zkclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -415,6 +415,11 @@ class KafkaST extends AbstractST {
                             .withPlain(listenerTls)
                         .endListeners()
                     .endKafka()
+                    .editEntityOperator()
+                        .editUserOperator()
+                            .withImage("scholzj/user-operator:latest")
+                        .endUserOperator()
+                    .endEntityOperator()
                 .endSpec().build()).done();
         resources().topic(CLUSTER_NAME, topicName).done();
         KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -415,11 +415,6 @@ class KafkaST extends AbstractST {
                             .withPlain(listenerTls)
                         .endListeners()
                     .endKafka()
-                    .editEntityOperator()
-                        .editUserOperator()
-                            .withImage("scholzj/user-operator:latest")
-                        .endUserOperator()
-                    .endEntityOperator()
                 .endSpec().build()).done();
         resources().topic(CLUSTER_NAME, topicName).done();
         KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();

--- a/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
+++ b/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
@@ -26,7 +26,7 @@ public class EmbeddedZooKeeper {
 
     private void start(InetSocketAddress addr) throws IOException, InterruptedException {
         factory = new NIOServerCnxnFactory();
-        factory.configure(addr, 10);
+        factory.configure(addr, 20);
         factory.startup(zk);
     }
 

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>kafka_2.12</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -59,7 +59,7 @@ public class Main {
         SecretOperator secretOperations = new SecretOperator(vertx, client);
         CrdOperator<KubernetesClient, KafkaUser, KafkaUserList, DoneableKafkaUser> crdOperations = new CrdOperator<>(vertx, client, KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
         SimpleAclOperator aclOperations = new SimpleAclOperator(vertx, authorizer);
-        ScramShaCredentials scramShaCredentials = new ScramShaCredentials(config.getZookeperConnect());
+        ScramShaCredentials scramShaCredentials = new ScramShaCredentials(config.getZookeperConnect(), (int) config.getZookeeperSessionTimeoutMs());
         ScramShaCredentialsOperator scramShaCredentialsOperator = new ScramShaCredentialsOperator(vertx, scramShaCredentials);
 
         KafkaUserOperator kafkaUserOperations = new KafkaUserOperator(vertx,

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
@@ -4,199 +4,176 @@
  */
 package io.strimzi.operator.user.operator;
 
-import io.strimzi.operator.common.process.ProcessHelper;
-import kafka.admin.ConfigCommand;
+import io.vertx.core.json.JsonObject;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.CharBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
-
+/**
+ * Utility class for managing Scram credentials
+ */
 public class ScramShaCredentials {
-
     private static final Logger log = LogManager.getLogger(SimpleAclOperator.class.getName());
 
+    private final static int ITERATIONS = 4096;
+    private final static int CONNECTION_TIMEOUT = 30_000;
+
     private final ScramMechanism mechanism = ScramMechanism.SCRAM_SHA_512;
+    private ZkClient zkClient;
 
-    private final String zookeeper;
-
-    public ScramShaCredentials(String zookeeper) {
-        this.zookeeper = zookeeper;
+    public ScramShaCredentials(String zookeeperUrl, int zookeeperSessionTimeout) {
+        zkClient = new ZkClient(zookeeperUrl, zookeeperSessionTimeout, CONNECTION_TIMEOUT, new BytesPushThroughSerializer());
     }
 
     /**
      * Create or update the SCRAM-SHA credentials for the given user.
-     * @param iterations If &lt;= 0 the default number of iterations will be used.
+     *
+     * @param username The name of the user which should be created or updated
+     * @param password The desired user password
      */
-    public void createOrUpdate(String username, String password, int iterations) {
-        if (0 < iterations && iterations < mechanism.minIterations()) {
-            throw new RuntimeException("Given number of iterations (" + iterations + ") " +
-                    "is less than minimum iterations for mechanism (" + mechanism.minIterations() + ")");
+    public void createOrUpdate(String username, String password) {
+        byte[] data = zkClient.readData("/config/users/" + username, true);
+
+        if (data != null)   {
+            log.debug("Updating {} credentials for user {}", mechanism.mechanismName(), username);
+            zkClient.writeData("/config/users/" + username, encodeUser(password));
+        } else {
+            log.debug("Creating {} credentials for user {}", mechanism.mechanismName(), username);
+            ensurePath("/config/users");
+            zkClient.createPersistent("/config/users/" + username, encodeUser(password));
         }
-        StringBuilder value = new StringBuilder(mechanism.mechanismName()).append("=[");
-        if (iterations > 0) {
-            value.append("iterations=").append(iterations).append(',');
-        }
-        value.append("password=").append(password).append(']');
-        try (ProcessHelper.ProcessResult pr = exec(asList(
-                    "--zookeeper", zookeeper,
-                    "--alter",
-                    "--entity-name", username,
-                    "--entity-type", "users",
-                    "--add-config", value.toString()))) {
-            Pattern compile = Pattern.compile("Completed Updating config for entity: user-principal '.*'\\.");
-            if (!matchResult(pr, pr.standardOutput(), 0, compile)) {
-                throw unexpectedOutput(pr);
-            }
-        }
+
+        notifyChanges(username);
     }
 
     /**
      * Delete the SCRAM-SHA credentials for the given user.
      * It is not an error if the user doesn't exist, or doesn't currently have any SCRAM-SHA credentials.
+     *
+     * @param username Name of the user
      */
     public void delete(String username) {
-        try (ProcessHelper.ProcessResult pr = exec(asList(
-                "--zookeeper", zookeeper,
-                "--alter",
-                "--entity-name", username,
-                "--entity-type", "users",
-                "--delete-config", mechanism.mechanismName()))) {
-            if (!matchResult(pr, pr.standardOutput(), 0,
-                    Pattern.compile("Completed Updating config for entity: user-principal '.*'\\."))
-                    && !matchResult(pr, pr.standardError(), 1,
-                    Pattern.compile(Pattern.quote("Invalid config(s): " + mechanism.mechanismName())))) {
-                throw unexpectedOutput(pr);
-            }
+        byte[] data = zkClient.readData("/config/users/" + username, true);
+
+        if (data != null)   {
+            log.debug("Deleting {} credentials for user {}", mechanism.mechanismName(), username);
+
+            JsonObject json = new JsonObject()
+                    .put("version", 1)
+                    .put("config", new JsonObject());
+
+            zkClient.writeData("/config/users/" + username, json.encode().getBytes(Charset.defaultCharset()));
+            notifyChanges(username);
+        } else {
+            log.warn("Credentials for user {} already don't exist", username);
         }
     }
 
     /**
      * Determine whether the given user has SCRAM-SHA credentials.
+     *
+     * @param username Name of the user
+     *
+     * @return True if the user exists and is configured for given mechanism
      */
     public boolean exists(String username) {
-        try (ProcessHelper.ProcessResult pr = exec(asList("kafka-configs.sh",
-            "--zookeeper", zookeeper,
-            "--describe",
-            "--entity-name", username,
-            "--entity-type", "users"))) {
-            if (matchResult(pr, pr.standardOutput(), 0,
-                    Pattern.compile("Configs for user-principal '.*?' are .*" + mechanism.mechanismName() + "=salt=[a-zA-Z0-9=]+,stored_key=([a-zA-Z0-9/+=]+),server_key=([a-zA-Z0-9/+=]+),iterations=[0-9]+"))) {
-                return true;
-            } else if (matchResult(pr, pr.standardOutput(), 0,
-                    Pattern.compile("Configs for user-principal '.*?' are .*(?!" + mechanism.mechanismName() + "=salt=[a-zA-Z0-9=]+,stored_key=([a-zA-Z0-9/+=]+),server_key=([a-zA-Z0-9/+=]+),iterations=[0-9]+)"))) {
-                return false;
-            } else {
-                throw unexpectedOutput(pr);
+        byte[] data = zkClient.readData("/config/users/" + username, true);
+
+        if (data != null)   {
+            String jsonString = new String(data, Charset.defaultCharset());
+            JsonObject json = new JsonObject(jsonString);
+            JsonObject config = json.getJsonObject("config");
+            String scramCredentials = config.getString(mechanism.mechanismName());
+
+            if (scramCredentials != null) {
+                try {
+                    ScramCredentialUtils.credentialFromString(scramCredentials);
+                    return true;
+                } catch (IllegalArgumentException e)    {
+                    log.warn("Invalid {} credentials for user {}", mechanism.mechanismName(), username);
+                }
             }
         }
+
+        return false;
     }
 
     /**
      * List users with SCRAM-SHA credentials
+     *
+     * @return List of usernames configured for given mechanism
      */
     public List<String> list() {
         List<String> result = new ArrayList<>();
-        try (ProcessHelper.ProcessResult pr = exec(asList("kafka-configs.sh",
-                "--zookeeper", zookeeper,
-                "--describe",
-                "--entity-type", "users"))) {
-            if (pr.exitCode() == 0) {
-                Pattern pattern = Pattern.compile("Configs for user-principal '(.*?)' are .*" + mechanism.mechanismName() + "=salt=[a-zA-Z0-9=]+,stored_key=([a-zA-Z0-9/+=]+),server_key=([a-zA-Z0-9/+=]+),iterations=[0-9]+");
-                try {
-                    try (FileChannel channel = new FileInputStream(pr.standardOutput()).getChannel()) {
-                        MappedByteBuffer byteBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, (int) channel.size());
-                        CharBuffer cs = Charset.defaultCharset().newDecoder().decode(byteBuffer);
-                        Matcher m = pattern.matcher(cs);
-                        while (m.find()) {
-                            result.add(m.group(1));
-                        }
-                    }
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+
+        if (zkClient.exists("/config/users"))   {
+            List<String> nodes = zkClient.getChildren("/config/users");
+
+            for (String node : nodes)   {
+                if (exists(node))   {
+                    result.add(node);
                 }
             }
         }
+
         return result;
     }
 
-    private RuntimeException unexpectedOutput(ProcessHelper.ProcessResult pr) {
-        log.debug("{} standard output:\n~~~\n{}\n~~~", pr, getFile(pr.standardOutput()));
-        log.debug("{} standard error:\n~~~\n{}\n~~~", pr, getFile(pr.standardError()));
-        return new RuntimeException(pr + " exited with code " + pr.exitCode() + " and is missing expected output");
+    /**
+     * This notifies Kafka about the changes we have made
+     *
+     * @param username  Name of the user whose configuration changed
+     */
+    private void notifyChanges(String username) {
+        log.debug("Notifying changes for user {}", username);
+
+        ensurePath("/config/changes");
+
+        JsonObject json = new JsonObject().put("version", 2).put("entity_path", "users/" + username);
+        zkClient.createPersistentSequential("/config/changes/config_change_", json.encode().getBytes(Charset.defaultCharset()));
     }
 
-    boolean matchResult(ProcessHelper.ProcessResult pr, File file, int expectedExitCode, Pattern pattern) {
-        try {
-            if (pr.exitCode() == expectedExitCode) {
-                try (FileChannel channel = new FileInputStream(file).getChannel()) {
-                    MappedByteBuffer byteBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, (int) channel.size());
-                    CharBuffer cs = Charset.defaultCharset().newDecoder().decode(byteBuffer);
-                    Matcher m = pattern.matcher(cs);
-                    if (m.find()) {
-                        log.debug("Found output indicating success: {}", m.group());
-                        return true;
-                    }
-                }
-            }
-            return false;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    /**
+     * Ensures that the path in Zookeeper exists.
+     * It checks whether it already exists and in case it doesn't, it will create the path.
+     *
+     * @param path The Zookeeper path which should exist
+     */
+    private void ensurePath(String path)    {
+        if (!zkClient.exists(path))   {
+            zkClient.createPersistent(path, true);
         }
     }
 
-    private static ProcessHelper.ProcessResult exec(List<String> kafkaConfigsOptions) {
-        String cp = System.getProperty("java.class.path");
-        File home = new File(System.getProperty("java.home"));
-        List<String> arguments = new ArrayList(asList(
-                new File(home, "bin/java").getAbsolutePath(),
-                "-cp", cp,
-                ConfigCommand.class.getName()));
-        arguments.addAll(kafkaConfigsOptions);
-
+    /**
+     * Generates the JSON with the credentials
+     *
+     * @param password  Password in String format
+     * @return  Returns the geenrated JSON as byte array
+     */
+    private byte[] encodeUser(String password)   {
         try {
-            return ProcessHelper.executeSubprocess(arguments, args -> args.stream()
-                    .map(arg ->
-                        arg.replaceAll("password=[^]]+", "[password=***]")
-                    )
-                    .collect(Collectors.toList()));
+            ScramFormatter formatter = new ScramFormatter(mechanism);
+            ScramCredential credentials = formatter.generateCredential(password, ITERATIONS);
 
-        } catch (IOException e) {
-            throw new RuntimeException("Error starting subprocess " + arguments, e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            JsonObject json = new JsonObject()
+                    .put("version", 1)
+                    .put("config", new JsonObject().put(mechanism.mechanismName(), ScramCredentialUtils.credentialToString(credentials)));
+
+            return json.encode().getBytes(Charset.defaultCharset());
+        } catch (NoSuchAlgorithmException e)    {
+            throw new RuntimeException("Failed to generate credentials", e);
         }
-        throw new RuntimeException("Error starting subprocess " + arguments);
-    }
-
-    private static String getFile(File out) {
-        try {
-            return new String(Files.readAllBytes(out.toPath()), Charset.defaultCharset());
-        } catch (IOException e) {
-            e.printStackTrace();
-            return "";
-        }
-    }
-
-    public static void main(String[] args) {
-        ScramShaCredentials scramSha = new ScramShaCredentials("localhost:2181");
-        scramSha.createOrUpdate("tom", "password", -1);
-        scramSha.createOrUpdate("tom", "password", 4096);
-        scramSha.delete("tom");
     }
 }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
@@ -27,7 +27,7 @@ public class ScramShaCredentialsOperator {
             future -> {
                 boolean exists = credsManager.exists(username);
                 if (password != null) {
-                    credsManager.createOrUpdate(username, password, -1);
+                    credsManager.createOrUpdate(username, password);
                     future.complete(exists ? ReconcileResult.created(null) : ReconcileResult.patched(null));
                 } else  {
                     if (exists) {

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramShaCredentialsTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramShaCredentialsTest.java
@@ -33,47 +33,42 @@ public class ScramShaCredentialsTest {
 
     @Before
     public void createSS() {
-        ss = new ScramShaCredentials(zkServer.getZkConnectString());
+        ss = new ScramShaCredentials(zkServer.getZkConnectString(), 6_000);
     }
 
     @Test
     public void normalCreate() {
-        ss.createOrUpdate("normalCreate", "foo-password", 10000);
+        ss.createOrUpdate("normalCreate", "foo-password");
     }
 
     @Test
     public void doubleCreate() {
-        ss.createOrUpdate("doubleCreate", "foo-password", 10000);
-        ss.createOrUpdate("doubleCreate", "foo-password", 10000);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void tooFewIterations() {
-        ss.createOrUpdate("tooFewIterations", "foo-password", 1);
+        ss.createOrUpdate("doubleCreate", "foo-password");
+        ss.createOrUpdate("doubleCreate", "foo-password");
     }
 
     @Test
     public void normalDelete() {
-        ss.createOrUpdate("normalDelete", "foo-password", 10000);
+        ss.createOrUpdate("normalDelete", "foo-password");
         ss.delete("normalDelete");
     }
 
     @Test
     public void doubleDelete() {
-        ss.createOrUpdate("doubleDelete", "foo-password", 10000);
+        ss.createOrUpdate("doubleDelete", "foo-password");
         ss.delete("doubleDelete");
         ss.delete("doubleDelete");
     }
 
     @Test
     public void changePassword() {
-        ss.createOrUpdate("changePassword", "changePassword-password", 10000);
-        ss.createOrUpdate("changePassword", "changePassword-password2", 10000);
+        ss.createOrUpdate("changePassword", "changePassword-password");
+        ss.createOrUpdate("changePassword", "changePassword-password2");
     }
 
     @Test
     public void userExists() {
-        ss.createOrUpdate("userExists", "foo-password", 10000);
+        ss.createOrUpdate("userExists", "foo-password");
         assertTrue(ss.exists("userExists"));
 
     }
@@ -85,7 +80,7 @@ public class ScramShaCredentialsTest {
 
     @Test
     public void listSome() {
-        ss.createOrUpdate("listSome", "foo-password", 10000);
+        ss.createOrUpdate("listSome", "foo-password");
         assertTrue(ss.list().contains("listSome"));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

The User Operator is currently using the `kafka-configs.sh` binary to manage SCRAM-SHA-512 users. This binary starts new VM inside the container and that doesn't scale well with multiple users, when the UO starts running out of memory after it tries to start multiple JVMs in parallel.

This PR changes the way the SCRAM users are managed to manage them directly in the Zookeeper database without starting new JVMs and using the `kafka-configs.sh` utility. That should allow it to scale better, as it should handle the resources in a better way.

This PR should close #965 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

