### PR TITLE
Added explicit log message format version config to Kafka examples

### DIFF
--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -13,6 +13,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      log.message.format.version: "2.1"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -13,6 +13,7 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      log.message.format.version: "2.1"
     storage:
       type: persistent-claim
       size: 100Gi

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -13,6 +13,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      log.message.format.version: "2.1"
     storage:
       type: persistent-claim
       size: 100Gi

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -63,10 +63,6 @@ parameters:
   displayName: Transaction state replication factor
   name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
   value: "3"
-- description: The version of the format using for storing messages
-  displayName: Log message format version
-  name: KAFKA_LOG_MESSAGE_FORMAT_VERSION
-  value: "2.1"
 objects:
 - apiVersion: kafka.strimzi.io/v1alpha1
   kind: Kafka
@@ -91,7 +87,7 @@ objects:
         default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
-        log.message.format.version: ${KAFKA_LOG_MESSAGE_FORMAT_VERSION}
+        log.message.format.version: ${KAFKA_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -63,6 +63,10 @@ parameters:
   displayName: Transaction state replication factor
   name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
   value: "3"
+- description: The version of the format using for storing messages
+  displayName: Log message format version
+  name: KAFKA_LOG_MESSAGE_FORMAT_VERSION
+  value: "2.1"
 objects:
 - apiVersion: kafka.strimzi.io/v1alpha1
   kind: Kafka
@@ -87,6 +91,7 @@ objects:
         default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
+        log.message.format.version: ${KAFKA_LOG_MESSAGE_FORMAT_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -69,10 +69,6 @@ parameters:
   displayName: Transaction state replication factor
   name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
   value: "3"
-- description: The version of the format using for storing messages
-  displayName: Log message format version
-  name: KAFKA_LOG_MESSAGE_FORMAT_VERSION
-  value: "2.1"
 objects:
 - apiVersion: kafka.strimzi.io/v1alpha1
   kind: Kafka
@@ -99,7 +95,7 @@ objects:
         default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
-        log.message.format.version: ${KAFKA_LOG_MESSAGE_FORMAT_VERSION}
+        log.message.format.version: ${KAFKA_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -69,6 +69,10 @@ parameters:
   displayName: Transaction state replication factor
   name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
   value: "3"
+- description: The version of the format using for storing messages
+  displayName: Log message format version
+  name: KAFKA_LOG_MESSAGE_FORMAT_VERSION
+  value: "2.1"
 objects:
 - apiVersion: kafka.strimzi.io/v1alpha1
   kind: Kafka
@@ -95,6 +99,7 @@ objects:
         default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
+        log.message.format.version: ${KAFKA_LOG_MESSAGE_FORMAT_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

From the Kafka upgrade documentation, it's clear that the `log.message.format.version` is needed to be set explicitly. Because users could use the examples in order to build their own Kafka resource, I think that it could be useful providing this field in the config section from the beginning to avoid them another rolling update during their first Kafka upgrade.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

