### PR TITLE
Turn off execution tracing for key stores password

### DIFF
--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +x
 
 if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
 export KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"

--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +x
 
 if [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER" ] || [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER" ]; then
     # Generate temporary keystore password

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +x
 
 if [ -f /opt/topic-operator/custom-config/log4j2.properties ];
 then


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR turns of execution tracing for Kafka Connect and Kafka Mirror Maker as it's already in place for Kafka. It's related to now show passwords for key stores in the log.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

