### PR TITLE
Routes should be using status instead of spec to get addresses

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -791,7 +791,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                     address.setHandler(res -> {
                         if (res.succeeded()) {
-                            String bootstrapAddress = routeOperations.get(namespace, routeName).getSpec().getHost();
+                            String bootstrapAddress = routeOperations.get(namespace, routeName).getStatus().getIngress().get(0).getHost();
                             this.kafkaExternalBootstrapDnsName = bootstrapAddress;
 
                             if (log.isTraceEnabled()) {
@@ -835,7 +835,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                         address.setHandler(res -> {
                             if (res.succeeded()) {
-                                String routeAddress = routeOperations.get(namespace, routeName).getSpec().getHost();
+                                String routeAddress = routeOperations.get(namespace, routeName).getStatus().getIngress().get(0).getHost();
                                 this.kafkaExternalAddresses.put(podNumber, routeAddress);
                                 this.kafkaExternalDnsNames.put(podNumber, routeAddress);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -884,9 +884,11 @@ public class KafkaAssemblyOperatorTest {
             when(supplier.routeOperations.hasAddress(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
             when(supplier.routeOperations.get(anyString(), anyString())).thenAnswer(i -> {
                 return new RouteBuilder()
-                        .withNewSpec()
+                        .withNewStatus()
+                        .addNewIngress()
                         .withHost(i.getArgument(0) + "." + i.getArgument(1) + ".mydomain.com")
-                        .endSpec()
+                        .endIngress()
+                        .endStatus()
                         .build();
             });
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -54,8 +54,10 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
         Resource<Route, DoneableRoute> resourceOp = operation().inNamespace(namespace).withName(name);
         Route resource = resourceOp.get();
 
-        if (resource != null && resource.getSpec().getHost() != null) {
-            return true;
+        if (resource != null && resource.getStatus() != null && resource.getStatus().getIngress() != null && resource.getStatus().getIngress() != null && resource.getStatus().getIngress().size() > 0) {
+            if (resource.getStatus().getIngress().get(0).getHost() != null) {
+                return true;
+            }
         }
 
         return false;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -54,7 +54,7 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
         Resource<Route, DoneableRoute> resourceOp = operation().inNamespace(namespace).withName(name);
         Route resource = resourceOp.get();
 
-        if (resource != null && resource.getStatus() != null && resource.getStatus().getIngress() != null && resource.getStatus().getIngress() != null && resource.getStatus().getIngress().size() > 0) {
+        if (resource != null && resource.getStatus() != null && resource.getStatus().getIngress() != null && resource.getStatus().getIngress().size() > 0) {
             if (resource.getStatus().getIngress().get(0).getHost() != null) {
                 return true;
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For some reason, exposing using routes is taking the address from the spec part of the Route resource. Instead, we should be probably using the status part. apparently, in some situations these two might differ :-o.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally