### PR TITLE
Avoid NPE when the Pods don't exist

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -97,11 +97,14 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             String podName = name + "-" + i;
             String pvcName = AbstractModel.getPersistentVolumeClaimName(name, i);
             Pod pod = podOperations.get(namespace, podName);
-            String value = Util.annotations(pod).get(ANNOTATION_MANUAL_DELETE_POD_AND_PVC);
-            if (value != null && Boolean.valueOf(value)) {
-                f = f.compose(ignored -> deletePvc(ss, pvcName))
-                        .compose(ignored -> maybeRestartPod(ss, podName, p -> true));
 
+            if (pod != null) {
+                String value = Util.annotations(pod).get(ANNOTATION_MANUAL_DELETE_POD_AND_PVC);
+                if (value != null && Boolean.valueOf(value)) {
+                    f = f.compose(ignored -> deletePvc(ss, pvcName))
+                            .compose(ignored -> maybeRestartPod(ss, podName, p -> true));
+
+                }
             }
         }
         return f;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In some situations, this method can be triggered when the pod doesn't exist. That ends up in an NPE. This should avoid the NPEs in these cases.