### PR TITLE
Added liveness and readiness probes to Sidecar CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
@@ -27,6 +27,9 @@ public class Sidecar implements Serializable {
 
     private Resources resources;
 
+    private Probe livenessProbe;
+    private Probe readinessProbe;
+
     @Description("The docker image for the container")
     public String getImage() {
         return image;
@@ -43,5 +46,25 @@ public class Sidecar implements Serializable {
 
     public void setResources(Resources resources) {
         this.resources = resources;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
@@ -27,9 +27,6 @@ public class Sidecar implements Serializable {
 
     private Resources resources;
 
-    private Probe livenessProbe;
-    private Probe readinessProbe;
-
     @Description("The docker image for the container")
     public String getImage() {
         return image;
@@ -46,25 +43,5 @@ public class Sidecar implements Serializable {
 
     public void setResources(Resources resources) {
         this.resources = resources;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
-        return livenessProbe;
-    }
-
-    public void setLivenessProbe(Probe livenessProbe) {
-        this.livenessProbe = livenessProbe;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
-        return readinessProbe;
-    }
-
-    public void setReadinessProbe(Probe readinessProbe) {
-        this.readinessProbe = readinessProbe;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
@@ -27,6 +27,8 @@ public class TlsSidecar extends Sidecar {
     private static final long serialVersionUID = 1L;
 
     private TlsSidecarLogLevel logLevel = TlsSidecarLogLevel.NOTICE;
+    private Probe livenessProbe;
+    private Probe readinessProbe;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The log level for the TLS sidecar. " +
@@ -39,6 +41,26 @@ public class TlsSidecar extends Sidecar {
 
     public void setLogLevel(TlsSidecarLogLevel logLevel) {
         this.logLevel = logLevel;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
     }
 
     @JsonAnyGetter

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -83,4 +83,9 @@ public class KafkaCrdIT extends AbstractCrdIT {
     public void testKafkaWithTemplate() {
         createDelete(Kafka.class, "Kafka-with-template.yaml");
     }
+
+    @Test
+    public void testKafkaWithTlsSidecarWithCustomConfiguration() {
+        createDelete(Kafka.class, "Kafka-with-tls-sidecar-with-custom-configuration.yaml");
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-tls-sidecar-with-custom-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-tls-sidecar-with-custom-configuration.yaml
@@ -1,0 +1,44 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 500Gi
+    listeners:
+      plain: {}
+      tls: {}
+    tlsSidecar:
+      logLevel: "info"
+      livenessProbe:
+        initialDelaySeconds: 5
+        timeoutSeconds: 1
+      readinessProbe:
+        initialDelaySeconds: 10
+        timeoutSeconds: 4
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral
+    tlsSidecar:
+      logLevel: "debug"
+      livenessProbe:
+        initialDelaySeconds: 5
+        timeoutSeconds: 1
+      readinessProbe:
+        initialDelaySeconds: 10
+        timeoutSeconds: 4
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+    tlsSidecar:
+      logLevel: "warning"
+      livenessProbe:
+        initialDelaySeconds: 5
+        timeoutSeconds: 1
+      readinessProbe:
+        initialDelaySeconds: 10
+        timeoutSeconds: 4

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -287,7 +287,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 [id='type-Probe-{context}']
 ### `Probe` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -388,12 +388,16 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`], xref:type
 
 [options="header"]
 |====
-|Field             |Description
-|image      1.2+<.<|The docker image for the container.
+|Field                  |Description
+|image           1.2+<.<|The docker image for the container.
 |string
-|logLevel   1.2+<.<|The log level for the TLS sidecar. Default value is `notice`.
+|livenessProbe   1.2+<.<|Pod liveness checking.
+|xref:type-Probe-{context}[`Probe`]
+|logLevel        1.2+<.<|The log level for the TLS sidecar. Default value is `notice`.
 |string (one of [emerg, debug, crit, err, alert, warning, notice, info])
-|resources  1.2+<.<|Resource constraints (limits and requests).
+|readinessProbe  1.2+<.<|Pod readiness checking.
+|xref:type-Probe-{context}[`Probe`]
+|resources       1.2+<.<|Resource constraints (limits and requests).
 |xref:type-Resources-{context}[`Resources`]
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -396,6 +396,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -407,6 +416,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -755,6 +773,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -766,6 +793,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -1029,6 +1065,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -1040,6 +1085,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -1379,6 +1433,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -1390,6 +1453,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -392,6 +392,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -403,6 +412,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -751,6 +769,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -762,6 +789,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -1025,6 +1061,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -1036,6 +1081,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -1375,6 +1429,15 @@ spec:
                   properties:
                     image:
                       type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     logLevel:
                       type: string
                       enum:
@@ -1386,6 +1449,15 @@ spec:
                       - notice
                       - info
                       - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR addresses part of #826 adding the liveness and readiness probes to the TLS sidecar.
They are added to the `Sidecar` base class because make sense not only for TLS sidecars (which is the only one we have today).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

