### PR TITLE
Use exitStatus==0 of 'minikube status' to determine if minikube is av…

### DIFF
--- a/api/src/test/java/io/strimzi/test/k8s/Minikube.java
+++ b/api/src/test/java/io/strimzi/test/k8s/Minikube.java
@@ -19,10 +19,7 @@ public class Minikube implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            String output = Exec.exec(CMD, "status").out();
-            return output.contains("minikube: Running")
-                    && output.contains("cluster: Running")
-                    && output.contains("kubectl: Correctly Configured:");
+            return Exec.exec(CMD, "status").exitStatus() == 0;
         } catch (KubeClusterException e) {
             return false;
         }


### PR DESCRIPTION
Use exitStatus==0 of 'minikube status' to determine if minikube is available
closes #1213

### Type of change

_Select the type of your PR_

- Bugfix

### Description
io.strimzi.test.k8s.Minikube does not correctly detect Minikube v0.32.0
```minikube status``` produces the result:
```
host: Running
kubelet: Running
apiserver: Running
kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100
```
The test support class was looking for result:
```
minikube: Running
cluster: Running
kubectl: Correctly Configured:
```

This changes checks for a zero result code of executing ```minikube status```.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

