### PR TITLE
Fix Volume Claim template diff on Kubernetes 1.13

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -52,6 +52,8 @@ public class StatefulSetDiff {
             "/spec/template/spec/volumes/[0-9]+/configMap/defaultMode",
             "/spec/template/spec/volumes/[0-9]+/secret/defaultMode",
             "/spec/volumeClaimTemplates/[0-9]+/status",
+            "/spec/volumeClaimTemplates/[0-9]+/spec/volumeMode",
+            "/spec/volumeClaimTemplates/[0-9]+/spec/dataSource",
             "/spec/template/spec/serviceAccount",
             "/status").stream().map(Pattern::compile).collect(Collectors.toList());
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

It seems that on Kubernetes 1.13, there are some new VolumeClaim fields which trigger a diff and warning message about storage configuration changes. Adding them to the ignored fields helps to avoid the warning.
