### PR TITLE
Comment out  fields from test YAML

### DIFF
--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
@@ -24,15 +24,17 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-        items:
-        - key: username
-          path: my-group/my-username
+# Uncomment after kubernetes/kubernetes#68466 is fixed
+#        items:
+#        - key: username
+#          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-        items:
-        - key: log_level
-          path: log_level
+# Uncomment after kubernetes/kubernetes#68466 is fixed
+#        items:
+#        - key: log_level
+#          path: log_level

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
@@ -36,15 +36,17 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-        items:
-        - key: username
-          path: my-group/my-username
+    # Uncomment after kubernetes/kubernetes#68466 is fixed
+#        items:
+#        - key: username
+#          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-        items:
-        - key: log_level
-          path: log_level
+# Uncomment after kubernetes/kubernetes#68466 is fixed
+#        items:
+#        - key: log_level
+#          path: log_level


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Due to a bug in Kubernetes, some of the tests for KafkaConnect CRD are currently not passing on some Kubernetes versions. In particular the word `items` seems to cause the issue. This PR comments these out so that when someone needs to run the tests on the affected versions they can pass.

This should close the issue #1212.