### PR TITLE
Add strimzi-admin files to the release archives - Closes #1243

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -10,5 +10,6 @@ release:
 	$(CP) -r ./cluster-operator $(RELEASE_PATH)/
 	$(CP) -r ./user-operator $(RELEASE_PATH)/
 	$(CP) -r ./topic-operator $(RELEASE_PATH)/
+	$(CP) -r ./strimzi-admin $(RELEASE_PATH)/
 
 .PHONY: all build clean docker_build docker_push docker_tag findbugs


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This `install/strimzi-admin` directory is missing form the release archives. This PR adds it to the packages. This should close #1243 