### PR TITLE
Get rid of StrimziRunner in the Java doc

### DIFF
--- a/api/src/test/java/io/strimzi/test/ClusterOperator.java
+++ b/api/src/test/java/io/strimzi/test/ClusterOperator.java
@@ -10,8 +10,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner to create a cluster operator before, and delete a cluster operator after,
+ * Annotation for test classes or methods using {@code @ExtendWith(StrimziExtension.class)}
+ * which enables to create a cluster operator before, and delete a cluster operator after,
  * the tests.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/api/src/test/java/io/strimzi/test/EnvVariables.java
+++ b/api/src/test/java/io/strimzi/test/EnvVariables.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
  * <p>
  * An example would be:
  * <pre>
- * &#064;RunWith({@link StrimziRunner})
+ * &#064;ExtendedWith({@link StrimziExtension})
  * &#064;ClusterOperator(envVariables = {
  * &#064;EnvVariables(key = "foo", value = "bar")
  * })

--- a/api/src/test/java/io/strimzi/test/Namespace.java
+++ b/api/src/test/java/io/strimzi/test/Namespace.java
@@ -11,8 +11,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner to create namespaces before, and delete namespaces after,
+ * Annotation for test classes or methods using {@code @ExtendWith(StrimziExtension.class)}
+ * which enables to create namespaces before, and delete namespaces after,
  * the tests.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/api/src/test/java/io/strimzi/test/Resources.java
+++ b/api/src/test/java/io/strimzi/test/Resources.java
@@ -11,8 +11,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner to create resources before, and delete resources after,
+ * Annotation for test classes or methods using {@code @ExtendWith(StrimziExtension.class)}
+ * which enables to create resources before, and delete resources after,
  * the tests.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This trivial PR gets rid of `StrimziRunner` mentions in the Java doc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

