### PR TITLE
Fixed empty `ResourceTemplate` and missing `MetadataTemplate` sections in the doc

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -179,6 +179,9 @@ class Property implements AnnotatedElement {
 
     private static boolean hasMethod(Class<?> c, Method m) {
         try {
+            if (!c.isAssignableFrom(m.getDeclaringClass()))
+                return false;
+
             c.getDeclaredMethod(m.getName(), m.getParameterTypes());
             return true;
         } catch (NoSuchMethodException e) {

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -440,7 +440,24 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 
 [options="header"]
 |====
-|Field|Description
+|Field            |Description
+|metadata  1.2+<.<|Metadata which should be applied to the resource.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|====
+
+[id='type-MetadataTemplate-{context}']
+### `MetadataTemplate` schema reference
+
+Used in: xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+
+
+[options="header"]
+|====
+|Field               |Description
+|labels       1.2+<.<|Labels which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+|map
+|annotations  1.2+<.<|Annotations which should be added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+|map
 |====
 
 [id='type-ZookeeperClusterSpec-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -453,28 +453,84 @@ spec:
                   properties:
                     statefulset:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     bootstrapService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     brokersService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapRoute:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     perPodRoute:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     perPodService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                 version:
                   type: string
               required:
@@ -834,16 +890,44 @@ spec:
                   properties:
                     statefulset:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     clientService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     nodesService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
               required:
               - replicas
               - storage
@@ -1509,10 +1593,24 @@ spec:
                   properties:
                     deployment:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
             clusterCa:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -278,13 +278,34 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 apiService:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             authentication:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -263,13 +263,34 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 apiService:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             authentication:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -412,10 +412,24 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             version:
               type: string
           required:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -449,28 +449,84 @@ spec:
                   properties:
                     statefulset:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     bootstrapService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     brokersService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapRoute:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     perPodRoute:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     perPodService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                 version:
                   type: string
               required:
@@ -830,16 +886,44 @@ spec:
                   properties:
                     statefulset:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     clientService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     nodesService:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
               required:
               - replicas
               - storage
@@ -1505,10 +1589,24 @@ spec:
                   properties:
                     deployment:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     pod:
                       type: object
-                      properties: {}
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
             clusterCa:
               type: object
               properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -274,13 +274,34 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 apiService:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             authentication:
               type: object
               properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -259,13 +259,34 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 apiService:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             authentication:
               type: object
               properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -408,10 +408,24 @@ spec:
               properties:
                 deployment:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
                 pod:
                   type: object
-                  properties: {}
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
             version:
               type: string
           required:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the bug related to an empty `ResourceTemplate` section in the documentation and the missing `MetadataTemplate` section as well.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

