### PR TITLE
Create new profile for systemtest and skip them by default

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -10,6 +10,10 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>systemtest</artifactId>
 
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -115,36 +119,13 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/IT*.java</include>
-                                <include>**/*IT.java</include>
-                                <include>**/ST*.java</include>
-                                <include>**/*ST*.java</include>
-                            </includes>
-                            <trimStackTrace>false</trimStackTrace>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${maven.failsafe.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>systemtests</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <junitTags>acceptance,regression</junitTags>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Tests in `systemtest` package are skipped by default now. For execute them we will use profile like this: 

- For run all tests: `mvn clean install -P systemtests` 
- For run only systemtests: `mvn clean install -pl systemtest -P systemtests` 

`mvn clean install` will execute unit and integration tests

### Checklist

- [ ] Make sure all tests pass

