### PR TITLE
Delete unexpected pods after each test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -1051,6 +1051,8 @@ public abstract class AbstractST {
             podStream.forEach(
                 p -> nonTerminated.append("\n").append(p.getMetadata().getName()).append(" - ").append(p.getStatus().getPhase())
             );
+            // Delete remaining pods if there are some
+            podStream.forEach(p -> waitForPodDeletion(client.getNamespace(),p.getMetadata().getName()));
             throw new Exception("There are some unexpected pods! Cleanup is not finished properly!" + nonTerminated);
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -92,7 +92,6 @@ class KafkaST extends AbstractST {
     @Test
     @Tag(REGRESSION)
     @OpenShiftOnly
-    @Resources(value = "../examples/templates/cluster-operator", asAdmin = true)
     void testDeployKafkaClusterViaTemplate() {
         Oc oc = (Oc) kubeClient;
         String clusterName = "openshift-my-cluster";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Added dynamic pod deletion after test in case, that are some unexpected remaining pods. If there were some pods after tests, they stay there for whole class and it affects other tests in the class.

### Checklist

- [ ] Make sure all tests pass

