### PR TITLE
Minor fixes in certificate handling

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -4,18 +4,14 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
-import io.strimzi.operator.cluster.model.ClusterCa;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.assembly.AbstractAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOperator;
-import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServer;
@@ -182,10 +178,5 @@ public class ClusterOperator extends AbstractVerticle {
 
     public static String secretName(String cluster) {
         return cluster + CERTS_SUFFIX;
-    }
-
-    public static Secret generateSecret(ClusterCa clusterCa, String namespace, String cluster) {
-        Secret secret = clusterCa.clusterOperatorSecret();
-        return ModelUtils.buildSecret(clusterCa, secret, namespace, ClusterOperator.secretName(cluster), "cluster-operator", Labels.fromString(""), null);
     }
 }

--- a/documentation/book/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/book/ref-list-of-kafka-cluster-resources.adoc
@@ -36,5 +36,6 @@ The following resources will created by the Cluster Operator in the {ProductPlat
 `_cluster-name_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
 `_cluster-name_-clients-ca`::  Secret with the Clients CA used to encrypt the communication between Kafka brokers and Kafka clients.
 `_cluster-name_-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka brokers.
+`_cluster-name_-cluster-operator-certs`:: Secret with Cluster operators keys for communication with Kafka and Zookeeper.
 `data-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
 `data-_cluster-name_-zookeeper-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Zookeeper node pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

While investigation using custom CAs with longer certificate chain, I noticed several issues which should be fixed with this PR:
* The labels for selecting the secrets with certificates should use only the Strimzi labels. This is because:
  * Only these labels are mentioned in the docs about using custom CAs
  * When using all labels as selectors, it can cause problems when the original Kafka resource would be relabelled
* The secrets with Cluster Operator certificates did not had proper labels and owner reference. Among others this caused it to be not deleted.
* The Cluster Operator secrets with certificate was missing in the list of resources

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally