### PR TITLE
Enabled CRDs unit tests about templates

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -85,7 +85,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     }
 
     @Test
-    public void testKafkaWithTemplate() {
+    public void testKafkaConnectWithTemplate() {
         createDelete(KafkaConnect.class, "KafkaConnect-with-template.yaml");
     }
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -79,6 +79,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
         }
     }
 
+    @Test
     public void testKafkaWithTemplate() {
         createDelete(Kafka.class, "Kafka-with-template.yaml");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -64,7 +64,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     }
 
     @Test
-    void testKafkaWithTlsAuthWithMissingRequired() {
+    void testKafkaMirrorMakerWithTlsAuthWithMissingRequired() {
         try {
             createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
         } catch (KubeClusterException.InvalidResource e) {
@@ -74,12 +74,13 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     }
 
     @Test
-    void testKafkaWithScramSha512Auth() {
+    void testKafkaMirrorMakerWithScramSha512Auth() {
         createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-scram-sha-512-auth.yaml");
     }
 
+    @Test
     public void testKafkaMirrorMakerWithTemplate() {
-        createDelete(Kafka.class, "KafkaMIrrorMaker-with-template.yaml");
+        createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-template.yaml");
     }
 }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #1132 enabling the CRDs unit tests about templates and doing a few refactoring.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

