### PR TITLE
WIP fix for wrong topic name

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -26,7 +26,7 @@ public interface K8s {
      * If a resource with the given name does not exist, the handler will be called with
      * a null {@link AsyncResult#result() result()}.
      */
-    void getFromName(ResourceName resourceName, Handler<AsyncResult<KafkaTopic>> handler);
+    void getFromName(String resourceName, Handler<AsyncResult<KafkaTopic>> handler);
 
     void createEvent(Event event, Handler<AsyncResult<Void>> handler);
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -703,7 +703,7 @@ public class TopicOperator {
                 } else {
                     resourceName = topicName.asKubeName();
                 }
-                k8s.getFromName(resourceName, kubeResult -> {
+                k8s.getFromName(resourceName.toString(), kubeResult -> {
                     if (kubeResult.succeeded()) {
                         KafkaTopic topic = kubeResult.result();
                         Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
@@ -975,7 +975,7 @@ public class TopicOperator {
                     TopicName topicName = new TopicName(name);
                     Future topicFuture = Future.future();
                     topicFutures.add(topicFuture);
-                    k8s.getFromName(topicName.asKubeName(), topicResult -> {
+                    k8s.getFromName(topicName.asKubeName().toString(), topicResult -> {
                         if (topicResult.succeeded()) {
                             KafkaTopic kafkaTopic = topicResult.result();
                             reconcile(kafkaTopic, topicName).setHandler(topicFuture);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
@@ -122,8 +122,8 @@ public class MockK8s implements K8s {
     }
 
     @Override
-    public void getFromName(ResourceName resourceName, Handler<AsyncResult<KafkaTopic>> handler) {
-        AsyncResult<KafkaTopic> resourceFuture = byName.get(resourceName);
+    public void getFromName(String topicName, Handler<AsyncResult<KafkaTopic>> handler) {
+        AsyncResult<KafkaTopic> resourceFuture = byName.get(new ResourceName(topicName));
         handler.handle(resourceFuture != null ? resourceFuture : Future.succeededFuture());
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -352,7 +352,7 @@ public class TopicOperatorTest {
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(resourceName, ar2 -> {
+            mockK8s.getFromName(resourceName.toString(), ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", TopicSerialization.fromTopicResource(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -455,7 +455,7 @@ public class TopicOperatorTest {
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName().toString(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -562,7 +562,7 @@ public class TopicOperatorTest {
                 context.assertEquals(mergedTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName().toString(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(mergedTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -606,7 +606,7 @@ public class TopicOperatorTest {
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName().toString(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -648,7 +648,7 @@ public class TopicOperatorTest {
                 context.assertEquals(resultTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName().toString(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(resultTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -731,7 +731,7 @@ public class TopicOperatorTest {
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(resourceName, ar2 -> {
+            mockK8s.getFromName(resourceName.toString(), ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", TopicSerialization.fromTopicResource(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
This PR fixes wrong TO behaviour. Let's say we have a k8s topic named "topic" and it has in `spec.topicName` set to "TOPIC-NAME".
When the user applies CR like this, k8s resource "topic" is created and TO creates Kafka topic "TOPIC-NAME". After $reconciliation_period the TO takes all the Kafka topics and looks for appropriate k8s resources. As it cannot find a k8s resource for "TOPIC-NAME" (Kafka topic name), it deletes this Kafka topic because it thinks the resource has been deleted. Immediately after that, it sees there is a k8s resource named "topic". TO also sees, it should create a Kafka topic named "TOPIC-NAME".
And this happens over and over again.

This PR improves getting k8s resources. At first, it looks into all k8s topic resources and checks whether its `spec.topicName` equals Kafka topic name. After that, it is looking for the k8s resource named the same as the Kafka topic (this is how it worked until now).
https://github.com/strimzi/strimzi-kafka-operator/issues/1221
### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

