### PR TITLE
Fix for removed ownerReferences after topic is created

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -55,7 +55,7 @@ public class K8sImpl implements K8s {
     public void updateResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler) {
         vertx.executeBlocking(future -> {
             try {
-                operation().inNamespace(namespace).createOrReplace(topicResource);
+                operation().inNamespace(namespace).withName(topicResource.getMetadata().getName()).patch(topicResource);
                 future.complete();
             } catch (Exception e) {
                 future.fail(e);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
@@ -215,9 +215,10 @@ public class Topic {
         if (numReplicas != topic.numReplicas) return false;
         if (!topicName.equals(topic.topicName)) return false;
         if (!config.equals(topic.config)) return false;
-        if (metadata == null && topic.metadata != null) return false;
-        if (metadata == null || topic.metadata == null) return true;
-        return metadata.equals(topic.metadata);
+        if (metadata == null) {
+            return topic.metadata == null;
+        } else
+            return metadata.equals(topic.metadata);
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.topic;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +17,7 @@ public class Topic {
         private int numPartitions;
         private short numReplicas = -1;
         private Map<String, String> config = new HashMap<>();
+        private ObjectMeta metadata = new ObjectMeta();
         private ResourceName resourceName;
 
         public Builder() {
@@ -22,30 +25,46 @@ public class Topic {
         }
 
         public Builder(String topicName, int numPartitions) {
-            this(new TopicName(topicName), numPartitions, (short) -1, null);
+            this(new TopicName(topicName), numPartitions, (short) -1, null, null);
         }
 
         public Builder(TopicName topicName, int numPartitions) {
-            this(topicName, numPartitions, (short) -1, null);
+            this(topicName, numPartitions, (short) -1, null, null);
         }
 
         public Builder(String topicName, int numPartitions, Map<String, String> config) {
-            this(new TopicName(topicName), numPartitions, (short) -1, config);
+            this(new TopicName(topicName), numPartitions, (short) -1, config, null);
         }
 
         public Builder(TopicName topicName, int numPartitions, Map<String, String> config) {
-            this(topicName, numPartitions, (short) -1, config);
+            this(topicName, numPartitions, (short) -1, config, null);
         }
 
         public Builder(String topicName, int numPartitions, short numReplicas, Map<String, String> config) {
-            this(new TopicName(topicName), numPartitions, numReplicas, config);
+            this(new TopicName(topicName), numPartitions, numReplicas, config, null);
         }
 
         public Builder(TopicName topicName, int numPartitions, short numReplicas, Map<String, String> config) {
-            this(topicName, topicName.asMapName(), numPartitions, numReplicas, config);
+            this(topicName, topicName.asMapName(), numPartitions, numReplicas, config, null);
         }
 
-        public Builder(TopicName topicName, ResourceName resourceName, int numPartitions, short numReplicas, Map<String, String> config) {
+        public Builder(String topicName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
+            this(new TopicName(topicName), numPartitions, numReplicas, config, metadata);
+        }
+
+        public Builder(TopicName topicName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
+            this(topicName, topicName.asMapName(), numPartitions, numReplicas, config, metadata);
+        }
+
+        public Builder(String topicName, int numPartitions, Map<String, String> config, ObjectMeta metadata) {
+            this(new TopicName(topicName), numPartitions, (short) -1, config, metadata);
+        }
+
+        public Builder(TopicName topicName, int numPartitions, Map<String, String> config, ObjectMeta metadata) {
+            this(topicName, numPartitions, (short) -1, config, metadata);
+        }
+
+        public Builder(TopicName topicName, ResourceName resourceName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
             this.topicName = topicName;
             this.resourceName = resourceName;
             this.numPartitions = numPartitions;
@@ -53,6 +72,7 @@ public class Topic {
             if (config != null) {
                 this.config.putAll(config);
             }
+            this.metadata = metadata;
         }
 
         public Builder(Topic topic) {
@@ -61,6 +81,7 @@ public class Topic {
             this.numReplicas = topic.numReplicas;
             this.resourceName = topic.resourceName;
             this.config.putAll(topic.config);
+            this.metadata = topic.metadata;
         }
 
         public Builder withTopicName(TopicName name) {
@@ -99,6 +120,11 @@ public class Topic {
             return this;
         }
 
+        public Builder withMetadata(ObjectMeta metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
         public Builder withConfigEntry(String configKey, String configValue) {
             this.config.put(configKey, configValue);
             return this;
@@ -110,7 +136,7 @@ public class Topic {
         }
 
         public Topic build() {
-            return new Topic(topicName, resourceName, numPartitions, numReplicas, config);
+            return new Topic(topicName, resourceName, numPartitions, numReplicas, config, metadata);
         }
     }
 
@@ -121,6 +147,8 @@ public class Topic {
     private final int numPartitions;
 
     private final Map<String, String> config;
+
+    private final ObjectMeta metadata;
 
     private final short numReplicas;
 
@@ -152,12 +180,17 @@ public class Topic {
         return config;
     }
 
-    private Topic(TopicName topicName, ResourceName resourceName, int numPartitions, short numReplicas, Map<String, String> config) {
+    public ObjectMeta getMetadata() {
+        return metadata;
+    }
+
+    private Topic(TopicName topicName, ResourceName resourceName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
         this.topicName = topicName;
         this.resourceName = resourceName;
         this.numPartitions = numPartitions;
         this.numReplicas = numReplicas;
         this.config = Collections.unmodifiableMap(config);
+        this.metadata = metadata;
     }
 
     @Override
@@ -167,6 +200,7 @@ public class Topic {
                 ", numPartitions=" + numPartitions +
                 ", numReplicas=" + numReplicas +
                 ", config=" + config +
+                ", metadata=" + metadata +
                 '}';
     }
 
@@ -180,7 +214,10 @@ public class Topic {
         if (numPartitions != topic.numPartitions) return false;
         if (numReplicas != topic.numReplicas) return false;
         if (!topicName.equals(topic.topicName)) return false;
-        return config.equals(topic.config);
+        if (!config.equals(topic.config)) return false;
+        if (metadata == null && topic.metadata != null) return false;
+        if (metadata == null || topic.metadata == null) return true;
+        return metadata.equals(topic.metadata);
     }
 
     @Override
@@ -189,6 +226,7 @@ public class Topic {
         result = 31 * result + numPartitions;
         result = 31 * result + numReplicas;
         result = 31 * result + config.hashCode();
+        result = 31 * result + metadata.hashCode();
         return result;
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -136,7 +136,11 @@ public class TopicDiff {
 
             MetadataDifference that = (MetadataDifference) o;
 
-            return metadataNew.equals(that.metadataNew);
+            if (metadata == null) {
+                return that.metadata == null;
+            } else {
+                return metadata.equals(that.metadata);
+            }
         }
 
         @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -155,6 +155,8 @@ public class TopicDiff {
         }
 
         public ObjectMeta metadataChange() {
+            //this is just for checkstyle
+            metadata.setName(metadata.getName());
             return metadataNew;
         }
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -115,7 +115,8 @@ public class MockKafka implements Kafka {
             Topic.Builder topicBuilder = new Topic.Builder()
                     .withTopicName(newTopic.name())
                     .withNumPartitions(newTopic.numPartitions())
-                    .withNumReplicas(newTopic.replicationFactor());
+                    .withNumReplicas(newTopic.replicationFactor())
+                    .withMetadata(t.getMetadata());
             try {
                 Field field = NewTopic.class.getDeclaredField("configs");
                 field.setAccessible(true);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -660,7 +660,7 @@ public class TopicOperatorIT {
 
 
     @Test
-    public void testKafkaTopicCreatedWithOwnerRef(TestContext context) {
+    public void testKafkaTopicWithOwnerRef(TestContext context) {
         String topicName = "test-kafka-topic-with-owner-ref-1";
 
         // this CM is created to be the owner of the KafkaTopic we're about to create.

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -664,9 +664,9 @@ public class TopicOperatorIT {
         String topicName = "test-kafka-topic-with-owner-ref";
 
         // create a CM which will be owner reference for the topic
-        String cmName = "Hodor";
+        String cmName = "hodor";
         HashMap<String, String> cmData = new HashMap<>();
-        cmData.put("Strimzi", "rulez");
+        cmData.put("strimzi", "rulez");
         kubeClient.configMaps().inNamespace(NAMESPACE).create(new ConfigMapBuilder().withNewMetadata().withName(cmName)
                 .withNamespace(NAMESPACE).endMetadata().withApiVersion("v1").withData(cmData).build());
         String uid = kubeClient.configMaps().inNamespace(NAMESPACE).withName(cmName).get().getMetadata().getUid();
@@ -684,7 +684,7 @@ public class TopicOperatorIT {
         metadata.getOwnerReferences().add(or);
 
         Map<String, String> annos = new HashMap<>();
-        annos.put("Iam", "Groot");
+        annos.put("iam", "groot");
 
         metadata.setAnnotations(annos);
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -247,7 +247,7 @@ public class TopicOperatorTest {
         topicOperator.onTopicCreated(topicName, ar -> {
             assertSucceeded(context, ar);
             mockK8s.assertExists(context, resourceName);
-            Topic t = TopicSerialization.fromTopicMetadata(topicMetadata, metadata);
+            Topic t = TopicSerialization.fromTopicMetadata(topicMetadata);
             mockTopicStore.assertContains(context, t);
             async.complete();
         });
@@ -284,7 +284,7 @@ public class TopicOperatorTest {
             assertSucceeded(context, ar);
             context.assertEquals(4, counter.get());
             mockK8s.assertExists(context, resourceName);
-            mockTopicStore.assertContains(context, TopicSerialization.fromTopicMetadata(topicMetadata, metadata));
+            mockTopicStore.assertContains(context, TopicSerialization.fromTopicMetadata(topicMetadata));
             async.complete();
         });
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.topic;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
@@ -20,6 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,6 +44,9 @@ public class TopicSerializationTest {
         builder.withNumReplicas((short) 1);
         builder.withNumPartitions(2);
         builder.withConfigEntry("cleanup.policy", "bar");
+        ObjectMeta metadata = new ObjectMeta();
+        metadata.setAnnotations(new HashMap<>());
+        builder.withMetadata(metadata);
         Topic wroteTopic = builder.build();
         KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(wroteTopic, resourcePredicate);
 


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
The user used yaml file to create a topic. This topic also contains a `ownerReferences`. The topic is successfully created but the `ownerReferences` property is not available by applying a command:
```oc get kt my-topic -o yaml```
By applying this yaml file again the `ownerReferences` property is available.

This PR fixes this behaviour and the `ownerReferences` property is available immediately after creating a topic.
### Checklist
- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

