### PR TITLE
Handled Kafka upgrade and downgrade exceptions with failed futures

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.InvalidConfigParameterException;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -155,7 +156,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                 lock.release();
                                 log.debug("{}: Lock {} released", reconciliation, lockName);
                                 if (createResult.failed()) {
-                                    if (createResult.cause() instanceof InvalidConfigParameterException) {
+                                    if (createResult.cause() instanceof InvalidResourceException) {
                                         log.error(createResult.cause().getMessage());
                                     } else {
                                         log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -484,14 +484,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                 // Force the user to explicitly set the log.message.format.version
                 // to match the old version
-                throw new KafkaUpgradeException(upgrade + " requires a message format change " +
+                return Future.failedFuture(new KafkaUpgradeException(upgrade + " requires a message format change " +
                         "from " + upgrade.from().messageVersion() + " to " + upgrade.to().messageVersion() + ". " +
                         "You must explicitly set " +
                         LOG_MESSAGE_FORMAT_VERSION + ": \"" + upgrade.from().messageVersion() + "\"" +
                         " in Kafka.spec.kafka.config to perform the upgrade. " +
                         "Then you can upgrade client applications. " +
                         "And finally you can remove " + LOG_MESSAGE_FORMAT_VERSION +
-                        " from Kafka.spec.kafka.config");
+                        " from Kafka.spec.kafka.config"));
             }
             // Otherwise both versions use the same message format, so we don't care.
 
@@ -639,14 +639,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // Force the user to explicitly set log.message.format.version
             // (Controller shouldn't break clients)
             if (oldMessageFormat == null || !oldMessageFormat.equals(upgrade.to().messageVersion())) {
-                throw new KafkaUpgradeException(
+                return Future.failedFuture(new KafkaUpgradeException(
                         String.format("Cannot downgrade Kafka cluster %s in namespace %s to version %s " +
                                         "because the current cluster is configured with %s=%s. " +
                                         "Downgraded brokers would not be able to understand existing " +
                                         "messages with the message version %s. ",
                                 name, namespace, upgrade.to(),
                                 LOG_MESSAGE_FORMAT_VERSION, oldMessageFormat,
-                                oldMessageFormat));
+                                oldMessageFormat)));
             }
 
             String lowerVersionProtocol = currentKafkaConfig.getConfigOption(INTERBROKER_PROTOCOL_VERSION);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

When an exception happens during a Kafka upgrade or downgrade, the entire stack trace is printed instead of just the error message as follow.

```
2019-01-03 16:56:59 ERROR AbstractAssemblyOperator:161 - Reconciliation #0(watch) Kafka(myproject/my-cluster): createOrUpdate failed
io.strimzi.operator.cluster.KafkaUpgradeException: Kafka version upgrade from 2.0.0 to 2.1.0 requires a message format change from 2.0 to 2.1. You must explicitly set log.message.format.version: "2.0" in Kafka.spec.kafka.config to perform the upgrade. Then you can upgrade client applications. And finally you can remove log.message.format.version from Kafka.spec.kafka.config
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.kafkaUpgradePhase1(KafkaAssemblyOperator.java:490) ~[classes/:?]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$null$14(KafkaAssemblyOperator.java:448) ~[classes/:?]
	at io.vertx.core.Future.lambda$compose$1(Future.java:265) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.SucceededFuture.setHandler(SucceededFuture.java:40) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.Future.compose(Future.java:261) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$kafkaUpgrade$18(KafkaAssemblyOperator.java:448) ~[classes/:?]
	at io.vertx.core.Future.lambda$compose$1(Future.java:265) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:151) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.Future.lambda$compose$1(Future.java:270) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:151) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:289) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339) ~[vertx-core-3.5.4.jar:3.5.4]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463) [netty-transport-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_191]
```
This PR add the exception handling using a failed Future and then printing just the ERROR message.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

