### PR TITLE
Replace the Apache Zookeeper project's client with ZkClient

### DIFF
--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -94,6 +94,7 @@ public class Config {
     public static final String TC_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String TC_ZK_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     public static final String TC_ZK_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
+    public static final String TC_ZK_CONNECTION_TIMEOUT_MS = "TC_ZK_CONNECTION_TIMEOUT_MS";
     public static final String TC_PERIODIC_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String TC_REASSIGN_THROTTLE = "STRIMZI_REASSIGN_THROTTLE";
     public static final String TC_REASSIGN_VERIFY_INTERVAL_MS = "STRIMZI_REASSIGN_VERIFY_INTERVAL_MS";
@@ -121,6 +122,9 @@ public class Config {
 
     /** The zookeeper session timeout. */
     public static final Value<Long> ZOOKEEPER_SESSION_TIMEOUT_MS = new Value<>(TC_ZK_SESSION_TIMEOUT_MS, DURATION, "20000");
+
+    /** The zookeeper connection timeout. */
+    public static final Value<Long> ZOOKEEPER_CONNECTION_TIMEOUT_MS = new Value<>(TC_ZK_CONNECTION_TIMEOUT_MS, DURATION, "20000");
 
     /** The period between full reconciliations. */
     public static final Value<Long> FULL_RECONCILIATION_INTERVAL_MS = new Value<>(TC_PERIODIC_INTERVAL_MS, DURATION, "900000");
@@ -155,6 +159,7 @@ public class Config {
         addConfigValue(configValues, NAMESPACE);
         addConfigValue(configValues, ZOOKEEPER_CONNECT);
         addConfigValue(configValues, ZOOKEEPER_SESSION_TIMEOUT_MS);
+        addConfigValue(configValues, ZOOKEEPER_CONNECTION_TIMEOUT_MS);
         addConfigValue(configValues, FULL_RECONCILIATION_INTERVAL_MS);
         addConfigValue(configValues, REASSIGN_THROTTLE);
         addConfigValue(configValues, REASSIGN_VERIFY_INTERVAL_MS);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -9,7 +9,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
-import org.apache.zookeeper.data.Stat;
 
 import java.util.List;
 
@@ -18,14 +17,14 @@ import java.util.List;
  */
 public interface Zk {
 
-    public static Zk create(Vertx vertx, String zkConnectionString, int sessionTimeout) {
-        return new ZkImpl(vertx, zkConnectionString, sessionTimeout, false);
+    public static Zk create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
+        return new ZkImpl(vertx, zkConnectionString, sessionTimeout, connectionTimeout);
     }
 
     /**
-     * Disconnect from the ZooKeeper server, synchronously.
+     * Disconnect from the ZooKeeper server, asynchronously.
      */
-    Zk disconnect() throws InterruptedException;
+    Zk disconnect(Handler<AsyncResult<Void>> handler);
 
     /**
      * Asynchronously create the znode at the given path and with the given data and ACL, using the
@@ -83,26 +82,6 @@ public interface Zk {
      * Remove the data watcher, if any, for the given {@code path}.
      */
     Zk unwatchData(String path);
-
-    /**
-     * Asynchronously check whether a znode exists at the given {@code path},
-     * calling the given handler with the result.
-     * The result will be null if no znode existed at the given {@code path}.
-     */
-    Zk exists(String path, Handler<AsyncResult<Stat>> handler);
-
-    /**
-     * Set given the existence {@code watcher} on the given {@code path}.
-     * A subsequent call to {@link #exists(String, Handler)} with the same path will register the existence {@code watcher}
-     * for the given {@code path} current at that time with zookeeper so
-     * that that {@code watcher} is called when a znode at that path is created or deleted.
-     */
-    Zk watchExists(String path, Handler<AsyncResult<Stat>> watcher);
-
-    /**
-     * Remove the existence watcher, if any, for the given {@code path}.
-     */
-    Zk unwatchExists(String path);
 
     // TODO getAcl(), setAcl(), multi()
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
@@ -8,22 +8,19 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import org.I0Itec.zkclient.IZkChildListener;
+import org.I0Itec.zkclient.IZkDataListener;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.exception.ZkNoNodeException;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
-import org.apache.zookeeper.data.Stat;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Implementation of {@link Zk}
@@ -31,359 +28,209 @@ import java.util.concurrent.ExecutionException;
 public class ZkImpl implements Zk {
 
     private final static Logger LOGGER = LogManager.getLogger(ZkImpl.class);
-    public static final String PREFIX_DATA = "data:";
-    public static final String PREFIX_CHILDREN = "children:";
-    public static final String PREFIX_EXISTS = "exists:";
-    private final boolean readOnly;
-
-    private final String zkConnectionString;
-    private final int sessionTimeout;
+    private static final <T> Handler<AsyncResult<T>> log(String msg) {
+        return ignored -> {
+            LOGGER.trace("{} returned {}", msg, ignored);
+        };
+    }
     private final Vertx vertx;
-    private final ZooKeeper zk;
+    private final ZkClient zookeeper;
 
     // Only accessed on the vertx context.
-    private final ConcurrentHashMap<String, Handler<? extends AsyncResult<?>>> watches = new ConcurrentHashMap<>();
 
-    // TODO We need to reset the watches on reconnection.
-    // TODO We need to retry methods which fail due to connection loss, up to some limit/time
-    // We should probably try to avoid stampede though, so random exponential backoff
+    private final ConcurrentHashMap<String, IZkDataListener> dataWatches = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, IZkChildListener> childWatches = new ConcurrentHashMap<>();
 
-    public ZkImpl(Vertx vertx, String zkConnectionString, int sessionTimeout, boolean readOnly) {
+    public ZkImpl(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
         this.vertx = vertx;
-        this.zkConnectionString = zkConnectionString;
-        this.sessionTimeout = sessionTimeout;
-        this.readOnly = readOnly;
-        CompletableFuture<Void> f = new CompletableFuture<>();
-        try {
-            zk = new ZooKeeper(zkConnectionString, sessionTimeout, watchedEvent -> {
-                // See https://wiki.apache.org/hadoop/ZooKeeper/FAQ
-                // for state transitions
-                Watcher.Event.KeeperState state = watchedEvent.getState();
-                LOGGER.debug("In state {}", state);
-                final Future<Zk> future;
-                final Handler<AsyncResult<Zk>> handler;
-                switch (state) {
-                    case AuthFailed:
-                        f.completeExceptionally(new RuntimeException("Zookeeper authentication failed"));
-                    case SaslAuthenticated:
-                        // TODO record that we're auth, so methods can reject ACLs with "auth" scheme?
-                        break;
-                    case ConnectedReadOnly:
-                        if (!readOnly) {
-                            // This should never happen
-                            throw new RuntimeException("Connected readonly");
-                        }
-                        /* fall through */
-                    case SyncConnected:
-                        LOGGER.debug("Connected, session id {}", zk().getSessionId());
-                        f.complete(null);
-                        break;
-                    case Expired:
-                        // We've just been reconnected to the emsemble, and our session has expired while
-                        // we were disconnected
-                        f.complete(null);
-                        break;
-                    case Disconnected:
-                        // We've just been disconnected from the emsemble. The ZooKeeper implementation
-                        // should reconnect us soon.
-                        break;
-                    default:
-                        // According to the KeeperState doc
-                        // the remaining states should be impossible
-                        throw new IllegalStateException("Unexpected state: " + state.toString() + "");
-                }
-            },
-            readOnly);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        try {
-            f.get();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new RuntimeException(cause);
-            }
-        }
+        this.zookeeper = new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout, new BytesPushThroughSerializer());
     }
 
-    private ZooKeeper zk() {
-        return zk;
-    }
-
-
-    /**
-     * Map the given rc result code to a KeeperException, then run the given handler on the vertx context.
-     */
-    private <T> void invokeOnContext(Handler<AsyncResult<T>> handler, String path, int rc, T result) {
-        Future<T> future = mapResult(path, rc, result);
-        vertx.runOnContext(ignored -> handler.handle(future));
-    }
-
-    private <T> Future<T> mapResult(String path, int rc, T result) {
-        KeeperException.Code code = KeeperException.Code.get(rc);
-        Future<T> future;
-        switch (code) {
-            case OK:
-                future = Future.succeededFuture(result);
-                break;
-            default:
-                future = Future.failedFuture(KeeperException.create(code, "for path: " + path));
-        }
-        return future;
-    }
 
     @Override
     public Zk create(String path, byte[] data, List<ACL> acls, CreateMode createMode, Handler<AsyncResult<Void>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        zookeeper.create(path, data == null ? new byte[0] : data, acls, createMode,
-            (rc, path2, ctx, name) -> invokeOnContext(handler, path, rc, null), null);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    zookeeper.create(path, data == null ? new byte[0] : data, acls, createMode);
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            handler);
         return this;
     }
-
 
     @Override
     public Zk setData(String path, byte[] data, int version, Handler<AsyncResult<Void>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        zookeeper.setData(path, data, version,
-            (int rc, String path2, Object ctx, Stat stat) -> invokeOnContext(handler, path, rc, null),
-                null);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    zookeeper.writeData(path, data, version);
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            handler);
         return this;
     }
 
     @Override
-    public Zk disconnect() throws InterruptedException {
-        zk.close();
+    public Zk disconnect(Handler<AsyncResult<Void>> handler) {
+
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    zookeeper.close();
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            handler);
         return this;
     }
 
     @Override
     public Zk getData(String path, Handler<AsyncResult<byte[]>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        final AsyncCallback.DataCallback callback = (rc, path2, ctx, data, stat) -> {
-            Watcher.Event.EventType eventType = (Watcher.Event.EventType) ctx;
-            if (eventType == null // first time
-                    || eventType == Watcher.Event.EventType.NodeDataChanged) {
-                Future<byte[]> future = mapResult(path2, rc, data);
-                vertx.runOnContext(ignored -> {
-                    final Handler<AsyncResult<byte[]>> watch = getDataWatchHandler(path);
-                    if (eventType != null && watch != null) {
-                        // Only call the handlers if callback fired due to watch
-                        watch.handle(future);
-                    }
-                    if (eventType == null && handler != null) {
-                        handler.handle(future);
-                    }
-                });
-            }
-        };
-        final Watcher watcher;
-        if (getDataWatchHandler(path) != null) {
-            watcher = new Watcher() {
-                @Override
-                public void process(WatchedEvent event) {
-                    if (getDataWatchHandler(path) != null) {
-                        // Reset the watch if there still is a handler
-                        zookeeper.getData(path, this,
-                                callback, event.getType());
-                    }
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    future.complete(zookeeper.readData(path));
+                } catch (Throwable t) {
+                    future.fail(t);
                 }
-            };
-        } else {
-            watcher = null;
-        }
-        zookeeper.getData(path, watcher, callback, null);
+            },
+            handler);
         return this;
     }
 
-    @SuppressWarnings("unchecked")
-    private Handler<AsyncResult<byte[]>> getDataWatchHandler(String path) {
-        return (Handler<AsyncResult<byte[]>>) watches.get(PREFIX_DATA + path);
-    }
+    static class DataWatchAdapter implements IZkDataListener {
 
-    @SuppressWarnings("unchecked")
-    private Handler<AsyncResult<List<String>>> getChildrenWatchHandler(String path) {
-        return (Handler<AsyncResult<List<String>>>) watches.get(PREFIX_CHILDREN + path);
-    }
+        private final Handler<AsyncResult<byte[]>> watcher;
 
-    @SuppressWarnings("unchecked")
-    private Handler<AsyncResult<Stat>> getExistsWatchHandler(String path) {
-        return (Handler<AsyncResult<Stat>>) watches.get(PREFIX_EXISTS + path);
+        public DataWatchAdapter(Handler<AsyncResult<byte[]>> watcher) {
+            this.watcher = watcher;
+        }
+
+        @Override
+        public void handleDataChange(String dataPath, Object data) throws Exception {
+            watcher.handle(Future.succeededFuture((byte[]) data));
+        }
+
+        @Override
+        public void handleDataDeleted(String dataPath) throws Exception {
+
+        }
     }
 
     @Override
     public Zk watchData(String path, Handler<AsyncResult<byte[]>> watcher) {
-        watches.put(PREFIX_DATA + path, watcher);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    IZkDataListener listener = new DataWatchAdapter(watcher);
+                    dataWatches.put(path, listener);
+                    zookeeper.subscribeDataChanges(path, listener);
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            log("watchData"));
         return this;
     }
 
     @Override
     public Zk unwatchData(String path) {
-        watches.remove(PREFIX_DATA + path);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    IZkDataListener listener = dataWatches.remove(path);
+                    if (listener != null) {
+                        zookeeper.unsubscribeDataChanges(path, listener);
+                    }
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            log("unwatchData"));
         return this;
     }
 
     @Override
     public Zk delete(String path, int version, Handler<AsyncResult<Void>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        Object ctx = null;
-        zookeeper.delete(path, version, (rc, path1, ctx1) -> invokeOnContext(handler, path, rc, null), ctx);
-        return this;
-    }
-
-    @Override
-    public Zk exists(String path, Handler<AsyncResult<Stat>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        final AsyncCallback.StatCallback callback = (rc, path1, ctx1, stat) -> {
-            Watcher.Event.EventType eventType = (Watcher.Event.EventType) ctx1;
-            if (eventType == null // first time
-                    || eventType == Watcher.Event.EventType.NodeCreated
-                    || eventType == Watcher.Event.EventType.NodeDeleted
-                    || KeeperException.Code.get(rc) != KeeperException.Code.OK) {
-                Future<Stat> future = mapResult(path1, rc, stat);
-                vertx.runOnContext(ignored -> {
-                    final Handler<AsyncResult<Stat>> watch = getExistsWatchHandler(path);
-                    if (eventType != null && watch != null) {
-                        // Only call the handlers if callback fired due to watch
-                        watch.handle(future);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    if (zookeeper.delete(path, version)) {
+                        future.complete();
+                    } else {
+                        future.fail(new ZkNoNodeException());
                     }
-                    if (eventType == null && handler != null) {
-                        handler.handle(future);
-                    }
-                });
-            }
-        };
-        final Watcher watcher;
-        if (getExistsWatchHandler(path) != null) {
-            watcher = new Watcher() {
-                @Override
-                public void process(WatchedEvent event) {
-                    if (getExistsWatchHandler(path) != null) {
-                        // Reset the watch if there still is a handler
-                        zookeeper.exists(path, this,
-                                callback, event.getType());
-                    }
+                } catch (Throwable t) {
+                    future.fail(t);
                 }
-            };
-        } else {
-            watcher = null;
-        }
-        zookeeper.exists(path, watcher, callback, null);
+            },
+            handler);
         return this;
     }
 
-    @Override
-    public Zk watchExists(String path, Handler<AsyncResult<Stat>> watcher) {
-        watches.put(PREFIX_EXISTS + path, watcher);
-        return this;
-    }
-
-    @Override
-    public Zk unwatchExists(String path) {
-        watches.remove(PREFIX_EXISTS + path);
-        return this;
+    private WorkerExecutor workerPool() {
+        return vertx.createSharedWorkerExecutor(getClass().getName(), 4);
     }
 
     @Override
     public Zk children(String path, Handler<AsyncResult<List<String>>> handler) {
-        ZooKeeper zookeeper;
-        synchronized (this) {
-            zookeeper = zk;
-        }
-        if (zookeeper == null) {
-            handler.handle(Future.failedFuture(new IllegalStateException("Not connected")));
-            return this;
-        }
-        final AsyncCallback.Children2Callback callback = (rc, path2, ctx, children, stat) -> {
-            Watcher.Event.EventType eventType = (Watcher.Event.EventType) ctx;
-            KeeperException.Code code = KeeperException.Code.get(rc);
-            LOGGER.debug("{}: {} {}", path2, eventType, code);
-            if (eventType == null // first time
-                    || eventType == Watcher.Event.EventType.NodeChildrenChanged
-                    || code != KeeperException.Code.OK) {
-                Future<List<String>> future = mapResult(path2, rc, children);
-                vertx.runOnContext(ignored -> {
-                    final Handler<AsyncResult<List<String>>> watch = getChildrenWatchHandler(path);
-                    if (eventType != null && watch != null) {
-                        // Only call the handlers if callback fired due to watch
-                        watch.handle(future);
-                    }
-                    if (eventType == null && handler != null) {
-                        handler.handle(future);
-                    }
-                });
-            }
-        };
-        final Watcher watcher;
-        if (getChildrenWatchHandler(path) != null) {
-            watcher = new Watcher() {
-                @Override
-                public void process(WatchedEvent event) {
-                    if (getChildrenWatchHandler(path) != null) {
-                        // Reset the watch if there still is a handler
-                        zookeeper.getChildren(path, this,
-                                callback, event.getType());
-                    }
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    future.complete(zookeeper.getChildren(path));
+                } catch (Throwable t) {
+                    future.fail(t);
                 }
-            };
-        } else {
-            watcher = null;
-        }
-        zookeeper.getChildren(path, watcher, callback, null);
+            },
+            handler);
         return this;
+
     }
 
     @Override
     public Zk watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
-        watches.put(PREFIX_CHILDREN + path, watcher);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    IZkChildListener listener = (parentPath, currentChilds) -> watcher.handle(Future.succeededFuture(currentChilds));
+                    childWatches.put(path, listener);
+                    zookeeper.subscribeChildChanges(path, listener);
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            log("watchChildren"));
         return this;
     }
 
     @Override
     public Zk unwatchChildren(String path) {
-        watches.remove(PREFIX_CHILDREN + path);
+        workerPool().executeBlocking(
+            future -> {
+                try {
+                    IZkChildListener listener = childWatches.remove(path);
+                    if (listener != null) {
+                        zookeeper.unsubscribeChildChanges(path, listener);
+                    }
+                    future.complete();
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            },
+            log("unwatchChildren"));
         return this;
     }
-
-
 
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
@@ -10,7 +10,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
-import org.apache.zookeeper.data.Stat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +39,8 @@ class MockZk implements Zk {
     }
 
     @Override
-    public Zk disconnect() {
+    public Zk disconnect(Handler<AsyncResult<Void>> handler) {
+        handler.handle(Future.succeededFuture());
         return this;
     }
 
@@ -94,21 +94,6 @@ class MockZk implements Zk {
 
     @Override
     public Zk delete(String path, int version, Handler<AsyncResult<Void>> handler) {
-        return null;
-    }
-
-    @Override
-    public Zk watchExists(String path, Handler<AsyncResult<Stat>> watcher) {
-        return null;
-    }
-
-    @Override
-    public Zk unwatchExists(String path) {
-        return null;
-    }
-
-    @Override
-    public Zk exists(String path, Handler<AsyncResult<Stat>> handler) {
         return null;
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -153,6 +153,7 @@ public class TopicOperatorIT {
                 topicsWatcher = session.topicsWatcher;
                 async.complete();
             } else {
+                ar.cause().printStackTrace();
                 context.fail("Failed to deploy session");
             }
         });

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -38,13 +38,15 @@ public class ZkTopicStoreTest {
             throws IOException, InterruptedException,
             TimeoutException, ExecutionException {
         this.zkServer = new EmbeddedZooKeeper();
-        zk = new ZkImpl(vertx, zkServer.getZkConnectString(), 60000, false);
+        zk = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
         this.store = new ZkTopicStore(zk);
     }
 
     @After
-    public void teardown() throws InterruptedException {
-        zk.disconnect();
+    public void teardown(TestContext context) {
+        Async async = context.async();
+        zk.disconnect(ar -> async.complete());
+        async.await();
         if (this.zkServer != null) {
             this.zkServer.close();
         }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Fixes #1030 and probably fixes #339 and #383

* Revise API for Zk to fit with ZkClient:
    * Asynchronous disconnect()
    * Remove methods which were only being called from test methods
* Rewrite ZkImpl accordingly for the new ZkClient
* Configurable connect timeout
* Fix tests


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

