### PR TITLE
Build script changes for Java11

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -10,6 +10,7 @@ The build also uses an Java annotation processor. Some IDEs (such as IntelliJ) d
 - [Build Pre-requisites](#build-pre-requisites)
 - [Docker images](#docker-images)
     - [Building Docker images](#building-docker-images)
+    - [Alternate Docker image JRE](#alternate-docker-image-jre)
     - [Tagging and pushing Docker images](#tagging-and-pushing-docker-images)
 - [Building everything](#building-everything)
 - [Pushing images to the cluster's Docker repo](#pushing-images-to-the-clusters-docker-repo)
@@ -55,6 +56,13 @@ The `docker_build` target will always build the images under the
 the base image you might have just built without modifying all Dockerfiles. 
 The `DOCKER_TAG` environment variable configures the Docker tag 
 to use (default is `latest`).
+
+### Alternate Docker image JRE
+
+The docker images can be built with an alternate java version by adding the environment variable JAVA_VERSION.
+For example, to build docker images that have java 11 package use `JAVA_VERSION=11 make docker_build`.
+If not present, JAVA_VERSION is defaulted to **1.8.0**.  At present, JAVA_VERSION does not determine the jdk which builds
+the operator, only the JRE which runs the operator and kafka components.
 
 ### Tagging and pushing Docker images
 

--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -18,15 +18,17 @@ function build {
     targets="$@"
     build_args="$DOCKER_BUILD_ARGS"
     tag="${DOCKER_TAG:-latest}"
+    JAVA_VERSION=${JAVA_VERSION:-1.8.0}
+
     # Images not depending on Kafka version
     for image in $(echo "$java_images $stunnel_images"); do
-        make -C "$image" "$targets"
+        DOCKER_BUILD_ARGS="--build-arg JAVA_VERSION=${JAVA_VERSION}" make -C "$image" "$targets"
     done
     # Images depending on Kafka version (possibly indirectly thru FROM)
     for kafka_version in ${!checksums[@]}; do
         sha=${checksums[$kafka_version]}
         for image in $(echo "$kafka_images"); do
-            DOCKER_BUILD_ARGS="--build-arg KAFKA_VERSION=${kafka_version} --build-arg KAFKA_SHA512=${sha} ${build_args}" \
+            DOCKER_BUILD_ARGS="--build-arg JAVA_VERSION=${JAVA_VERSION} --build-arg KAFKA_VERSION=${kafka_version} --build-arg KAFKA_SHA512=${sha} ${build_args}" \
             DOCKER_TAG="${tag}-kafka-${kafka_version}" \
             BUILD_TAG="build-kafka-${kafka_version}" \
             make -C "$image" "$targets"

--- a/docker-images/java-base/Dockerfile
+++ b/docker-images/java-base/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:7
+ARG JAVA_VERSION
 
-RUN yum -y install java-1.8.0-openjdk-headless openssl && yum -y clean all
+RUN yum -y install java-${JAVA_VERSION}-openjdk-headless openssl && yum -y clean all
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/java
@@ -11,3 +12,5 @@ RUN useradd -r -m -u 1001 -g 0 strimzi
 
 # Copy scripts for starting Java apps
 COPY scripts/* /bin/
+
+CMD ["java", "-version"]

--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:7
 
+ARG JAVA_VERSION
 ARG KAFKA_SHA512
 ARG KAFKA_VERSION
 
-RUN yum -y install java-1.8.0-openjdk-headless gettext nmap-ncat openssl && yum clean all -y
+RUN yum -y install java-${JAVA_VERSION}-openjdk-headless gettext nmap-ncat openssl && yum clean all -y
 
 # set Kafka home folder
 ENV KAFKA_HOME=/opt/kafka


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Support docker images with alternate java versions.  To build with java11, add ```export JAVA_VERSION=11``` to the make invocation.  Defaults to 1.8.0.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

