### PR TITLE
Use an unprivileged gid in init containers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -93,7 +93,7 @@ public abstract class AbstractModel {
     private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
     protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
     private static final Long VOLUME_MOUNT_HACK_USERID = 1001L;
-    private static final Long VOLUME_MOUNT_HACK_GROUPID = 0L;
+    private static final Long VOLUME_MOUNT_HACK_GROUPID = 1001L;
 
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.yml";
     public static final String ANCILLARY_CM_KEY_LOG_CONFIG = "log4j.properties";


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

In #1017 the `fsGroup` of the StatefulSets' security context was removed, and in #1036 it was replaced, but with gid 0 instead of 1001. This is incompatible with our Pod Security Policies.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

