### PR TITLE
fix for gc logging in EO

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
@@ -30,8 +30,9 @@ public class EntityOperatorJvmOptions implements Serializable {
         return gcLoggingEnabled;
     }
 
-    public void setGcLoggingEnabled(boolean gcLoggingEnabled) {
-        this.gcLoggingEnabled = gcLoggingEnabled;
+    public void setGcLoggingEnabled(Boolean gcLoggingEnabled) {
+        if (gcLoggingEnabled != null)
+            this.gcLoggingEnabled = gcLoggingEnabled;
     }
 }
 


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
The logic of `gcLoggingDisabled` was based on the default value of boolean value (false), so the config which does not set `gcLoggingDisabled` set its value to false so the gc logging was enabled by default.
```entityOperator:
    topicOperator:
       jvmOptions:
           someProperty: value
```
With the change which replaced `gcLoggingDisabled` by `gcLoggingEnabled` this is not valid and we have to perform one more check to set correct value.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

