### PR TITLE
ST: Recreate/clear test environment after failed tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -73,7 +73,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
-import static io.strimzi.test.StrimziExtension.CO_INSTALL_DIR;
+import static io.strimzi.test.extensions.StrimziExtension.CO_INSTALL_DIR;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.toYamlString;
 import static io.strimzi.test.TestUtils.waitFor;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -50,9 +50,11 @@ import java.io.StringReader;
 import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -125,6 +127,9 @@ public abstract class AbstractST {
     static String testClass;
     static String testName;
     Random rng = new Random();
+
+    public static String baseClusterOperatorNamespace = kubeClient.defaultNamespace();
+    public static List<String> baseBindingsNamespaces = new ArrayList<>();
 
     protected static NamespacedKubernetesClient namespacedClient() {
         return client.inNamespace(kubeClient.namespace());
@@ -1075,10 +1080,9 @@ public abstract class AbstractST {
      * Wait till all pods in specific namespace being deleted and recreate testing environment in case of some pods cannot be deleted.
      * @param time timeout in miliseconds
      * @param coNamespace namespace where cluster operator is deployed to
-     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to. Make sure, that first namespace from this array is namespace where CO is deployed
      * @throws Exception exception
      */
-    void waitForDeletion(long time, String coNamespace, String... bindingsNamespaces) throws Exception {
+    void waitForDeletion(long time, String coNamespace) throws Exception {
         LOGGER.info("Wait for {} ms after cleanup to make sure everything is deleted", time);
         Thread.sleep(time);
         long podCount = client.pods().inNamespace(coNamespace).list().getItems().stream().filter(
@@ -1092,19 +1096,9 @@ public abstract class AbstractST {
                 p -> nonTerminated.append("\n").append(p.getMetadata().getName()).append(" - ").append(p.getStatus().getPhase())
             );
 
-            recreateTestEnv(coNamespace, bindingsNamespaces);
+            recreateTestEnv(baseClusterOperatorNamespace, baseBindingsNamespaces);
             throw new Exception("There are some unexpected pods! Cleanup is not finished properly!" + nonTerminated);
         }
-    }
-
-    /**
-     * Wait till all pods in specific namespace are deleted and recreate testing environment in case of some pods cannot be deleted.
-     * @param time timeout in miliseconds
-     * @param coNamespace namespace where cluster operator is deployed to
-     * @throws Exception exception
-     */
-    void waitForDeletion(long time, String coNamespace) throws Exception {
-        waitForDeletion(time, coNamespace, coNamespace);
     }
 
     /**
@@ -1112,7 +1106,7 @@ public abstract class AbstractST {
      * @param coNamespace namespace where CO will be deployed to
      * @param bindingsNamespaces array of namespaces where Bindings should be deployed to. Make sure, that first namespace from this array is namespace where CO is deployed
      */
-    void recreateTestEnv(String coNamespace, String... bindingsNamespaces) {
+    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         LOGGER.info("There are some unexpected pods! Cleanup is not finished properly! Wait till env will be recreated.");
         testClassResources.deleteResources();
         kubeClient.namespace(DEFAULT_NAMESPACE);
@@ -1141,25 +1135,35 @@ public abstract class AbstractST {
     /**
      * Method for apply Strimzi cluster operator specific Role and CLusterRole bindings for specific namespaces.
      * @param namespace namespace where CO will be deployed to
-     * @param clientNamespaces list of namespaces where Bindings should be deployed to
+     * @param bindingsNamespaces list of namespaces where Bindings should be deployed to
      */
-    static void applyRoleBindings(String namespace, String... clientNamespaces) {
-        for (String clientNamespace : clientNamespaces) {
+    static void applyRoleBindings(String namespace, List<String> bindingsNamespaces) {
+        for (String bindingsNamespace : bindingsNamespaces) {
             // 020-RoleBinding
-            testClassResources.kubernetesRoleBinding("../install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, clientNamespace);
+            testClassResources.kubernetesRoleBinding("../install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
             // 021-ClusterRoleBinding
-            testClassResources.kubernetesClusterRoleBinding("../install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml", namespace, clientNamespace);
+            testClassResources.kubernetesClusterRoleBinding("../install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
             // 030-ClusterRoleBinding
-            testClassResources.kubernetesClusterRoleBinding("../install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml", namespace, clientNamespace);
+            testClassResources.kubernetesClusterRoleBinding("../install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml", namespace, bindingsNamespace);
             // 031-RoleBinding
-            testClassResources.kubernetesRoleBinding("../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, clientNamespace);
+            testClassResources.kubernetesRoleBinding("../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
             // 032-RoleBinding
-            testClassResources.kubernetesRoleBinding("../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, clientNamespace);
+            testClassResources.kubernetesRoleBinding("../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, bindingsNamespace);
         }
     }
 
     static void applyRoleBindings(String namespace) {
-        applyRoleBindings(namespace, namespace);
+        applyRoleBindings(namespace, Collections.singletonList(namespace));
+    }
+
+    public static void setNamespacesInfo(String coNamespace, String... bindigsNamespaces) {
+        baseClusterOperatorNamespace = coNamespace;
+        baseBindingsNamespaces = asList(bindigsNamespaces);
+    }
+
+    public static void setNamespacesInfo(String coNamespace) {
+        baseClusterOperatorNamespace = coNamespace;
+        baseBindingsNamespaces = asList(coNamespace);
     }
 
     @BeforeEach
@@ -1171,5 +1175,12 @@ public abstract class AbstractST {
     static void createTestClassResources(TestInfo testInfo) {
         createClusterOperatorResources();
         testClass = testInfo.getTestClass().get().getSimpleName();
+    }
+
+    @AfterEach
+    void teardownEnvironmet(ExtensionContext context) {
+        if (context.getExecutionException().isPresent()) {
+            recreateTestEnv(baseClusterOperatorNamespace, baseBindingsNamespaces);
+        }
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -75,7 +75,7 @@ class ConnectS2IST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -75,7 +75,6 @@ class ConnectS2IST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -75,6 +75,7 @@ class ConnectS2IST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -261,7 +262,7 @@ class ConnectST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE, Collections.singletonList(NAMESPACE));
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,8 +63,6 @@ class ConnectST extends AbstractST {
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "internal.value.converter.schemas.enable=false\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n");
-
-    private static Resources classResources;
 
     @Test
     @Tag(ACCEPTANCE)
@@ -262,26 +259,20 @@ class ConnectST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(NAMESPACE, Collections.singletonList(NAMESPACE));
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
-
-        classResources = new Resources(namespacedClient());
 
         Map<String, Object> kafkaConfig = new HashMap<>();
         kafkaConfig.put("offsets.topic.replication.factor", "3");
         kafkaConfig.put("transaction.state.log.replication.factor", "3");
         kafkaConfig.put("transaction.state.log.min.isr", "2");
 
-        classResources().kafkaEphemeral(KAFKA_CLUSTER_NAME, 3)
+        testClassResources.kafkaEphemeral(KAFKA_CLUSTER_NAME, 3)
             .editSpec()
                 .editKafka()
                     .withConfig(kafkaConfig)
                 .endKafka()
             .endSpec().done();
-    }
-
-    private static Resources classResources() {
-        return classResources;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -259,7 +259,6 @@ class ConnectST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -259,6 +259,7 @@ class ConnectST extends AbstractST {
     @BeforeAll
     static void createClassResources() {
         LOGGER.info("Creating resources before the test class");
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -10,7 +10,6 @@ import io.strimzi.test.extensions.StrimziExtension;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -48,10 +47,5 @@ class HelmChartST extends AbstractST {
     void deleteTestResources() throws Exception {
         deleteResources();
         waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
-    }
-
-    @BeforeAll
-    static void setupEnvironment() {
-        setNamespacesInfo(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -10,6 +10,7 @@ import io.strimzi.test.extensions.StrimziExtension;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -47,5 +48,10 @@ class HelmChartST extends AbstractST {
     void deleteTestResources() throws Exception {
         deleteResources();
         waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
+    }
+
+    @BeforeAll
+    static void setupEnvironment() {
+        setNamespacesInfo(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -964,6 +964,7 @@ class KafkaST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -964,7 +964,6 @@ class KafkaST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -157,7 +157,6 @@ class KafkaST extends AbstractST {
         // scale down
         LOGGER.info("Scaling down");
         operationID = startTimeMeasuring(Operation.SCALE_DOWN);
-        //client.apps().statefulSets().inNamespace(DEFAULT_NAMESPACE).withName(kafkaStatefulSetName(CLUSTER_NAME)).scale(initialReplicas, true);
         replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getKafka().setReplicas(initialReplicas);
         });
@@ -965,7 +964,7 @@ class KafkaST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -150,7 +151,7 @@ class LogLevelST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Create resources for the tests");
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE, Collections.singletonList(NAMESPACE));
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
@@ -207,10 +208,6 @@ class LogLevelST extends AbstractST {
     @AfterAll
     static void deleteClassResources() {
         TimeMeasuringSystem.stopOperation(operationID);
-    }
-
-    private static Resources classResources() {
-        return classResources;
     }
 
     private static String startDeploymentMeasuring() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -151,7 +150,7 @@ class LogLevelST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Create resources for the tests");
-        applyRoleBindings(NAMESPACE, Collections.singletonList(NAMESPACE));
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -150,6 +150,7 @@ class LogLevelST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Create resources for the tests");
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -150,7 +150,6 @@ class LogLevelST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Create resources for the tests");
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
@@ -97,14 +96,14 @@ class MultipleNamespaceST extends AbstractST {
     @AfterEach
     void deleteSecondNamespaceResources() throws Exception {
         secondNamespaceResources.deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE, Arrays.asList(CO_NAMESPACE, TO_NAMESPACE));
+        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
         kubeClient.namespace(CO_NAMESPACE);
     }
 
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(CO_NAMESPACE, Arrays.asList(CO_NAMESPACE, TO_NAMESPACE));
+        applyRoleBindings(CO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", CO_NAMESPACE, TO_NAMESPACE)).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
@@ -96,14 +97,16 @@ class MultipleNamespaceST extends AbstractST {
     @AfterEach
     void deleteSecondNamespaceResources() throws Exception {
         secondNamespaceResources.deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
+        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE);
         kubeClient.namespace(CO_NAMESPACE);
     }
 
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(CO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
+        setNamespacesInfo(CO_NAMESPACE, TO_NAMESPACE);
+
+        applyRoleBindings(CO_NAMESPACE, Arrays.asList(CO_NAMESPACE, TO_NAMESPACE));
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", CO_NAMESPACE, TO_NAMESPACE)).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
@@ -97,16 +96,14 @@ class MultipleNamespaceST extends AbstractST {
     @AfterEach
     void deleteSecondNamespaceResources() throws Exception {
         secondNamespaceResources.deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE);
+        waitForDeletion(TEARDOWN_GLOBAL_WAIT, TO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
         kubeClient.namespace(CO_NAMESPACE);
     }
 
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
-        setNamespacesInfo(CO_NAMESPACE, TO_NAMESPACE);
-
-        applyRoleBindings(CO_NAMESPACE, Arrays.asList(CO_NAMESPACE, TO_NAMESPACE));
+        applyRoleBindings(CO_NAMESPACE, CO_NAMESPACE, TO_NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", CO_NAMESPACE, TO_NAMESPACE)).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -188,7 +188,7 @@ class RecoveryST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -188,7 +188,6 @@ class RecoveryST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -188,6 +188,7 @@ class RecoveryST extends AbstractST {
     @BeforeAll
     static void createClassResources(TestInfo testInfo) {
         LOGGER.info("Creating resources before the test class");
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -495,7 +495,6 @@ class SecurityST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -495,6 +495,7 @@ class SecurityST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -495,7 +495,7 @@ class SecurityST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -166,7 +166,7 @@ public class StrimziUpgradeST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -166,6 +166,7 @@ public class StrimziUpgradeST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -166,7 +166,6 @@ public class StrimziUpgradeST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -104,7 +104,7 @@ class UserST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        applyRoleBindings(NAMESPACE, NAMESPACE);
+        applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -104,7 +104,6 @@ class UserST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
-        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -104,6 +104,7 @@ class UserST extends AbstractST {
 
     @BeforeAll
     static void createClusterOperator() {
+        setNamespacesInfo(NAMESPACE);
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

In case when test fail we want to have fresh env for the next tests. This includes deletion of all pods, recreate namespace and deploy CO again. This PR introduce this possibility. There is only one problem right now - duplicate code for CO deployment. However, I am planning to do refactor of whole StrimziExtension.java and remove almost all custom annotations from there for more friendly deployment a quick updates. I suggest to merge this ASAP and do refactor in next PR (it will contain huge changes and it will need some time for testing).

Note: PR is based on changes from [PR#1204](https://github.com/strimzi/strimzi-kafka-operator/pull/1204).

### Checklist


- [x] Make sure all tests pass
- [x] Update documentation

