### PR TITLE
Remove dependency on commons-collections from API package

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -129,11 +129,6 @@
             <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>${commons.collections.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/test/java/io/strimzi/test/StrimziExtension.java
+++ b/api/src/test/java/io/strimzi/test/StrimziExtension.java
@@ -10,7 +10,6 @@ import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Minishift;
 import io.strimzi.test.k8s.OpenShift;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
@@ -308,7 +307,7 @@ public class StrimziExtension implements AfterAllCallback, BeforeAllCallback, Af
                     context.getDisplayName(), declaredTags, enabledTags);
             return false;
         } else {
-            if (CollectionUtils.containsAny(enabledTags, declaredTags) || declaredTags.isEmpty()) {
+            if (containsAny(enabledTags, declaredTags) || declaredTags.isEmpty()) {
                 LOGGER.info("Test class {} with tags {} does not have any tag restrictions by tags: {}. Checking method tags ...",
                         context.getDisplayName(), declaredTags, enabledTags);
                 for (Method method : testClass.getDeclaredMethods()) {
@@ -722,5 +721,14 @@ public class StrimziExtension implements AfterAllCallback, BeforeAllCallback, Af
         } else {
             return a.toString();
         }
+    }
+
+    private boolean containsAny(Collection<String> enabledTags, Collection<String> declaredTags) {
+        for (String declaredTag : declaredTags) {
+            if (enabledTags.contains(declaredTag)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,6 @@
         <jupiter.version>5.3.1</jupiter.version>
         <junit.platform.version>1.3.1</junit.platform.version>
         <gson.version>2.8.2</gson.version>
-
-        <commons.collections.version>3.2.2</commons.collections.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Systemtest part in API used `common-collections` for compare items in two collections. I create method with same funcitonality and removed whole dependency.

### Checklist

- [x] Make sure all tests pass


