### PR TITLE
Added more information about namespace replacing for Prometheus

### DIFF
--- a/documentation/book/appendix_metrics.adoc
+++ b/documentation/book/appendix_metrics.adoc
@@ -52,12 +52,11 @@ The following resources are defined:
 
 ==== Deploying on {OpenShiftName}
 
-The provided YAML file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
-If you're not using this namespace then download the resource file locally and update it as follow.
+The provided `kubernetes.yaml` file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
+If you are using a different namespace, download the resource file and update it as follows:
 
 [source,shell,subs=attributes+]
-curl -o prometheus.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
-sed -i 's/namespace: .\*/namespace: _my-namespace_/' prometheus.yaml
+curl -s https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml | sed -e 's/namespace: .\*/namespace: _my-namespace_/' > prometheus.yaml
 
 To deploy all these resources you can run the following.
 
@@ -68,12 +67,11 @@ oc apply -f prometheus.yaml
 ifdef::Kubernetes[]
 ==== Deploying on {KubernetesName}
 
-The provided YAML file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
-If you're not using this namespace then download the resource file locally and update it as follow.
+The provided `kubernetes.yaml` file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
+If you are using a different namespace, download the resource file and update it as follows:
 
 [source,shell,subs=attributes+]
-curl -o prometheus.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
-sed -i 's/namespace: .\*/namespace: _my-namespace_/' prometheus.yaml
+curl -s https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml | sed -e 's/namespace: .\*/namespace: _my-namespace_/' > prometheus.yaml
 
 To deploy all these resources you can run the following.
 

--- a/documentation/book/appendix_metrics.adoc
+++ b/documentation/book/appendix_metrics.adoc
@@ -52,19 +52,33 @@ The following resources are defined:
 
 ==== Deploying on {OpenShiftName}
 
-To deploy all these resources you can run the following.  Note that this file creates a `ClusterRoleBinding` in the `myproject` namespace.  If you're not using this namespace then download the resource file locally and update it.
+The provided YAML file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
+If you're not using this namespace then download the resource file locally and update it as follow.
+
+[source,shell,subs=attributes+]
+curl -o prometheus.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' prometheus.yaml
+
+To deploy all these resources you can run the following.
 
 [source,shell,subs=attributes+]
 oc login -u system:admin
-oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
+oc apply -f prometheus.yaml
 
 ifdef::Kubernetes[]
 ==== Deploying on {KubernetesName}
 
-To deploy all these resources you can run the following.  Note that this file creates a `ClusterRoleBinding` in the `myproject` namespace.  If you're not using this namespace then download the resource file locally and update it.
+The provided YAML file, with all the Prometheus related resources, creates a `ClusterRoleBinding` in the `myproject` namespace.
+If you're not using this namespace then download the resource file locally and update it as follow.
 
 [source,shell,subs=attributes+]
-kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
+curl -o prometheus.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{GithubVersion}/metrics/examples/prometheus/kubernetes.yaml
+sed -i 's/namespace: .\*/namespace: _my-namespace_/' prometheus.yaml
+
+To deploy all these resources you can run the following.
+
+[source,shell,subs=attributes+]
+kubectl apply -f prometheus.yaml
 
 endif::Kubernetes[]
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

From the current documentation my impression is that people just run the `apply` command in order to deploy the Prometheus resource without paying attention to change the namespace (if needed).
This PR explicit this step using `sed` command in the same way we describe for the cluster operator deployment.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

