### PR TITLE
Use the correct common name for TO and EO certificates

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -61,6 +61,17 @@ public class KafkaResources {
     }
 
     /**
+     * Returns the name of the Entity Operator {@code Secret} for a {@code Kafka} cluster of the given name.
+     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator} is configured in the
+     * {@code Kafka} resource with the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Entity Operator {@code Secret}.
+     */
+    public static String entityOperatorSecretName(String clusterName) {
+        return entityOperatorDeploymentName(clusterName) + "-certs";
+    }
+
+    /**
      * Returns the name of the Cluster CA certificate {@code Secret} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The name of the corresponding Cluster CA certificate {@code Secret}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -33,8 +33,6 @@ import static java.util.Arrays.asList;
  * Represents the Entity Operator deployment
  */
 public class EntityOperator extends AbstractModel {
-
-    private static final String CERTS_SUFFIX = "-certs";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
@@ -101,7 +99,7 @@ public class EntityOperator extends AbstractModel {
     }
 
     public static String secretName(String cluster) {
-        return KafkaResources.entityOperatorDeploymentName(cluster) + CERTS_SUFFIX;
+        return KafkaResources.entityOperatorSecretName(cluster);
     }
 
     public void setDeployed(boolean isDeployed) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -34,8 +34,7 @@ import static java.util.Arrays.asList;
  */
 public class EntityOperator extends AbstractModel {
 
-    private static final String NAME_SUFFIX = "-entity-operator";
-    private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
+    private static final String CERTS_SUFFIX = "-certs";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
@@ -102,7 +101,7 @@ public class EntityOperator extends AbstractModel {
     }
 
     public static String secretName(String cluster) {
-        return cluster + CERTS_SUFFIX;
+        return KafkaResources.entityOperatorDeploymentName(cluster) + CERTS_SUFFIX;
     }
 
     public void setDeployed(boolean isDeployed) {
@@ -249,7 +248,7 @@ public class EntityOperator extends AbstractModel {
             return null;
         }
         Secret secret = clusterCa.entityOperatorSecret();
-        return ModelUtils.buildSecret(clusterCa, secret, namespace, EntityOperator.secretName(cluster), "entity-operator", labels, createOwnerReference());
+        return ModelUtils.buildSecret(clusterCa, secret, namespace, EntityOperator.secretName(cluster), name, "entity-operator", labels, createOwnerReference());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -198,13 +198,13 @@ public class ModelUtils {
                         tlsSidecar.getLogLevel() : TlsSidecarLogLevel.NOTICE).toValue());
     }
 
-    public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName, String keyCertName, Labels labels, OwnerReference ownerReference) {
+    public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName, String commonName, String keyCertName, Labels labels, OwnerReference ownerReference) {
         Map<String, String> data = new HashMap<>();
         if (secret == null || clusterCa.certRenewed()) {
             log.debug("Generating certificates");
             try {
                 log.debug(keyCertName + " certificate to generate");
-                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(secretName, Ca.IO_STRIMZI);
+                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
                 data.put(keyCertName + ".key", eoCertAndKey.keyAsBase64String());
                 data.put(keyCertName + ".crt", eoCertAndKey.certAsBase64String());
             } catch (IOException e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -360,7 +360,8 @@ public class TopicOperator extends AbstractModel {
      */
     public Secret generateSecret(ClusterCa clusterCa) {
         Secret topicOperatorSecret = clusterCa.topicOperatorSecret();
-        return ModelUtils.buildSecret(clusterCa, topicOperatorSecret, namespace, TopicOperator.secretName(cluster), "entity-operator", labels, createOwnerReference());
+        // TO is using the keyCertName as "entity-operato". This is not typo.
+        return ModelUtils.buildSecret(clusterCa, topicOperatorSecret, namespace, TopicOperator.secretName(cluster), name, "entity-operator", labels, createOwnerReference());
     }
 
     protected void setTlsSidecar(TlsSidecar tlsSidecar) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -360,7 +360,7 @@ public class TopicOperator extends AbstractModel {
      */
     public Secret generateSecret(ClusterCa clusterCa) {
         Secret topicOperatorSecret = clusterCa.topicOperatorSecret();
-        // TO is using the keyCertName as "entity-operato". This is not typo.
+        // TO is using the keyCertName as "entity-operator". This is not typo.
         return ModelUtils.buildSecret(clusterCa, topicOperatorSecret, namespace, TopicOperator.secretName(cluster), name, "entity-operator", labels, createOwnerReference());
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1781,7 +1781,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withController(false)
                     .build();
 
-            Secret secret = ModelUtils.buildSecret(clusterCa, clusterCa.clusterOperatorSecret(), namespace, ClusterOperator.secretName(name), "cluster-operator", labels, ownerRef);
+            Secret secret = ModelUtils.buildSecret(clusterCa, clusterCa.clusterOperatorSecret(), namespace, ClusterOperator.secretName(name), "cluster-operator", "cluster-operator", labels, ownerRef);
 
             return withVoid(secretOperations.reconcile(namespace, ClusterOperator.secretName(name),
                     secret));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The certificate common names for TO and EO are currently wrong. That makes the TO (and probably some features in UO) not working. This PR should fix it by restoring the original common names.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally