### PR TITLE
Use local loopback address instead of 'any' address for ZkImplTest

### DIFF
--- a/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
+++ b/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
@@ -9,6 +9,7 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 
@@ -21,7 +22,7 @@ public class EmbeddedZooKeeper {
     public EmbeddedZooKeeper() throws IOException, InterruptedException {
         dir = Files.createTempDirectory("strimzi").toFile();
         zk = new ZooKeeperServer(dir, dir, 1000);
-        start(new InetSocketAddress(0));
+        start(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 0));
     }
 
     private void start(InetSocketAddress addr) throws IOException, InterruptedException {

--- a/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
+++ b/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
@@ -9,7 +9,7 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 
@@ -22,7 +22,7 @@ public class EmbeddedZooKeeper {
     public EmbeddedZooKeeper() throws IOException, InterruptedException {
         dir = Files.createTempDirectory("strimzi").toFile();
         zk = new ZooKeeperServer(dir, dir, 1000);
-        start(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 0));
+        start(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     }
 
     private void start(InetSocketAddress addr) throws IOException, InterruptedException {


### PR DESCRIPTION
closes #1197

### Type of change
- Bugfix

### Description
Use local loopback address instead of 'any' address for ZkImplTest

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [N/A] Update/write design documentation in `./design`
- [N/A] Write tests
- [Done] Make sure all tests pass
- [N/A] Update documentation
- [N/A] Check RBAC rights for Kubernetes / OpenShift roles
- [N/A] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [N/A] Reference relevant issue(s) and close them after merging
- [N/A] Update CHANGELOG.md

