### PR TITLE
Use new Annotations API

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -53,6 +53,7 @@ import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 
@@ -125,13 +126,12 @@ public class KafkaCluster extends AbstractModel {
     // Suffixes for secrets with certificates
     private static final String SECRET_BROKERS_SUFFIX = NAME_SUFFIX + "-brokers";
 
-    public static final Map<String, String> IMAGE_MAP = parseImageMap(System.getenv().get(ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES));
     /** Records the Kafka version currently running inside Kafka StatefulSet */
-    public static final String ANNO_STRIMZI_IO_KAFKA_VERSION = "strimzi.io/kafka-version";
+    public static final String ANNO_STRIMZI_IO_KAFKA_VERSION = Annotations.STRIMZI_DOMAIN + "/kafka-version";
     /** Records the state of the Kafka upgrade process. Unset outside of upgrades. */
-    public static final String ANNO_STRIMZI_IO_FROM_VERSION = "strimzi.io/from-version";
+    public static final String ANNO_STRIMZI_IO_FROM_VERSION = Annotations.STRIMZI_DOMAIN + "/from-version";
     /** Records the state of the Kafka upgrade process. Unset outside of upgrades. */
-    public static final String ANNO_STRIMZI_IO_TO_VERSION = "strimzi.io/to-version";
+    public static final String ANNO_STRIMZI_IO_TO_VERSION = Annotations.STRIMZI_DOMAIN + "/to-version";
 
     // Kafka configuration
     private String zookeeperConnect;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -52,7 +52,6 @@ import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.certs.CertAndKey;
-import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
@@ -67,7 +66,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.parseImageMap;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -415,9 +415,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     log.debug("Does SS {} need to be upgraded?", ss.getMetadata().getName());
                     Future<?> result;
                     // Get the current version of the cluster
-                    KafkaVersion currentVersion = versions.version(ss.getMetadata().getAnnotations().get(ANNO_STRIMZI_IO_KAFKA_VERSION));
+                    KafkaVersion currentVersion = versions.version(Annotations.annotations(ss).get(ANNO_STRIMZI_IO_KAFKA_VERSION));
                     log.debug("SS {} has current version {}", ss.getMetadata().getName(), currentVersion);
-                    String fromVersionAnno = ss.getMetadata().getAnnotations().get(ANNO_STRIMZI_IO_FROM_VERSION);
+                    String fromVersionAnno = Annotations.annotations(ss).get(ANNO_STRIMZI_IO_FROM_VERSION);
                     KafkaVersion fromVersion;
                     if (fromVersionAnno != null) { // We're mid-upgrade
                         fromVersion = versions.version(fromVersionAnno);
@@ -425,7 +425,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         fromVersion = currentVersion;
                     }
                     log.debug("SS {} is from version {}", ss.getMetadata().getName(), fromVersion);
-                    String toVersionAnno = ss.getMetadata().getAnnotations().get(ANNO_STRIMZI_IO_TO_VERSION);
+                    String toVersionAnno = Annotations.annotations(ss).get(ANNO_STRIMZI_IO_TO_VERSION);
                     KafkaVersion toVersion;
                     if (toVersionAnno != null) { // We're mid-upgrade
                         toVersion = versions.version(toVersionAnno);
@@ -467,7 +467,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Future<StatefulSet> kafkaUpgradePhase1(StatefulSet ss, KafkaUpgrade upgrade, String upgradedImage) {
             log.info("{}: {}, phase 1", reconciliation, upgrade);
 
-            Map<String, String> annotations = ss.getMetadata().getAnnotations();
+            Map<String, String> annotations = Annotations.annotations(ss);
             Map<String, String> env = ModelUtils.getKafkaContainerEnv(ss);
             String string = env.getOrDefault(ENV_VAR_KAFKA_CONFIGURATION, "");
             log.debug("Current config {}", string);
@@ -571,7 +571,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // Cluster is now using new binaries, but old proto version
             log.info("{}: {}, phase 2", reconciliation, upgrade);
             // Remove the strimzi.io/from-version and strimzi.io/to-version since this is the last phase
-            Map<String, String> annotations = ss.getMetadata().getAnnotations();
+            Map<String, String> annotations = Annotations.annotations(ss);
             log.info("{}: Upgrade: Removing annotations {}, {}",
                     reconciliation, ANNO_STRIMZI_IO_FROM_VERSION, ANNO_STRIMZI_IO_TO_VERSION);
             annotations.remove(ANNO_STRIMZI_IO_FROM_VERSION);
@@ -629,7 +629,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Future<StatefulSet> kafkaDowngradePhase1(StatefulSet ss, KafkaUpgrade upgrade) {
             log.info("{}: {}, phase 1", reconciliation, upgrade);
 
-            Map<String, String> annotations = ss.getMetadata().getAnnotations();
+            Map<String, String> annotations = Annotations.annotations(ss);
             Map<String, String> env = ModelUtils.getKafkaContainerEnv(ss);
             KafkaConfiguration currentKafkaConfig = KafkaConfiguration.unvalidated(env.getOrDefault(ENV_VAR_KAFKA_CONFIGURATION, ""));
 
@@ -713,7 +713,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             log.info("{}: {}, phase 2", reconciliation, downgrade);
             // Remove the strimzi.io/from-version and strimzi.io/to-version since this is the last phase
 
-            Map<String, String> annotations = ss.getMetadata().getAnnotations();
+            Map<String, String> annotations = Annotations.annotations(ss);
 
             log.info("{}: Upgrade: Removing annotations {}, {}",
                     reconciliation, ANNO_STRIMZI_IO_FROM_VERSION, ANNO_STRIMZI_IO_TO_VERSION);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

I managed to forget to fix the Kafka version PR to use the new `Annotations` class before I merge it. This PR fixes that omission.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

