### PR TITLE
Added check on size for persistent-claim storage type

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -105,7 +105,7 @@
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->
-            <property name="max" value="18"/>
+            <property name="max" value="19"/>
         </module>
         <module name="JavaNCSS">
             <!-- default is 50 -->

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -284,6 +284,12 @@ public class KafkaCluster extends AbstractModel {
             result.setMetricsEnabled(true);
             result.setMetricsConfig(metrics.entrySet());
         }
+        if (kafkaClusterSpec.getStorage() instanceof PersistentClaimStorage) {
+            PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) kafkaClusterSpec.getStorage();
+            if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
+                throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
+            }
+        }
         result.setStorage(kafkaClusterSpec.getStorage());
         result.setUserAffinity(kafkaClusterSpec.getAffinity());
         result.setResources(kafkaClusterSpec.getResources());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -182,6 +182,12 @@ public class ZookeeperCluster extends AbstractModel {
             zk.setMetricsEnabled(true);
             zk.setMetricsConfig(metrics.entrySet());
         }
+        if (zookeeperClusterSpec.getStorage() instanceof PersistentClaimStorage) {
+            PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) zookeeperClusterSpec.getStorage();
+            if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
+                throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
+            }
+        }
         zk.setStorage(zookeeperClusterSpec.getStorage());
         zk.setConfiguration(new ZookeeperConfiguration(zookeeperClusterSpec.getConfig().entrySet()));
         zk.setResources(zookeeperClusterSpec.getResources());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -192,7 +192,7 @@ public class KafkaClusterTest {
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
                 .editKafka()
-                .withNewPersistentClaimStorageStorage().withSelector(selector).endPersistentClaimStorageStorage()
+                .withNewPersistentClaimStorageStorage().withSelector(selector).withSize("100Gi").endPersistentClaimStorageStorage()
                 .endKafka()
                 .endSpec()
                 .build();
@@ -207,7 +207,7 @@ public class KafkaClusterTest {
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
                 .editKafka()
-                .withNewPersistentClaimStorageStorage().withSelector(emptyMap()).endPersistentClaimStorageStorage()
+                .withNewPersistentClaimStorageStorage().withSelector(emptyMap()).withSize("100Gi").endPersistentClaimStorageStorage()
                 .endKafka()
                 .endSpec()
                 .build();
@@ -325,7 +325,7 @@ public class KafkaClusterTest {
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
                     .editKafka()
-                        .withStorage(new PersistentClaimStorageBuilder().withDeleteClaim(false).build())
+                        .withStorage(new PersistentClaimStorageBuilder().withDeleteClaim(false).withSize("100Gi").build())
                     .endKafka()
                 .endSpec()
                 .build();
@@ -337,7 +337,7 @@ public class KafkaClusterTest {
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
                     .editKafka()
-                        .withStorage(new PersistentClaimStorageBuilder().withDeleteClaim(true).build())
+                        .withStorage(new PersistentClaimStorageBuilder().withDeleteClaim(true).withSize("100Gi").build())
                     .endKafka()
                 .endSpec()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -235,7 +235,7 @@ public class ZookeeperClusterTest {
         ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
                 .editSpec()
                     .editZookeeper()
-                        .withNewPersistentClaimStorageStorage().withDeleteClaim(true).endPersistentClaimStorageStorage()
+                        .withNewPersistentClaimStorageStorage().withDeleteClaim(true).withSize("100Gi").endPersistentClaimStorageStorage()
                     .endZookeeper()
                 .endSpec()
             .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -464,6 +464,7 @@ public class KafkaAssemblyOperatorMockTest {
         Kafka changedClusterCm = new KafkaBuilder(cluster).editSpec().editKafka()
                 .withNewPersistentClaimStorageStorage()
                     .withStorageClass(changedClass)
+                    .withSize("100Gi")
                 .endPersistentClaimStorageStorage().endKafka().endSpec().build();
         kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(changedClusterCm);
 
@@ -594,6 +595,7 @@ public class KafkaAssemblyOperatorMockTest {
         Kafka changedClusterCm = new KafkaBuilder(cluster).editSpec().editKafka()
                 .withNewPersistentClaimStorageStorage()
                 .withDeleteClaim(!originalKafkaDeleteClaim)
+                .withSize("100Gi")
                 .endPersistentClaimStorageStorage().endKafka().endSpec().build();
         kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(changedClusterCm);
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fixes #1251 checking that `size` is specified for `persistent-claim` storage type.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

