### PR TITLE
Docs: use oc instead of kubectl when dealing with Openshift

### DIFF
--- a/documentation/book/proc-installing-your-own-ca-certificates.adoc
+++ b/documentation/book/proc-installing-your-own-ca-certificates.adoc
@@ -78,7 +78,7 @@ oc delete secret _<ca-key-secret>_
 # Create the new one
 oc create secret generic _<ca-key-secret>_ \
   --from-file=ca.key=_<ca-key-file>_ \
-  && kubectl label secret _<ca-key-secret>_ \
+  && oc label secret _<ca-key-secret>_ \
   strimzi.io/kind=Kafka \
   strimzi.io/cluster=_<my-cluster>_
 ----
@@ -98,4 +98,4 @@ spec:
 
 //.Additional resources
 //
-//* For the procedure for renewing CA certificates you have previousy //installed, see xref:renewing-your-own-ca-certificates-{context}[]
+//* For the procedure for renewing CA certificates you have previously //installed, see xref:renewing-your-own-ca-certificates-{context}[]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Docs: use oc instead of kubectl when dealing with Openshift
Fix typo
 
### Checklist

- [x] Update documentation

