### PR TITLE
Changed GC logging option to the "enable" logic

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -35,7 +35,7 @@ public class CertificateAuthority implements Serializable {
     private int renewalDays;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("The number of days generated certificates should be valid for. Default is 365.")
+    @Description("The number of days generated certificates should be valid for. The default is 365.")
     @Minimum(1)
     public int getValidityDays() {
         return validityDays;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
@@ -25,7 +25,7 @@ public class EntityOperatorJvmOptions implements Serializable {
 
     private boolean gcLoggingEnabled = true;
 
-    @Description("Specifies whether the Garbage Collection logging is enabled")
+    @Description("Specifies whether the Garbage Collection logging is enabled. The default is true.")
     public boolean isGcLoggingEnabled() {
         return gcLoggingEnabled;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
@@ -23,15 +23,15 @@ public class EntityOperatorJvmOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean gcLoggingDisabled = false;
+    private boolean gcLoggingEnabled = true;
 
-    @Description("Disable garbage collection logging")
-    public boolean isGcLoggingDisabled() {
-        return gcLoggingDisabled;
+    @Description("If the Garbage Collection logging is enabled")
+    public boolean isGcLoggingEnabled() {
+        return gcLoggingEnabled;
     }
 
-    public void setGcLoggingDisabled(boolean gcLoggingDisabled) {
-        this.gcLoggingDisabled = gcLoggingDisabled;
+    public void setGcLoggingEnabled(boolean gcLoggingEnabled) {
+        this.gcLoggingEnabled = gcLoggingEnabled;
     }
 }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
@@ -25,7 +25,7 @@ public class EntityOperatorJvmOptions implements Serializable {
 
     private boolean gcLoggingEnabled = true;
 
-    @Description("If the Garbage Collection logging is enabled")
+    @Description("Specifies whether the Garbage Collection logging is enabled")
     public boolean isGcLoggingEnabled() {
         return gcLoggingEnabled;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -68,7 +68,7 @@ public class JvmOptions implements Serializable {
         this.server = server;
     }
 
-    @Description("Enable or disable Garbage Collection logging. It's enabled by default.")
+    @Description("Enable or disable Garbage Collection logging. It is enabled by default.")
     public boolean isGcLoggingEnabled() {
         return gcLoggingEnabled;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -32,7 +32,7 @@ public class JvmOptions implements Serializable {
     private String xmx;
     private String xms;
     private Boolean server;
-    private boolean gcLoggingDisabled;
+    private boolean gcLoggingEnabled = true;
     private Map<String, String> xx;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -68,13 +68,13 @@ public class JvmOptions implements Serializable {
         this.server = server;
     }
 
-    @Description("Disable garbage collection logging")
-    public boolean isGcLoggingDisabled() {
-        return gcLoggingDisabled;
+    @Description("Enable or disable Garbage Collection logging. It's enabled by default.")
+    public boolean isGcLoggingEnabled() {
+        return gcLoggingEnabled;
     }
 
-    public void setGcLoggingDisabled(boolean gcLoggingDisabled) {
-        this.gcLoggingDisabled = gcLoggingDisabled;
+    public void setGcLoggingEnabled(boolean gcLoggingEnabled) {
+        this.gcLoggingEnabled = gcLoggingEnabled;
     }
 
     @JsonProperty("-XX")

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -68,7 +68,7 @@ public class JvmOptions implements Serializable {
         this.server = server;
     }
 
-    @Description("Enable or disable Garbage Collection logging. It is enabled by default.")
+    @Description("Specifies whether the Garbage Collection logging is enabled. The default is true.")
     public boolean isGcLoggingEnabled() {
         return gcLoggingEnabled;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -155,7 +155,7 @@ public abstract class AbstractModel {
     protected Map validLoggerFields;
     private final String[] validLoggerValues = new String[]{"INFO", "ERROR", "WARN", "TRACE", "DEBUG", "FATAL", "OFF" };
     private Logging logging;
-    protected boolean gcLoggingDisabled;
+    protected boolean gcLoggingEnabled = true;
 
     // Templates
     protected Map<String, String> templateStatefulSetLabels;
@@ -266,11 +266,11 @@ public abstract class AbstractModel {
     }
 
     public String getGcLoggingOptions() {
-        return gcLoggingDisabled ? " " : DEFAULT_KAFKA_GC_LOGGING;
+        return gcLoggingEnabled ? DEFAULT_KAFKA_GC_LOGGING : " ";
     }
 
-    protected void setGcLoggingDisabled(boolean gcLoggingDisabled) {
-        this.gcLoggingDisabled = gcLoggingDisabled;
+    protected void setGcLoggingEnabled(boolean gcLoggingEnabled) {
+        this.gcLoggingEnabled = gcLoggingEnabled;
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -177,7 +177,7 @@ public class EntityTopicOperator extends AbstractModel {
 
     @Override
     public String getGcLoggingOptions() {
-        return gcLoggingDisabled ? " " : DEFAULT_STRIMZI_GC_LOGGING;
+        return gcLoggingEnabled ? DEFAULT_STRIMZI_GC_LOGGING : " ";
     }
 
     /**
@@ -207,7 +207,7 @@ public class EntityTopicOperator extends AbstractModel {
                 result.setZookeeperSessionTimeoutMs(topicOperatorSpec.getZookeeperSessionTimeoutSeconds() * 1_000);
                 result.setTopicMetadataMaxAttempts(topicOperatorSpec.getTopicMetadataMaxAttempts());
                 result.setLogging(topicOperatorSpec.getLogging());
-                result.setGcLoggingDisabled(topicOperatorSpec.getJvmOptions() == null ? false : topicOperatorSpec.getJvmOptions().isGcLoggingDisabled());
+                result.setGcLoggingEnabled(topicOperatorSpec.getJvmOptions() == null ? true : topicOperatorSpec.getJvmOptions().isGcLoggingEnabled());
                 result.setResources(topicOperatorSpec.getResources());
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -141,7 +141,7 @@ public class EntityUserOperator extends AbstractModel {
 
     @Override
     public String getGcLoggingOptions() {
-        return gcLoggingDisabled ? " " : DEFAULT_STRIMZI_GC_LOGGING;
+        return gcLoggingEnabled ? DEFAULT_STRIMZI_GC_LOGGING : " ";
     }
 
     /**
@@ -170,7 +170,7 @@ public class EntityUserOperator extends AbstractModel {
                 result.setReconciliationIntervalMs(userOperatorSpec.getReconciliationIntervalSeconds() * 1_000);
                 result.setZookeeperSessionTimeoutMs(userOperatorSpec.getZookeeperSessionTimeoutSeconds() * 1_000);
                 result.setLogging(userOperatorSpec.getLogging());
-                result.setGcLoggingDisabled(userOperatorSpec.getJvmOptions() == null ? false : userOperatorSpec.getJvmOptions().isGcLoggingDisabled());
+                result.setGcLoggingEnabled(userOperatorSpec.getJvmOptions() == null ? true : userOperatorSpec.getJvmOptions().isGcLoggingEnabled());
                 result.setResources(userOperatorSpec.getResources());
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -274,7 +274,7 @@ public class KafkaCluster extends AbstractModel {
         result.setInitImage(initImage);
         Logging logging = kafkaClusterSpec.getLogging();
         result.setLogging(logging == null ? new InlineLogging() : logging);
-        result.setGcLoggingDisabled(kafkaClusterSpec.getJvmOptions() == null ? false : kafkaClusterSpec.getJvmOptions().isGcLoggingDisabled());
+        result.setGcLoggingEnabled(kafkaClusterSpec.getJvmOptions() == null ? true : kafkaClusterSpec.getJvmOptions().isGcLoggingEnabled());
         result.setJvmOptions(kafkaClusterSpec.getJvmOptions());
         result.setConfiguration(new KafkaConfiguration(kafkaClusterSpec.getConfig().entrySet()));
         Map<String, Object> metrics = kafkaClusterSpec.getMetrics();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -140,7 +140,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
             kafkaConnect.setResources(spec.getResources());
             kafkaConnect.setLogging(spec.getLogging());
-            kafkaConnect.setGcLoggingDisabled(spec.getJvmOptions() == null ? false : spec.getJvmOptions().isGcLoggingDisabled());
+            kafkaConnect.setGcLoggingEnabled(spec.getJvmOptions() == null ? true : spec.getJvmOptions().isGcLoggingEnabled());
             kafkaConnect.setJvmOptions(spec.getJvmOptions());
             if (spec.getReadinessProbe() != null) {
                 kafkaConnect.setReadinessInitialDelay(spec.getReadinessProbe().getInitialDelaySeconds());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -170,7 +170,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                     kafkaMirrorMaker.getSpec().getImage(),
                     kafkaMirrorMaker.getSpec().getVersion()));
             kafkaMirrorMakerCluster.setLogging(kafkaMirrorMaker.getSpec().getLogging());
-            kafkaMirrorMakerCluster.setGcLoggingDisabled(kafkaMirrorMaker.getSpec().getJvmOptions() == null ? false : kafkaMirrorMaker.getSpec().getJvmOptions().isGcLoggingDisabled());
+            kafkaMirrorMakerCluster.setGcLoggingEnabled(kafkaMirrorMaker.getSpec().getJvmOptions() == null ? true : kafkaMirrorMaker.getSpec().getJvmOptions().isGcLoggingEnabled());
 
             Map<String, Object> metrics = kafkaMirrorMaker.getSpec().getMetrics();
             if (metrics != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -205,7 +205,7 @@ public class TopicOperator extends AbstractModel {
 
     @Override
     public String getGcLoggingOptions() {
-        return gcLoggingDisabled ? " " : DEFAULT_STRIMZI_GC_LOGGING;
+        return gcLoggingEnabled ? DEFAULT_STRIMZI_GC_LOGGING : " ";
     }
 
     /**
@@ -231,7 +231,7 @@ public class TopicOperator extends AbstractModel {
             result.setZookeeperSessionTimeoutMs(tcConfig.getZookeeperSessionTimeoutSeconds() * 1_000);
             result.setTopicMetadataMaxAttempts(tcConfig.getTopicMetadataMaxAttempts());
             result.setLogging(tcConfig.getLogging());
-            result.setGcLoggingDisabled(tcConfig.getJvmOptions() == null ? false : tcConfig.getJvmOptions().isGcLoggingDisabled());
+            result.setGcLoggingEnabled(tcConfig.getJvmOptions() == null ? true : tcConfig.getJvmOptions().isGcLoggingEnabled());
             result.setResources(tcConfig.getResources());
             result.setUserAffinity(tcConfig.getAffinity());
             result.setTlsSidecar(tcConfig.getTlsSidecar());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -174,7 +174,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
         Logging logging = zookeeperClusterSpec.getLogging();
         zk.setLogging(logging == null ? new InlineLogging() : logging);
-        zk.setGcLoggingDisabled(zookeeperClusterSpec.getJvmOptions() == null ? false : zookeeperClusterSpec.getJvmOptions().isGcLoggingDisabled());
+        zk.setGcLoggingEnabled(zookeeperClusterSpec.getJvmOptions() == null ? true : zookeeperClusterSpec.getJvmOptions().isGcLoggingEnabled());
         Map<String, Object> metrics = zookeeperClusterSpec.getMetrics();
         if (metrics != null) {
             zk.setMetricsEnabled(true);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -256,6 +256,7 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
         assertEquals("foo=bar" + LINE_SEPARATOR, AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
+        assertEquals(KafkaCluster.DEFAULT_KAFKA_GC_LOGGING, AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_KAFKA_GC_LOG_OPTS));
         assertEquals(KafkaCluster.BROKER_CERTS_VOLUME, containers.get(0).getVolumeMounts().get(2).getName());
         assertEquals(KafkaCluster.BROKER_CERTS_VOLUME_MOUNT, containers.get(0).getVolumeMounts().get(2).getMountPath());
         assertEquals(KafkaCluster.CLUSTER_CA_CERTS_VOLUME, containers.get(0).getVolumeMounts().get(1).getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -125,7 +125,7 @@ public class KafkaMirrorMakerClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_WHITELIST).withValue(whitelist).build());
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_GROUPID_CONSUMER).withValue(groupId).build());
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_NUMSTREAMS).withValue(Integer.toString(numStreams)).build());
-        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_GC_LOG_OPTS).withValue(KafkaConnectCluster.DEFAULT_KAFKA_GC_LOGGING).build());
+        expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_GC_LOG_OPTS).withValue(KafkaMirrorMakerCluster.DEFAULT_KAFKA_GC_LOGGING).build());
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_HEAP_OPTS).withValue(kafkaHeapOpts).build());
         return expected;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -175,6 +175,7 @@ public class ZookeeperClusterTest {
                         "initLimit=5" + LINE_SEPARATOR +
                         "foo=bar" + LINE_SEPARATOR;
         assertEquals(expectedConfig, AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
+        assertEquals(ZookeeperCluster.DEFAULT_KAFKA_GC_LOGGING, AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_KAFKA_GC_LOG_OPTS));
         // checks on the TLS sidecar container
         Container tlsSidecarContainer = containers.get(1);
         assertEquals(ZookeeperClusterSpec.DEFAULT_TLS_SIDECAR_IMAGE, tlsSidecarContainer.getImage());

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -316,7 +316,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 |string
 |-Xmx              1.2+<.<|-Xmx option to to the JVM.
 |string
-|gcLoggingEnabled  1.2+<.<|Enable or disable Garbage Collection logging. It's enabled by default.
+|gcLoggingEnabled  1.2+<.<|Enable or disable Garbage Collection logging. It is enabled by default.
 |boolean
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -316,7 +316,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 |string
 |-Xmx              1.2+<.<|-Xmx option to to the JVM.
 |string
-|gcLoggingEnabled  1.2+<.<|Enable or disable Garbage Collection logging. It is enabled by default.
+|gcLoggingEnabled  1.2+<.<|Specifies whether the Garbage Collection logging is enabled. The default is true.
 |boolean
 |====
 
@@ -547,7 +547,7 @@ Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`],
 [options="header"]
 |====
 |Field                    |Description
-|gcLoggingEnabled  1.2+<.<|Specifies whether the Garbage Collection logging is enabled.
+|gcLoggingEnabled  1.2+<.<|Specifies whether the Garbage Collection logging is enabled. The default is true.
 |boolean
 |====
 
@@ -657,7 +657,7 @@ Configuration of how TLS certificates are used within the cluster. This applies 
 |Field                                |Description
 |generateCertificateAuthority  1.2+<.<|If true then Certificate Authority certificates will be generated automatically. Otherwise the user will need to provide a Secret with the CA certificate. Default is true.
 |boolean
-|validityDays                  1.2+<.<|The number of days generated certificates should be valid for. Default is 365.
+|validityDays                  1.2+<.<|The number of days generated certificates should be valid for. The default is 365.
 |integer
 |renewalDays                   1.2+<.<|The number of days in the certificate renewal period. This is the number of days before the a certificate expires during which renewal actions may be performed. When `generateCertificateAuthority` is true, this will cause the generation of a new certificate. When `generateCertificateAuthority` is true, this will cause extra logging at WARN level about the pending certificate expiry. Default is 30.
 |integer

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -309,14 +309,14 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-Kaf
 
 [options="header"]
 |====
-|Field                     |Description
-|-XX                1.2+<.<|A map of -XX options to the JVM.
+|Field                    |Description
+|-XX               1.2+<.<|A map of -XX options to the JVM.
 |map
-|-Xms               1.2+<.<|-Xms option to to the JVM.
+|-Xms              1.2+<.<|-Xms option to to the JVM.
 |string
-|-Xmx               1.2+<.<|-Xmx option to to the JVM.
+|-Xmx              1.2+<.<|-Xmx option to to the JVM.
 |string
-|gcLoggingDisabled  1.2+<.<|Disable garbage collection logging.
+|gcLoggingEnabled  1.2+<.<|Enable or disable Garbage Collection logging. It's enabled by default.
 |boolean
 |====
 
@@ -546,8 +546,8 @@ Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`],
 
 [options="header"]
 |====
-|Field                     |Description
-|gcLoggingDisabled  1.2+<.<|Disable garbage collection logging.
+|Field                    |Description
+|gcLoggingEnabled  1.2+<.<|If the Garbage Collection logging is enabled.
 |boolean
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -547,7 +547,7 @@ Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`],
 [options="header"]
 |====
 |Field                    |Description
-|gcLoggingEnabled  1.2+<.<|If the Garbage Collection logging is enabled.
+|gcLoggingEnabled  1.2+<.<|Specifies whether the Garbage Collection logging is enabled.
 |boolean
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -354,7 +354,7 @@ spec:
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
                 resources:
                   type: object
@@ -735,7 +735,7 @@ spec:
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
                 resources:
                   type: object
@@ -1138,7 +1138,7 @@ spec:
                 jvmOptions:
                   type: object
                   properties:
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
             entityOperator:
               type: object
@@ -1197,7 +1197,7 @@ spec:
                     jvmOptions:
                       type: object
                       properties:
-                        gcLoggingDisabled:
+                        gcLoggingEnabled:
                           type: boolean
                 userOperator:
                   type: object
@@ -1250,7 +1250,7 @@ spec:
                     jvmOptions:
                       type: object
                       properties:
-                        gcLoggingDisabled:
+                        gcLoggingEnabled:
                           type: boolean
                 affinity:
                   type: object

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -58,7 +58,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             affinity:
               type: object

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -58,7 +58,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             affinity:
               type: object

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -389,7 +389,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             logging:
               type: object

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -350,7 +350,7 @@ spec:
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
                 resources:
                   type: object
@@ -731,7 +731,7 @@ spec:
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
                 resources:
                   type: object
@@ -1134,7 +1134,7 @@ spec:
                 jvmOptions:
                   type: object
                   properties:
-                    gcLoggingDisabled:
+                    gcLoggingEnabled:
                       type: boolean
             entityOperator:
               type: object
@@ -1193,7 +1193,7 @@ spec:
                     jvmOptions:
                       type: object
                       properties:
-                        gcLoggingDisabled:
+                        gcLoggingEnabled:
                           type: boolean
                 userOperator:
                   type: object
@@ -1246,7 +1246,7 @@ spec:
                     jvmOptions:
                       type: object
                       properties:
-                        gcLoggingDisabled:
+                        gcLoggingEnabled:
                           type: boolean
                 affinity:
                   type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -54,7 +54,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             affinity:
               type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -54,7 +54,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             affinity:
               type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -385,7 +385,7 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                gcLoggingDisabled:
+                gcLoggingEnabled:
                   type: boolean
             logging:
               type: object


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes #1171 so that the `gcLoggingDisabled` in the JVM options is now `gcLoggingEnabled` but it's `true` as default so that the previous behavior (GC logging enabled by default) doesn't change.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

