### PR TITLE
Configurable Kafka version for connect and mirror maker

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
+ * {@code KafkaConnect} cluster.
+ */
+public class KafkaConnectResources {
+
+    private KafkaConnectResources() { }
+
+    /**
+     * Returns the name of the Kafka Connect {@code Deployment} for a {@code KafkaConnect} cluster of the given name.
+     * @param connectName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding Kafka Connect {@code Deployment}.
+     */
+    public static String kafkaConnectDeploymentName(String connectName) {
+        return connectName + "-connect";
+    }
+
+    /**
+     * Returns the name of the Kafka Connect REST API {@code Service} for a {@code KafkaConnect} cluster of the given name.
+     * @param connectName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding Kafka Connect REST API {@code Service}.
+     */
+    public static String kafkaConnectRestApiServiceName(String connectName) {
+        return connectName + "-connect-api";
+    }
+
+    public static String kafkaConnectRestApiAddress(String connectName) {
+        return kafkaConnectRestApiServiceName(connectName) + ":8083";
+    }
+
+    /**
+     * Returns the name of the Kafka Connect metrics and log {@code ConfigMap} for a {@code KafkaConnect} cluster of the given name.
+     * @param connectName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding Kafka Connect metrics and log {@code ConfigMap}.
+     */
+    public static String kafkaConnectMetricsAndLogConfigMapName(String connectName) {
+        return connectName + "-connect-config";
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -22,6 +22,7 @@ import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTls;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
@@ -40,10 +41,6 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final int REST_API_PORT = 8083;
     protected static final String REST_API_PORT_NAME = "rest-api";
 
-    private static final String NAME_SUFFIX = "-connect";
-    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-api";
-
-    private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
     protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/connect-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT = "/opt/kafka/connect-password/";
 
@@ -99,15 +96,15 @@ public class KafkaConnectCluster extends AbstractModel {
     }
 
     public static String kafkaConnectClusterName(String cluster) {
-        return cluster + KafkaConnectCluster.NAME_SUFFIX;
+        return KafkaConnectResources.kafkaConnectDeploymentName(cluster);
     }
 
     public static String serviceName(String cluster) {
-        return cluster + KafkaConnectCluster.SERVICE_NAME_SUFFIX;
+        return KafkaConnectResources.kafkaConnectRestApiServiceName(cluster);
     }
 
     public static String logAndMetricsConfigName(String cluster) {
-        return cluster + KafkaConnectCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
+        return KafkaConnectResources.kafkaConnectMetricsAndLogConfigMapName(cluster);
     }
 
     public static KafkaConnectCluster fromCrd(KafkaConnect kafkaConnect) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR builds on top of #918, adding a `version` property to `KafkaConnect`, `KafkaConnectS2I` and `KafkaMirrorMaker` CRs, which can be used to specify the Kafka version to be used for the corresponding `Deployment`s. The same mechanism of passing a mapping of version number to default image is used as in #918. Similar build changes are used to generate the helm charts according to the configured versions in `/kafka-versions`. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

