### PR TITLE
Removed check on spec field now checked by related assembly operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -57,7 +57,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 Labels.fromResource(kafkaConnectS2I).withKind(kafkaConnectS2I.getKind())));
 
         cluster.setOwnerReference(kafkaConnectS2I);
-        cluster.setInsecureSourceRepository(spec != null ? spec.isInsecureSourceRepository() : false);
+        cluster.setInsecureSourceRepository(spec.isInsecureSourceRepository());
 
         return cluster;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -163,21 +163,20 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
         kafkaMirrorMakerCluster.setReplicas(kafkaMirrorMaker.getSpec() != null && kafkaMirrorMaker.getSpec().getReplicas() > 0 ? kafkaMirrorMaker.getSpec().getReplicas() : DEFAULT_REPLICAS);
 
-        if (kafkaMirrorMaker.getSpec() != null) {
-            kafkaMirrorMakerCluster.setWhitelist(kafkaMirrorMaker.getSpec().getWhitelist());
-            kafkaMirrorMakerCluster.setProducer(kafkaMirrorMaker.getSpec().getProducer());
-            kafkaMirrorMakerCluster.setConsumer(kafkaMirrorMaker.getSpec().getConsumer());
-            kafkaMirrorMakerCluster.setImage(versions.kafkaMirrorMakerImage(
-                    kafkaMirrorMaker.getSpec().getImage(),
-                    kafkaMirrorMaker.getSpec().getVersion()));
-            kafkaMirrorMakerCluster.setLogging(kafkaMirrorMaker.getSpec().getLogging());
-            kafkaMirrorMakerCluster.setGcLoggingEnabled(kafkaMirrorMaker.getSpec().getJvmOptions() == null ? true : kafkaMirrorMaker.getSpec().getJvmOptions().isGcLoggingEnabled());
 
-            Map<String, Object> metrics = kafkaMirrorMaker.getSpec().getMetrics();
-            if (metrics != null) {
-                kafkaMirrorMakerCluster.setMetricsEnabled(true);
-                kafkaMirrorMakerCluster.setMetricsConfig(metrics.entrySet());
-            }
+        kafkaMirrorMakerCluster.setWhitelist(kafkaMirrorMaker.getSpec().getWhitelist());
+        kafkaMirrorMakerCluster.setProducer(kafkaMirrorMaker.getSpec().getProducer());
+        kafkaMirrorMakerCluster.setConsumer(kafkaMirrorMaker.getSpec().getConsumer());
+        kafkaMirrorMakerCluster.setImage(versions.kafkaMirrorMakerImage(
+                kafkaMirrorMaker.getSpec().getImage(),
+                kafkaMirrorMaker.getSpec().getVersion()));
+        kafkaMirrorMakerCluster.setLogging(kafkaMirrorMaker.getSpec().getLogging());
+        kafkaMirrorMakerCluster.setGcLoggingEnabled(kafkaMirrorMaker.getSpec().getJvmOptions() == null ? true : kafkaMirrorMaker.getSpec().getJvmOptions().isGcLoggingEnabled());
+
+        Map<String, Object> metrics = kafkaMirrorMaker.getSpec().getMetrics();
+        if (metrics != null) {
+            kafkaMirrorMakerCluster.setMetricsEnabled(true);
+            kafkaMirrorMakerCluster.setMetricsConfig(metrics.entrySet());
         }
 
         setClientAuth(kafkaMirrorMakerCluster, kafkaMirrorMaker.getSpec().getConsumer());


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Because the check of nullability of `spec` is done by the corresponding assembly operator, logging an error and avoiding an NPE, this PR removes the check on `spec` field in the connect and mirror maker models (this check doesn't exist in kafka and zookeeper as well) for consistency.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

