### PR TITLE
Add more null checks when trying to dig out the CA generation from EO annotations

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1247,10 +1247,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         private int getDeploymentCaCertGeneration(Deployment dep, Ca ca) {
             int caCertGeneration = 0;
-            if (dep != null) {
+            if (dep != null && dep.getSpec().getTemplate().getMetadata().getAnnotations() != null) {
                 String depAnnotation = getCaCertAnnotation(ca);
-                caCertGeneration =
-                        Integer.parseInt(dep.getSpec().getTemplate().getMetadata().getAnnotations().get(depAnnotation));
+
+                if (dep.getSpec().getTemplate().getMetadata().getAnnotations().get(depAnnotation) != null) {
+                    caCertGeneration =
+                            Integer.parseInt(dep.getSpec().getTemplate().getMetadata().getAnnotations().get(depAnnotation));
+                }
             }
             return caCertGeneration;
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When upgrading from 0.8.2, there is an NPE because of missing EO annotations. This PR adds additional null checks to avoid this.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
