### PR TITLE
Added TLS sidecar healthchecks documentation

### DIFF
--- a/documentation/book/assembly-tls-sidecar.adoc
+++ b/documentation/book/assembly-tls-sidecar.adoc
@@ -10,11 +10,11 @@
 
 = TLS sidecar
 
-A sidecar is a container which is running in a pod and serves an auxiliary purpose.
-The purpose of the TLS sidecar is to encrypt or decrypt the communication between {ProductName} components and Zookeeper since Zookeeper does not support TLS encryption natively.
-Therefore {ProductName} uses the sidecar to add TLS support.
+A sidecar is a container that runs in a pod but serves a supporting purpose.
+In {ProductName}, the TLS sidecar uses TLS to encrypt and decrypt all communication between the various components and Zookeeper.
+Zookeeper does not have native TLS support.
 
-The TLS sidecar is currently being used in:
+The TLS sidecar is used in:
 
 * Kafka brokers
 * Zookeeper nodes

--- a/documentation/book/assembly-tls-sidecar.adoc
+++ b/documentation/book/assembly-tls-sidecar.adoc
@@ -12,7 +12,7 @@
 
 A sidecar is a container which is running in a pod and serves an auxiliary purpose.
 The purpose of the TLS sidecar is to encrypt or decrypt the communication between {ProductName} components and Zookeeper since Zookeeper does not support TLS encryption natively.
-Therefore {ProductName} uses the sidecar to add the TLS support.
+Therefore {ProductName} uses the sidecar to add TLS support.
 
 The TLS sidecar is currently being used in:
 

--- a/documentation/book/assembly-tls-sidecar.adoc
+++ b/documentation/book/assembly-tls-sidecar.adoc
@@ -10,15 +10,14 @@
 
 = TLS sidecar
 
-Sidecar is a container which is running in a pod and serves an auxiliary purpose.
+A sidecar is a container which is running in a pod and serves an auxiliary purpose.
 The purpose of the TLS sidecar is to encrypt or decrypt the communication between {ProductName} components and Zookeeper since Zookeeper does not support TLS encryption natively.
-Zookeeper does not support TLS encryption natively.
 Therefore {ProductName} uses the sidecar to add the TLS support.
 
-The TLS sidecar is currrently being used in:
+The TLS sidecar is currently being used in:
 
 * Kafka brokers
-* Zookeeper
+* Zookeeper nodes
 * Entity Operator
 
 include::ref-tls-sidecar.adoc[leveloffset=+1]

--- a/documentation/book/ref-healthchecks.adoc
+++ b/documentation/book/ref-healthchecks.adoc
@@ -8,7 +8,10 @@
 Liveness and readiness probes can be configured using the `livenessProbe` and `readinessProbe` properties in following resources:
 
 * `Kafka.spec.kafka`
+* `Kafka.spec.kafka.tlsSidecar`
 * `Kafka.spec.zookeeper`
+* `Kafka.spec.zookeeper.tlsSidecar`
+* `Kafka.spec.entityOperator.tlsSidecar`
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
 

--- a/documentation/book/ref-tls-sidecar.adoc
+++ b/documentation/book/ref-tls-sidecar.adoc
@@ -11,11 +11,13 @@ The TLS sidecar can be configured using the `tlsSidecar` property in:
 * `Kafka.spec.zookeeper`
 * `Kafka.spec.entityOperator`
 
-The TLS sidecar supports three additional options:
+The TLS sidecar supports the following additional options:
 
 * `image`
 * `resources`
 * `logLevel`
+* `readinessProbe`
+* `livenessProbe`
 
 The `resources` property can be used to specify the xref:assembly-resource-limits-and-requests-{context}[memory and CPU resources] allocated for the TLS sidecar.
 
@@ -35,6 +37,8 @@ Following logging levels are supported:
 * debug
 
 The default value is _notice_.
+
+For more information about configuring the `readinessProbe` and `livenessProbe` properties for the healthchecks, see xref:ref-healthchecks-{context}[].
 
 .Example of TLS sidecar configuration
 [source,yaml,subs=attributes+]
@@ -56,6 +60,12 @@ spec:
           cpu: 500m
           memory: 128Mi
       logLevel: debug
+      readinessProbe:
+        initialDelaySeconds: 15
+        timeoutSeconds: 5
+      livenessProbe:
+        initialDelaySeconds: 15
+        timeoutSeconds: 5
     # ...
   zookeeper:
     # ...


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR is about documenting the TLS sidecar health checks #1141.
It's also related to the implementation via #1162 (which fixes #826)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

