### PR TITLE
Fix the fix for supported versions generator which broker it on Linux

### DIFF
--- a/multi-platform-support.sh
+++ b/multi-platform-support.sh
@@ -12,7 +12,7 @@ GREP=grep
 WC=wc
 
 UNAME_S=$(uname -s)
-if [ $UNAME_S="Darwin" ];
+if [ $UNAME_S = "Darwin" ];
 then
     # MacOS GNU versions which can be installed through Homebrew
     FIND=gfind


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The PR #1184 contained a bug in the multi-platform support which breaks it on Linux (missing spaces in the `if`). This PR should fix that.