### PR TITLE
Unit tests should not rely on Properties ordering

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -5,19 +5,11 @@
 
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.operator.cluster.InvalidConfigParameterException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract class for processing and generating configuration passed by the user.
@@ -25,7 +17,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractConfiguration {
     private static final Logger log = LogManager.getLogger(AbstractConfiguration.class.getName());
 
-    private final Properties options;
+    private final OrderedProperties options = new OrderedProperties();
 
     /**
      * Constructor used to instantiate this class from String configuration. Should be used to create configuration
@@ -37,7 +29,8 @@ public abstract class AbstractConfiguration {
      *                           these keys will be ignored.
      */
     public AbstractConfiguration(String configuration, List<String> forbiddenOptions) {
-        this(configuration, forbiddenOptions, new Properties());
+        options.addStringPairs(configuration);
+        filterForbidden(forbiddenOptions);
     }
 
     /**
@@ -50,49 +43,10 @@ public abstract class AbstractConfiguration {
      *                          these keys will be ignored.
      * @param defaults          Properties object with default options
      */
-    public AbstractConfiguration(String configuration, List<String> forbiddenOptions, Properties defaults) {
-        Properties options = parseProperties(configuration, (Map<String, String>) (Map) defaults);
-        this.options = filterForbidden(options, forbiddenOptions);
-    }
-
-    protected static Properties parseProperties(String configuration, Map<String, String> defaults) {
-        Properties options = new Properties();
-        options.putAll(defaults);
-        try (StringReader reader = new StringReader(configuration)) {
-            options.load(reader);
-        } catch (IOException | IllegalArgumentException e)   {
-            log.error("Failed to read the configuration from String", e);
-        }
-        return options;
-    }
-
-    /**
-     * Converts the values from the configuration Json object to string or logs error if they have unsupported type
-     *
-     * @param json  JSON object with the configuration
-     * @return  Map with configuration values as String
-     */
-    private Map<String, String> convertToStrings(Iterable<Map.Entry<String, Object>> json)  {
-        Map<String, String> map = new HashMap<>();
-
-        for (Map.Entry<String, Object> entry : json)    {
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            if (value instanceof String)    {
-                map.put(key, (String) value);
-            } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean || value instanceof Double || value instanceof Float) {
-                map.put(key, String.valueOf(value));
-            } else if (value == null) {
-                log.error("A null value for key {} is not allowed", key);
-                throw new InvalidConfigParameterException(key, "A null value is not allowed for this key");
-            } else  {
-                log.error("Unsupported type {} in configuration for key {}", value.getClass(), key);
-                throw new InvalidConfigParameterException(key, " - Unsupported type " + value.getClass() + " in configuration for this key");
-            }
-        }
-
-        return map;
+    public AbstractConfiguration(String configuration, List<String> forbiddenOptions, Map<String, String> defaults) {
+        options.addMapPairs(defaults);
+        options.addStringPairs(configuration);
+        filterForbidden(forbiddenOptions);
     }
 
     /**
@@ -104,7 +58,8 @@ public abstract class AbstractConfiguration {
      *                           these keys will be ignored.
      */
     public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions) {
-        this(jsonOptions, forbiddenOptions, new Properties());
+        options.addIterablePairs(jsonOptions);
+        filterForbidden(forbiddenOptions);
     }
 
     /**
@@ -116,61 +71,45 @@ public abstract class AbstractConfiguration {
      *                           these keys will be ignored.
      * @param defaults          Properties object with default options
      */
-    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, Properties defaults) {
-        Properties options = new Properties();
-        options.putAll(defaults);
-        options.putAll(convertToStrings(jsonOptions));
-        this.options = filterForbidden(options, forbiddenOptions);
-    }
-
-    public AbstractConfiguration(Properties options) {
-        this.options = options;
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, Map<String, String> defaults) {
+        options.addMapPairs(defaults);
+        options.addIterablePairs(jsonOptions);
+        filterForbidden(forbiddenOptions);
     }
 
     /**
      * Filters forbidden values from the configuration.
      *
-     * @param options   Properties object with configuration options
      * @param forbiddenOptions  List with configuration keys which are not allowed. All keys which start with one of
      *                          these keys will be ignored.
      * @return  New Properties object which contains only allowed options.
      */
-    private Properties filterForbidden(Properties options, List<String> forbiddenOptions)   {
-        Properties filtered = new Properties();
-
-        Map<String, String> m = options.entrySet().stream()
-            .filter(e -> !forbiddenOptions.stream().anyMatch(s -> {
-                boolean forbidden = ((String) e.getKey()).toLowerCase(Locale.ENGLISH).startsWith(s);
-                if (forbidden) {
-                    log.warn("Configuration option \"{}\" is forbidden and will be ignored", e.getKey());
-                } else {
-                    log.trace("Configuration option \"{}\" is allowed and will be passed to the assembly", e.getKey());
-                }
-                return forbidden;
-            }))
-            .collect(Collectors.toMap(
-                v -> (String) v.getKey(), v -> (String) v.getValue()
-            ));
-
-        filtered.putAll(m);
-
-        return filtered;
+    private void filterForbidden(List<String> forbiddenOptions)   {
+        options.filter(k -> forbiddenOptions.stream().anyMatch(s -> {
+            boolean forbidden = k.toLowerCase(Locale.ENGLISH).startsWith(s);
+            if (forbidden) {
+                log.warn("Configuration option \"{}\" is forbidden and will be ignored", k);
+            } else {
+                log.trace("Configuration option \"{}\" is allowed and will be passed to the assembly", k);
+            }
+            return forbidden;
+        }));
     }
 
     public String getConfigOption(String configOption) {
-        return getConfigOption(configOption, null);
+        return options.asMap().get(configOption);
     }
 
     public String getConfigOption(String configOption, String defaultValue) {
-        return options.getProperty(configOption, defaultValue);
+        return options.asMap().getOrDefault(configOption, defaultValue);
     }
 
     public void setConfigOption(String configOption, String value) {
-        options.setProperty(configOption, value);
+        options.asMap().put(configOption, value);
     }
 
     public void removeConfigOption(String configOption) {
-        options.remove(configOption);
+        options.asMap().remove(configOption);
     }
 
     /**
@@ -179,35 +118,15 @@ public abstract class AbstractConfiguration {
      * @return  String with one or more lines containing key=value pairs with the configuration options.
      */
     public String getConfiguration() {
-        String configuration = "";
-
-        try (StringWriter writer = new StringWriter()) {
-            options.store(writer, null);
-            configuration = stripComments(writer.toString());
-        } catch (IOException e) {
-            log.error("Failed to store configuration into String", e);
-        }
-
-        return configuration;
+        return options.asPairs();
     }
 
     /**
-     * Strip comments from configuration string. Comments are lines starting with #. The default comment with timestamp
-     * which is always added by Proeprties class is otherwise triggering rolling update when used in EnvVar.
-     *
-     * @param configuration String with configuration which should be strip of comments (lines starting with #)
-     * @return  String with configuration without comments
+     * Get access to underlying key-value pairs.  Any changes to OrderedProperties will be reflected in
+     * in value returned by subsequent calls to getConfiguration()
+     * @return A map of keys to values.
      */
-    private String stripComments(String configuration)  {
-        StringBuilder builder = new StringBuilder();
-        String[] lines = configuration.split("\n");
-
-        for (String line : lines)   {
-            if (!line.startsWith("#"))  {
-                builder.append(line + "\n");
-            }
-        }
-
-        return builder.toString();
+    OrderedProperties asOrderedProperties() {
+        return options;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -9,10 +9,9 @@ import io.strimzi.api.kafka.model.KafkaClusterSpec;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyList;
 
 /**
  * Class for handling Kafka configuration passed by the user
@@ -36,7 +35,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
      *                      pairs.
      */
     public KafkaConfiguration(String configuration) {
-        super(configuration, FORBIDDEN_OPTIONS);
+        this(configuration, FORBIDDEN_OPTIONS);
     }
 
     /**
@@ -49,8 +48,8 @@ public class KafkaConfiguration extends AbstractConfiguration {
         super(jsonOptions, FORBIDDEN_OPTIONS);
     }
 
-    private KafkaConfiguration(Properties properties) {
-        super(properties);
+    private KafkaConfiguration(String configuration, List<String> forbiddenOptions) {
+        super(configuration, forbiddenOptions);
     }
 
     /**
@@ -59,6 +58,6 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @return The KafkaConfiguration
      */
     public static KafkaConfiguration unvalidated(String string) {
-        return new KafkaConfiguration(parseProperties(string, emptyMap()));
+        return new KafkaConfiguration(string, emptyList());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -7,9 +7,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaConnectSpec;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.util.Arrays.asList;
 
@@ -18,22 +18,22 @@ import static java.util.Arrays.asList;
  */
 public class KafkaConnectConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_OPTIONS;
-    private static final Properties DEFAULTS;
+    private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
 
-        DEFAULTS = new Properties();
-        DEFAULTS.setProperty("group.id", "connect-cluster");
-        DEFAULTS.setProperty("offset.storage.topic", "connect-cluster-offsets");
-        DEFAULTS.setProperty("config.storage.topic", "connect-cluster-configs");
-        DEFAULTS.setProperty("status.storage.topic", "connect-cluster-status");
-        DEFAULTS.setProperty("key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.setProperty("value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.setProperty("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.setProperty("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.setProperty("internal.key.converter.schemas.enable", "false");
-        DEFAULTS.setProperty("internal.value.converter.schemas.enable", "false");
+        DEFAULTS = new HashMap<>();
+        DEFAULTS.put("group.id", "connect-cluster");
+        DEFAULTS.put("offset.storage.topic", "connect-cluster-offsets");
+        DEFAULTS.put("config.storage.topic", "connect-cluster-configs");
+        DEFAULTS.put("status.storage.topic", "connect-cluster-status");
+        DEFAULTS.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULTS.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULTS.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULTS.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULTS.put("internal.key.converter.schemas.enable", "false");
+        DEFAULTS.put("internal.value.converter.schemas.enable", "false");
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -7,9 +7,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.util.Arrays.asList;
 
@@ -19,12 +19,12 @@ import static java.util.Arrays.asList;
 public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_OPTIONS;
-    private static final Properties DEFAULTS;
+    private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
 
-        DEFAULTS = new Properties();
+        DEFAULTS = new HashMap<>();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -7,9 +7,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.util.Arrays.asList;
 
@@ -19,12 +19,12 @@ import static java.util.Arrays.asList;
 public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_OPTIONS;
-    private static final Properties DEFAULTS;
+    private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
 
-        DEFAULTS = new Properties();
+        DEFAULTS = new HashMap<>();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.operator.cluster.InvalidConfigParameterException;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+
+/**
+ * A Set of insertion ordered Name/Value pairs.
+ */
+public class OrderedProperties {
+
+    private final Map<String, String> pairs = new LinkedHashMap<>();
+
+    /**
+     * Filter key/value pairs
+     *
+     * @param filter The predicate which determines wheather key/value pair will be retained.  The
+     * predicate is invoked with the key.  The pair is removed if the predicate returns true.
+     * @return this instance for chaining
+     */
+    public OrderedProperties filter(Predicate<String> filter) {
+        for (Iterator<Entry<String, String>> it = pairs.entrySet().iterator(); it.hasNext(); ) {
+            if (filter.test(it.next().getKey())) {
+                it.remove();
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Add Key/Value pairs
+     *
+     * @param additionalPairs Key/Value pairs to add to current set (may be null)
+     * @return this instance for chaining
+     */
+    public OrderedProperties addMapPairs(Map<?, ?> additionalPairs) {
+        addIterablePairs(additionalPairs.entrySet());
+        return this;
+    }
+
+    /**
+     * Converts the values from the Iterable into String values and adds the pairs to the current set.
+     *
+     * @param iterable Key/Value pairs
+     * @return this instance for chaining
+     * @throws InvalidConfigParameterException if value is null or is of an unsupported type
+     */
+    public OrderedProperties addIterablePairs(Iterable<? extends Map.Entry<?, ?>> iterable) {
+        for (Map.Entry<?, ?> entry : iterable) {
+            Object obj = entry.getKey();
+            if (!(obj instanceof String)) {
+                throw new InvalidConfigParameterException(
+                  obj != null ? obj.getClass().getCanonicalName() : "null", "Key must be a string");
+            }
+            String key = (String) obj;
+            Object value = entry.getValue();
+
+            if (value instanceof String) {
+                pairs.put(key, (String) value);
+            } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean
+                || value instanceof Double || value instanceof Float) {
+                pairs.put(key, String.valueOf(value));
+            } else if (value == null) {
+                throw new InvalidConfigParameterException(key, "A null value is not allowed for this key");
+            } else {
+                throw new InvalidConfigParameterException(key,
+                    " - Unsupported type " + value.getClass() + " in configuration for this key");
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Parse key/value pairs and add to the current pair set.
+     * N.B. values containing a newline or other control characters will probably cause problems!
+     * @param keyValuePairs Pairs in key=value format, pairs separated by newlines
+     * @throws InvalidConfigParameterException if value is null
+     * @return this instance for chaining
+     */
+    public OrderedProperties addStringPairs(String keyValuePairs) {
+        PropertiesReader reader = new PropertiesReader(pairs);
+        reader.read(keyValuePairs);
+        return this;
+    }
+
+    /**
+     * Add a key/value pair
+     * @param key The key
+     * @param value The value
+     * @return this instance for chaining
+     */
+    public OrderedProperties addPair(String key, String value) {
+        pairs.put(key, value);
+        return this;
+    }
+
+    /**
+     * Generate a string with pairs formatted as key=value separated by newlines.  This string is
+     * expected to be used as an environment variable in a bash script and subsequently used in a bash
+     * <a href="https://www.tldp.org/LDP/abs/html/here-docs.html">here document</a> to create a
+     * properties file.
+     *
+     * @return String with one or more lines containing key=value pairs with the configuration options.
+     */
+    public String asPairs() {
+        return new PropertiesWriter(pairs).writeString();
+    }
+
+    /**
+     * Return a Map view of the underlying key-value pairs. Any changes to this map will be reflected in
+     * in value returned by subsequent calls.
+     *
+     * @return A map of keys to values.
+     */
+    public Map<String, String> asMap() {
+        return pairs;
+    }
+
+    @Override
+    public int hashCode() {
+        return pairs.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof OrderedProperties && pairs.equals(((OrderedProperties) obj).pairs);
+    }
+
+    /**
+     * Read values into a Map&lt;String, String&gt; from a Properties compatible format.
+     * An instance of this class is not thread-safe; the result of invoking any of the
+     * read methods simultaneously is not defined.
+     */
+    static private class PropertiesReader {
+        private static final int EOF = -1;
+        private static final int NO_CHAR = -2;
+
+        private final Map<String, String> map;
+        private BufferedReader bufferedReader;
+        private int peekChar = NO_CHAR;
+
+        public PropertiesReader(Map<String, String> map) {
+            this.map = map;
+        }
+
+        /**
+         * Read map values from a String.
+         *
+         * @param keyValuePairs String containing name=value pairs separated by newlines.
+         */
+        public void read(String keyValuePairs) {
+            try {
+                read(new StringReader(keyValuePairs));
+            } catch (IOException e) {
+                throw new IllegalStateException("StringReader should not cause IOException", e);
+            }
+        }
+
+        /**
+         * Read map values from a Reader.  The Reader is closed after all values are read.
+         *
+         * @param reader Reader containing name=value pairs separated by newlines.
+         * @throws IOException when read or close fails
+         */
+        public void read(Reader reader) throws IOException {
+            try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+                read(bufferedReader);
+            }
+        }
+
+        /**
+         * Read map values from a BufferedReader.  The BufferedReader is not closed after all values are
+         * read.
+         *
+         * @param bufferedReader Reader containing name=value pairs separated by newlines.
+         * @throws IOException when read or close fails
+         */
+        public void read(BufferedReader bufferedReader) throws IOException {
+            this.bufferedReader = bufferedReader;
+            for (; ; ) {
+                ignoreWhitespace(true);
+                if (peekChar == EOF) {
+                    return;
+                }
+
+                if (isComment()) {
+                    ignoreToEndOfLine();
+                    continue;
+                }
+
+                String key = readToken(true);
+
+                ignoreWhitespace(false);
+                if (isKeySeparator()) {
+                    peekChar = NO_CHAR;
+                    ignoreWhitespace(false);
+                }
+
+                String value = readToken(false);
+                map.put(key, value);
+            }
+        }
+
+        private String readToken(boolean breakOnKeySeperator) throws IOException {
+            StringBuilder sb = new StringBuilder();
+            for (; ; ) {
+                switch (peekChar) {
+                    case '\t':
+                    case '\f':
+                    case ' ':
+                    case ':':
+                    case '=':
+                        if (!breakOnKeySeperator) {
+                            break;
+                        }
+                    case '\r':
+                    case '\n':
+                    case EOF:
+                        return sb.toString();
+                    case '\\':
+                        sb.append(readEscape());
+                        continue;
+                }
+                sb.append((char) peekChar);
+                peekChar = bufferedReader.read();
+            }
+        }
+
+        private String readEscape() throws IOException {
+            int ec = bufferedReader.read();
+            String rc;
+            switch (ec) {
+                case '\r':
+                    peekChar = bufferedReader.read();
+                    if (peekChar != '\n') {
+                        return "";
+                    }
+                case '\n':
+                    rc = "";
+                    break;
+                case 'u':
+                    rc = readUnicode();
+                    break;
+                case 't':
+                    rc = "\t";
+                    break;
+                case 'f':
+                    rc = "\f";
+                    break;
+                case 'r':
+                    rc = "\r";
+                    break;
+                case 'n':
+                    rc = "\n";
+                    break;
+                default:
+                    rc = Character.toString((char) ec);
+                    break;
+            }
+            peekChar = bufferedReader.read();
+            return rc;
+        }
+
+        private String readUnicode() throws IOException {
+            int sum = 0;
+            for (int h = 0; h < 4; ++h) {
+                int hexIt;
+                peekChar = bufferedReader.read();
+                if (peekChar >= '0' && peekChar <= '9') {
+                    hexIt = peekChar - '0';
+                } else if (peekChar >= 'a' && peekChar <= 'f') {
+                    hexIt = peekChar - 'a' + 10;
+                } else if (peekChar >= 'A' && peekChar <= 'F') {
+                    hexIt = peekChar - 'A' + 10;
+                } else {
+                    throw new IllegalArgumentException("Malformed \\uxxxx encoding");
+                }
+                sum = sum * 16 + hexIt;
+            }
+            return Character.toString((char) sum);
+        }
+
+        /*
+         * On entry, peekChar is at comment char
+         * On exit, peekChar is at newline or EOF
+         */
+        private void ignoreToEndOfLine() throws IOException {
+            for (; ; ) {
+                peekChar = bufferedReader.read();
+                if (isEol()) {
+                    break;
+                }
+            }
+        }
+
+        /*
+         * On entry, peekChar is at NO_CHAR or after key
+         * On exit, peekChar is at non-whitespace, newline or EOF
+         */
+        private void ignoreWhitespace(boolean includeNewLine) throws IOException {
+            for (; ; peekChar = bufferedReader.read()) {
+                switch (peekChar) {
+                    case '\r':
+                    case '\n':
+                        if (!includeNewLine) {
+                            return;
+                        }
+                    case '\t':
+                    case '\f':
+                    case ' ':
+                    case NO_CHAR:
+                        continue;
+                    default:
+                        return;
+                }
+            }
+        }
+
+        private boolean isComment() {
+            switch (peekChar) {
+                case '!':
+                case '#':
+                    return true;
+            }
+            return false;
+        }
+
+        private boolean isKeySeparator() {
+            switch (peekChar) {
+                case '=':
+                case ':':
+                    return true;
+            }
+            return false;
+        }
+
+        private boolean isEol() {
+            switch (peekChar) {
+                case '\r':
+                case '\n':
+                case EOF:
+                    return true;
+            }
+            return false;
+        }
+    }
+
+
+    /**
+     * Write values from a Map&lt;String, String&gt; in a Properties compatible format.
+     * Unlike Properties.store(), no comments are added to beginning of output and escapes sequences are
+     * minimized.
+     *
+     * Each line contains name=value.
+     * Any '=', ':', ' ', '\t', '\f', or '\n' in the name will be escaped with '\'.
+     * Any '\r', '\n' in the value will be escaped with '\'.
+     * Any leading ' ', '\t', '\f' in value will be escaped with '\'.
+     *
+     * An instance of this class is thread-safe as long as iterating the wrapped map is thread-safe.
+     */
+    static private class PropertiesWriter {
+        private final Map<String, String> map;
+        private BufferedWriter bufferedWriter;
+
+        public PropertiesWriter(Map<String, String> map) {
+            this.map = map;
+        }
+
+        /**
+         * Write map values to a String.
+         *
+         * @return A String containing name=value pairs separated by newlines.
+         */
+        public String writeString() {
+            StringWriter sw = new StringWriter();
+            try {
+                write(sw);
+            } catch (IOException e) {
+                throw new IllegalStateException("StringWriter should not cause IOException", e);
+            }
+            return sw.toString();
+        }
+
+        /**
+         * Write map values to Writer.  The Writer is not closed.
+         *
+         * @param writer Writer to write values to.
+         */
+        public void write(Writer writer) throws IOException {
+            write(new BufferedWriter(writer));
+        }
+
+        /**
+         * Write map values to BufferedWriter.  The BufferedWriter is not closed.
+         *
+         * @param bufferedWriter BufferedWriter to write values to.
+         */
+        public void write(BufferedWriter bufferedWriter) throws IOException {
+            this.bufferedWriter = bufferedWriter;
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                escapeKey(entry.getKey());
+                bufferedWriter.append('=');
+                escapeValue(entry.getValue());
+                bufferedWriter.newLine();
+            }
+            bufferedWriter.flush();
+        }
+
+        /**
+         * A properties key may not contain '=', ':', ' ', '\t', '\f', or '\n'.
+         * Escape the key
+         */
+        private void escapeKey(String k) throws IOException {
+            for (int i = 0; i < k.length(); ++i) {
+                char c = k.charAt(i);
+                switch (c) {
+                    case '\n':
+                        bufferedWriter.append("\\n");
+                        continue;
+                    case '=':
+                    case ':':
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                    case '\\':
+                        bufferedWriter.append('\\');
+                }
+                bufferedWriter.append(c);
+            }
+        }
+
+        /**
+         * A properties value may not contain '\r', '\n'.  Value may not have leading white space.
+         * Escape the value
+         */
+        private void escapeValue(String v) throws IOException {
+            for (int i = 0; i < v.length(); ++i) {
+                char c = v.charAt(i);
+                switch (c) {
+                    case '\r':
+                        bufferedWriter.append("\\r");
+                        break;
+                    case '\n':
+                        bufferedWriter.append("\\n");
+                        break;
+                    case '\\':
+                        bufferedWriter.append("\\\\");
+                        break;
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                        // Value may not have leading white space.
+                        if (i == 0) {
+                            bufferedWriter.append('\\');
+                        }
+                    default:
+                        bufferedWriter.append(c);
+                }
+            }
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
@@ -47,7 +47,7 @@ public class OrderedProperties {
      * @param additionalPairs Key/Value pairs to add to current set (may be null)
      * @return this instance for chaining
      */
-    public OrderedProperties addMapPairs(Map<?, ?> additionalPairs) {
+    public OrderedProperties addMapPairs(Map<String, String> additionalPairs) {
         addIterablePairs(additionalPairs.entrySet());
         return this;
     }
@@ -55,18 +55,13 @@ public class OrderedProperties {
     /**
      * Converts the values from the Iterable into String values and adds the pairs to the current set.
      *
-     * @param iterable Key/Value pairs
+     * @param iterable Key/Value pairs These are Map.Entry&lt;?, ?&gt; due to Properties extending Hashtable&lt;?, ?&gt;
      * @return this instance for chaining
      * @throws InvalidConfigParameterException if value is null or is of an unsupported type
      */
-    public OrderedProperties addIterablePairs(Iterable<? extends Map.Entry<?, ?>> iterable) {
-        for (Map.Entry<?, ?> entry : iterable) {
-            Object obj = entry.getKey();
-            if (!(obj instanceof String)) {
-                throw new InvalidConfigParameterException(
-                  obj != null ? obj.getClass().getCanonicalName() : "null", "Key must be a string");
-            }
-            String key = (String) obj;
+    public OrderedProperties addIterablePairs(Iterable<? extends Map.Entry<String, ?>> iterable) {
+        for (Map.Entry<String, ?> entry : iterable) {
+            String key = entry.getKey();
             Object value = entry.getValue();
 
             if (value instanceof String) {
@@ -86,7 +81,6 @@ public class OrderedProperties {
 
     /**
      * Parse key/value pairs and add to the current pair set.
-     * N.B. values containing a newline or other control characters will probably cause problems!
      * @param keyValuePairs Pairs in key=value format, pairs separated by newlines
      * @throws InvalidConfigParameterException if value is null
      * @return this instance for chaining
@@ -245,13 +239,10 @@ public class OrderedProperties {
             String rc;
             switch (ec) {
                 case '\r':
-                    peekChar = bufferedReader.read();
-                    if (peekChar != '\n') {
-                        return "";
-                    }
                 case '\n':
-                    rc = "";
-                    break;
+                    peekChar = bufferedReader.read();
+                    ignoreWhitespace(true);
+                    return "";
                 case 'u':
                     rc = readUnicode();
                     break;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -7,9 +7,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.util.Arrays.asList;
 
@@ -19,17 +19,17 @@ import static java.util.Arrays.asList;
 public class ZookeeperConfiguration extends AbstractConfiguration {
 
     private static final List<String> FORBIDDEN_OPTIONS;
-    private static final Properties DEFAULTS;
+    private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(
                 ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(" *, *"));
 
-        DEFAULTS = new Properties();
-        DEFAULTS.setProperty("timeTick", "2000");
-        DEFAULTS.setProperty("initLimit", "5");
-        DEFAULTS.setProperty("syncLimit", "2");
-        DEFAULTS.setProperty("autopurge.purgeInterval", "1");
+        DEFAULTS = new HashMap<>();
+        DEFAULTS.put("timeTick", "2000");
+        DEFAULTS.put("initLimit", "5");
+        DEFAULTS.put("syncLimit", "2");
+        DEFAULTS.put("autopurge.purgeInterval", "1");
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -66,28 +65,20 @@ public class KafkaConnectClusterTest {
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
-    private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
-            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
-            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
-            "foo=bar" + LINE_SEPARATOR +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
-    private final String defaultConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
-            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
-            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
-
+    private final OrderedProperties defaultConfiguration = new OrderedProperties()
+            .addPair("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("config.storage.topic", "connect-cluster-configs")
+            .addPair("group.id", "connect-cluster")
+            .addPair("status.storage.topic", "connect-cluster-status")
+            .addPair("internal.value.converter.schemas.enable", "false")
+            .addPair("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("offset.storage.topic", "connect-cluster-offsets")
+            .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("internal.key.converter.schemas.enable", "false")
+            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+    private final OrderedProperties expectedConfiguration = new OrderedProperties()
+            .addMapPairs(defaultConfiguration.asMap())
+            .addPair("foo", "bar");
     private final KafkaConnect resource = new KafkaConnectBuilder(ResourceUtils.createEmptyKafkaConnectCluster(namespace, cluster))
             .withNewSpec()
             .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))
@@ -132,7 +123,7 @@ public class KafkaConnectClusterTest {
     protected List<EnvVar> getExpectedEnvVars() {
 
         List<EnvVar> expected = new ArrayList<>();
-        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration.asPairs()).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_OPTS).withValue(KafkaConnectCluster.DEFAULT_KAFKA_GC_LOGGING).build());
@@ -150,7 +141,7 @@ public class KafkaConnectClusterTest {
         assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.readinessTimeout);
         assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY, kc.livenessInitialDelay);
         assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.livenessTimeout);
-        assertEquals(defaultConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(defaultConfiguration, kc.getConfiguration().asOrderedProperties());
     }
 
     @Test
@@ -161,7 +152,7 @@ public class KafkaConnectClusterTest {
         assertEquals(healthTimeout, kc.readinessTimeout);
         assertEquals(healthDelay, kc.livenessInitialDelay);
         assertEquals(healthTimeout, kc.livenessTimeout);
-        assertEquals(expectedConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(expectedConfiguration, kc.getConfiguration().asOrderedProperties());
         assertEquals(bootstrapServers, kc.bootstrapServers);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -73,27 +72,20 @@ public class KafkaConnectS2IClusterTest {
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
-    private final String expectedConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
-            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
-            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
-            "foo=bar" + LINE_SEPARATOR +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
-    private final String defaultConfiguration = "group.id=connect-cluster" + LINE_SEPARATOR +
-            "key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.key.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "config.storage.topic=connect-cluster-configs" + LINE_SEPARATOR +
-            "status.storage.topic=connect-cluster-status" + LINE_SEPARATOR +
-            "offset.storage.topic=connect-cluster-offsets" + LINE_SEPARATOR +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR +
-            "internal.value.converter.schemas.enable=false" + LINE_SEPARATOR +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter" + LINE_SEPARATOR;
+    private final OrderedProperties defaultConfiguration = new OrderedProperties()
+            .addPair("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("config.storage.topic", "connect-cluster-configs")
+            .addPair("group.id", "connect-cluster")
+            .addPair("status.storage.topic", "connect-cluster-status")
+            .addPair("internal.value.converter.schemas.enable", "false")
+            .addPair("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("offset.storage.topic", "connect-cluster-offsets")
+            .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
+            .addPair("internal.key.converter.schemas.enable", "false")
+            .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+    private final OrderedProperties expectedConfiguration = new OrderedProperties()
+            .addMapPairs(defaultConfiguration.asMap())
+            .addPair("foo", "bar");
     private final boolean insecureSourceRepo = false;
 
 
@@ -132,7 +124,7 @@ public class KafkaConnectS2IClusterTest {
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
-        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration).build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration.asPairs()).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
         expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_OPTS).withValue(KafkaConnectCluster.DEFAULT_KAFKA_GC_LOGGING).build());
@@ -151,7 +143,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.readinessTimeout);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_DELAY, kc.livenessInitialDelay);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.livenessTimeout);
-        assertEquals(defaultConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(defaultConfiguration, kc.getConfiguration().asOrderedProperties());
         assertFalse(kc.isInsecureSourceRepository());
     }
 
@@ -164,7 +156,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(healthTimeout, kc.readinessTimeout);
         assertEquals(healthDelay, kc.livenessInitialDelay);
         assertEquals(healthTimeout, kc.livenessTimeout);
-        assertEquals(expectedConfiguration, kc.getConfiguration().getConfiguration());
+        assertEquals(expectedConfiguration, kc.getConfiguration().asOrderedProperties());
         assertEquals(bootstrapServers, kc.bootstrapServers);
         assertFalse(kc.isInsecureSourceRepository());
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OrderedPropertiesTest {
+
+    private OrderedProperties createTestKeyValues() {
+        return new OrderedProperties()
+            .addPair("first", "1")
+            .addPair("second", "2")
+            .addPair("third", "3")
+            .addPair("FOURTH", "4");
+    }
+
+    private void assertKeyOrder(OrderedProperties pairs, String... expected) {
+        Assert.assertArrayEquals(expected, pairs.asMap().keySet().toArray(new String[] {}));
+    }
+
+    private void assertValueOrder(OrderedProperties pairs, String... expected) {
+        Assert.assertArrayEquals(expected, pairs.asMap().values().toArray(new String[] {}));
+    }
+
+    @Test
+    public void insertOrder() {
+        assertKeyOrder(createTestKeyValues(), "first", "second", "third", "FOURTH");
+    }
+
+    @Test
+    public void filter() {
+        OrderedProperties pairs = createTestKeyValues();
+        pairs.filter(k -> k.equalsIgnoreCase("second"));
+        assertKeyOrder(pairs, "first", "third", "FOURTH");
+    }
+
+    @Test
+    public void addMapPairs() {
+        Map<String, String> additional = new LinkedHashMap<>();
+        additional.put("fifth", "5");
+        additional.put("first", "6");
+
+        OrderedProperties pairs = createTestKeyValues().addMapPairs(additional);
+        assertKeyOrder(pairs, "first", "second", "third", "FOURTH", "fifth");
+        assertValueOrder(pairs, "6", "2", "3", "4", "5");
+    }
+
+    @Test
+    public void addIterablePairs() {
+        Map<String, Object> additional = new LinkedHashMap<>();
+        additional.put("fifth", 5);
+        additional.put("first", 6L);
+        additional.put("second", true);
+        additional.put("third", 2.3);
+        additional.put("FOURTH", 4.6D);
+
+        OrderedProperties pairs = createTestKeyValues().addIterablePairs(additional.entrySet());
+        assertKeyOrder(pairs, "first", "second", "third", "FOURTH", "fifth");
+        assertValueOrder(pairs, "6", "true", "2.3", "4.6", "5");
+    }
+
+    @Test
+    public void addStringPairs() {
+        OrderedProperties pairs = new OrderedProperties()
+            .addStringPairs("first=1\nsecond=2\nthird=3\nFOURTH=4");
+        assertValueOrder(pairs, "1", "2", "3", "4");
+    }
+
+    @Test
+    public void asPairs() {
+        Assert.assertEquals("first=1\nsecond=2\nthird=3\nFOURTH=4\n", createTestKeyValues().asPairs());
+    }
+
+    @Test
+    public void asMap() {
+        OrderedProperties pairs = createTestKeyValues();
+        pairs.asMap().put("fifth", "5");
+        assertKeyOrder(pairs, "first", "second", "third", "FOURTH", "fifth");
+    }
+
+    private static Properties loadProperties(String string) throws IOException {
+        Properties actual = new Properties();
+        actual.load(new StringReader(string));
+        return actual;
+    }
+
+    static private void propertiesCompatibility(OrderedProperties pairs) throws IOException {
+        Properties actual = loadProperties(pairs.asPairs());
+        Map<String, String> expected = pairs.asMap();
+        Assert.assertEquals(expected, actual);
+    }
+
+    static private Map<String, String> propertiesCompatibility(String pairs) throws IOException {
+        Properties expected = loadProperties(pairs);
+        Map<String, String> actual = new OrderedProperties().addStringPairs(pairs).asMap();
+        Assert.assertEquals(expected, actual);
+        return actual;
+    }
+
+    @Test
+    public void simpleProperties() throws IOException {
+        propertiesCompatibility(createTestKeyValues());
+    }
+
+    @Test
+    public void propertiesContainsEscapes() throws IOException {
+        OrderedProperties pairs = new OrderedProperties()
+            .addPair(" leading", " leading")
+            .addPair("trailing ", "trailing ")
+            .addPair("with\\escape", "with\\escape\r\n\f\t")
+            .addPair("two\nparts", " leading and trailing ")
+            .addPair("\\", "\\")
+            .addPair("", "");
+        propertiesCompatibility(pairs);
+    }
+
+    @Test
+    public void roundTrip() {
+        OrderedProperties expected = new OrderedProperties()
+            .addPair(" leading", " leading")
+            .addPair("trailing ", "trailing ")
+            .addPair("with\\escape", "with\\escape\r\n\f\t")
+            .addPair("two\nparts", " leading and trailing ")
+            .addPair("\\", "\\")
+            .addPair("", "");
+        Assert.assertEquals(expected, new OrderedProperties().addMapPairs(expected.asMap()));
+    }
+
+    @Test
+    public void propertiesComments() throws IOException {
+        Map<String, String> actual = propertiesCompatibility("! ignore\n  # ignore #\n bare_key");
+
+        OrderedProperties expected = new OrderedProperties().addPair("bare_key", "");
+        Assert.assertEquals(expected.asMap(), actual);
+    }
+
+    @Test
+    public void lineContinuation() throws IOException {
+        Map<String, String> actual = propertiesCompatibility("cr:split\\\rvalue\nnl:split\\\nvalue\ncrnl:split\\\r\nvalue\nno:split");
+
+        OrderedProperties expected = new OrderedProperties()
+            .addPair("cr", "splitvalue")
+            .addPair("nl", "splitvalue")
+            .addPair("crnl", "splitvalue")
+            .addPair("no", "split");
+        Assert.assertEquals(expected.asMap(), actual);
+    }
+
+    @Test
+    public void unicodeEscape() throws IOException {
+        Map<String, String> actual = propertiesCompatibility("unicode=\\u0123X\\uAbBa");
+
+        OrderedProperties expected = new OrderedProperties()
+            .addPair("unicode", "\u0123X\uAbBa");
+        Assert.assertEquals(expected.asMap(), actual);
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
@@ -143,6 +143,24 @@ public class OrderedPropertiesTest {
     }
 
     @Test
+    public void propertiesLeadingSpaceAfterNewLine() throws IOException {
+        Map<String, String> actual = propertiesCompatibility("key : multi\\\n \\\r\n \t line");
+
+        OrderedProperties expected = new OrderedProperties().addPair("key", "multiline");
+        Assert.assertEquals(expected.asMap(), actual);
+    }
+
+    @Test
+    public void spacesBeforeAndAfterKey() throws IOException {
+        Map<String, String> actual = propertiesCompatibility("  before: 1\nafter : 2");
+
+        OrderedProperties expected = new OrderedProperties()
+            .addPair("before", "1")
+            .addPair("after", "2");
+        Assert.assertEquals(expected.asMap(), actual);
+    }
+
+    @Test
     public void lineContinuation() throws IOException {
         Map<String, String> actual = propertiesCompatibility("cr:split\\\rvalue\nnl:split\\\nvalue\ncrnl:split\\\r\nvalue\nno:split");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -175,12 +174,15 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(healthDelay), containers.get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
-        String expectedConfig = "timeTick=2000" + LINE_SEPARATOR +
-                        "autopurge.purgeInterval=1" + LINE_SEPARATOR +
-                        "syncLimit=2" + LINE_SEPARATOR +
-                        "initLimit=5" + LINE_SEPARATOR +
-                        "foo=bar" + LINE_SEPARATOR;
-        assertEquals(expectedConfig, AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
+        OrderedProperties expectedConfig = new OrderedProperties()
+                    .addPair("timeTick", "2000")
+                    .addPair("autopurge.purgeInterval", "1")
+                    .addPair("syncLimit", "2")
+                    .addPair("initLimit", "5")
+                    .addPair("foo", "bar");
+        OrderedProperties actual = new OrderedProperties()
+                    .addStringPairs(AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
+        assertEquals(expectedConfig, actual);
         assertEquals(ZookeeperCluster.DEFAULT_KAFKA_GC_LOGGING, AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_OPTS));
         // checks on the TLS sidecar container
         Container tlsSidecarContainer = containers.get(1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -54,7 +54,7 @@ class ConnectST extends AbstractST {
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.plainBootstrapAddress(KAFKA_CLUSTER_NAME);
-    private static final String EXPECTED_CONFIG = "group.id=connect-cluster\n" +
+    private static final Map EXPECTED_CONFIG = loadProperties("group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.key.converter.schemas.enable=false\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
@@ -63,7 +63,7 @@ class ConnectST extends AbstractST {
             "offset.storage.topic=connect-cluster-offsets\n" +
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n");
 
     private static Resources classResources;
 
@@ -78,8 +78,7 @@ class ConnectST extends AbstractST {
 
         assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
                 hasItem(KAFKA_CONNECT_BOOTSTRAP_SERVERS)));
-        assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONNECT_CONFIGURATION"),
-                hasItem(EXPECTED_CONFIG)));
+        assertEquals(EXPECTED_CONFIG, getPropertiesFromJson(kafkaPodJson, "KAFKA_CONNECT_CONFIGURATION"));
         testDockerImagesForKafkaConnect();
     }
 


### PR DESCRIPTION
closes #1194

### Type of change

_Select the type of your PR_

- Bugfix
- Refactoring

### Description

Refactor AbstractConfiguration and unit tests to not rely upon Properties ordering.  (Different implementations have different ordering)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [N/A] Update/write design documentation in `./design`
- [done] Write tests
- [done] Make sure all tests pass
- [N/A] Update documentation
- [N/A] Check RBAC rights for Kubernetes / OpenShift roles
- [N/A] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [N/A] Update CHANGELOG.md

