### PR TITLE
Add support for NetworkPolicy peers in listener configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * `operator.strimzi.io/delete-pod-and-pvc` → `strimzi.io/delete-pod-and-pvc`
     * `operator.strimzi.io/generation` → `strimzi.io/generation`
 * Add support for mounting Secrets and Config Maps into Kafka Connect and Kafka Connect S2I
+* Add support for NetworkPolicy peers in listener configurations
 
 ## 0.9.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -50,10 +50,10 @@ public abstract class KafkaListenerExternal implements Serializable {
 
     public abstract void setAuth(KafkaListenerAuthentication auth);
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public abstract List<NetworkPolicyPeer> getNetworkPolicyPeers();

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -54,7 +54,7 @@ public abstract class KafkaListenerExternal implements Serializable {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public abstract List<NetworkPolicyPeer> getNetworkPolicyPeers();
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternal.java
@@ -10,10 +10,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,6 +49,16 @@ public abstract class KafkaListenerExternal implements Serializable {
     public abstract KafkaListenerAuthentication getAuth();
 
     public abstract void setAuth(KafkaListenerAuthentication auth);
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public abstract List<NetworkPolicyPeer> getNetworkPolicyPeers();
+
+    public abstract void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers);
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -5,11 +5,15 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
 
 /**
  * Configures the external listener which exposes Kafka outside of Kubernetes using LoadBalancers
@@ -28,6 +32,7 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
 
     private KafkaListenerAuthentication auth;
     private boolean tls = true;
+    private List<NetworkPolicyPeer> networkPolicyPeers;
 
     @Description("Must be `" + TYPE_LOADBALANCER + "`")
     @Override
@@ -55,5 +60,19 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
 
     public void setTls(boolean tls) {
         this.tls = tls;
+    }
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
+        return networkPolicyPeers;
+    }
+
+    public void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers) {
+        this.networkPolicyPeers = networkPolicyPeers;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -62,10 +62,10 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
         this.tls = tls;
     }
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -66,7 +66,7 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
         return networkPolicyPeers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalLoadBalancer.java
@@ -5,7 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -66,7 +66,7 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
         return networkPolicyPeers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -62,10 +62,10 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
         this.tls = tls;
     }
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -5,7 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalNodePort.java
@@ -5,11 +5,15 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
 
 /**
  * Configures the external listener which exposes Kafka outside of Kubernetes using NodePorts
@@ -28,6 +32,7 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
 
     private KafkaListenerAuthentication auth;
     private boolean tls = true;
+    private List<NetworkPolicyPeer> networkPolicyPeers;
 
     @Description("Must be `" + TYPE_NODEPORT + "`")
     @Override
@@ -55,5 +60,19 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
 
     public void setTls(boolean tls) {
         this.tls = tls;
+    }
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
+        return networkPolicyPeers;
+    }
+
+    public void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers) {
+        this.networkPolicyPeers = networkPolicyPeers;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -7,7 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -53,7 +53,7 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
         return networkPolicyPeers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -7,8 +7,12 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
 
 /**
  * Configures the external listener which exposes Kafka outside of OpenShift using Routes
@@ -26,6 +30,7 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
     public static final String TYPE_ROUTE = "route";
 
     private KafkaListenerAuthentication auth;
+    private List<NetworkPolicyPeer> networkPolicyPeers;
 
     @Description("Must be `" + TYPE_ROUTE + "`")
     @Override
@@ -42,5 +47,19 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
 
     public void setAuth(KafkaListenerAuthentication auth) {
         this.auth = auth;
+    }
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
+        return networkPolicyPeers;
+    }
+
+    public void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers) {
+        this.networkPolicyPeers = networkPolicyPeers;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerExternalRoute.java
@@ -49,10 +49,10 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
         this.auth = auth;
     }
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
@@ -7,11 +7,14 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -31,6 +34,7 @@ public class KafkaListenerPlain implements Serializable {
     private Map<String, Object> additionalProperties;
 
     private KafkaListenerAuthentication authentication;
+    private List<NetworkPolicyPeer> networkPolicyPeers;
 
     @Description("Authentication configuration for this listener. " +
             "Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`.")
@@ -40,6 +44,20 @@ public class KafkaListenerPlain implements Serializable {
 
     public void setAuthentication(KafkaListenerAuthentication authentication) {
         this.authentication = authentication;
+    }
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
+        return networkPolicyPeers;
+    }
+
+    public void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers) {
+        this.networkPolicyPeers = networkPolicyPeers;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
@@ -7,7 +7,7 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
@@ -46,10 +46,10 @@ public class KafkaListenerPlain implements Serializable {
         this.authentication = authentication;
     }
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerPlain.java
@@ -50,7 +50,7 @@ public class KafkaListenerPlain implements Serializable {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
         return networkPolicyPeers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -8,11 +8,14 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -31,6 +34,7 @@ public class KafkaListenerTls implements Serializable {
 
     private KafkaListenerAuthentication auth;
     private Map<String, Object> additionalProperties;
+    private List<NetworkPolicyPeer> networkPolicyPeers;
 
     @Description("Authentication configuration for this listener.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -41,6 +45,20 @@ public class KafkaListenerTls implements Serializable {
 
     public void setAuth(KafkaListenerAuthentication auth) {
         this.auth = auth;
+    }
+
+    @Description("List of sources which should be able to connect to this listener. " +
+            "Peers in this list are combined using a logical OR operation. " +
+            "If this field is empty or missing, all connections will be allowed for this listener. " +
+            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
+        return networkPolicyPeers;
+    }
+
+    public void setNetworkPolicyPeers(List<NetworkPolicyPeer> networkPolicyPeers) {
+        this.networkPolicyPeers = networkPolicyPeers;
     }
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -51,7 +51,7 @@ public class KafkaListenerTls implements Serializable {
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
             "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
-    @KubeLink(group = "networking.k8s.io", version = "v1", kind = "NetworkPolicyPeer")
+    @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {
         return networkPolicyPeers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.fabric8.kubernetes.api.model.extensions.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaListenerTls.java
@@ -47,10 +47,10 @@ public class KafkaListenerTls implements Serializable {
         this.auth = auth;
     }
 
-    @Description("List of sources which should be able to connect to this listener. " +
+    @Description("List of peers which should be able to connect to this listener. " +
             "Peers in this list are combined using a logical OR operation. " +
             "If this field is empty or missing, all connections will be allowed for this listener. " +
-            "If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.")
+            "If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.")
     @KubeLink(group = "networking", version = "v1", kind = "networkpolicypeer")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<NetworkPolicyPeer> getNetworkPolicyPeers() {

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -17,13 +17,52 @@ spec:
       plain:
         authentication:
           type: "scram-sha-512"
+        networkPolicyPeers:
+        - namespaceSelector:
+            matchExpressions: []
+            matchLabels:
+              kafka-enabled: "true"
+          podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-consumer"
+        - podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-producer"
       tls:
+        networkPolicyPeers:
+        - namespaceSelector:
+            matchExpressions: []
+            matchLabels:
+              kafka-enabled: "true"
+          podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-consumer"
+        - podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-producer"
         authentication:
           type: "tls"
       external:
         type: "route"
         authentication:
           type: "tls"
+        networkPolicyPeers:
+        - namespaceSelector:
+            matchExpressions: []
+            matchLabels:
+              kafka-enabled: "true"
+          podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-consumer"
+        - podSelector:
+            matchExpressions: []
+            matchLabels:
+              app: "kafka-producer"
     authorization:
       type: "simple"
       superUsers:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.yaml
@@ -40,13 +40,43 @@ spec:
       plain:
         authentication:
           type: scram-sha-512
+        networkPolicyPeers:
+          - namespaceSelector:
+              matchLabels:
+                kafka-enabled: true
+            podSelector:
+              matchLabels:
+                app: kafka-consumer
+          - podSelector:
+              matchLabels:
+                app: kafka-producer
       tls:
         authentication:
           type: tls
+        networkPolicyPeers:
+          - namespaceSelector:
+              matchLabels:
+                kafka-enabled: true
+            podSelector:
+              matchLabels:
+                app: kafka-consumer
+          - podSelector:
+              matchLabels:
+                app: kafka-producer
       external:
         type: route
         authentication:
           type: tls
+        networkPolicyPeers:
+          - namespaceSelector:
+              matchLabels:
+                kafka-enabled: true
+            podSelector:
+              matchLabels:
+                app: kafka-consumer
+          - podSelector:
+              matchLabels:
+                app: kafka-producer
     authorization:
       type: simple
       superUsers:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -922,7 +922,7 @@ public class KafkaCluster extends AbstractModel {
 
                 NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
                         .withPorts(plainPort)
-                        .withFrom()
+                        .withFrom(listeners.getPlain().getNetworkPolicyPeers())
                         .build();
 
                 rules.add(plainRule);
@@ -934,7 +934,7 @@ public class KafkaCluster extends AbstractModel {
 
                 NetworkPolicyIngressRule tlsRule = new NetworkPolicyIngressRuleBuilder()
                         .withPorts(tlsPort)
-                        .withFrom()
+                        .withFrom(listeners.getTls().getNetworkPolicyPeers())
                         .build();
 
                 rules.add(tlsRule);
@@ -946,7 +946,7 @@ public class KafkaCluster extends AbstractModel {
 
                 NetworkPolicyIngressRule externalRule = new NetworkPolicyIngressRuleBuilder()
                         .withPorts(externalPort)
-                        .withFrom()
+                        .withFrom(listeners.getExternal().getNetworkPolicyPeers())
                         .build();
 
                 rules.add(externalRule);

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -156,7 +156,7 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |Field                      |Description
 |authentication      1.2+<.<|Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
@@ -203,7 +203,7 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |Field                      |Description
 |authentication      1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
@@ -224,7 +224,7 @@ It must have the value `route` for the type `KafkaListenerExternalRoute`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
@@ -245,7 +245,7 @@ It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBal
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
@@ -268,7 +268,7 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -156,10 +156,10 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |Field                      |Description
 |authentication      1.2+<.<|Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
-|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerAuthenticationTls-{context}']
@@ -203,10 +203,10 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |Field                      |Description
 |authentication      1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
-|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerExternalRoute-{context}']
@@ -224,10 +224,10 @@ It must have the value `route` for the type `KafkaListenerExternalRoute`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
-|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerExternalLoadBalancer-{context}']
@@ -245,10 +245,10 @@ It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBal
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
-|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
 |tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====
@@ -268,10 +268,10 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
-|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
 |tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -153,9 +153,13 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 [options="header"]
 |====
-|Field                  |Description
-|authentication  1.2+<.<|Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|Field                      |Description
+|authentication      1.2+<.<|Authentication configuration for this listener. Since this listener does not use TLS transport you cannot configure an authentication with `type: tls`. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerAuthenticationTls-{context}']
@@ -196,9 +200,13 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 [options="header"]
 |====
-|Field                  |Description
-|authentication  1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|Field                      |Description
+|authentication      1.2+<.<|Authentication configuration for this listener. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerExternalRoute-{context}']
@@ -211,11 +219,15 @@ The `type` property is a discriminator that distinguishes the use of the type `K
 It must have the value `route` for the type `KafkaListenerExternalRoute`.
 [options="header"]
 |====
-|Field                  |Description
-|type            1.2+<.<|Must be `route`.
+|Field                      |Description
+|type                1.2+<.<|Must be `route`.
 |string
-|authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerExternalLoadBalancer-{context}']
@@ -228,12 +240,16 @@ The `type` property is a discriminator that distinguishes the use of the type `K
 It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBalancer`.
 [options="header"]
 |====
-|Field                  |Description
-|type            1.2+<.<|Must be `loadbalancer`.
+|Field                      |Description
+|type                1.2+<.<|Must be `loadbalancer`.
 |string
-|authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====
 
@@ -247,12 +263,16 @@ The `type` property is a discriminator that distinguishes the use of the type `K
 It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 [options="header"]
 |====
-|Field                  |Description
-|type            1.2+<.<|Must be `nodeport`.
+|Field                      |Description
+|type                1.2+<.<|Must be `nodeport`.
 |string
-|authentication  1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
-|tls             1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
+|networkPolicyPeers  1.2+<.<|List of sources which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least on item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[networking.k8s.io/v1 NetworkPolicyPeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#NetworkPolicyPeer-v1-networking.k8s.io[NetworkPolicyPeer] array
+|tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -72,6 +72,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:
@@ -126,6 +135,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:
@@ -180,6 +198,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -67,6 +67,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                     tls:
                       type: object
                       properties:
@@ -80,6 +121,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                     external:
                       type: object
                       properties:
@@ -93,6 +175,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                         tls:
                           type: boolean
                         type:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -63,6 +63,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                     tls:
                       type: object
                       properties:
@@ -76,6 +117,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                     external:
                       type: object
                       properties:
@@ -89,6 +171,47 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
                         tls:
                           type: boolean
                         type:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -68,6 +68,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:
@@ -122,6 +131,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:
@@ -176,6 +194,15 @@ spec:
                           items:
                             type: object
                             properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
                               namespaceSelector:
                                 type: object
                                 properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the possibility to define NetworkPolicyPeers as part of the Kafka listener configurations. These peers are added to the NetworkPolicies. This allows users to manage the NetworkPolicies and allow only specific applications to connect to the different Kafka listeners. The rules are different for each Kafka listener. When no rules are specified, all apps will have access.

An example snippet of the configuration is here:

```yaml
    listeners:
      plain:
        authentication:
          type: scram-sha-512
        networkPolicyPeers:
          - podSelector:
              matchLabels:
                app: kafka-consumer
          - podSelector:
              matchLabels:
                app: kafka-producer
      tls:
        authentication:
          type: tls
        networkPolicyPeers:
          - podSelector:
              matchLabels:
                app: kafka-consumer
          - podSelector:
              matchLabels:
                app: kafka-producer
      external:
        type: route
        authentication:
          type: tls
        networkPolicyPeers:
          - podSelector:
              matchLabels:
                app: kafka-consumer
          - podSelector:
              matchLabels:
                app: kafka-producer
```

Documentation will be provided in a separate PR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

