### PR TITLE
Avoid double-GET of Pod resources in pod rolling

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -4,13 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.strimzi.operator.common.operator.resource.AbstractResourceOperatorTest;
-import io.strimzi.operator.common.operator.resource.PodOperator;
-import io.strimzi.operator.common.operator.resource.PvcOperator;
-import io.strimzi.operator.common.operator.resource.ScalableResourceOperatorTest;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
-import io.strimzi.operator.common.operator.resource.TimeoutException;
-
 import io.fabric8.kubernetes.api.model.apps.DoneableStatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
@@ -21,12 +14,17 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.strimzi.operator.common.operator.resource.AbstractResourceOperatorTest;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.operator.common.operator.resource.PvcOperator;
+import io.strimzi.operator.common.operator.resource.ScalableResourceOperatorTest;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import org.junit.Test;
 
-import java.util.UUID;
 import java.util.function.BiPredicate;
 
 import static org.junit.Assert.assertTrue;
@@ -142,11 +140,6 @@ public class StatefulSetOperatorTest
             protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
                 return true;
             }
-
-            @Override
-            protected Future<String> getUid(String namespace, String podName) {
-                return Future.succeededFuture(UUID.randomUUID().toString());
-            }
         };
 
         Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
@@ -183,12 +176,6 @@ public class StatefulSetOperatorTest
             protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
                 return true;
             }
-
-            @Override
-            protected Future<String> getUid(String namespace, String podName) {
-                return Future.succeededFuture(UUID.randomUUID().toString());
-            }
-
         };
 
         Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
@@ -227,11 +214,6 @@ public class StatefulSetOperatorTest
             protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
                 return true;
             }
-
-            @Override
-            protected Future<String> getUid(String namespace, String podName) {
-                return Future.succeededFuture(UUID.randomUUID().toString());
-            }
         };
 
         Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
@@ -269,11 +251,6 @@ public class StatefulSetOperatorTest
             @Override
             protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
                 return true;
-            }
-
-            @Override
-            protected Future<String> getUid(String namespace, String podName) {
-                return Future.succeededFuture(UUID.randomUUID().toString());
             }
         };
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
@@ -81,6 +81,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
     public void createWhenExistsIsAPatch(TestContext context) {
         createWhenExistsIsAPatch(context, true);
     }
+
     public void createWhenExistsIsAPatch(TestContext context, boolean cascade) {
         T resource = resource();
         Resource mockResource = mock(resourceType());

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -65,6 +65,7 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
                 .build();
     }
 
+    @Override
     public void createWhenExistsIsAPatch(TestContext context, boolean cascade) {
         PodDisruptionBudget resource = resource();
         Resource mockResource = mock(resourceType());


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We were getting the Pod to call `podRestart.test(pod)`, but then `getUid()`
was immediately getting the same pod again. Instead we should use the pod
we already got. Also, using `Future<Void>` avoids needing to use a raw `Future`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

