### PR TITLE
fixed #1154

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -89,7 +89,8 @@ public abstract class AbstractModel {
     protected static final int CERTS_EXPIRATION_DAYS = 365;
     protected static final String DEFAULT_JVM_XMS = "128M";
 
-    private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
+    private static final String VOLUME_MOUNT_HACK_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_VOLUME_MOUNT_HACK_IMAGE", "busybox");
     protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
     private static final Long VOLUME_MOUNT_HACK_USERID = 1001L;
     private static final Long VOLUME_MOUNT_HACK_GROUPID = 0L;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -90,7 +90,7 @@ public abstract class AbstractModel {
     protected static final String DEFAULT_JVM_XMS = "128M";
 
     private static final String VOLUME_MOUNT_HACK_IMAGE =
-            System.getenv().getOrDefault("STRIMZI_DEFAULT_VOLUME_MOUNT_HACK_IMAGE", "busybox");
+            System.getenv().getOrDefault("STRIMZI_VOLUME_MOUNT_INIT_IMAGE", "busybox");
     protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
     private static final Long VOLUME_MOUNT_HACK_USERID = 1001L;
     private static final Long VOLUME_MOUNT_HACK_GROUPID = 0L;

--- a/documentation/book/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/book/ref-operators-cluster-operator-configuration.adoc
@@ -66,3 +66,7 @@ if no image is specified as the `Kafka.spec.entityOperator.userOperator.image` i
 `STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE`:: Optional, default `strimzi/entity-operator-stunnel:latest`.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the `Kafka.spec.entityOperator.tlsSidecar.image` in the xref:assembly-configuring-container-images-deployment-configuration-kafka[].
+
+`STRIMZI_VOLUME_MOUNT_INIT_IMAGE`:: Optional, default `busybox`.
+The image to use as default for the init container required for volume mounting on kubernetes.
+If a persistent volume claim is requested and the running cluster is a Kubernetes one there is an hack on volume mounting which needs an "init-container".

--- a/documentation/book/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/book/ref-operators-cluster-operator-configuration.adoc
@@ -69,4 +69,4 @@ no image is specified as the `Kafka.spec.entityOperator.tlsSidecar.image` in the
 
 `STRIMZI_VOLUME_MOUNT_INIT_IMAGE`:: Optional, default `busybox`.
 The image to use as default for the init container required for volume mounting on kubernetes.
-If a persistent volume claim is requested and the running cluster is a Kubernetes one there is an hack on volume mounting which needs an "init-container".
+If a persistent volume claim is requested and the running cluster is Kubernetes this image will be used to execute an "init-container" to `chown` of volume mount path to that it is accessible by the main pod container.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

fixed #1154 by adding `STRIMZI_DEFAULT_VOLUME_MOUNT_HACK_IMAGE` env config, for custom `busybox` configuration

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

