### PR TITLE
Allow make findbugs to run from modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,7 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_check
 docu_check:
 	./.travis/check_docs.sh
 
-findbugs:
-	mvn org.codehaus.mojo:findbugs-maven-plugin:check
+findbugs: $(SUBDIRS)
 
 docu_pushtowebsite: docu_htmlnoheader docu_html
 	./.travis/docu-push-to-website.sh

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -17,3 +17,6 @@ java_install: java_install_root
 java_clean:
 	echo "Cleaning Maven build ..."
 	mvn clean
+
+findbugs:
+	mvn org.codehaus.mojo:findbugs-maven-plugin:check

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -10,4 +10,4 @@ $(DOCKER_TARGETS): $(SUBDIRS)
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-.PHONY: build clean release all $(SUBDIRS) $(DOCKER_TARGETS)
+.PHONY: build clean release all $(SUBDIRS) $(DOCKER_TARGETS) findbugs

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,4 +12,4 @@ release:
 	$(CP) -r ./user $(RELEASE_PATH)/
 	$(CP) -r ./topic $(RELEASE_PATH)/
 
-.PHONY: all build clean docker_build docker_push docker_tag
+.PHONY: all build clean docker_build docker_push docker_tag findbugs

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -61,4 +61,4 @@ docker_push:
 all: docker_build
 clean: helm_clean
 
-.PHONY: build clean release
+.PHONY: build clean release findbugs

--- a/install/Makefile
+++ b/install/Makefile
@@ -9,4 +9,4 @@ release:
 	$(CP) -r ./user-operator $(RELEASE_PATH)/
 	$(CP) -r ./topic-operator $(RELEASE_PATH)/
 
-.PHONY: all build clean docker_build docker_push docker_tag
+.PHONY: all build clean docker_build docker_push docker_tag findbugs

--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -8,4 +8,4 @@ release:
 	$(CP) -r ./examples/kafka/* $(RELEASE_PATH)/
 	$(CP) -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
 
-.PHONY: all build clean docker_build docker_push docker_tag
+.PHONY: all build clean docker_build docker_push docker_tag findbugs


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `make findbugs` has to be currently run only on the global level for all modules. This PR moves it to the module level to allow run `make findbugs` also individually for different modules. It can be still called from the top level, in which case it would call make findbugs individually for all modules.