### PR TITLE
Stop running findbugs on every compile, use make findbugs instead

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,8 +8,8 @@ export DOCKER_ORG=${DOCKER_ORG:-strimzici}
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io}
 export DOCKER_TAG=$COMMIT
 
-./.travis/check_docs.sh
-
+make docu_check
+make findbugs
 make docker_build
 
 if [ ! -e  documentation/book/appendix_crds.adoc ] ; then

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_check
 docu_check:
 	./.travis/check_docs.sh
 
+findbugs:
+	mvn org.codehaus.mojo:findbugs-maven-plugin:check
+
 docu_pushtowebsite: docu_htmlnoheader docu_html
 	./.travis/docu-push-to-website.sh
 
@@ -116,4 +119,4 @@ helm_install: helm-charts
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests
+.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests findbugs docu_check

--- a/pom.xml
+++ b/pom.xml
@@ -432,18 +432,6 @@
                     <!-- Configures the file for excluding warnings -->
                     <excludeFilterFile>${project.basedir}/../.findbugs/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
-                <executions>
-                    <!--
-                        Ensures that FindBugs inspects source code when project is compiled.
-                    -->
-                    <execution>
-                        <id>analyze-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Type of change

- Build change

### Description

Stop running findbugs on every compile, use `make findbugs` instead.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

