### PR TITLE
Added unit test about invalid TLS sidecar loglevel

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -88,4 +88,13 @@ public class KafkaCrdIT extends AbstractCrdIT {
     public void testKafkaWithTlsSidecarWithCustomConfiguration() {
         createDelete(Kafka.class, "Kafka-with-tls-sidecar-with-custom-configuration.yaml");
     }
+
+    @Test
+    public void testKafkaWithTlsSidecarWithInvalidLogLevel() {
+        try {
+            createDelete(Kafka.class, "Kafka-with-tls-sidecar-invalid-loglevel.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.kafka.tlsSidecar.logLevel in body should be one of [emerg alert crit err warning notice info debug]"));
+        }
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-tls-sidecar-invalid-loglevel.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-tls-sidecar-invalid-loglevel.yaml
@@ -1,0 +1,19 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 500Gi
+    listeners:
+      plain: {}
+      tls: {}
+    tlsSidecar:
+      logLevel: "invalid"
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This trivial PR just adds a missing unit test about invalid TLS sidecar loglevel.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

