### PR TITLE
Standardize annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.10.0
 
+* Rename annotations to use the `strimzi.io` domain consistently:
+    * `cluster.operator.strimzi.io/delete-claim` → `strimzi.io/delete-claim` 
+    * `operator.strimzi.io/manual-rolling-update` → `strimzi.io/manual-rolling-update` 
+    * `operator.strimzi.io/delete-pod-and-pvc` → `strimzi.io/delete-pod-and-pvc`
+    * `operator.strimzi.io/generation` → `strimzi.io/generation`
+The old annotations are deprecated, but still functional.
+
 ## 0.9.0
 
 * Add possibility to label and annotate different resources (#1093)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -32,8 +32,6 @@ public class ClusterOperator extends AbstractVerticle {
 
     private static final Logger log = LogManager.getLogger(ClusterOperator.class.getName());
 
-    public static final String STRIMZI_CLUSTER_OPERATOR_DOMAIN = "cluster.operator.strimzi.io";
-
     private static final int HEALTH_SERVER_PORT = 8080;
 
     private final KubernetesClient client;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -103,8 +103,7 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
     public static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
 
-    private static final String DELETE_CLAIM_ANNOTATION =
-            ClusterOperator.STRIMZI_CLUSTER_OPERATOR_DOMAIN + "/delete-claim";
+    private static final String DELETE_CLAIM_ANNOTATION = Annotations.STRIMZI_DOMAIN + "/delete-claim";
 
     protected final String cluster;
     protected final String namespace;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -60,7 +60,7 @@ import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.operator.cluster.ClusterOperator;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -1062,7 +1062,7 @@ public abstract class AbstractModel {
 
     public static boolean deleteClaim(StatefulSet ss) {
         if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
-            return Boolean.valueOf(Util.annotations(ss).getOrDefault(DELETE_CLAIM_ANNOTATION, "false"));
+            return Boolean.valueOf(Annotations.annotations(ss).getOrDefault(DELETE_CLAIM_ANNOTATION, "false"));
         } else {
             return false;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -102,7 +102,9 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
     public static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
 
-    private static final String DELETE_CLAIM_ANNOTATION = Annotations.STRIMZI_DOMAIN + "/delete-claim";
+    private static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "/delete-claim";
+    @Deprecated
+    private static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = "cluster.operator.strimzi.io/delete-claim";
 
     protected final String cluster;
     protected final String namespace;
@@ -771,7 +773,7 @@ public abstract class AbstractModel {
 
         Map<String, String> annotations = new HashMap<>();
 
-        annotations.put(DELETE_CLAIM_ANNOTATION,
+        annotations.put(ANNO_STRIMZI_IO_DELETE_CLAIM,
                 String.valueOf(storage instanceof PersistentClaimStorage
                         && ((PersistentClaimStorage) storage).isDeleteClaim()));
 
@@ -1060,7 +1062,8 @@ public abstract class AbstractModel {
 
     public static boolean deleteClaim(StatefulSet ss) {
         if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
-            return Boolean.valueOf(Annotations.annotations(ss).getOrDefault(DELETE_CLAIM_ANNOTATION, "false"));
+            return Annotations.booleanAnnotation(ss, ANNO_STRIMZI_IO_DELETE_CLAIM,
+                    false, ANNO_CO_STRIMZI_IO_DELETE_CLAIM);
         } else {
             return false;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -59,7 +59,6 @@ import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Storage;
-import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.json.JsonObject;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -22,6 +22,7 @@ import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 
@@ -54,7 +55,7 @@ public class TopicOperator extends AbstractModel {
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
     protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_NAME = "cluster-ca-certs";
     protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
-
+    public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
 
     protected static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -42,6 +43,7 @@ import java.util.Map;
 public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<KubernetesClient, KafkaConnect, KafkaConnectAssemblyList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> {
 
     private static final Logger log = LogManager.getLogger(KafkaConnectAssemblyOperator.class.getName());
+    public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
     private final ServiceOperator serviceOperations;
     private final DeploymentOperator deploymentOperations;
     private final ConfigMapOperator configMapOperations;
@@ -88,7 +90,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                 null);
 
         Map<String, String> annotations = new HashMap();
-        annotations.put("strimzi.io/logging", logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
+        annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Connect cluster", reconciliation, name, namespace);
         return deploymentOperations.scaleDown(namespace, connect.getName(), connect.getReplicas())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.model.KafkaConnectS2ICluster;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -45,6 +46,7 @@ import java.util.List;
 public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IAssemblyList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> {
 
     private static final Logger log = LogManager.getLogger(KafkaConnectS2IAssemblyOperator.class.getName());
+    public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
     private final ServiceOperator serviceOperations;
     private final DeploymentConfigOperator deploymentConfigOperations;
     private final ImageStreamOperator imagesStreamOperations;
@@ -99,7 +101,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                     null);
 
             HashMap<String, String> annotations = new HashMap();
-            annotations.put("strimzi.io/logging", logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
+            annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
 
             return deploymentConfigOperations.scaleDown(namespace, connect.getName(), connect.getReplicas())
                     .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -42,6 +43,7 @@ import java.util.Map;
 public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> {
 
     private static final Logger log = LogManager.getLogger(KafkaMirrorMakerAssemblyOperator.class.getName());
+    public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
 
     private final DeploymentOperator deploymentOperations;
     private final ConfigMapOperator configMapOperations;
@@ -89,7 +91,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 null);
 
         Map<String, String> annotations = new HashMap();
-        annotations.put("strimzi.io/logging", logAndMetricsConfigMap.getData().get(mirror.ANCILLARY_CM_KEY_LOG_CONFIG));
+        annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(mirror.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Mirror Maker cluster", reconciliation, name, namespace);
         return deploymentOperations.scaleDown(namespace, mirror.getName(), mirror.getReplicas())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 /**
@@ -99,8 +100,8 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             Pod pod = podOperations.get(namespace, podName);
 
             if (pod != null) {
-                String value = Annotations.annotations(pod).get(ANNO_STRIMZI_IO_DELETE_POD_AND_PVC);
-                if (Boolean.parseBoolean(value)) {
+                if (Annotations.booleanAnnotation(pod, ANNO_STRIMZI_IO_DELETE_POD_AND_PVC,
+                        false, ANNO_OP_STRIMZI_IO_DELETE_POD_AND_PVC)) {
                     f = f.compose(ignored -> deletePvc(ss, pvcName))
                             .compose(ignored -> maybeRestartPod(ss, podName, p -> true));
 
@@ -189,23 +190,14 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
     }
 
     private void setGeneration(StatefulSet desired, int nextGeneration) {
-        templateMetadata(desired).getAnnotations().put(ANNO_STRIMZI_IO_GENERATION, String.valueOf(nextGeneration));
-    }
-
-    private static int getGeneration(ObjectMeta objectMeta) {
-        if (objectMeta.getAnnotations().get(ANNO_STRIMZI_IO_GENERATION) == null) {
-            return NO_GENERATION;
-        }
-        String generationAnno = objectMeta.getAnnotations().get(ANNO_STRIMZI_IO_GENERATION);
-        if (generationAnno == null) {
-            return NO_GENERATION;
-        } else {
-            return Integer.parseInt(generationAnno);
-        }
+        Map<String, String> annotations = Annotations.annotations(desired);
+        annotations.remove(ANNO_OP_STRIMZI_IO_GENERATION);
+        annotations.put(ANNO_STRIMZI_IO_GENERATION, String.valueOf(nextGeneration));
     }
 
     protected void incrementGeneration(StatefulSet current, StatefulSet desired) {
-        final int generation = Integer.parseInt(templateMetadata(current).getAnnotations().getOrDefault(ANNO_STRIMZI_IO_GENERATION, String.valueOf(INIT_GENERATION)));
+        final int generation = Annotations.intAnnotation(current, ANNO_STRIMZI_IO_GENERATION,
+                INIT_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
         final int nextGeneration = generation + 1;
         setGeneration(desired, nextGeneration);
     }
@@ -216,14 +208,16 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         if (resource == null) {
             return NO_GENERATION;
         }
-        return getGeneration(templateMetadata(resource));
+        return Annotations.intAnnotation(resource.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION,
+                NO_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
     }
 
     public static int getPodGeneration(Pod resource) {
         if (resource == null) {
             return NO_GENERATION;
         }
-        return getGeneration(resource.getMetadata());
+        return Annotations.intAnnotation(resource, ANNO_STRIMZI_IO_GENERATION,
+                NO_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -190,13 +190,13 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
     }
 
     private void setGeneration(StatefulSet desired, int nextGeneration) {
-        Map<String, String> annotations = Annotations.annotations(desired);
+        Map<String, String> annotations = Annotations.annotations(desired.getSpec().getTemplate());
         annotations.remove(ANNO_OP_STRIMZI_IO_GENERATION);
         annotations.put(ANNO_STRIMZI_IO_GENERATION, String.valueOf(nextGeneration));
     }
 
     protected void incrementGeneration(StatefulSet current, StatefulSet desired) {
-        final int generation = Annotations.intAnnotation(current, ANNO_STRIMZI_IO_GENERATION,
+        final int generation = Annotations.intAnnotation(current.getSpec().getTemplate(), ANNO_STRIMZI_IO_GENERATION,
                 INIT_GENERATION, ANNO_OP_STRIMZI_IO_GENERATION);
         final int nextGeneration = generation + 1;
         setGeneration(desired, nextGeneration);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -232,11 +232,11 @@ public class KafkaAssemblyOperatorMockTest {
             context.assertTrue(ar.succeeded());
             StatefulSet kafkaSs = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get();
             context.assertNotNull(kafkaSs);
-            context.assertEquals("0", kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().get(StatefulSetOperator.ANNOTATION_GENERATION));
+            context.assertEquals("0", kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION));
             context.assertEquals("0", kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION));
             context.assertEquals("0", kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION));
             StatefulSet zkSs = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME)).get();
-            context.assertEquals("0", zkSs.getSpec().getTemplate().getMetadata().getAnnotations().get(StatefulSetOperator.ANNOTATION_GENERATION));
+            context.assertEquals("0", zkSs.getSpec().getTemplate().getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION));
             context.assertEquals("0", zkSs.getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION));
             context.assertNotNull(zkSs);
             context.assertNotNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(TopicOperator.topicOperatorName(CLUSTER_NAME)).get());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -158,12 +158,12 @@ public class PartialRollingUpdateTest {
 
     @Test
     public void testReconcileOfPartiallyRolledKafkaCluster(TestContext context) {
-        kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "3");
-        kafkaPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "3");
-        kafkaPod1.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "3");
-        kafkaPod2.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "2");
-        kafkaPod3.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "1");
-        kafkaPod4.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "1");
+        kafkaSs.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
+        kafkaPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
+        kafkaPod1.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
+        kafkaPod2.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "2");
+        kafkaPod3.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "1");
+        kafkaPod4.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "1");
 
         // Now start the KafkaAssemblyOperator with those pods and that statefulset
         startKube();
@@ -174,7 +174,7 @@ public class PartialRollingUpdateTest {
             context.assertTrue(ar.succeeded());
             for (int i = 0; i <= 4; i++) {
                 Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, i)).get();
-                String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNOTATION_GENERATION);
+                String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION);
                 context.assertEquals("3", generation,
                         "Pod " + i + " had unexpected generation " + generation);
             }
@@ -184,10 +184,10 @@ public class PartialRollingUpdateTest {
 
     @Test
     public void testReconcileOfPartiallyRolledZookeeperCluster(TestContext context) {
-        zkSs.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "3");
-        zkPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "3");
-        zkPod1.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "2");
-        zkPod2.getMetadata().getAnnotations().put(StatefulSetOperator.ANNOTATION_GENERATION, "1");
+        zkSs.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
+        zkPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
+        zkPod1.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "2");
+        zkPod2.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "1");
 
         // Now start the KafkaAssemblyOperator with those pods and that statefulset
         startKube();
@@ -199,7 +199,7 @@ public class PartialRollingUpdateTest {
             context.assertTrue(ar.succeeded());
             for (int i = 0; i <= 2; i++) {
                 Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, i)).get();
-                String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNOTATION_GENERATION);
+                String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION);
                 context.assertEquals("3", generation,
                         "Pod " + i + " had unexpected generation " + generation);
             }

--- a/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-kafka.adoc
@@ -27,12 +27,12 @@ For example, if the cluster is named _cluster-name_, the pods are named _cluster
 ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate pod _cluster-name_-kafka-_index_ operator.strimzi.io/delete-pod-and-pvc=true
+kubectl annotate pod _cluster-name_-kafka-_index_ strimzi.io/delete-pod-and-pvc=true
 endif::Kubernetes[]
 +
 On {OpenShiftName} use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate pod _cluster-name_-kafka-_index_ operator.strimzi.io/delete-pod-and-pvc=true
+oc annotate pod _cluster-name_-kafka-_index_ strimzi.io/delete-pod-and-pvc=true
 +
 . Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.
 

--- a/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
+++ b/documentation/book/proc-manual-delete-pod-pvc-zookeeper.adoc
@@ -27,12 +27,12 @@ For example, if the cluster is named _cluster-name_, the pods are named _cluster
 ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate pod _cluster-name_-zookeeper-_index_ operator.strimzi.io/delete-pod-and-pvc=true
+kubectl annotate pod _cluster-name_-zookeeper-_index_ strimzi.io/delete-pod-and-pvc=true
 endif::Kubernetes[]
 +
 On {OpenShiftName} use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate pod _cluster-name_-zookeeper-_index_ operator.strimzi.io/delete-pod-and-pvc=true
+oc annotate pod _cluster-name_-zookeeper-_index_ strimzi.io/delete-pod-and-pvc=true
 +
 . Wait for the next reconciliation, when the annotated pod with the underlying persistent volume claim will be deleted and then recreated.
 

--- a/documentation/book/proc-manual-rolling-update-kafka.adoc
+++ b/documentation/book/proc-manual-rolling-update-kafka.adoc
@@ -24,12 +24,12 @@ For example, if your Kafka cluster is named _my-cluster_, the corresponding `Sta
 ifdef::Kubernetes[]
 On {KubernetesName}, use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate statefulset _cluster-name_-kafka operator.strimzi.io/manual-rolling-update=true
+kubectl annotate statefulset _cluster-name_-kafka strimzi.io/manual-rolling-update=true
 endif::Kubernetes[]
 +
 On {OpenShiftName}, use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate statefulset _cluster-name_-kafka operator.strimzi.io/manual-rolling-update=true
+oc annotate statefulset _cluster-name_-kafka strimzi.io/manual-rolling-update=true
 +
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of all pods within the annotated `StatefulSet` is triggered, as long as the annotation was detected by the reconciliation process.

--- a/documentation/book/proc-manual-rolling-update-zookeeper.adoc
+++ b/documentation/book/proc-manual-rolling-update-zookeeper.adoc
@@ -24,12 +24,12 @@ For example, if your Kafka cluster is named _my-cluster_, the corresponding `Sta
 ifdef::Kubernetes[]
 On {KubernetesName}, use `kubectl annotate`:
 [source,shell,subs=+quotes]
-kubectl annotate statefulset _cluster-name_-zookeeper operator.strimzi.io/manual-rolling-update=true
+kubectl annotate statefulset _cluster-name_-zookeeper strimzi.io/manual-rolling-update=true
 endif::Kubernetes[]
 +
 On {OpenShiftName}, use `oc annotate`:
 [source,shell,subs=+quotes]
-oc annotate statefulset _cluster-name_-zookeeper operator.strimzi.io/manual-rolling-update=true
+oc annotate statefulset _cluster-name_-zookeeper strimzi.io/manual-rolling-update=true
 +
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of all pods within the annotated `StatefulSet` is triggered, as long as the annotation was detected by the reconciliation process.

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -42,7 +42,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.lang.Integer.parseInt;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
@@ -316,7 +315,8 @@ public abstract class Ca {
         // cluster CA certificate generation annotation handling
         int caCertGeneration = INIT_GENERATION;
         if (caCertSecret != null && caCertSecret.getData().get(CA_CRT) != null) {
-            caCertGeneration = parseInt(Annotations.annotations(caCertSecret).getOrDefault(ANNO_STRIMZI_IO_CA_CERT_GENERATION, String.valueOf(INIT_GENERATION)));
+            caCertGeneration = Annotations.intAnnotation(caCertSecret, ANNO_STRIMZI_IO_CA_CERT_GENERATION,
+                    INIT_GENERATION);
             if (caRenewed) {
                 caCertGeneration++;
             }
@@ -342,7 +342,7 @@ public abstract class Ca {
             result = true;
             this.caRenewed = caKeySecret != null;
         } else if (this.caCertSecret.getMetadata() != null
-                && "true".equals(Annotations.annotations(this.caCertSecret).get(ANNO_STRIMZI_IO_FORCE_RENEW))) {
+                && Annotations.booleanAnnotation(this.caCertSecret, ANNO_STRIMZI_IO_FORCE_RENEW, false)) {
             reason = "CA certificate secret " + caCertSecretName + " is annotated with " + ANNO_STRIMZI_IO_FORCE_RENEW;
             result = true;
             this.caRenewed = true;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -11,7 +11,7 @@ import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.certs.Subject;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.Annotations;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static java.lang.Integer.parseInt;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
@@ -80,10 +81,10 @@ public abstract class Ca {
     public static final String CA_KEY = "ca.key";
     public static final String CA_CRT = "ca.crt";
     public static final String IO_STRIMZI = "io.strimzi";
-    public static final String ANNO_STRIMZI_IO_FORCE_RENEW = "strimzi.io/force-renew";
-    public static final String ANNO_STRIMZI_IO_CA_CERT_GENERATION = "strimzi.io/ca-cert-generation";
-    public static final String ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION = "strimzi.io/cluster-ca-cert-generation";
-    public static final String ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION = "strimzi.io/clients-ca-cert-generation";
+    public static final String ANNO_STRIMZI_IO_FORCE_RENEW = Annotations.STRIMZI_DOMAIN + "/force-renew";
+    public static final String ANNO_STRIMZI_IO_CA_CERT_GENERATION = Annotations.STRIMZI_DOMAIN + "/ca-cert-generation";
+    public static final String ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION = Annotations.STRIMZI_DOMAIN + "/cluster-ca-cert-generation";
+    public static final String ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION = Annotations.STRIMZI_DOMAIN + "/clients-ca-cert-generation";
     public static final int INIT_GENERATION = 0;
 
     /**
@@ -315,12 +316,9 @@ public abstract class Ca {
         // cluster CA certificate generation annotation handling
         int caCertGeneration = INIT_GENERATION;
         if (caCertSecret != null && caCertSecret.getData().get(CA_CRT) != null) {
-            String caCertGenerationAnnotation = Util.annotations(caCertSecret).get(ANNO_STRIMZI_IO_CA_CERT_GENERATION);
-            if (caCertGenerationAnnotation != null) {
-                caCertGeneration = Integer.parseInt(caCertGenerationAnnotation);
-                if (caRenewed) {
-                    caCertGeneration++;
-                }
+            caCertGeneration = parseInt(Annotations.annotations(caCertSecret).getOrDefault(ANNO_STRIMZI_IO_CA_CERT_GENERATION, String.valueOf(INIT_GENERATION)));
+            if (caRenewed) {
+                caCertGeneration++;
             }
         }
 
@@ -344,7 +342,7 @@ public abstract class Ca {
             result = true;
             this.caRenewed = caKeySecret != null;
         } else if (this.caCertSecret.getMetadata() != null
-                && "true".equals(Util.annotations(this.caCertSecret).get(ANNO_STRIMZI_IO_FORCE_RENEW))) {
+                && "true".equals(Annotations.annotations(this.caCertSecret).get(ANNO_STRIMZI_IO_FORCE_RENEW))) {
             reason = "CA certificate secret " + caCertSecretName + " is annotated with " + ANNO_STRIMZI_IO_FORCE_RENEW;
             result = true;
             this.caRenewed = true;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -11,13 +11,16 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+
 public class Annotations {
 
     public static final String STRIMZI_DOMAIN = "strimzi.io";
 
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";
 
-    private static Map<String, String> putAnnotation(ObjectMeta metadata) {
+    private static Map<String, String> annotations(ObjectMeta metadata) {
         Map<String, String> annotations = metadata.getAnnotations();
         if (annotations == null) {
             annotations = new HashMap<>(3);
@@ -27,11 +30,45 @@ public class Annotations {
     }
 
     public static Map<String, String> annotations(HasMetadata resource) {
-        return putAnnotation(resource.getMetadata());
+        return annotations(resource.getMetadata());
     }
 
     public static Map<String, String> annotations(PodTemplateSpec podSpec) {
-        return putAnnotation(podSpec.getMetadata());
+        return annotations(podSpec.getMetadata());
+    }
+
+    public static boolean booleanAnnotation(HasMetadata resource, String annotation, boolean defaultValue, String... deprecatedAnnotations) {
+        ObjectMeta metadata = resource.getMetadata();
+        String str = annotation(annotation, null, metadata, deprecatedAnnotations);
+        return str != null ? parseBoolean(str) : defaultValue;
+    }
+
+    public static int intAnnotation(HasMetadata resource, String annotation, int defaultValue, String... deprecatedAnnotations) {
+        ObjectMeta metadata = resource.getMetadata();
+        String str = annotation(annotation, null, metadata, deprecatedAnnotations);
+        return str != null ? parseInt(str) : defaultValue;
+    }
+
+    public static int intAnnotation(PodTemplateSpec podSpec, String annotation, int defaultValue, String... deprecatedAnnotations) {
+        ObjectMeta metadata = podSpec.getMetadata();
+        String str = annotation(annotation, null, metadata, deprecatedAnnotations);
+        return str != null ? parseInt(str) : defaultValue;
+    }
+
+    private static String annotation(String annotation, String defaultValue, ObjectMeta metadata, String[] deprecatedAnnotations) {
+        String value = annotations(metadata).get(annotation);
+        if (value == null) {
+            for (String deprecated : deprecatedAnnotations) {
+                value = annotations(metadata).get(deprecated);
+                if (value != null) {
+                    break;
+                }
+            }
+            if (value == null) {
+                value = defaultValue;
+            }
+        }
+        return value;
     }
 
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -56,10 +56,11 @@ public class Annotations {
     }
 
     private static String annotation(String annotation, String defaultValue, ObjectMeta metadata, String[] deprecatedAnnotations) {
-        String value = annotations(metadata).get(annotation);
+        Map<String, String> annotations = annotations(metadata);
+        String value = annotations.get(annotation);
         if (value == null) {
             for (String deprecated : deprecatedAnnotations) {
-                value = annotations(metadata).get(deprecated);
+                value = annotations.get(deprecated);
                 if (value != null) {
                     break;
                 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Annotations {
+
+    public static final String STRIMZI_DOMAIN = "strimzi.io";
+
+    public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";
+
+    private static Map<String, String> putAnnotation(ObjectMeta metadata) {
+        Map<String, String> annotations = metadata.getAnnotations();
+        if (annotations == null) {
+            annotations = new HashMap<>(3);
+            metadata.setAnnotations(annotations);
+        }
+        return annotations;
+    }
+
+    public static Map<String, String> annotations(HasMetadata resource) {
+        return putAnnotation(resource.getMetadata());
+    }
+
+    public static Map<String, String> annotations(PodTemplateSpec podSpec) {
+        return putAnnotation(podSpec.getMetadata());
+    }
+
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -12,24 +11,11 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Map;
 import java.util.function.BooleanSupplier;
-
-import static java.util.Collections.emptyMap;
 
 public class Util {
 
     private static final Logger LOGGER = LogManager.getLogger(Util.class);
-
-    public static Map<String, String> annotations(HasMetadata resource) {
-        Map<String, String> annotations;
-        if (resource.getMetadata() != null) {
-            annotations = resource.getMetadata().getAnnotations();
-            return annotations != null ? annotations : emptyMap();
-        } else {
-            return emptyMap();
-        }
-    }
 
     /**
      * Returns a future that completes when the given {@code ready} indicates readiness.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -32,7 +32,11 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
         extends AbstractReadyResourceOperator<C, T, L, D, R> {
 
     public static final String ANNO_STRIMZI_IO_GENERATION = Annotations.STRIMZI_DOMAIN + "/generation";
+    @Deprecated
+    public static final String ANNO_OP_STRIMZI_IO_GENERATION = "operator.strimzi.io/generation";
     public static final String ANNO_STRIMZI_IO_DELETE_POD_AND_PVC = Annotations.STRIMZI_DOMAIN + "/delete-pod-and-pvc";
+    @Deprecated
+    public static final String ANNO_OP_STRIMZI_IO_DELETE_POD_AND_PVC = "operator.strimzi.io/delete-pod-and-pvc";
 
     private final Logger log = LogManager.getLogger(getClass());
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import io.strimzi.operator.common.Annotations;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
@@ -30,9 +31,8 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
             R extends ScalableResource<T, D>>
         extends AbstractReadyResourceOperator<C, T, L, D, R> {
 
-    public static final String STRIMZI_OPERATOR_DOMAIN = "operator.strimzi.io";
-    public static final String ANNOTATION_GENERATION = STRIMZI_OPERATOR_DOMAIN + "/generation";
-    public static final String ANNOTATION_MANUAL_DELETE_POD_AND_PVC = STRIMZI_OPERATOR_DOMAIN + "/delete-pod-and-pvc";
+    public static final String ANNO_STRIMZI_IO_GENERATION = Annotations.STRIMZI_DOMAIN + "/generation";
+    public static final String ANNO_STRIMZI_IO_DELETE_POD_AND_PVC = Annotations.STRIMZI_DOMAIN + "/delete-pod-and-pvc";
 
     private final Logger log = LogManager.getLogger(getClass());
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -11,12 +11,10 @@ import io.fabric8.kubernetes.api.model.extensions.DoneableDeployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-
-import java.util.HashMap;
 
 /**
  * Operations for {@code Deployment}s.
@@ -72,11 +70,8 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
 
     @Override
     protected Future<ReconcileResult<Deployment>> internalPatch(String namespace, String name, Deployment current, Deployment desired, boolean cascading) {
-        String k8sRev = Util.annotations(current).get("deployment.kubernetes.io/revision");
-        if (desired.getMetadata().getAnnotations() == null) {
-            desired.getMetadata().setAnnotations(new HashMap<>(1));
-        }
-        desired.getMetadata().getAnnotations().put("deployment.kubernetes.io/revision", k8sRev);
+        String k8sRev = Annotations.annotations(current).get(Annotations.ANNO_DEP_KUBE_IO_REVISION);
+        Annotations.annotations(desired).put(Annotations.ANNO_DEP_KUBE_IO_REVISION, k8sRev);
         return super.internalPatch(namespace, name, current, desired, cascading);
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -28,8 +28,6 @@ public class UserOperator extends AbstractVerticle {
 
     private static final Logger log = LogManager.getLogger(UserOperator.class.getName());
 
-    public static final String STRIMZI_CLUSTER_OPERATOR_DOMAIN = "user.operator.strimzi.io";
-
     private static final int HEALTH_SERVER_PORT = 8081;
 
     private final KubernetesClient client;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Fixes #1152 by standardizing on the `strimzi.io` domain for all annotations, adding a new `Annotations` class to hold a constant for the domain. Refactors all existing annotation usages to use this new prefix. Moves the recently added `annotations()` method from `Util` to the new `Annotations` class, where is more naturally belongs. Added another method for getting the annotations from a `PodTemplateSpec`, as recently discussed; fixing call sites for that. Not that the `annotations()` methods now set a non-null map on the `PodTemplateSpec` or `HasMetadata` by side-effect. This isn't ideal for call sites which only need to read the annotations, but is does make for more natural semantics when it comes to setting annotations. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

