### PR TITLE
Added CRD changes for supporting `jbod` storage type

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EphemeralStorage.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class EphemeralStorage extends Storage {
+public class EphemeralStorage extends SingleVolumeStorage {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JbodStorage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
+
+/**
+ * Representation for JBOD storage.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JbodStorage extends Storage {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<Storage> volumes;
+
+    @Description("Must be `" + TYPE_JBOD + "`")
+    @Override
+    public String getType() {
+        return TYPE_JBOD;
+    }
+
+    @Description("List of volumes as Storage objects representing the JBOD disks array")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Storage> getVolumes() {
+        return volumes;
+    }
+
+    public void setVolumes(List<Storage> volumes) {
+        this.volumes = volumes;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JbodStorage.java
@@ -23,7 +23,7 @@ public class JbodStorage extends Storage {
 
     private static final long serialVersionUID = 1L;
 
-    private List<Storage> volumes;
+    private List<SingleVolumeStorage> volumes;
 
     @Description("Must be `" + TYPE_JBOD + "`")
     @Override
@@ -33,11 +33,11 @@ public class JbodStorage extends Storage {
 
     @Description("List of volumes as Storage objects representing the JBOD disks array")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<Storage> getVolumes() {
+    public List<SingleVolumeStorage> getVolumes() {
         return volumes;
     }
 
-    public void setVolumes(List<Storage> volumes) {
+    public void setVolumes(List<SingleVolumeStorage> volumes) {
         this.volumes = volumes;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PersistentClaimStorage.java
@@ -22,7 +22,7 @@ import java.util.Map;
 )
 @JsonPropertyOrder({"type", "size", "storageClass", "selector", "deleteClaim"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class PersistentClaimStorage extends Storage {
+public class PersistentClaimStorage extends SingleVolumeStorage {
 
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/SingleVolumeStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/SingleVolumeStorage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.strimzi.crdgenerator.annotations.Description;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = EphemeralStorage.class, name = Storage.TYPE_EPHEMERAL),
+        @JsonSubTypes.Type(value = PersistentClaimStorage.class, name = Storage.TYPE_PERSISTENT_CLAIM)}
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class SingleVolumeStorage extends Storage {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    @Description("Storage type, must be either 'ephemeral' or 'persistent-claim'.")
+    public abstract String getType();
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
@@ -25,7 +25,8 @@ import java.util.Map;
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(value = EphemeralStorage.class, name = Storage.TYPE_EPHEMERAL),
-        @JsonSubTypes.Type(value = PersistentClaimStorage.class, name = Storage.TYPE_PERSISTENT_CLAIM)}
+        @JsonSubTypes.Type(value = PersistentClaimStorage.class, name = Storage.TYPE_PERSISTENT_CLAIM),
+        @JsonSubTypes.Type(value = JbodStorage.class, name = Storage.TYPE_JBOD)}
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class Storage implements Serializable {
@@ -34,6 +35,7 @@ public abstract class Storage implements Serializable {
 
     public static final String TYPE_EPHEMERAL = "ephemeral";
     public static final String TYPE_PERSISTENT_CLAIM = "persistent-claim";
+    public static final String TYPE_JBOD = "jbod";
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Storage type, must be either 'ephemeral' or 'persistent-claim'.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
@@ -38,7 +38,7 @@ public abstract class Storage implements Serializable {
     public static final String TYPE_JBOD = "jbod";
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Storage type, must be either 'ephemeral' or 'persistent-claim'.")
+    @Description("Storage type, must be either 'ephemeral', 'persistent-claim' or 'jbod'.")
     public abstract String getType();
 
     @JsonAnyGetter

--- a/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Storage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -36,10 +37,22 @@ public abstract class Storage implements Serializable {
     public static final String TYPE_EPHEMERAL = "ephemeral";
     public static final String TYPE_PERSISTENT_CLAIM = "persistent-claim";
     public static final String TYPE_JBOD = "jbod";
+
+    private int id = 0;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Storage type, must be either 'ephemeral', 'persistent-claim' or 'jbod'.")
     public abstract String getType();
+
+    @Description("Storage identification number. It's mandatory only for storage volumes defined in a storage of type 'jbod'")
+    @Minimum(1)
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -49,7 +49,7 @@ public class ZookeeperClusterSpec implements Serializable {
             System.getenv().getOrDefault("STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE", "strimzi/zookeeper-stunnel:latest");
     public static final int DEFAULT_REPLICAS = 3;
 
-    protected Storage storage;
+    protected SingleVolumeStorage storage;
 
     private Map<String, Object> config = new HashMap<>(0);
 
@@ -80,11 +80,11 @@ public class ZookeeperClusterSpec implements Serializable {
 
     @Description("Storage configuration (disk). Cannot be updated.")
     @JsonProperty(required = true)
-    public Storage getStorage() {
+    public SingleVolumeStorage getStorage() {
         return storage;
     }
 
-    public void setStorage(Storage storage) {
+    public void setStorage(SingleVolumeStorage storage) {
         this.storage = storage;
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -97,4 +97,27 @@ public class KafkaCrdIT extends AbstractCrdIT {
             assertTrue(e.getMessage().contains("spec.kafka.tlsSidecar.logLevel in body should be one of [emerg alert crit err warning notice info debug]"));
         }
     }
+
+    @Test
+    public void testKafkaWithJbodStorage() {
+        createDelete(Kafka.class, "Kafka-with-jbod-storage.yaml");
+    }
+
+    @Test
+    public void testKafkaWithJbodStorageOnZookeeper() {
+        try {
+            createDelete(Kafka.class, "Kafka-with-jbod-storage-on-zookeeper.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.zookeeper.storage.type in body should be one of [ephemeral persistent-claim]"));
+        }
+    }
+
+    @Test
+    public void testKafkaWithInvalidStorage() {
+        try {
+            createDelete(Kafka.class, "Kafka-with-invalid-storage.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.kafka.storage.type in body should be one of [ephemeral persistent-claim jbod]"));
+        }
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-invalid-storage.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-invalid-storage.yaml
@@ -1,0 +1,16 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: foobar
+    listeners:
+      plain: {}
+      tls: {}
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage-on-zookeeper.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage-on-zookeeper.yaml
@@ -15,10 +15,13 @@ spec:
     storage:
       type: jbod
       volumes:
-        - type: persistent-claim
+        - id: 1
+          type: persistent-claim
           size: 100Gi
           deleteClaim: false
-        - type: persistent-claim
+        - id: 2
+          type: persistent-claim
           size: 200Gi
           deleteClaim: true
-        - type: ephemeral
+        - id: 3
+          type: ephemeral

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage-on-zookeeper.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage-on-zookeeper.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: ephemeral
+    listeners:
+      plain: {}
+      tls: {}
+  zookeeper:
+    replicas: 3
+    storage:
+      type: jbod
+      volumes:
+        - type: persistent-claim
+          size: 100Gi
+          deleteClaim: false
+        - type: persistent-claim
+          size: 200Gi
+          deleteClaim: true
+        - type: ephemeral

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: strimzi-ephemeral
+spec:
+  kafka:
+    replicas: 3
+    storage:
+      type: jbod
+      volumes:
+      - type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+      - type: persistent-claim
+        size: 200Gi
+        deleteClaim: true
+      - type: ephemeral
+    listeners:
+      plain: {}
+      tls: {}
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-jbod-storage.yaml
@@ -8,13 +8,16 @@ spec:
     storage:
       type: jbod
       volumes:
-      - type: persistent-claim
+      - id: 1
+        type: persistent-claim
         size: 100Gi
         deleteClaim: false
-      - type: persistent-claim
+      - id: 2
+        type: persistent-claim
         size: 200Gi
         deleteClaim: true
-      - type: ephemeral
+      - id: 3
+        type: ephemeral
     listeners:
       plain: {}
       tls: {}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -484,8 +484,8 @@ public abstract class AbstractModel {
         this.configuration = configuration;
     }
 
-    public String getVolumeName() {
-        return this.VOLUME_NAME;
+    protected String getVolumeName() {
+        return storage.getId() != 0 ? VOLUME_NAME + "-" + storage.getId() : VOLUME_NAME;
     }
 
     public String getImage() {
@@ -512,6 +512,14 @@ public abstract class AbstractModel {
 
     public static String getPersistentVolumeClaimName(String name, int podId) {
         return VOLUME_NAME + "-" + name + "-" + podId;
+    }
+
+    public static String getPersistentVolumeClaimName(StatefulSet ss) {
+        if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
+            return ss.getSpec().getVolumeClaimTemplates().get(0).getMetadata().getName();
+        } else {
+            return null;
+        }
     }
 
     public String getPodName(int podId) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -621,7 +621,7 @@ public class KafkaCluster extends AbstractModel {
     private List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
         if (storage instanceof EphemeralStorage) {
-            volumeList.add(createEmptyDirVolume(VOLUME_NAME));
+            volumeList.add(createEmptyDirVolume(getVolumeName()));
         }
 
         if (rack != null || isExposedWithNodePort()) {
@@ -638,14 +638,14 @@ public class KafkaCluster extends AbstractModel {
     private List<PersistentVolumeClaim> getVolumeClaims() {
         List<PersistentVolumeClaim> pvcList = new ArrayList<>();
         if (storage instanceof PersistentClaimStorage) {
-            pvcList.add(createPersistentVolumeClaim(VOLUME_NAME));
+            pvcList.add(createPersistentVolumeClaim(getVolumeName()));
         }
         return pvcList;
     }
 
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMountList = new ArrayList<>();
-        volumeMountList.add(createVolumeMount(VOLUME_NAME, mountPath));
+        volumeMountList.add(createVolumeMount(getVolumeName(), mountPath));
 
         volumeMountList.add(createVolumeMount(CLUSTER_CA_CERTS_VOLUME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
         volumeMountList.add(createVolumeMount(BROKER_CERTS_VOLUME, BROKER_CERTS_VOLUME_MOUNT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -422,7 +422,7 @@ public class ZookeeperCluster extends AbstractModel {
     private List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
         if (storage instanceof EphemeralStorage) {
-            volumeList.add(createEmptyDirVolume(VOLUME_NAME));
+            volumeList.add(createEmptyDirVolume(getVolumeName()));
         }
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));
@@ -433,14 +433,14 @@ public class ZookeeperCluster extends AbstractModel {
     private List<PersistentVolumeClaim> getVolumeClaims() {
         List<PersistentVolumeClaim> pvcList = new ArrayList<>();
         if (storage instanceof PersistentClaimStorage) {
-            pvcList.add(createPersistentVolumeClaim(VOLUME_NAME));
+            pvcList.add(createPersistentVolumeClaim(getVolumeName()));
         }
         return pvcList;
     }
 
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMountList = new ArrayList<>();
-        volumeMountList.add(createVolumeMount(VOLUME_NAME, mountPath));
+        volumeMountList.add(createVolumeMount(getVolumeName(), mountPath));
         volumeMountList.add(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
 
         return volumeMountList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -26,6 +26,7 @@ import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
@@ -267,7 +268,8 @@ public class ResourceUtils {
                                            Map<String, Object> metricsCm,
                                            Map<String, Object> kafkaConfiguration,
                                            Map<String, Object> zooConfiguration,
-                                           Storage storage,
+                                           Storage kafkaStorage,
+                                           SingleVolumeStorage zkStorage,
                                            TopicOperatorSpec topicOperatorSpec,
                                            Logging kafkaLogging, Logging zkLogging) {
         Kafka result = new Kafka();
@@ -296,7 +298,7 @@ public class ResourceUtils {
         if (kafkaConfiguration != null) {
             kafkaClusterSpec.setConfig(kafkaConfiguration);
         }
-        kafkaClusterSpec.setStorage(storage);
+        kafkaClusterSpec.setStorage(kafkaStorage);
         spec.setKafka(kafkaClusterSpec);
 
         ZookeeperClusterSpec zk = new ZookeeperClusterSpec();
@@ -310,7 +312,7 @@ public class ResourceUtils {
         if (zooConfiguration != null) {
             zk.setConfig(zooConfiguration);
         }
-        zk.setStorage(storage);
+        zk.setStorage(zkStorage);
         if (metricsCm != null) {
             zk.setMetrics(metricsCm);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.ProbeBuilder;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
@@ -50,7 +51,8 @@ public class TopicOperatorTest {
     private final Map<String, Object> metricsCm = singletonMap("animal", "wombat");
     private final Map<String, Object> kafkaConfig = singletonMap("foo", "bar");
     private final Map<String, Object> zooConfig = singletonMap("foo", "bar");
-    private final Storage storage = new EphemeralStorage();
+    private final Storage kafkaStorage = new EphemeralStorage();
+    private final SingleVolumeStorage zkStorage = new EphemeralStorage();
     private final InlineLogging kafkaLogJson = new InlineLogging();
     private final InlineLogging zooLogJson = new InlineLogging();
     private final InlineLogging topicOperatorLogging = new InlineLogging();
@@ -82,7 +84,7 @@ public class TopicOperatorTest {
             .withTlsSidecar(tlsSidecar)
             .build();
 
-    private final Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig, storage, topicOperator, kafkaLogJson, zooLogJson);
+    private final Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig, kafkaStorage, zkStorage, topicOperator, kafkaLogJson, zooLogJson);
     private final TopicOperator tc = TopicOperator.fromCrd(resource);
 
     private List<EnvVar> getExpectedEnvVars() {
@@ -112,7 +114,7 @@ public class TopicOperatorTest {
     public void testFromConfigMapDefaultConfig() {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
-                storage, new TopicOperatorSpec(), kafkaLogJson, zooLogJson);
+                kafkaStorage, zkStorage, new TopicOperatorSpec(), kafkaLogJson, zooLogJson);
         TopicOperator tc = TopicOperator.fromCrd(resource);
         Assert.assertEquals(TopicOperatorSpec.DEFAULT_IMAGE, tc.getImage());
         assertEquals(namespace, tc.getWatchedNamespace());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -75,7 +75,7 @@ public class ZookeeperClusterTest {
             .withReadinessProbe(new ProbeBuilder().withInitialDelaySeconds(tlsHealthDelay).withTimeoutSeconds(tlsHealthTimeout).build())
             .build();
 
-    private final Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson, null, null, kafkaLogConfigJson, zooLogConfigJson))
+    private final Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson, null, null, null, kafkaLogConfigJson, zooLogConfigJson))
             .editSpec()
                 .editZookeeper()
                     .withTlsSidecar(tlsSidecar)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -125,7 +125,7 @@ public class KafkaAssemblyOperatorMockTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<KafkaAssemblyOperatorMockTest.Params> data() {
         int[] replicas = {1, 3};
-        io.strimzi.api.kafka.model.Storage[] kafkaStorageConfigs = {
+        Storage[] kafkaStorageConfigs = {
             new EphemeralStorage(),
             new PersistentClaimStorageBuilder()
                 .withSize("123")
@@ -138,7 +138,7 @@ public class KafkaAssemblyOperatorMockTest {
                 .withDeleteClaim(false)
                 .build()
         };
-        io.strimzi.api.kafka.model.SingleVolumeStorage[] zkStorageConfigs = {
+        SingleVolumeStorage[] zkStorageConfigs = {
             new EphemeralStorage(),
             new PersistentClaimStorageBuilder()
                     .withSize("123")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -25,6 +25,7 @@ import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.ResourcesBuilder;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
@@ -86,7 +87,7 @@ public class KafkaAssemblyOperatorMockTest {
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"), emptyMap(), emptyMap(), emptyMap()) { };
 
     private final int zkReplicas;
-    private final Storage zkStorage;
+    private final SingleVolumeStorage zkStorage;
 
     private final int kafkaReplicas;
     private final Storage kafkaStorage;
@@ -95,14 +96,14 @@ public class KafkaAssemblyOperatorMockTest {
 
     public static class Params {
         private final int zkReplicas;
-        private final Storage zkStorage;
+        private final SingleVolumeStorage zkStorage;
 
         private final int kafkaReplicas;
         private final Storage kafkaStorage;
         private Resources resources;
 
         public Params(int zkReplicas,
-                      Storage zkStorage, int kafkaReplicas,
+                      SingleVolumeStorage zkStorage, int kafkaReplicas,
                       Storage kafkaStorage,
                       Resources resources) {
             this.kafkaReplicas = kafkaReplicas;
@@ -124,7 +125,7 @@ public class KafkaAssemblyOperatorMockTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<KafkaAssemblyOperatorMockTest.Params> data() {
         int[] replicas = {1, 3};
-        io.strimzi.api.kafka.model.Storage[] storageConfigs = {
+        io.strimzi.api.kafka.model.Storage[] kafkaStorageConfigs = {
             new EphemeralStorage(),
             new PersistentClaimStorageBuilder()
                 .withSize("123")
@@ -136,6 +137,19 @@ public class KafkaAssemblyOperatorMockTest {
                 .withStorageClass("foo")
                 .withDeleteClaim(false)
                 .build()
+        };
+        io.strimzi.api.kafka.model.SingleVolumeStorage[] zkStorageConfigs = {
+            new EphemeralStorage(),
+            new PersistentClaimStorageBuilder()
+                    .withSize("123")
+                    .withStorageClass("foo")
+                    .withDeleteClaim(true)
+                    .build(),
+            new PersistentClaimStorageBuilder()
+                    .withSize("123")
+                    .withStorageClass("foo")
+                    .withDeleteClaim(false)
+                    .build()
         };
         Resources[] resources = {
             new ResourcesBuilder()
@@ -152,9 +166,9 @@ public class KafkaAssemblyOperatorMockTest {
         List<KafkaAssemblyOperatorMockTest.Params> result = new ArrayList();
 
         for (int zkReplica : replicas) {
-            for (Storage zkStorage : storageConfigs) {
+            for (SingleVolumeStorage zkStorage : zkStorageConfigs) {
                 for (int kafkaReplica : replicas) {
-                    for (Storage kafkaStorage : storageConfigs) {
+                    for (Storage kafkaStorage : kafkaStorageConfigs) {
                         for (Resources resource : resources) {
                             result.add(new KafkaAssemblyOperatorMockTest.Params(
                                     zkReplica, zkStorage,

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -50,8 +50,8 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |integer
 |image                1.2+<.<|The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
 |string
-|storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
-|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
+|storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim, jbod].
+|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`], xref:type-JbodStorage-{context}[`JbodStorage`]
 |listeners            1.2+<.<|Configures listeners of Kafka brokers.
 |xref:type-KafkaListeners-{context}[`KafkaListeners`]
 |authorization        1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
@@ -93,7 +93,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 [id='type-EphemeralStorage-{context}']
 ### `EphemeralStorage` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `EphemeralStorage` from xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`].
@@ -108,7 +108,7 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 [id='type-PersistentClaimStorage-{context}']
 ### `PersistentClaimStorage` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `PersistentClaimStorage` from xref:type-EphemeralStorage-{context}[`EphemeralStorage`].
@@ -126,6 +126,23 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |boolean
 |class        1.2+<.<|The storage class to use for dynamic volume allocation.
 |string
+|====
+
+[id='type-JbodStorage-{context}']
+### `JbodStorage` schema reference
+
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `JbodStorage` from xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`].
+It must have the value `jbod` for the type `JbodStorage`.
+[options="header"]
+|====
+|Field           |Description
+|type     1.2+<.<|Must be `jbod`.
+|string
+|volumes  1.2+<.<|List of volumes as Storage objects representing the JBOD disks array.
+|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`] array
 |====
 
 [id='type-KafkaListeners-{context}']

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -101,6 +101,8 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 [options="header"]
 |====
 |Field        |Description
+|id    1.2+<.<|Storage identification number. It's mandatory only for storage volumes defined in a storage of type 'jbod'.
+|integer
 |type  1.2+<.<|Must be `ephemeral`.
 |string
 |====
@@ -126,6 +128,8 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |boolean
 |class        1.2+<.<|The storage class to use for dynamic volume allocation.
 |string
+|id           1.2+<.<|Storage identification number. It's mandatory only for storage volumes defined in a storage of type 'jbod'.
+|integer
 |====
 
 [id='type-JbodStorage-{context}']
@@ -139,6 +143,8 @@ It must have the value `jbod` for the type `JbodStorage`.
 [options="header"]
 |====
 |Field           |Description
+|id       1.2+<.<|Storage identification number. It's mandatory only for storage volumes defined in a storage of type 'jbod'.
+|integer
 |type     1.2+<.<|Must be `jbod`.
 |string
 |volumes  1.2+<.<|List of volumes as Storage objects representing the JBOD disks array.

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -49,6 +49,27 @@ spec:
                       enum:
                       - ephemeral
                       - persistent-claim
+                      - jbod
+                    volumes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                          deleteClaim:
+                            type: boolean
+                          selector:
+                            type: object
+                          size:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                            - ephemeral
+                            - persistent-claim
+                        required:
+                        - type
                   required:
                   - type
                 listeners:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -40,6 +40,9 @@ spec:
                       type: string
                     deleteClaim:
                       type: boolean
+                    id:
+                      type: integer
+                      minimum: 1
                     selector:
                       type: object
                     size:
@@ -59,6 +62,9 @@ spec:
                             type: string
                           deleteClaim:
                             type: boolean
+                          id:
+                            type: integer
+                            minimum: 1
                           selector:
                             type: object
                           size:
@@ -807,6 +813,9 @@ spec:
                       type: string
                     deleteClaim:
                       type: boolean
+                    id:
+                      type: integer
+                      minimum: 1
                     selector:
                       type: object
                     size:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -36,6 +36,9 @@ spec:
                       type: string
                     deleteClaim:
                       type: boolean
+                    id:
+                      type: integer
+                      minimum: 1
                     selector:
                       type: object
                     size:
@@ -55,6 +58,9 @@ spec:
                             type: string
                           deleteClaim:
                             type: boolean
+                          id:
+                            type: integer
+                            minimum: 1
                           selector:
                             type: object
                           size:
@@ -803,6 +809,9 @@ spec:
                       type: string
                     deleteClaim:
                       type: boolean
+                    id:
+                      type: integer
+                      minimum: 1
                     selector:
                       type: object
                     size:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -45,6 +45,27 @@ spec:
                       enum:
                       - ephemeral
                       - persistent-claim
+                      - jbod
+                    volumes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                          deleteClaim:
+                            type: boolean
+                          selector:
+                            type: object
+                          size:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                            - ephemeral
+                            - persistent-claim
+                        required:
+                        - type
                   required:
                   - type
                 listeners:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is the first PR for #482 in order to add the changes to the CRD for handling the new `jbod` storage type.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

