### PR TITLE
Fix broken docker images build on MacOS

### DIFF
--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 java_images="java-base"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `docker-images` `build.sh` script is using the `-A` of the `declare` command. Tis option is available only in Bash 4. In Bash 3 this fails with an error. However, the script is at the same time using `#!/bin/bash` as its shebang. This on MacOS starts the built-in bash 3 instead of the bash 4 installed for example through Homebrew. This PR changes the shebang to `#!/usr/bin/env bash` which should pick the right bash.