### PR TITLE
Make it possible to run Strimzi across all namespaces

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -75,9 +75,9 @@ public class ClusterOperatorConfig {
         if (namespacesList == null || namespacesList.isEmpty()) {
             throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " cannot be null");
         } else {
-            if (namespacesList.equals(AbstractWatchableResourceOperator.ANY_NAMESPACE)) {
+            if (namespacesList.trim().equals(AbstractWatchableResourceOperator.ANY_NAMESPACE)) {
                 namespaces = Collections.singleton(AbstractWatchableResourceOperator.ANY_NAMESPACE);
-            } else if (namespacesList.matches("([a-z0-9.-]+,)*[a-z0-9.-]+")) {
+            } else if (namespacesList.matches("(\\s?[a-z0-9.-]+\\s?,)*\\s?[a-z0-9.-]+\\s?")) {
                 namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
             } else {
                 throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -77,12 +77,12 @@ public class ClusterOperatorConfig {
         } else {
             if (namespacesList.equals(AbstractWatchableResourceOperator.ANY_NAMESPACE)) {
                 namespaces = Collections.singleton(AbstractWatchableResourceOperator.ANY_NAMESPACE);
+            } else if (namespacesList.matches("([a-z0-9.-]+,)*[a-z0-9.-]+")) {
+                namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
             } else {
-                if (namespacesList.matches("([a-z0-9.-]+,)*[a-z0-9.-]+")) {
-                    namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
-                } else {
-                    throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " is not a valid list of namespaces.");
-                }
+                throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE
+                        + " is not a valid list of namespaces nor the 'any namespace' wildcard "
+                        + AbstractWatchableResourceOperator.ANY_NAMESPACE);
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -7,12 +7,15 @@ package io.strimzi.operator.cluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
@@ -73,7 +76,15 @@ public class ClusterOperatorConfig {
         if (namespacesList == null || namespacesList.isEmpty()) {
             throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " cannot be null");
         } else {
-            namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
+            if (namespacesList.equals(AbstractWatchableResourceOperator.ANY_NAMESPACE)) {
+                namespaces = Collections.singleton(AbstractWatchableResourceOperator.ANY_NAMESPACE);
+            } else {
+                if (namespacesList.matches("([a-z0-9.-]+,)*[a-z0-9.-]+")) {
+                    namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
+                } else {
+                    throw new InvalidConfigurationException(ClusterOperatorConfig.STRIMZI_NAMESPACE + " is not a valid list of namespaces.");
+                }
+            }
         }
 
         long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -79,7 +79,7 @@ public class ClusterOperatorConfigTest {
     public void testListOfNamespaces() {
 
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
-        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "foo, bar ,, baz , ");
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "foo,bar,baz");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
@@ -100,5 +100,22 @@ public class ClusterOperatorConfigTest {
     public void testEmptyEnvVars() {
 
         ClusterOperatorConfig.fromMap(Collections.emptyMap());
+    }
+
+    @Test
+    public void testAnyNamespace() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "*");
+
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
+        assertEquals(new HashSet<>(asList("*")), config.getNamespaces());
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testAnyNamespaceInList() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "foo,*,bar,baz");
+
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -77,14 +77,20 @@ public class ClusterOperatorConfigTest {
 
     @Test
     public void testListOfNamespaces() {
-
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "foo,bar,baz");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
-        assertEquals(30_000, config.getReconciliationIntervalMs());
-        assertEquals(30_000, config.getOperationTimeoutMs());
+    }
+
+    @Test
+    public void testListOfNamespacesWithSpaces() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, " foo ,bar , baz ");
+
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
+        assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -106,6 +112,15 @@ public class ClusterOperatorConfigTest {
     public void testAnyNamespace() {
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "*");
+
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
+        assertEquals(new HashSet<>(asList("*")), config.getNamespaces());
+    }
+
+    @Test
+    public void testAnyNamespaceWithSpaces() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, " * ");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("*")), config.getNamespaces());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -140,18 +140,6 @@ public class ClusterOperatorTest {
             when(mockCms.inNamespace(namespace)).thenReturn(mockNamespacedCms);
         }
 
-        FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
-        when(mockFilteredCms.watch(any())).thenAnswer(invo -> {
-            numWatchers.incrementAndGet();
-            Watch mockWatch = mock(Watch.class);
-            doAnswer(invo2 -> {
-                ((Watcher) invo.getArgument(0)).onClose(null);
-                return null;
-            }).when(mockWatch).close();
-            return mockWatch;
-        });
-        when(mockCms.inAnyNamespace()).thenReturn(mockFilteredCms);
-
         Async async = context.async();
 
         Map<String, String> env = new HashMap<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -88,7 +88,7 @@ public class ClusterOperatorTest {
     }
 
     /**
-     * Does the CC start and then stop a verticle per namespace?
+     * Does the CO start and then stop a verticle per namespace?
      * @param context
      * @param namespaces
      */
@@ -110,15 +110,14 @@ public class ClusterOperatorTest {
             throw new RuntimeException(e);
         }
         MixedOperation mockCms = mock(MixedOperation.class);
-        //when(client.configMaps()).thenReturn(mockCms);
         NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> mockCrds = mock(NonNamespaceOperation.class);
-        Resource<CustomResourceDefinition, DoneableCustomResourceDefinition> y = mock(Resource.class);
+        Resource<CustomResourceDefinition, DoneableCustomResourceDefinition> mockResource = mock(Resource.class);
         if (openShift) {
-            when(y.get()).thenReturn(Crds.kafkaConnectS2I());
+            when(mockResource.get()).thenReturn(Crds.kafkaConnectS2I());
         } else {
-            when(y.get()).thenReturn(null);
+            when(mockResource.get()).thenReturn(null);
         }
-        when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(y);
+        when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
         when(client.customResourceDefinitions()).thenReturn(mockCrds);
         when(client.customResources(any(), any(), any(), any())).thenReturn(mockCms);
 
@@ -173,7 +172,7 @@ public class ClusterOperatorTest {
     }
 
     /**
-     * Does the CC start and then stop with the namespace wildcard (*)?
+     * Does the CO start and then stop with the namespace wildcard (*)?
      * @param context
      * @param namespaces
      */
@@ -195,15 +194,14 @@ public class ClusterOperatorTest {
             throw new RuntimeException(e);
         }
         MixedOperation mockCms = mock(MixedOperation.class);
-        //when(client.configMaps()).thenReturn(mockCms);
         NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> mockCrds = mock(NonNamespaceOperation.class);
-        Resource<CustomResourceDefinition, DoneableCustomResourceDefinition> y = mock(Resource.class);
+        Resource<CustomResourceDefinition, DoneableCustomResourceDefinition> mockResource = mock(Resource.class);
         if (openShift) {
-            when(y.get()).thenReturn(Crds.kafkaConnectS2I());
+            when(mockResource.get()).thenReturn(Crds.kafkaConnectS2I());
         } else {
-            when(y.get()).thenReturn(null);
+            when(mockResource.get()).thenReturn(null);
         }
-        when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(y);
+        when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(mockResource);
         when(client.customResourceDefinitions()).thenReturn(mockCrds);
         when(client.customResources(any(), any(), any(), any())).thenReturn(mockCms);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefin
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -76,6 +77,16 @@ public class ClusterOperatorTest {
         startStop(context, "namespace1,namespace2", false);
     }
 
+    @Test
+    public void startStopAllNamespacesOs(TestContext context) {
+        startStopAllNamespaces(context, "*", true);
+    }
+
+    @Test
+    public void startStopAllNamespacesK8s(TestContext context) {
+        startStopAllNamespaces(context, "*", false);
+    }
+
     /**
      * Does the CC start and then stop a verticle per namespace?
      * @param context
@@ -128,6 +139,19 @@ public class ClusterOperatorTest {
             when(mockNamespacedCms.withLabels(any())).thenReturn(mockNamespacedCms);
             when(mockCms.inNamespace(namespace)).thenReturn(mockNamespacedCms);
         }
+
+        FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
+        when(mockFilteredCms.watch(any())).thenAnswer(invo -> {
+            numWatchers.incrementAndGet();
+            Watch mockWatch = mock(Watch.class);
+            doAnswer(invo2 -> {
+                ((Watcher) invo.getArgument(0)).onClose(null);
+                return null;
+            }).when(mockWatch).close();
+            return mockWatch;
+        });
+        when(mockCms.inAnyNamespace()).thenReturn(mockFilteredCms);
+
         Async async = context.async();
 
         Map<String, String> env = new HashMap<>();
@@ -160,4 +184,82 @@ public class ClusterOperatorTest {
         }
     }
 
+    /**
+     * Does the CC start and then stop with the namespace wildcard (*)?
+     * @param context
+     * @param namespaces
+     */
+    private void startStopAllNamespaces(TestContext context, String namespaces, boolean openShift) {
+        AtomicInteger numWatchers = new AtomicInteger(0);
+        KubernetesClient client;
+        if (openShift) {
+            client = mock(OpenShiftClient.class);
+            when(client.isAdaptable(eq(OpenShiftClient.class))).thenReturn(true);
+            when(client.adapt(eq(OpenShiftClient.class))).thenReturn((OpenShiftClient) client);
+        } else {
+            client = mock(KubernetesClient.class);
+            when(client.isAdaptable(eq(OpenShiftClient.class))).thenReturn(false);
+        }
+        when(client.isAdaptable(eq(OkHttpClient.class))).thenReturn(true);
+        try {
+            when(client.getMasterUrl()).thenReturn(new URL("http://localhost"));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+        MixedOperation mockCms = mock(MixedOperation.class);
+        //when(client.configMaps()).thenReturn(mockCms);
+        NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> mockCrds = mock(NonNamespaceOperation.class);
+        Resource<CustomResourceDefinition, DoneableCustomResourceDefinition> y = mock(Resource.class);
+        if (openShift) {
+            when(y.get()).thenReturn(Crds.kafkaConnectS2I());
+        } else {
+            when(y.get()).thenReturn(null);
+        }
+        when(mockCrds.withName(KafkaConnectS2I.CRD_NAME)).thenReturn(y);
+        when(client.customResourceDefinitions()).thenReturn(mockCrds);
+        when(client.customResources(any(), any(), any(), any())).thenReturn(mockCms);
+
+        FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
+        when(mockFilteredCms.watch(any())).thenAnswer(invo -> {
+            numWatchers.incrementAndGet();
+            Watch mockWatch = mock(Watch.class);
+            doAnswer(invo2 -> {
+                ((Watcher) invo.getArgument(0)).onClose(null);
+                return null;
+            }).when(mockWatch).close();
+            return mockWatch;
+        });
+        when(mockCms.inAnyNamespace()).thenReturn(mockFilteredCms);
+
+        Async async = context.async();
+
+        Map<String, String> env = new HashMap<>();
+        env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
+        env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
+        Main.run(vertx, client, openShift, ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
+            context.assertNull(ar.cause(), "Expected all verticles to start OK");
+            async.complete();
+        });
+        async.await();
+
+        context.assertEquals(1, vertx.deploymentIDs().size(), "A verticle per namespace");
+
+        List<Async> asyncs = new ArrayList<>();
+        for (String deploymentId: vertx.deploymentIDs()) {
+            Async async2 = context.async();
+            asyncs.add(async2);
+            vertx.undeploy(deploymentId, ar -> {
+                context.assertNull(ar.cause(), "Didn't expect error when undeploying verticle " + deploymentId);
+                async2.complete();
+            });
+        }
+
+        for (Async async2: asyncs) {
+            async2.await();
+        }
+
+        if (numWatchers.get() > (openShift ? 4 : 3)) {
+            context.fail("Looks like there were more watchers than we should");
+        }
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -63,7 +63,7 @@ public class ClusterOperatorTest {
 
     @Test
     public void startStopMultiNamespaceOs(TestContext context) {
-        startStop(context, "namespace1, namespace2", true);
+        startStop(context, "namespace1,namespace2", true);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ClusterOperatorTest {
 
     @Test
     public void startStopMultiNamespaceK8s(TestContext context) {
-        startStop(context, "namespace1, namespace2", false);
+        startStop(context, "namespace1,namespace2", false);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -935,6 +935,91 @@ public class KafkaAssemblyOperatorTest {
         context.assertEquals(new HashSet(asList("foo", "bar")), createdOrUpdated);
     }
 
+    @Test
+    public void testReconcileAllNamespaces(TestContext context) throws InterruptedException {
+        Async async = context.async(2);
+
+        // create CM, Service, headless service, statefulset
+        ResourceOperatorSupplier supplier = supplierWithMocks();
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        KafkaSetOperator mockKsOps = supplier.kafkaSetOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        String clusterCmNamespace = "test";
+
+        Kafka foo = getKafkaAssembly("foo");
+        foo.getMetadata().setNamespace("namespace1");
+        Kafka bar = getKafkaAssembly("bar");
+        bar.getMetadata().setNamespace("namespace2");
+        when(mockKafkaOps.list(eq("*"), any())).thenReturn(
+                asList(foo, bar)
+        );
+        // when requested Custom Resource for a specific Kafka cluster
+        when(mockKafkaOps.get(eq("namespace1"), eq("foo"))).thenReturn(foo);
+        when(mockKafkaOps.get(eq("namespace2"), eq("bar"))).thenReturn(bar);
+
+        // providing certificates Secrets for existing clusters
+        List<Secret> fooSecrets = ResourceUtils.createKafkaClusterInitialSecrets("namespace1", "foo");
+        List<Secret> barSecrets = ResourceUtils.createKafkaClusterSecretsWithReplicas("namespace2", "bar",
+                bar.getSpec().getKafka().getReplicas(),
+                bar.getSpec().getZookeeper().getReplicas());
+        ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
+        ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
+                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
+
+        // providing the list of ALL StatefulSets for all the Kafka clusters
+        Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
+        when(mockKsOps.list(eq("*"), eq(newLabels))).thenReturn(
+                asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift))
+        );
+
+        //when(mockSecretOps.get(eq("namespace1"), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName()))))
+        //        .thenReturn(
+        //                fooSecrets.get(0));
+        //when(mockSecretOps.reconcile(eq("namespace1"), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+
+        // providing the list StatefulSets for already "existing" Kafka clusters
+        Labels barLabels = Labels.forCluster("bar");
+        KafkaCluster barCluster = KafkaCluster.fromCrd(bar, VERSIONS);
+        when(mockKsOps.list(eq("*"), eq(barLabels))).thenReturn(
+                asList(barCluster.generateStatefulSet(openShift))
+        );
+        when(mockSecretOps.list(eq("*"), eq(barLabels))).thenAnswer(
+                invocation -> new ArrayList<>(asList(
+                        barClientsCa.caKeySecret(),
+                        barClientsCa.caCertSecret(),
+                        barCluster.generateBrokersSecret(),
+                        barClusterCa.caCertSecret()))
+        );
+        //when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
+        //when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
+
+        Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
+        //Set<String> deleted = new CopyOnWriteArraySet<>();
+
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
+                ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
+                certManager,
+                supplier,
+                VERSIONS) {
+            @Override
+            public Future<Void> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
+                createdOrUpdated.add(kafkaAssembly.getMetadata().getName());
+                async.countDown();
+                return Future.succeededFuture();
+            }
+        };
+
+        // Now try to reconcile all the Kafka clusters
+        ops.reconcileAll("test", "*").await();
+
+        async.await();
+
+        context.assertEquals(new HashSet(asList("foo", "bar")), createdOrUpdated);
+    }
+
     private ResourceOperatorSupplier supplierWithMocks() {
         RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -860,7 +860,7 @@ public class KafkaAssemblyOperatorTest {
         ServiceAccountOperator mockSao = supplier.serviceAccountOperator;
         RoleBindingOperator mockRbo = supplier.roleBindingOperator;
         ClusterRoleBindingOperator mockCrbo = supplier.clusterRoleBindingOperator;
-        String clusterCmNamespace = "myNamespace";
+        String clusterCmNamespace = "test";
 
         Kafka foo = getKafkaAssembly("foo");
         Kafka bar = getKafkaAssembly("bar");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -944,7 +944,6 @@ public class KafkaAssemblyOperatorTest {
         CrdOperator mockKafkaOps = supplier.kafkaOperator;
         KafkaSetOperator mockKsOps = supplier.kafkaSetOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
-        String clusterCmNamespace = "test";
 
         Kafka foo = getKafkaAssembly("foo");
         foo.getMetadata().setNamespace("namespace1");
@@ -975,11 +974,6 @@ public class KafkaAssemblyOperatorTest {
                 asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift))
         );
 
-        //when(mockSecretOps.get(eq("namespace1"), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName()))))
-        //        .thenReturn(
-        //                fooSecrets.get(0));
-        //when(mockSecretOps.reconcile(eq("namespace1"), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
-
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
         KafkaCluster barCluster = KafkaCluster.fromCrd(bar, VERSIONS);
@@ -987,17 +981,14 @@ public class KafkaAssemblyOperatorTest {
                 asList(barCluster.generateStatefulSet(openShift))
         );
         when(mockSecretOps.list(eq("*"), eq(barLabels))).thenAnswer(
-                invocation -> new ArrayList<>(asList(
-                        barClientsCa.caKeySecret(),
-                        barClientsCa.caCertSecret(),
-                        barCluster.generateBrokersSecret(),
-                        barClusterCa.caCertSecret()))
+            invocation -> new ArrayList<>(asList(
+                    barClientsCa.caKeySecret(),
+                    barClientsCa.caCertSecret(),
+                    barCluster.generateBrokersSecret(),
+                    barClusterCa.caCertSecret()))
         );
-        //when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
-        //when(mockSecretOps.reconcile(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())), any(Secret.class))).thenReturn(Future.succeededFuture());
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
-        //Set<String> deleted = new CopyOnWriteArraySet<>();
 
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/NamespaceAndName.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/NamespaceAndName.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.model;
+
+public class NamespaceAndName {
+    private final String namespace;
+    private final String name;
+
+    public NamespaceAndName(String namespace, String name)   {
+        this.namespace = namespace;
+        this.name = name;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if (obj instanceof NamespaceAndName) {
+            NamespaceAndName nrn = (NamespaceAndName) obj;
+            if ((nrn.getName() == null && name == null) ||
+                    (nrn.getName().equals(name) && ((nrn.getNamespace() == null && namespace == null)
+                            || nrn.getNamespace().equals(namespace)))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = namespace != null ? namespace.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return namespace + "/" + name;
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -228,7 +228,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
         }
     }
 
-    public List<T> listInNamespace(String namespace, Labels selector) {
+    protected List<T> listInNamespace(String namespace, Labels selector) {
         NonNamespaceOperation<T, L, D, R> tldrNonNamespaceOperation = operation().inNamespace(namespace);
 
         if (selector != null) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
@@ -23,6 +23,8 @@ public abstract class AbstractWatchableResourceOperator<
         R extends Resource<T, D>>
         extends AbstractResourceOperator<C, T, L, D, R> {
 
+    public final static String ANY_NAMESPACE = "*";
+
     /**
      * Constructor.
      *
@@ -34,11 +36,35 @@ public abstract class AbstractWatchableResourceOperator<
         super(vertx, client, resourceKind);
     }
 
-    public Watch watch(String namespace, Watcher<T> watcher) {
+    protected Watch watchInAnyNamespace(Watcher<T> watcher) {
+        return operation().inAnyNamespace().watch(watcher);
+    }
+
+    protected Watch watchInNamespace(String namespace, Watcher<T> watcher) {
         return operation().inNamespace(namespace).watch(watcher);
     }
 
-    public Watch watch(String namespace, Labels selector, Watcher<T> watcher) {
+    public Watch watch(String namespace, Watcher<T> watcher) {
+        if (ANY_NAMESPACE.equals(namespace))    {
+            return watchInAnyNamespace(watcher);
+        } else {
+            return watchInNamespace(namespace, watcher);
+        }
+    }
+
+    protected Watch watchInAnyNamespace(Labels selector, Watcher<T> watcher) {
+        return operation().inAnyNamespace().withLabels(selector.toMap()).watch(watcher);
+    }
+
+    protected Watch watchInNamespace(String namespace, Labels selector, Watcher<T> watcher) {
         return operation().inNamespace(namespace).withLabels(selector.toMap()).watch(watcher);
+    }
+
+    public Watch watch(String namespace, Labels selector, Watcher<T> watcher) {
+        if (ANY_NAMESPACE.equals(namespace))    {
+            return watchInAnyNamespace(selector, watcher);
+        } else {
+            return watchInNamespace(namespace, selector, watcher);
+        }
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
@@ -20,8 +20,8 @@ public class NamespaceAndNameTest {
 
     @Test
     public void testToString()   {
-        NamespaceAndName NaN = new NamespaceAndName("namespace1", "name1");
+        NamespaceAndName nan = new NamespaceAndName("namespace1", "name1");
 
-        Assert.assertEquals("namespace1/name1", NaN.toString());
+        Assert.assertEquals("namespace1/name1", nan.toString());
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NamespaceAndNameTest {
+    @Test
+    public void testEquals()   {
+        NamespaceAndName original = new NamespaceAndName("namespace1", "name1");
+
+        Assert.assertTrue(original.equals(new NamespaceAndName("namespace1", "name1")));
+        Assert.assertFalse(original.equals(new NamespaceAndName("namespace2", "name1")));
+        Assert.assertFalse(original.equals(new NamespaceAndName("namespace1", "name2")));
+        Assert.assertFalse(original.equals(new NamespaceAndName("namespace2", "name2")));
+    }
+
+    @Test
+    public void testToString()   {
+        NamespaceAndName NaN = new NamespaceAndName("namespace1", "name1");
+
+        Assert.assertEquals("namespace1/name1", NaN.toString());
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the ability to run Strimzi across all namespaces by setting the `STRIMZI_NAMESPACE` option to `*`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

