### PR TITLE
Docs: Add network policies to listeners

### DIFF
--- a/documentation/book/assembly-configuring-kafka-listeners.adoc
+++ b/documentation/book/assembly-configuring-kafka-listeners.adoc
@@ -30,4 +30,6 @@ include::proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]
 
 include::proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
 
+include::proc-restricting-access-to-listeners-using-network-policies.adoc[leveloffset=+1]
+
 :context: {parent-context}

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -125,13 +125,15 @@ listeners:
 
 Authentication must be configured when using the User Operator to manage `KafkaUsers`.
 
-== Network Policies
+== Network policies
 
-For every enabled listener, {ProductName} will automatically create a NetworkPolicy which will by default grant all applications access to the listener.
-You can restrict the access only to selected applications using the `networkPolicyPeers` field.
-You can use different `networkPolicyPeers` configuration for each listener.
+{ProductName} automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
+By default, a `NetworkPolicy` grants access to a listener to all applications and namespaces.
+If you want to restrict access to a listener to only selected applications or namespaces, use the `networkPolicyPeers` field.
+Each listener can have a different `networkPolicyPeers` configuration.
 
-.An example where the `plain` and `tls` listeners allow connections only from selected pods
+The following example shows a `networkPolicyPeers` configuration for a `plain` and a `tls` listener:
+
 [source,yaml,subs="attributes+"]
 ----
 # ...
@@ -159,12 +161,13 @@ listeners:
 # ...
 ----
 
-In the example above:
+In the above example:
 
-* Only the application pods matching the labels `app: kafka-sasl-consumer` and `app: kafka-sasl-producer` which are running in the same namespace as the Kafka brokers can connect to the `plain` listener.
-* Only the application pods running in the namespaces matching the labels `project: myproject` and `project: myproject2` can connect to the `tls` listener.
+* Only application pods matching the labels `app: kafka-sasl-consumer` and `app: kafka-sasl-producer` can connect to the `plain` listener.
+The application pods must be running in the same namespace as the Kafka broker.
+* Only application pods running in namespaces matching the labels `project: myproject` and `project: myproject2` can connect to the `tls` listener.
 
-The syntax of the `networkPolicyPeers` field uses the same syntax as the `from` field in Kubernetes NetworkPolicies.
-For more information about the schema, see {K8sNetworkPolicyPeerAPI} and xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
+The syntax of the `networkPolicyPeers` field is the same as the `from` field in the `NetworkPolicy` resource in {KubernetesName}.
+For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
-NOTE: To use NetworkPolicies, your {ProductPlatformName} needs to support Ingress NetworkPolicies.
+NOTE: To use NetworkPolicies, your {ProductPlatformName} must support Ingress NetworkPolicies.

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -170,4 +170,4 @@ The application pods must be running in the same namespace as the Kafka broker.
 The syntax of the `networkPolicyPeers` field is the same as the `from` field in the `NetworkPolicy` resource in {KubernetesName}.
 For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
-NOTE: To use NetworkPolicies, your {ProductPlatformName} must support Ingress NetworkPolicies.
+NOTE: Your configuration of {ProductPlatformName} must support Ingress NetworkPolicies in order to use network policies in {ProductName}.

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -159,8 +159,12 @@ listeners:
 # ...
 ----
 
-In the example above, only applications with matching labels will be allowed to connect to the `plain` listener and only applications from the namespaces matching the labels will be allowed to connect.
+In the example above:
+
+* Only the application pods matching the labels `app: kafka-sasl-consumer` and `app: kafka-sasl-producer` which are running in the same namespace as the Kafka brokers can connect to the `plain` listener.
+* Only the application pods running in the namespaces matching the labels `project: myproject` and `project: myproject2` can connect to the `tls` listener.
+
 The syntax of the `networkPolicyPeers` field uses the same syntax as the `from` field in Kubernetes NetworkPolicies.
 For more information about the schema, see {K8sNetworkPolicyPeerAPI} and xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
-NOTE: To use NetworkPolicies, your {ProductPlatformName} needs to use SDN with Ingress NetworkPolicy support.
+NOTE: To use NetworkPolicies, your {ProductPlatformName} needs to support Ingress NetworkPolicies.

--- a/documentation/book/con-kafka-listeners.adoc
+++ b/documentation/book/con-kafka-listeners.adoc
@@ -124,3 +124,43 @@ listeners:
 
 
 Authentication must be configured when using the User Operator to manage `KafkaUsers`.
+
+== Network Policies
+
+For every enabled listener, {ProductName} will automatically create a NetworkPolicy which will by default grant all applications access to the listener.
+You can restrict the access only to selected applications using the `networkPolicyPeers` field.
+You can use different `networkPolicyPeers` configuration for each listener.
+
+.An example where the `plain` and `tls` listeners allow connections only from selected pods
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+      plain:
+        authentication:
+          type: scram-sha-512
+        networkPolicyPeers:
+          - podSelector:
+              matchLabels:
+                app: kafka-sasl-consumer
+          - podSelector:
+              matchLabels:
+                app: kafka-sasl-producer
+      tls:
+        authentication:
+          type: tls
+        networkPolicyPeers:
+          - namespaceSelector:
+              matchLabels:
+                project: myproject
+          - namespaceSelector:
+              matchLabels:
+                project: myproject2
+# ...
+----
+
+In the example above, only applications with matching labels will be allowed to connect to the `plain` listener and only applications from the namespaces matching the labels will be allowed to connect.
+The syntax of the `networkPolicyPeers` field uses the same syntax as the `from` field in Kubernetes NetworkPolicies.
+For more information about the schema, see {K8sNetworkPolicyPeerAPI} and xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
+
+NOTE: To use NetworkPolicies, your {ProductPlatformName} needs to use SDN with Ingress NetworkPolicy support.

--- a/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
+++ b/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring-kafka-listeners.adoc
+
+[id='proc-restricting-access-to-listeners-using-network-policies-{context}']
+= Restricting access to Kafka listeners using NetworkPolicies
+
+.Prerequisites
+
+* An {ProductPlatformName} cluster with SDN supporting Ingress NetworkPolicies
+* A running Cluster Operator
+
+.Procedure
+
+. Deploy Kafka cluster and configure the pods or namespaces which will be allowed to access it in the `networkPolicyPeers` field.
+An example configuration with an `tls` listener configured to allow connections from Pods which have the label `app` set to `kafka-client`:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    listeners:
+      tls:
+        networkPolicyPeers:
+          - podSelector:
+              matchLabels:
+                app: kafka-client
+    # ...
+  zookeeper:
+    # ...
+----
+
+. Create or update the resource.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _your-file_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f _your-file_
+
+.Additional resources
+* For more information about the schema, see {K8sNetworkPolicyPeerAPI} and xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
+++ b/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
@@ -3,12 +3,14 @@
 // assembly-configuring-kafka-listeners.adoc
 
 [id='proc-restricting-access-to-listeners-using-network-policies-{context}']
-= Restricting access to Kafka listeners using NetworkPolicies
+= Restricting access to Kafka listeners using `networkPolicyPeers`
+
+You can restrict access to a listener to only selected applications by using the `networkPolicyPeers` field.
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster with SDN supporting Ingress NetworkPolicies
-* A running Cluster Operator
+* An {ProductPlatformName} cluster with support for Ingress NetworkPolicies.
+* The Cluster Operator is running.
 
 .Procedure
 
@@ -36,15 +38,15 @@ spec:
 . Create or update the resource.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName} use `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _your-file_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName} use `oc apply`:
 +
 [source,shell,subs=+quotes]
 oc apply -f _your-file_
 
 .Additional resources
-* For more information about the schema, see {K8sNetworkPolicyPeerAPI} and xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
+* For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].

--- a/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
+++ b/documentation/book/proc-restricting-access-to-listeners-using-network-policies.adoc
@@ -14,8 +14,11 @@ You can restrict access to a listener to only selected applications by using the
 
 .Procedure
 
-. Deploy Kafka cluster and configure the pods or namespaces which will be allowed to access it in the `networkPolicyPeers` field.
-An example configuration with an `tls` listener configured to allow connections from Pods which have the label `app` set to `kafka-client`:
+. Open the `Kafka` resource.
+
+. In the `networkPolicyPeers` field, define the application pods or namespaces that will be allowed to access the Kafka cluster.
++
+For example, to configure a `tls` listener to allow connections only from application pods with the label `app` set to `kafka-client`:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -52,8 +52,7 @@
 :K8sLivenessReadinessProbes: link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Configure Liveness and Readiness Probes^]
 :K8sPullingImagesFromPrivateRegistries: link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/[Pull an Image from a Private Registry^]
 :K8sConfigureSecurityContext: link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Configure a Security Context for a Pod or Container^]
-
-
+:K8sNetworkPolicyPeerAPI: link:https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer API reference^]
 
 :ApacheKafkaBrokerConfig: link:http://kafka.apache.org/20/documentation.html#brokerconfigs[Apache Kafka documentation^]
 :ApacheKafkaConnectConfig: link:http://kafka.apache.org/20/documentation.html#connectconfigs[Apache Kafka documentation^]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the documentation to Network Policy Peer support in Kafka listeners. The code PR is #1186.

### Checklist

- [x] Update documentation