### PR TITLE
Add missing CHANGELOG items for KAfka 2.1.0 and Kafka upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.0
 
+* Support for Kafka 2.1.0
+* Support for Kafka upgrades 
 * Rename annotations to use the `strimzi.io` domain consistently:
     * `cluster.operator.strimzi.io/delete-claim` → `strimzi.io/delete-claim` 
     * `operator.strimzi.io/manual-rolling-update` → `strimzi.io/manual-rolling-update` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.10.0
 
 * Support for Kafka 2.1.0
-* Support for Kafka upgrades 
+* Support for Kafka upgrades
+* Add healthchecks to TLS sidecars
 * Rename annotations to use the `strimzi.io` domain consistently:
     * `cluster.operator.strimzi.io/delete-claim` → `strimzi.io/delete-claim` 
     * `operator.strimzi.io/manual-rolling-update` → `strimzi.io/manual-rolling-update` 


### PR DESCRIPTION
It seems that we are missing some of the 0.10.0 items in the `CHANGELOG.md`. In particular:
* Kafka 2.1.0 support
* Kafka upgrades