### PR TITLE
Fix name of the temp files used for TLS key

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -526,7 +526,7 @@ public abstract class Ca {
 
         Base64.Decoder decoder = Base64.getDecoder();
         byte[] bytes = decoder.decode(caKeySecret.getData().get(CA_KEY));
-        File keyFile = File.createTempFile("ererver", "dffbvd");
+        File keyFile = File.createTempFile("tls", commonName + "-key");
         try {
             Files.write(keyFile.toPath(), bytes);
             File certFile = File.createTempFile("tls", commonName + "-cert");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix the gibberish name for the `keyFile`.
