### PR TITLE
Zk rolling test fix

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -1122,7 +1122,7 @@ public abstract class AbstractST {
         LOGGER.info("Passed hashes: {}",
                 podHashes.toString());
         TestUtils.waitFor("test", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
-                () -> comparePodHashLists(podHashes, getPodsHash(namePrefix)));
+            () -> comparePodHashLists(podHashes, getPodsHash(namePrefix)));
         LOGGER.info("All zk pods are ready");
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -1123,6 +1123,15 @@ public abstract class AbstractST {
                 podHashes.toString());
         TestUtils.waitFor("test", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
             () -> comparePodHashLists(podHashes, getPodsHash(namePrefix)));
+
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        checkPodsReadiness();
+
         LOGGER.info("All zk pods are ready");
     }
 
@@ -1147,11 +1156,6 @@ public abstract class AbstractST {
             }
         }
         return true;
-    }
-
-    void waitForPod(Pod pod) throws InterruptedException {
-        LOGGER.info("Waiting for pod {}", pod.getMetadata().getName());
-        client.resource(pod).waitUntilReady(1, TimeUnit.MINUTES);
     }
 
     boolean comparePodHashLists(List<Integer> oldHash, List<Integer> newHash) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -193,10 +193,10 @@ class KafkaST extends AbstractST {
 
         final int scaleZkTo = initialZkReplicas + 4;
         final List<String> newZkPodNames = new ArrayList<String>() {{
-            for (int i = 0; i < scaleZkTo; i++) {
-                add(zookeeperPodName(CLUSTER_NAME, i));
-            }
-        }};
+                for (int i = 0; i < scaleZkTo; i++) {
+                    add(zookeeperPodName(CLUSTER_NAME, i));
+                }
+            }};
 
         Set<Integer> podHashes = getPodsHash(zookeeperClusterName(CLUSTER_NAME));
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -214,7 +214,6 @@ class KafkaST extends AbstractST {
 
         podHashes.remove(new Integer(client.pods().withName(newZkPodName[1]).get().hashCode()));
         waitForZkPodsRollUp(zookeeperClusterName(CLUSTER_NAME), podHashes);
-        checkPodsReadiness();
 
         // check the new node is either in leader or follower state
         waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2, 3, 4);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -179,6 +180,7 @@ class KafkaST extends AbstractST {
         assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, operationID));
     }
 
+    @Disabled
     @Test
     @Tag(FLAKY)
     void testZookeeperScaleUpScaleDown() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -26,6 +26,7 @@ import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.annotations.Resources;
 import io.strimzi.test.extensions.StrimziExtension;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.Oc;
 import org.apache.logging.log4j.LogManager;
@@ -43,9 +44,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
 import static io.strimzi.systemtest.k8s.Events.Created;
 import static io.strimzi.systemtest.k8s.Events.Failed;
 import static io.strimzi.systemtest.k8s.Events.FailedSync;
@@ -92,6 +95,7 @@ class KafkaST extends AbstractST {
     private static final long TIMEOUT_FOR_TOPIC_CREATION = 60_000;
     private static final long POLL_INTERVAL_SECRET_CREATION = 5_000;
     private static final long TIMEOUT_FOR_SECRET_CREATION = 360_000;
+    private static final long TIMEOUT_FOR_ZK_CLUSTER_STABILIZATION = 450_000;
 
     @Test
     @Tag(REGRESSION)
@@ -180,7 +184,6 @@ class KafkaST extends AbstractST {
         assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, operationID));
     }
 
-    @Disabled
     @Test
     @Tag(FLAKY)
     void testZookeeperScaleUpScaleDown() {
@@ -198,21 +201,14 @@ class KafkaST extends AbstractST {
                     add(zookeeperPodName(CLUSTER_NAME, i));
                 }
             }};
-        final List<String> zkPodNames = new ArrayList<String>() {{
-                for (int i = 0; i < scaleZkTo; i++) {
-                    add(zookeeperPodName(CLUSTER_NAME, i));
-                }
-            }};
-
-        Map<Integer, String> podHashes = getPodsHash(zookeeperClusterName(CLUSTER_NAME));
 
         LOGGER.info("Scaling up to {}", scaleZkTo);
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getZookeeper().setReplicas(scaleZkTo));
 
-        waitForZkPods(podHashes, zkPodNames);
+        waitForZkPods(newZkPodNames);
         // check the new node is either in leader or follower state
         waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2, 3, 4, 5, 6);
-        checkZkPodsLog(zkPodNames);
+        checkZkPodsLog(newZkPodNames);
 
         //Test that CO doesn't have any exceptions in log
         TimeMeasuringSystem.stopOperation(operationID);
@@ -947,6 +943,45 @@ class KafkaST extends AbstractST {
         Job jobReadMessagesForTarget = waitForJobSuccess(readMessagesFromClusterJob(CLUSTER_NAME + "-target", nameConsumerTarget, topicName, messagesCount, userTarget, true));
         // Check consumed messages in target cluster
         checkRecordsForConsumer(messagesCount, jobReadMessagesForTarget);
+    }
+
+    void waitForZkRollUp() {
+        LOGGER.info("Waiting for cluster stability");
+        Map<String, String>[] zkPods = new Map[1];
+        AtomicInteger count = new AtomicInteger();
+        zkPods[0] = StUtils.ssSnapshot(client, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME));
+        TestUtils.waitFor("Cluster stable and ready", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_ZK_CLUSTER_STABILIZATION, () -> {
+            Map<String, String> zkSnapshot = StUtils.ssSnapshot(client, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME));
+            boolean zkSameAsLast = zkSnapshot.equals(zkPods[0]);
+            if (!zkSameAsLast) {
+                LOGGER.info("ZK Cluster not stable");
+            }
+            if (zkSameAsLast) {
+                int c = count.getAndIncrement();
+                LOGGER.info("All stable for {} polls", c);
+                return c > 60;
+            }
+            zkPods[0] = zkSnapshot;
+            count.set(0);
+            return false;
+        });
+    }
+
+    void checkZkPodsLog(List<String> newZkPodNames) {
+        for (String name : newZkPodNames) {
+            //Test that second pod does not have errors or failures in events
+            LOGGER.info("Checking logs fro pod {}", name);
+            List<Event> eventsForSecondPod = getEvents("Pod", name);
+            assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
+        }
+    }
+
+    void waitForZkPods(List<String> newZkPodNames) {
+        for (String name : newZkPodNames) {
+            kubeClient.waitForPod(name);
+            LOGGER.info("Pod {} is ready", name);
+        }
+        waitForZkRollUp();
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -614,6 +614,8 @@ public class Resources {
                     envVar.setValue(namespace);
                     envVar.setValueFrom(null);
                     break;
+                case "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS":
+                    envVar.setValue("30000");
                 default:
                     if (envVar.getName().contains("STRIMZI_DEFAULT")) {
                         envVar.setValue(TestUtils.changeOrgAndTag(envVar.getValue()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -245,7 +245,7 @@ public class Resources {
                             .withMetrics(new HashMap<>())
                         .endKafka()
                         .withNewZookeeper()
-                            .withReplicas(1)
+                            .withReplicas(3)
                             .withNewResources()
                                 .withNewRequests()
                                     .withMemory("1G")


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

New strategy for ZK scaleup has specific steps - new pod is created and after that all other pods are being rolled, this is done after creation of each new pod. However, our test for zkScaleUp does care about pods rolling so we have to check if all pods are rolled already before scale down phase. Changes in this PR check hash codes of each pods created before last ZK pod. 

Since zk scaleup is not working properly, I am going to disable this test till rolling will work properly.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Make sure all tests pass


