### PR TITLE
WIP: Kubernetes client for ST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -9,14 +9,14 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.batch.Job;
+import io.fabric8.kubernetes.api.model.batch.JobBuilder;
+import io.fabric8.kubernetes.api.model.batch.JobStatus;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -37,16 +37,13 @@ import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
 import io.strimzi.systemtest.timemeasuring.Operation;
 import io.strimzi.systemtest.timemeasuring.TimeMeasuringSystem;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.TimeoutException;
-import io.strimzi.test.k8s.Kubernetes;
 import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterException;
 import io.strimzi.test.k8s.KubeClusterResource;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Properties;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,6 +51,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -62,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -1054,7 +1054,7 @@ public abstract class AbstractST {
                 p -> nonTerminated.append("\n").append(p.getMetadata().getName()).append(" - ").append(p.getStatus().getPhase())
             );
             // Delete remaining pods if there are some
-            podStream.forEach(p -> kubernetes.waitForPodDeletion(p.getMetadata().getName()));
+            podStream.forEach(p -> StUtils.waitForPodDeletion(p.getMetadata().getName()));
             throw new Exception("There are some unexpected pods! Cleanup is not finished properly!" + nonTerminated);
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -400,28 +400,28 @@ public abstract class AbstractST {
     }
 
     public String getContainerImageNameFromPod(String podName) {
-        String clusterOperatorJson = kubeClient.getResourceAsJson("pod", podName);
-        return JsonPath.parse(clusterOperatorJson).read("$.spec.containers[*].image").toString().replaceAll("[\"\\[\\]\\\\]", "");
+        return kubernetes.getPod(podName).getSpec().getContainers().get(0).getImage();
     }
 
     public String getContainerImageNameFromPod(String podName, String containerName) {
-        String clusterOperatorJson = kubeClient.getResourceAsJson("pod", podName);
-        return JsonPath.parse(clusterOperatorJson).read("$.spec.containers[?(@.name =='" + containerName + "')].image").toString().replaceAll("[\"\\[\\]\\\\]", "");
+        return kubernetes.getPod(podName).getSpec().getContainers().stream()
+                .filter(c -> c.getName().equals(containerName))
+                .findFirst().get().getImage();
     }
 
     public String  getInitContainerImageName(String podName) {
-        String clusterOperatorJson = kubeClient.getResourceAsJson("pod", podName);
-        return JsonPath.parse(clusterOperatorJson).read("$.spec.initContainers[-1].image");
+        return kubernetes.getPod(podName).getSpec().getInitContainers().stream()
+                .findFirst().get().getImage();
     }
 
     protected void createResources() {
         LOGGER.info("Creating resources before the test");
-        resources = new Resources(kubernetes.getInstance());
+        resources = new Resources();
     }
 
     protected static void createClusterOperatorResources() {
         LOGGER.info("Creating cluster operator resources");
-        testClassResources = new Resources(kubernetes.getInstance());
+        testClassResources = new Resources();
     }
 
     protected void deleteResources() throws Exception {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -112,6 +112,9 @@ public abstract class AbstractST {
     static final long TEARDOWN_GLOBAL_WAIT = 10000;
 
     public static KubeClusterResource cluster = new KubeClusterResource();
+
+    // This field has been deprecated, please use Kubernetes client
+    @Deprecated
     static KubeClient<?> kubeClient = cluster.client();
     static Kubernetes kubernetes = getKubernetes();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -176,7 +176,7 @@ public abstract class AbstractST {
 
     private <T extends CustomResource, L extends CustomResourceList<T>, D extends Doneable<T>>
         void replaceCrdResource(Class<T> crdClass, Class<L> listClass, Class<D> doneableClass, String resourceName, Consumer<T> editor) {
-        Resource<T, D> namedResource = Crds.operation(kubernetes.getInstance(), crdClass, listClass, doneableClass).inNamespace(kubeClient.namespace()).withName(resourceName);
+        Resource<T, D> namedResource = Crds.operation(kubernetes.getInstance(), crdClass, listClass, doneableClass).inNamespace(kubernetes.getNamespace()).withName(resourceName);
         T resource = namedResource.get();
         editor.accept(resource);
         namedResource.replace(resource);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -40,7 +40,7 @@ import io.strimzi.systemtest.timemeasuring.TimeMeasuringSystem;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.TimeoutException;
-import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.KubeExecClient;
 import io.strimzi.test.k8s.KubeClusterException;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Kubernetes;
@@ -115,7 +115,7 @@ public abstract class AbstractST {
 
     // This field has been deprecated, please use Kubernetes client
     @Deprecated
-    static KubeClient<?> kubeClient = cluster.client();
+    static KubeExecClient<?> kubeClient = cluster.client();
     static Kubernetes kubernetes = getKubernetes();
 
     Resources resources;

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -55,7 +55,7 @@ class ConnectS2IST extends AbstractST {
 
         // Start a new image build using the plugins directory
         kubeClient.exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
-        kubernetes.waitForPodDeletion(connectS2IPodName);
+        StUtils.waitForPodDeletion(connectS2IPodName);
 
         kubeClient.waitForDeploymentConfig(CONNECT_DEPLOYMENT_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -57,12 +57,12 @@ class ConnectS2IST extends AbstractST {
 
         // Start a new image build using the plugins directory
         kubeClient.exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
-        kubeClient.kubeAPIClient().waitForPodDeletion(connectS2IPodName);
+        kubernetes.waitForPodDeletion(connectS2IPodName);
 
         kubeClient.waitForDeploymentConfig(CONNECT_DEPLOYMENT_NAME);
 
-        connectS2IPodName = ((Pod) kubeClient.kubeAPIClient().listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0)).getMetadata().getName();
-        String plugins = kubeClient.kubeAPIClient().execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins");
+        connectS2IPodName = ((Pod) kubernetes.listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0)).getMetadata().getName();
+        String plugins = kubernetes.execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins");
 
         assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));
     }
@@ -84,7 +84,7 @@ class ConnectS2IST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
+        classResources = new Resources(kubernetes.getInstance());
         classResources().kafkaEphemeral(CONNECT_CLUSTER_NAME, 3).done();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -10,6 +10,7 @@ import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.extensions.StrimziExtension;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -83,7 +84,7 @@ class ConnectS2IST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(namespacedClient());
+        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
         classResources().kafkaEphemeral(CONNECT_CLUSTER_NAME, 3).done();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -56,12 +56,12 @@ class ConnectS2IST extends AbstractST {
 
         // Start a new image build using the plugins directory
         kubeClient.exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
-        kubernetes.waitForPodDeletion(connectS2IPodName);
+        kubeClient.kubeAPIClient().waitForPodDeletion(connectS2IPodName);
 
         kubeClient.waitForDeploymentConfig(CONNECT_DEPLOYMENT_NAME);
 
-        connectS2IPodName = ((Pod) kubernetes.listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0)).getMetadata().getName();
-        String plugins = kubernetes.execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins");
+        connectS2IPodName = ((Pod) kubeClient.kubeAPIClient().listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0)).getMetadata().getName();
+        String plugins = kubeClient.kubeAPIClient().execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins");
 
         assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -4,13 +4,11 @@
  */
 package io.strimzi.systemtest;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.extensions.StrimziExtension;
-import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -53,7 +51,7 @@ class ConnectS2IST extends AbstractST {
 
         File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.3.0/debezium-connector-mongodb-0.3.0-plugin.zip");
 
-        String connectS2IPodName = kubeClient.listResourcesByLabel("pod", "type=kafka-connect-s2i").get(0);
+        String connectS2IPodName = kubernetes.listPods(Collections.singletonMap("type", "type=kafka-connect-s2i")).get(0).getMetadata().getName();
 
         // Start a new image build using the plugins directory
         kubeClient.exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
@@ -61,7 +59,7 @@ class ConnectS2IST extends AbstractST {
 
         kubeClient.waitForDeploymentConfig(CONNECT_DEPLOYMENT_NAME);
 
-        connectS2IPodName = ((Pod) kubernetes.listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0)).getMetadata().getName();
+        connectS2IPodName = kubernetes.listPods(Collections.singletonMap("type", "kafka-connect-s2i")).get(0).getMetadata().getName();
         String plugins = kubernetes.execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins");
 
         assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -84,7 +84,7 @@ class ConnectS2IST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(kubernetes.getInstance());
+        classResources = new Resources();
         classResources().kafkaEphemeral(CONNECT_CLUSTER_NAME, 3).done();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -266,7 +266,7 @@ class ConnectST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(kubernetes.getInstance());
+        classResources = new Resources();
 
         Map<String, Object> kafkaConfig = new HashMap<>();
         kafkaConfig.put("offsets.topic.replication.factor", "3");

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -11,6 +11,7 @@ import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -239,7 +240,7 @@ class ConnectST extends AbstractST {
         String connectImageName = getContainerImageNameFromPod(kubeClient.listResourcesByLabel("pod",
                 "strimzi.io/kind=KafkaConnect").get(0));
 
-        String connectVersion = Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(KAFKA_CLUSTER_NAME).get().getSpec().getVersion();
+        String connectVersion = Crds.kafkaConnectOperation(kubeClient.kubeAPIClient().getInstance()).inNamespace(NAMESPACE).withName(KAFKA_CLUSTER_NAME).get().getSpec().getVersion();
         if (connectVersion == null) {
             connectVersion = "2.1.0";
         }
@@ -265,7 +266,7 @@ class ConnectST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(namespacedClient());
+        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
 
         Map<String, Object> kafkaConfig = new HashMap<>();
         kafkaConfig.put("offsets.topic.replication.factor", "3");

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -253,7 +253,7 @@ class ConnectST extends AbstractST {
         //Verifying docker image for kafka connect
         String connectImageName = getContainerImageNameFromPod(kubernetes.listPods(Collections.singletonMap("strimzi.io/kind", "KafkaConnect")).get(0).getMetadata().getName());
 
-        String connectVersion = Crds.kafkaConnectOperation(kubernetes.getInstance()).inNamespace(NAMESPACE).withName(KAFKA_CLUSTER_NAME).get().getSpec().getVersion();
+        String connectVersion = Crds.kafkaConnectOperation(kubernetes.getInstance()).withName(KAFKA_CLUSTER_NAME).get().getSpec().getVersion();
         if (connectVersion == null) {
             connectVersion = "2.1.0";
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -96,13 +96,13 @@ class ConnectST extends AbstractST {
 
         String connectorConfig = getFileAsString("../systemtest/src/test/resources/file/sink/connector.json");
         String kafkaConnectPodName = kubeClient.listResourcesByLabel("pod", "type=kafka-connect").get(0);
-        kubeClient.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
+        kubernetes.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 
         sendMessages(kafkaConnectPodName, KAFKA_CLUSTER_NAME, TEST_TOPIC_NAME, 2);
 
         TestUtils.waitFor("messages in file sink", 1_000, 30_000,
-            () -> kubeClient.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out().equals("0\n1\n"));
+            () -> kubernetes.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").equals("0\n1\n"));
     }
 
     @Test
@@ -159,7 +159,7 @@ class ConnectST extends AbstractST {
         connectPods = kubeClient.listResourcesByLabel("pod", "strimzi.io/kind=KafkaConnect");
         assertEquals(scaleTo, connectPods.size());
         for (String pod : connectPods) {
-            kubeClient.waitForPod(pod);
+            kubernetes.waitForPod(pod);
             List<Event> events = getEvents("Pod", pod);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest;
 
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
@@ -35,8 +36,8 @@ class HelmChartST extends AbstractST {
         resources().kafkaEphemeral(CLUSTER_NAME, 3).done();
         resources().topic(CLUSTER_NAME, TOPIC_NAME).done();
         LOGGER.info("Running testDeployKafkaClusterViaHelmChart {}", CLUSTER_NAME);
-        kubeClient.waitForStatefulSet(zookeeperClusterName(CLUSTER_NAME), 1);
-        kubeClient.waitForStatefulSet(kafkaClusterName(CLUSTER_NAME), 3);
+        StUtils.waitForAllStatefulSetPodsReady(zookeeperClusterName(CLUSTER_NAME));
+        StUtils.waitForAllStatefulSetPodsReady(kafkaClusterName(CLUSTER_NAME));
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -111,7 +111,7 @@ class KafkaST extends AbstractST {
 
         client.pods().list().getItems().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(clusterName))
-                .forEach(p -> kubeClient.kubeAPIClient().waitForPodDeletion(p.getMetadata().getName()));
+                .forEach(p -> kubernetes.waitForPodDeletion(p.getMetadata().getName()));
     }
 
     @Test
@@ -145,7 +145,7 @@ class KafkaST extends AbstractST {
         }
 
         //Test that the new pod does not have errors or failures in events
-        List<Event> events = kubeClient.kubeAPIClient().getEvents("Pod", newPodName);
+        List<Event> events = kubernetes.getEvents("Pod", newPodName);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
         //Test that CO doesn't have any exceptions in log
@@ -169,9 +169,9 @@ class KafkaST extends AbstractST {
                 "Expect the added broker, " + newBrokerId + ",  to no longer be present in output of kafka-broker-api-versions.sh");
 
         //Test that the new broker has event 'Killing'
-        assertThat(kubeClient.kubeAPIClient().getEvents("Pod", newPodName), hasAllOfReasons(Killing));
+        assertThat(kubernetes.getEvents("Pod", newPodName), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
-        assertThat(kubeClient.kubeAPIClient().getEvents("StatefulSet", kafkaClusterName(CLUSTER_NAME)), hasAllOfReasons(SuccessfulDelete));
+        assertThat(kubernetes.getEvents("StatefulSet", kafkaClusterName(CLUSTER_NAME)), hasAllOfReasons(SuccessfulDelete));
         //Test that CO doesn't have any exceptions in log
         TimeMeasuringSystem.stopOperation(operationID);
         assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, operationID));
@@ -201,19 +201,19 @@ class KafkaST extends AbstractST {
         replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getZookeeper().setReplicas(scaleZkTo);
         });
-        kubeClient.kubeAPIClient().waitForPod(newZkPodName[0]);
-        kubeClient.kubeAPIClient().waitForPod(newZkPodName[1]);
+        kubernetes.waitForPod(newZkPodName[0]);
+        kubernetes.waitForPod(newZkPodName[1]);
 
         // check the new node is either in leader or follower state
         waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2);
 
         //Test that first pod does not have errors or failures in events
-        List<Event> eventsForFirstPod = kubeClient.kubeAPIClient().getEvents("Pod", newZkPodName[0]);
+        List<Event> eventsForFirstPod = kubernetes.getEvents("Pod", newZkPodName[0]);
         assertThat(eventsForFirstPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(eventsForFirstPod, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
 
         //Test that second pod does not have errors or failures in events
-        List<Event> eventsForSecondPod = kubeClient.kubeAPIClient().getEvents("Pod", newZkPodName[1]);
+        List<Event> eventsForSecondPod = kubernetes.getEvents("Pod", newZkPodName[1]);
         assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(eventsForSecondPod, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
 
@@ -232,9 +232,9 @@ class KafkaST extends AbstractST {
         waitForZkMntr(Pattern.compile("zk_server_state\\s+standalone"), 0);
 
         //Test that the second pod has event 'Killing'
-        assertThat(kubeClient.kubeAPIClient().getEvents("Pod", newZkPodName[1]), hasAllOfReasons(Killing));
+        assertThat(kubernetes.getEvents("Pod", newZkPodName[1]), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
-        assertThat(kubeClient.kubeAPIClient().getEvents("StatefulSet", zookeeperClusterName(CLUSTER_NAME)), hasAllOfReasons(SuccessfulDelete));
+        assertThat(kubernetes.getEvents("StatefulSet", zookeeperClusterName(CLUSTER_NAME)), hasAllOfReasons(SuccessfulDelete));
         // Stop measuring
         TimeMeasuringSystem.stopOperation(operationID);
         //Test that CO doesn't have any exceptions in log
@@ -327,11 +327,11 @@ class KafkaST extends AbstractST {
 
         for (int i = 0; i < expectedZKPods; i++) {
             kubeClient.waitForResourceUpdate("pod", zookeeperPodName(CLUSTER_NAME, i), zkPodStartTime.get(i));
-            kubeClient.kubeAPIClient().waitForPod(zookeeperPodName(CLUSTER_NAME,  i));
+            kubernetes.waitForPod(zookeeperPodName(CLUSTER_NAME,  i));
         }
         for (int i = 0; i < expectedKafkaPods; i++) {
             kubeClient.waitForResourceUpdate("pod", kafkaPodName(CLUSTER_NAME, i), kafkaPodStartTime.get(i));
-            kubeClient.kubeAPIClient().waitForPod(kafkaPodName(CLUSTER_NAME,  i));
+            kubernetes.waitForPod(kafkaPodName(CLUSTER_NAME,  i));
         }
 
         LOGGER.info("Verify values after update");
@@ -436,7 +436,7 @@ class KafkaST extends AbstractST {
         resources().topic(CLUSTER_NAME, topicName).done();
         KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
-        String brokerPodLog = kubeClient.kubeAPIClient().logs(CLUSTER_NAME + "-kafka-0", "kafka");
+        String brokerPodLog = kubernetes.logs(CLUSTER_NAME + "-kafka-0", "kafka");
         Pattern p = Pattern.compile("^.*" + Pattern.quote(kafkaUser) + ".*$", Pattern.MULTILINE);
         Matcher m = p.matcher(brokerPodLog);
         boolean found = false;
@@ -699,15 +699,15 @@ class KafkaST extends AbstractST {
         testDockerImagesForKafkaCluster(CLUSTER_NAME, 1, 1, true);
 
         String kafkaPodName = kafkaPodName(CLUSTER_NAME, 0);
-        kubeClient.kubeAPIClient().waitForPod(kafkaPodName);
+        kubernetes.waitForPod(kafkaPodName);
 
-        String rackId = kubeClient.kubeAPIClient().execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /opt/kafka/init/rack.id");
+        String rackId = kubernetes.execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /opt/kafka/init/rack.id");
         assertEquals("zone", rackId);
 
-        String brokerRack = kubeClient.kubeAPIClient().execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack");
+        String brokerRack = kubernetes.execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack");
         assertTrue(brokerRack.contains("broker.rack=zone"));
 
-        List<Event> events = kubeClient.kubeAPIClient().getEvents("Pod", kafkaPodName);
+        List<Event> events = kubernetes.getEvents("Pod", kafkaPodName);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -111,7 +111,7 @@ class KafkaST extends AbstractST {
 
         client.pods().list().getItems().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(clusterName))
-                .forEach(p -> kubeClient.kubeAPIClient().waitForPodDeletion(NAMESPACE, p.getMetadata().getName()));
+                .forEach(p -> kubeClient.kubeAPIClient().waitForPodDeletion(p.getMetadata().getName()));
     }
 
     @Test
@@ -436,7 +436,7 @@ class KafkaST extends AbstractST {
         resources().topic(CLUSTER_NAME, topicName).done();
         KafkaUser user = resources().scramShaUser(CLUSTER_NAME, kafkaUser).done();
         waitTillSecretExists(kafkaUser);
-        String brokerPodLog = podLog(CLUSTER_NAME + "-kafka-0", "kafka");
+        String brokerPodLog = kubeClient.kubeAPIClient().logs(CLUSTER_NAME + "-kafka-0", "kafka");
         Pattern p = Pattern.compile("^.*" + Pattern.quote(kafkaUser) + ".*$", Pattern.MULTILINE);
         Matcher m = p.matcher(brokerPodLog);
         boolean found = false;

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
-import static io.strimzi.test.k8s.BaseKubeClient.STATEFUL_SET;
+import static io.strimzi.test.k8s.BaseKubeExecClient.STATEFUL_SET;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(StrimziExtension.class)

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogLevelST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest;
 
 import io.strimzi.systemtest.timemeasuring.Operation;
 import io.strimzi.systemtest.timemeasuring.TimeMeasuringSystem;
+import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
@@ -134,7 +135,7 @@ class LogLevelST extends AbstractST {
         boolean result = false;
         for (Map.Entry<String, String> entry : loggers.entrySet()) {
             LOGGER.info("Check log level setting since {} seconds. Logger: {} Expected: {}", since, entry.getKey(), entry.getValue());
-            String configMap = kubeClient.get("configMap", configMapName);
+            String configMap = TestUtils.toJsonString(kubernetes.getConfigMap(configMapName));
             String loggerConfig = String.format("%s=%s", entry.getKey(), entry.getValue());
             result = configMap.contains(loggerConfig);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -90,7 +90,7 @@ class MultipleNamespaceST extends AbstractST {
     @BeforeEach
     void createSecondNamespaceResources() {
         kubeClient.namespace(SECOND_NAMESPACE);
-        secondNamespaceResources = new Resources(kubernetes.getInstance());
+        secondNamespaceResources = new Resources();
         kubeClient.namespace(DEFAULT_NAMESPACE);
     }
 
@@ -109,7 +109,7 @@ class MultipleNamespaceST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", DEFAULT_NAMESPACE, SECOND_NAMESPACE)).done();
 
-        classResources = new Resources(kubernetes.getInstance());
+        classResources = new Resources();
         classResources().kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -8,6 +8,7 @@ import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -89,7 +90,7 @@ class MultipleNamespaceST extends AbstractST {
     @BeforeEach
     void createSecondNamespaceResources() {
         kubeClient.namespace(SECOND_NAMESPACE);
-        secondNamespaceResources = new Resources(namespacedClient());
+        secondNamespaceResources = new Resources(kubeClient.kubeAPIClient().getInstance());
         kubeClient.namespace(DEFAULT_NAMESPACE);
     }
 
@@ -108,7 +109,7 @@ class MultipleNamespaceST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", DEFAULT_NAMESPACE, SECOND_NAMESPACE)).done();
 
-        classResources = new Resources(namespacedClient());
+        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
         classResources().kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -90,7 +90,7 @@ class MultipleNamespaceST extends AbstractST {
     @BeforeEach
     void createSecondNamespaceResources() {
         kubeClient.namespace(SECOND_NAMESPACE);
-        secondNamespaceResources = new Resources(kubeClient.kubeAPIClient().getInstance());
+        secondNamespaceResources = new Resources(kubernetes.getInstance());
         kubeClient.namespace(DEFAULT_NAMESPACE);
     }
 
@@ -109,7 +109,7 @@ class MultipleNamespaceST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(String.join(",", DEFAULT_NAMESPACE, SECOND_NAMESPACE)).done();
 
-        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
+        classResources = new Resources(kubernetes.getInstance());
         classResources().kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -6,10 +6,10 @@ package io.strimzi.systemtest;
 
 import io.strimzi.systemtest.timemeasuring.Operation;
 import io.strimzi.systemtest.timemeasuring.TimeMeasuringSystem;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
-import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,10 +19,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
-import static io.strimzi.test.k8s.BaseKubeClient.CM;
-import static io.strimzi.test.k8s.BaseKubeClient.DEPLOYMENT;
-import static io.strimzi.test.k8s.BaseKubeClient.SERVICE;
-import static io.strimzi.test.k8s.BaseKubeClient.STATEFUL_SET;
 
 @ExtendWith(StrimziExtension.class)
 @Namespace(RecoveryST.NAMESPACE)
@@ -43,11 +39,11 @@ class RecoveryST extends AbstractST {
         String entityOperatorDeploymentName = entityOperatorDeploymentName(CLUSTER_NAME);
         LOGGER.info("Running testRecoveryFromEntityOperatorDeletion with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(DEPLOYMENT, entityOperatorDeploymentName);
-        kubeClient.waitForResourceDeletion(DEPLOYMENT, entityOperatorDeploymentName);
+        kubernetes.deleteDeployment(entityOperatorDeploymentName);
+        StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName);
 
         LOGGER.info("Waiting for recovery {}", entityOperatorDeploymentName);
-        kubeClient.waitForDeployment(entityOperatorDeploymentName, 1);
+        StUtils.waitForDeploymentReady(entityOperatorDeploymentName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -60,11 +56,11 @@ class RecoveryST extends AbstractST {
         String kafkaStatefulSetName = kafkaClusterName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaStatefulSet with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(STATEFUL_SET, kafkaStatefulSetName);
-        kubeClient.waitForResourceDeletion(STATEFUL_SET, kafkaStatefulSetName);
+        kubernetes.deleteStatefulSet(kafkaStatefulSetName);
+        StUtils.waitForStatefulSetDeletion(kafkaStatefulSetName);
 
         LOGGER.info("Waiting for recovery {}", kafkaStatefulSetName);
-        kubeClient.waitForStatefulSet(kafkaStatefulSetName, 1);
+        StUtils.waitForStatefulSetReady(kafkaStatefulSetName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -77,11 +73,11 @@ class RecoveryST extends AbstractST {
         String zookeeperStatefulSetName = zookeeperClusterName(CLUSTER_NAME);
         LOGGER.info("Running deleteZookeeperStatefulSet with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(STATEFUL_SET, zookeeperStatefulSetName);
-        kubeClient.waitForResourceDeletion(STATEFUL_SET, zookeeperStatefulSetName);
+        kubernetes.deleteStatefulSet(zookeeperStatefulSetName);
+        StUtils.waitForStatefulSetDeletion(zookeeperStatefulSetName);
 
         LOGGER.info("Waiting for recovery {}", zookeeperStatefulSetName);
-        kubeClient.waitForStatefulSet(zookeeperStatefulSetName, 1);
+        StUtils.waitForStatefulSetReady(zookeeperStatefulSetName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -94,10 +90,10 @@ class RecoveryST extends AbstractST {
         String kafkaServiceName = kafkaServiceName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaService with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(SERVICE, kafkaServiceName);
+        kubernetes.deleteService(kafkaServiceName);
 
         LOGGER.info("Waiting for creation {}", kafkaServiceName);
-        kubeClient.waitForResourceCreation(SERVICE, kafkaServiceName);
+        StUtils.waitForServiceReady(kafkaServiceName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -111,10 +107,10 @@ class RecoveryST extends AbstractST {
 
         LOGGER.info("Running deleteKafkaService with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(SERVICE, zookeeperServiceName);
+        kubernetes.deleteService(zookeeperServiceName);
 
         LOGGER.info("Waiting for creation {}", zookeeperServiceName);
-        kubeClient.waitForResourceCreation(SERVICE, zookeeperServiceName);
+        StUtils.waitForServiceReady(zookeeperServiceName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -127,10 +123,10 @@ class RecoveryST extends AbstractST {
         String kafkaHeadlessServiceName = kafkaHeadlessServiceName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaHeadlessService with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(SERVICE, kafkaHeadlessServiceName);
+        kubernetes.deleteService(kafkaHeadlessServiceName);
 
         LOGGER.info("Waiting for creation {}", kafkaHeadlessServiceName);
-        kubeClient.waitForResourceCreation(SERVICE, kafkaHeadlessServiceName);
+        StUtils.waitForServiceReady(kafkaHeadlessServiceName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -143,10 +139,10 @@ class RecoveryST extends AbstractST {
         String zookeeperHeadlessServiceName = zookeeperHeadlessServiceName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaHeadlessService with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(SERVICE, zookeeperHeadlessServiceName);
+        kubernetes.deleteService(zookeeperHeadlessServiceName);
 
         LOGGER.info("Waiting for creation {}", zookeeperHeadlessServiceName);
-        kubeClient.waitForResourceCreation(SERVICE, zookeeperHeadlessServiceName);
+        StUtils.waitForServiceReady(zookeeperHeadlessServiceName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -159,11 +155,11 @@ class RecoveryST extends AbstractST {
         String kafkaMetricsConfigName = kafkaMetricsConfigName(CLUSTER_NAME);
         LOGGER.info("Running deleteKafkaMetricsConfig with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(CM, kafkaMetricsConfigName);
-        kubeClient.waitForResourceDeletion(CM, kafkaMetricsConfigName);
+        kubernetes.deleteConfigMap(kafkaMetricsConfigName);
+        StUtils.waitForConfigMapDeletion(kafkaMetricsConfigName);
 
         LOGGER.info("Waiting for creation {}", kafkaMetricsConfigName);
-        kubeClient.waitForResourceCreation(CM, kafkaMetricsConfigName);
+        StUtils.waitForConfigMapReady(kafkaMetricsConfigName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();
@@ -176,11 +172,11 @@ class RecoveryST extends AbstractST {
         String zookeeperMetricsConfigName = zookeeperMetricsConfigName(CLUSTER_NAME);
         LOGGER.info("Running deleteZookeeperMetricsConfig with cluster {}", CLUSTER_NAME);
 
-        kubeClient.deleteByName(CM, zookeeperMetricsConfigName);
-        kubeClient.waitForResourceDeletion(CM, zookeeperMetricsConfigName);
+        kubernetes.deleteConfigMap(zookeeperMetricsConfigName);
+        StUtils.waitForConfigMapDeletion(zookeeperMetricsConfigName);
 
         LOGGER.info("Waiting for creation {}", zookeeperMetricsConfigName);
-        kubeClient.waitForResourceCreation(CM, zookeeperMetricsConfigName);
+        StUtils.waitForConfigMapReady(zookeeperMetricsConfigName);
 
         //Test that CO doesn't have any exceptions in log
         assertNoErrorLogged();

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -193,7 +193,7 @@ class RecoveryST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
+        classResources = new Resources(kubernetes.getInstance());
         classResources().kafkaEphemeral(CLUSTER_NAME, 1).done();
         testClass = testInfo.getTestClass().get().getSimpleName();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -9,6 +9,7 @@ import io.strimzi.systemtest.timemeasuring.TimeMeasuringSystem;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.extensions.StrimziExtension;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -192,7 +193,7 @@ class RecoveryST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(namespacedClient());
+        classResources = new Resources(kubeClient.kubeAPIClient().getInstance());
         classResources().kafkaEphemeral(CLUSTER_NAME, 1).done();
         testClass = testInfo.getTestClass().get().getSimpleName();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -193,7 +193,7 @@ class RecoveryST extends AbstractST {
         // 050-Deployment
         testClassResources.clusterOperator(NAMESPACE).done();
 
-        classResources = new Resources(kubernetes.getInstance());
+        classResources = new Resources();
         classResources().kafkaEphemeral(CLUSTER_NAME, 1).done();
         testClass = testInfo.getTestClass().get().getSimpleName();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -21,8 +21,8 @@ import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
@@ -78,13 +78,13 @@ public class Resources {
     public static final String STRIMZI_PATH_TO_CO_CONFIG = "../install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml";
     public static final String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
 
-    private final NamespacedKubernetesClient client;
+    private final KubernetesClient client;
 
-    Resources(NamespacedKubernetesClient client) {
+    Resources(KubernetesClient client) {
         this.client = client;
     }
 
-    private NamespacedKubernetesClient client() {
+    private KubernetesClient client() {
         return client;
     }
 
@@ -425,14 +425,14 @@ public class Resources {
         String namespace = kafka.getMetadata().getNamespace();
         waitForStatefulSet(namespace, KafkaResources.zookeeperStatefulSetName(name));
         waitForStatefulSet(namespace, KafkaResources.kafkaStatefulSetName(name));
-        StUtils.waitForDeploymentReady(namespace, KafkaResources.entityOperatorDeploymentName(name));
+        StUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
         return kafka;
     }
 
     KafkaConnect waitFor(KafkaConnect kafkaConnect) {
         LOGGER.info("Waiting for Kafka Connect {}", kafkaConnect.getMetadata().getName());
         String namespace = kafkaConnect.getMetadata().getNamespace();
-        StUtils.waitForDeploymentReady(namespace, kafkaConnect.getMetadata().getName() + "-connect");
+        StUtils.waitForDeploymentReady(kafkaConnect.getMetadata().getName() + "-connect");
         return kafkaConnect;
     }
 
@@ -446,14 +446,13 @@ public class Resources {
     private KafkaMirrorMaker waitFor(KafkaMirrorMaker kafkaMirrorMaker) {
         LOGGER.info("Waiting for Kafka Mirror Maker {}", kafkaMirrorMaker.getMetadata().getName());
         String namespace = kafkaMirrorMaker.getMetadata().getNamespace();
-        StUtils.waitForDeploymentReady(namespace, kafkaMirrorMaker.getMetadata().getName() + "-mirror-maker");
+        StUtils.waitForDeploymentReady(kafkaMirrorMaker.getMetadata().getName() + "-mirror-maker");
         return kafkaMirrorMaker;
     }
 
     private Deployment waitFor(Deployment clusterOperator) {
         LOGGER.info("Waiting for Cluster Operator {}", clusterOperator.getMetadata().getName());
-        String namespace = client.getNamespace();
-        StUtils.waitForDeploymentReady(namespace, clusterOperator.getMetadata().getName());
+        StUtils.waitForDeploymentReady(clusterOperator.getMetadata().getName());
         return clusterOperator;
     }
 
@@ -667,7 +666,7 @@ public class Resources {
 
     DoneableKubernetesRoleBinding kubernetesRoleBinding(KubernetesRoleBinding roleBinding, String clientNamespace) {
         LOGGER.info("Apply RoleBinding in namespace {}", clientNamespace);
-        client.inNamespace(clientNamespace).rbac().kubernetesRoleBindings().createOrReplace(roleBinding);
+        client.rbac().kubernetesRoleBindings().createOrReplace(roleBinding);
         return new DoneableKubernetesRoleBinding(roleBinding);
     }
 
@@ -687,7 +686,7 @@ public class Resources {
 
     DoneableKubernetesClusterRoleBinding kubernetesClusterRoleBinding(KubernetesClusterRoleBinding clusterRoleBinding, String clientNamespace) {
         LOGGER.info("Apply ClusterRoleBinding in namespace {}", clientNamespace);
-        client.inNamespace(clientNamespace).rbac().kubernetesClusterRoleBindings().createOrReplace(clusterRoleBinding);
+        client.rbac().kubernetesClusterRoleBindings().createOrReplace(clusterRoleBinding);
         return new DoneableKubernetesClusterRoleBinding(clusterRoleBinding);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -7,21 +7,19 @@ package io.strimzi.systemtest;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -87,7 +85,7 @@ public class Resources {
 
     // This logic is necessary only for the deletion of resources with `cascading: true`
     private <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResourcesWithCascading(Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
-        return new CustomResourceOperationsImpl<T, L, D>(((DefaultKubernetesClient) kubernetes.getInstance()).getHttpClient(), kubernetes.getInstance().getConfiguration(), Crds.kafka().getSpec().getGroup(), Crds.kafka().getSpec().getVersion(), "kafkas", true, kubernetes.getNamespace(), null, true, null, null, false, resourceType, listClass, doneClass);
+        return new CustomResourceOperationsImpl<T, L, D>(kubernetes.getInstance().getHttpClient(), kubernetes.getInstance().getConfiguration(), Crds.kafka().getSpec().getGroup(), Crds.kafka().getSpec().getVersion(), "kafkas", true, kubernetes.getNamespace(), null, true, null, null, false, resourceType, listClass, doneClass);
     }
 
     private MixedOperation<KafkaConnect, KafkaConnectAssemblyList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnect() {
@@ -465,10 +463,10 @@ public class Resources {
         String namespace = kafka.getMetadata().getNamespace();
 
         IntStream.rangeClosed(0, kafka.getSpec().getZookeeper().getReplicas() - 1).forEach(podIndex ->
-            StUtils.waitForPodDeletion(namespace, kafka.getMetadata().getName() + "-zookeeper-" + podIndex));
+            StUtils.waitForPodDeletion(kafka.getMetadata().getName() + "-zookeeper-" + podIndex));
 
         IntStream.rangeClosed(0, kafka.getSpec().getKafka().getReplicas() - 1).forEach(podIndex ->
-                StUtils.waitForPodDeletion(namespace, kafka.getMetadata().getName() + "-kafka-" + podIndex));
+                StUtils.waitForPodDeletion(kafka.getMetadata().getName() + "-kafka-" + podIndex));
     }
 
     private void waitForDeletion(KafkaConnect kafkaConnect) {
@@ -477,7 +475,7 @@ public class Resources {
 
         kubernetes.listPods().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(kafkaConnect.getMetadata().getName() + "-connect-"))
-                .forEach(p -> StUtils.waitForPodDeletion(namespace, p.getMetadata().getName()));
+                .forEach(p -> StUtils.waitForPodDeletion(p.getMetadata().getName()));
     }
 
     private void waitForDeletion(KafkaConnectS2I kafkaConnectS2I) {
@@ -486,7 +484,7 @@ public class Resources {
 
         kubernetes.listPods().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(kafkaConnectS2I.getMetadata().getName() + "-connect-"))
-                .forEach(p -> StUtils.waitForPodDeletion(namespace, p.getMetadata().getName()));
+                .forEach(p -> StUtils.waitForPodDeletion(p.getMetadata().getName()));
     }
 
     private void waitForDeletion(KafkaMirrorMaker kafkaMirrorMaker) {
@@ -495,7 +493,7 @@ public class Resources {
 
         kubernetes.listPods().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(kafkaMirrorMaker.getMetadata().getName() + "-mirror-maker-"))
-                .forEach(p -> StUtils.waitForPodDeletion(namespace, p.getMetadata().getName()));
+                .forEach(p -> StUtils.waitForPodDeletion(p.getMetadata().getName()));
     }
 
     DoneableKafkaTopic topic(String clusterName, String topicName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/Resources.java
@@ -453,7 +453,7 @@ public class Resources {
      * Wait until the SS is ready and all of its Pods are also ready
      */
     public void waitForStatefulSet(String namespace, String name) {
-        StUtils.waitForAllStatefulSetPodsReady(namespace, name);
+        StUtils.waitForAllStatefulSetPodsReady(name);
     }
 
     private void waitForDeploymentConfig(String namespace, String name) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -15,6 +15,7 @@ import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.extensions.StrimziExtension;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterException;
+import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -323,6 +324,7 @@ class SecurityST extends AbstractST {
     }
 
     private AvailabilityVerifier waitForInitialAvailability(String userName) {
+        kubeClient.kubeAPIClient();
         AvailabilityVerifier mp = new AvailabilityVerifier(kubeClient.kubeAPIClient().getInstance(), NAMESPACE, CLUSTER_NAME, userName);
         mp.start();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -232,10 +232,10 @@ class SecurityST extends AbstractST {
         String bobUserName = "bob";
         resources().tlsUser(CLUSTER_NAME, bobUserName).done();
         waitFor("", 1_000, 60_000, () -> {
-            return client.secrets().inNamespace(NAMESPACE).withName(bobUserName).get() != null;
+            return kubeClient.kubeAPIClient().getSecret(bobUserName) != null;
         },
             () -> {
-                LOGGER.error("Couldn't find user secret {}", client.secrets().inNamespace(NAMESPACE).list().getItems());
+                LOGGER.error("Couldn't find user secret {}", kubeClient.kubeAPIClient().getListSecrets());
             });
 
         mp = waitForInitialAvailability(bobUserName);
@@ -249,8 +249,8 @@ class SecurityST extends AbstractST {
         String aliceUserName = "alice";
         resources().tlsUser(CLUSTER_NAME, aliceUserName).done();
         waitFor("Alic's secret to exist", 1_000, 60_000,
-            () -> client.secrets().inNamespace(NAMESPACE).withName(aliceUserName).get() != null,
-            () -> LOGGER.error("Couldn't find user secret {}", client.secrets().inNamespace(NAMESPACE).list().getItems()));
+            () -> kubeClient.kubeAPIClient().getSecret(aliceUserName) != null,
+            () -> LOGGER.error("Couldn't find user secret {}", kubeClient.kubeAPIClient().getListSecrets()));
 
         AvailabilityVerifier mp = waitForInitialAvailability(aliceUserName);
 
@@ -323,7 +323,7 @@ class SecurityST extends AbstractST {
     }
 
     private AvailabilityVerifier waitForInitialAvailability(String userName) {
-        AvailabilityVerifier mp = new AvailabilityVerifier(client, NAMESPACE, CLUSTER_NAME, userName);
+        AvailabilityVerifier mp = new AvailabilityVerifier(kubeClient.kubeAPIClient().getInstance(), NAMESPACE, CLUSTER_NAME, userName);
         mp.start();
 
         TestUtils.waitFor("Some messages sent received", 1_000, TIMEOUT_FOR_SEND_RECEIVE_MSG,

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -9,13 +9,12 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.utils.AvailabilityVerifier;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ClusterOperator;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.extensions.StrimziExtension;
-import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterException;
-import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -39,9 +38,9 @@ import static io.strimzi.api.kafka.model.KafkaResources.clusterCaCertificateSecr
 import static io.strimzi.api.kafka.model.KafkaResources.clusterCaKeySecretName;
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.api.kafka.model.KafkaResources.zookeeperStatefulSetName;
-import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
 import static io.strimzi.test.TestUtils.map;
 import static io.strimzi.test.TestUtils.waitFor;
+import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -179,7 +178,7 @@ class SecurityST extends AbstractST {
         String userName = "alice";
         resources().tlsUser(CLUSTER_NAME, userName).done();
         waitFor("", 1_000, TIMEOUT_FOR_GET_SECRETS, () -> kubernetes.getSecret("alice") != null,
-            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.getListSecrets()));
+            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.listSecrets()));
 
         AvailabilityVerifier mp = waitForInitialAvailability(userName);
 
@@ -236,7 +235,7 @@ class SecurityST extends AbstractST {
             return kubernetes.getSecret(bobUserName) != null;
         },
             () -> {
-                LOGGER.error("Couldn't find user secret {}", kubernetes.getListSecrets());
+                LOGGER.error("Couldn't find user secret {}", kubernetes.listSecrets());
             });
 
         mp = waitForInitialAvailability(bobUserName);
@@ -251,7 +250,7 @@ class SecurityST extends AbstractST {
         resources().tlsUser(CLUSTER_NAME, aliceUserName).done();
         waitFor("Alic's secret to exist", 1_000, 60_000,
             () -> kubernetes.getSecret(aliceUserName) != null,
-            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.getListSecrets()));
+            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.listSecrets()));
 
         AvailabilityVerifier mp = waitForInitialAvailability(aliceUserName);
 
@@ -317,7 +316,7 @@ class SecurityST extends AbstractST {
         resources().tlsUser(CLUSTER_NAME, bobUserName).done();
         waitFor("Bob's secret to exist", 1_000, 60_000,
             () -> kubernetes.getSecret(bobUserName) != null,
-            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.getListSecrets()));
+            () -> LOGGER.error("Couldn't find user secret {}", kubernetes.listSecrets()));
 
         mp = waitForInitialAvailability(bobUserName);
         mp.stop(30_000);

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -87,9 +87,9 @@ public class StrimziUpgradeST extends AbstractST {
             String zkSsName = KafkaResources.zookeeperStatefulSetName("my-cluster");
             String kafkaSsName = KafkaResources.kafkaStatefulSetName("my-cluster");
             String eoDepName = KafkaResources.entityOperatorDeploymentName("my-cluster");
-            Map<String, String> zkPods = StUtils.ssSnapshot(client, NAMESPACE, zkSsName);
-            Map<String, String> kafkaPods = StUtils.ssSnapshot(client, NAMESPACE, kafkaSsName);
-            Map<String, String> eoPods = StUtils.depSnapshot(client, NAMESPACE, eoDepName);
+            Map<String, String> zkPods = StUtils.ssSnapshot(NAMESPACE, zkSsName);
+            Map<String, String> kafkaPods = StUtils.ssSnapshot(NAMESPACE, kafkaSsName);
+            Map<String, String> eoPods = StUtils.depSnapshot(NAMESPACE, eoDepName);
 
             List<Pod> pods = client.pods().inNamespace(NAMESPACE).withLabels(client.apps().statefulSets().inNamespace(NAMESPACE).withName(zkSsName).get().getSpec().getSelector().getMatchLabels()).list().getItems();
             for (Pod pod : pods) {
@@ -103,18 +103,18 @@ public class StrimziUpgradeST extends AbstractST {
             kubeClient.waitForDeployment("strimzi-cluster-operator", 1);
 
             LOGGER.info("Waiting for ZK SS roll");
-            StUtils.waitTillSsHasRolled(client, NAMESPACE, zkSsName, zkPods);
+            StUtils.waitTillSsHasRolled(NAMESPACE, zkSsName, zkPods);
             LOGGER.info("Checking ZK pods using new image");
             waitTillAllPodsUseImage(client.apps().statefulSets().inNamespace(NAMESPACE).withName(zkSsName).get().getSpec().getSelector().getMatchLabels(),
                     "strimzi/zookeeper:latest-kafka-2.0.0");
             LOGGER.info("Waiting for Kafka SS roll");
-            StUtils.waitTillSsHasRolled(client, NAMESPACE, kafkaSsName, kafkaPods);
+            StUtils.waitTillSsHasRolled(NAMESPACE, kafkaSsName, kafkaPods);
             LOGGER.info("Checking Kafka pods using new image");
             waitTillAllPodsUseImage(client.apps().statefulSets().inNamespace(NAMESPACE).withName(kafkaSsName).get().getSpec().getSelector().getMatchLabels(),
                     "strimzi/kafka:latest-kafka-2.1.0");
             LOGGER.info("Waiting for EO Dep roll");
             // Check the TO and UO also got upgraded
-            StUtils.waitTillDepHasRolled(client, NAMESPACE, eoDepName, eoPods);
+            StUtils.waitTillDepHasRolled(NAMESPACE, eoDepName, eoPods);
             LOGGER.info("Checking EO pod using new image");
             waitTillAllContainersUseImage(
                     client.extensions().deployments().inNamespace(NAMESPACE).withName(eoDepName).get().getSpec().getSelector().getMatchLabels(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -91,7 +91,7 @@ public class StrimziUpgradeST extends AbstractST {
             Map<String, String> kafkaPods = StUtils.ssSnapshot(NAMESPACE, kafkaSsName);
             Map<String, String> eoPods = StUtils.depSnapshot(NAMESPACE, eoDepName);
 
-            List<Pod> pods = client.pods().inNamespace(NAMESPACE).withLabels(client.apps().statefulSets().inNamespace(NAMESPACE).withName(zkSsName).get().getSpec().getSelector().getMatchLabels()).list().getItems();
+            List<Pod> pods = kubeClient.kubeAPIClient().listPods(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, zkSsName).getMatchLabels());
             for (Pod pod : pods) {
                 LOGGER.info("Pod {} has image {}", pod.getMetadata().getName(), pod.getSpec().getContainers().get(0).getImage());
             }
@@ -105,23 +105,23 @@ public class StrimziUpgradeST extends AbstractST {
             LOGGER.info("Waiting for ZK SS roll");
             StUtils.waitTillSsHasRolled(NAMESPACE, zkSsName, zkPods);
             LOGGER.info("Checking ZK pods using new image");
-            waitTillAllPodsUseImage(client.apps().statefulSets().inNamespace(NAMESPACE).withName(zkSsName).get().getSpec().getSelector().getMatchLabels(),
+            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, zkSsName).getMatchLabels(),
                     "strimzi/zookeeper:latest-kafka-2.0.0");
             LOGGER.info("Waiting for Kafka SS roll");
             StUtils.waitTillSsHasRolled(NAMESPACE, kafkaSsName, kafkaPods);
             LOGGER.info("Checking Kafka pods using new image");
-            waitTillAllPodsUseImage(client.apps().statefulSets().inNamespace(NAMESPACE).withName(kafkaSsName).get().getSpec().getSelector().getMatchLabels(),
+            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, kafkaSsName).getMatchLabels(),
                     "strimzi/kafka:latest-kafka-2.1.0");
             LOGGER.info("Waiting for EO Dep roll");
             // Check the TO and UO also got upgraded
             StUtils.waitTillDepHasRolled(NAMESPACE, eoDepName, eoPods);
             LOGGER.info("Checking EO pod using new image");
             waitTillAllContainersUseImage(
-                    client.extensions().deployments().inNamespace(NAMESPACE).withName(eoDepName).get().getSpec().getSelector().getMatchLabels(),
+                    kubeClient.kubeAPIClient().getDeploymentSelectors(NAMESPACE, eoDepName).getMatchLabels(),
                     0,
                     "strimzi/topic-operator:latest");
             waitTillAllContainersUseImage(
-                    client.extensions().deployments().inNamespace(NAMESPACE).withName(eoDepName).get().getSpec().getSelector().getMatchLabels(),
+                    kubeClient.kubeAPIClient().getDeploymentSelectors(NAMESPACE, eoDepName).getMatchLabels(),
                     1,
                     "strimzi/user-operator:latest");
 
@@ -144,7 +144,7 @@ public class StrimziUpgradeST extends AbstractST {
 
     private void waitTillAllContainersUseImage(Map<String, String> matchLabels, int container, String image) {
         TestUtils.waitFor("All pods matching " + matchLabels + " to have image " + image, GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT, () -> {
-            List<Pod> pods1 = client.pods().inNamespace(NAMESPACE).withLabels(matchLabels).list().getItems();
+            List<Pod> pods1 = kubeClient.kubeAPIClient().listPods(matchLabels);
             for (Pod pod : pods1) {
                 if (!image.equals(pod.getSpec().getContainers().get(container).getImage())) {
                     return false;

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -91,7 +91,7 @@ public class StrimziUpgradeST extends AbstractST {
             Map<String, String> kafkaPods = StUtils.ssSnapshot(NAMESPACE, kafkaSsName);
             Map<String, String> eoPods = StUtils.depSnapshot(NAMESPACE, eoDepName);
 
-            List<Pod> pods = kubeClient.kubeAPIClient().listPods(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, zkSsName).getMatchLabels());
+            List<Pod> pods = kubeClient.kubeAPIClient().listPods(kubeClient.kubeAPIClient().getStatefulSetSelectors(zkSsName).getMatchLabels());
             for (Pod pod : pods) {
                 LOGGER.info("Pod {} has image {}", pod.getMetadata().getName(), pod.getSpec().getContainers().get(0).getImage());
             }
@@ -105,23 +105,23 @@ public class StrimziUpgradeST extends AbstractST {
             LOGGER.info("Waiting for ZK SS roll");
             StUtils.waitTillSsHasRolled(NAMESPACE, zkSsName, zkPods);
             LOGGER.info("Checking ZK pods using new image");
-            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, zkSsName).getMatchLabels(),
+            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(zkSsName).getMatchLabels(),
                     "strimzi/zookeeper:latest-kafka-2.0.0");
             LOGGER.info("Waiting for Kafka SS roll");
             StUtils.waitTillSsHasRolled(NAMESPACE, kafkaSsName, kafkaPods);
             LOGGER.info("Checking Kafka pods using new image");
-            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(NAMESPACE, kafkaSsName).getMatchLabels(),
+            waitTillAllPodsUseImage(kubeClient.kubeAPIClient().getStatefulSetSelectors(kafkaSsName).getMatchLabels(),
                     "strimzi/kafka:latest-kafka-2.1.0");
             LOGGER.info("Waiting for EO Dep roll");
             // Check the TO and UO also got upgraded
             StUtils.waitTillDepHasRolled(NAMESPACE, eoDepName, eoPods);
             LOGGER.info("Checking EO pod using new image");
             waitTillAllContainersUseImage(
-                    kubeClient.kubeAPIClient().getDeploymentSelectors(NAMESPACE, eoDepName).getMatchLabels(),
+                    kubeClient.kubeAPIClient().getDeploymentSelectors(eoDepName).getMatchLabels(),
                     0,
                     "strimzi/topic-operator:latest");
             waitTillAllContainersUseImage(
-                    kubeClient.kubeAPIClient().getDeploymentSelectors(NAMESPACE, eoDepName).getMatchLabels(),
+                    kubeClient.kubeAPIClient().getDeploymentSelectors(eoDepName).getMatchLabels(),
                     1,
                     "strimzi/user-operator:latest");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
@@ -240,4 +240,9 @@ public class StUtils {
         LOGGER.info("Deployment Config {} is ready", name);
     }
 
+    public static String getPodNameByPrefix (String prefix) {
+        return kubernetes.listPods().stream().filter(pod -> pod.getMetadata().getName().startsWith(prefix))
+                .findFirst().get().getMetadata().getName();
+    }
+
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
@@ -10,11 +10,8 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Resources;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeClient;
-import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Kubernetes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,7 +34,6 @@ import static io.strimzi.test.k8s.Kubernetes.getKubernetes;
 public class StUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(StUtils.class);
-    private static KubeClient kubeClient = AbstractST.cluster.client();
     private static Kubernetes kubernetes = getKubernetes();
 
     private StUtils() { }

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -235,6 +236,12 @@ public class StUtils {
         });
     }
 
+    public static void waitForPodUpdate(String podName, Date startTime) {
+        TestUtils.waitFor(podName + " update",Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+            startTime.before(kubernetes.getCreationTimestampForPod(podName))
+        );
+    }
+
     public static void waitForPodDeletion(String name) {
         LOGGER.info("Waiting when Pod {} will be deleted", name);
 
@@ -330,8 +337,15 @@ public class StUtils {
 
     public static void waitForKafkaUserDeletion (String userName) {
         LOGGER.info("Waiting for Kafka user deletion {}", userName);
-        TestUtils.waitFor("Waits for Kafka user deletion " + userName, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS, () -> {
-            return Crds.kafkaUserOperation(kubernetes.getInstance()).inNamespace(kubernetes.getNamespace()).withName(userName).get() == null;
-        });
+        TestUtils.waitFor("Waits for Kafka user deletion " + userName, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS, () ->
+            Crds.kafkaUserOperation(kubernetes.getInstance()).inNamespace(kubernetes.getNamespace()).withName(userName).get() == null
+        );
+    }
+
+    public static void waitForKafkaTopicDeletion (String topicName) {
+        LOGGER.info("Waiting for Kafka topic deletion {}", topicName);
+        TestUtils.waitFor("Waits for Kafka topic deletion " + topicName, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS, () ->
+                Crds.topicOperation(kubernetes.getInstance()).inNamespace(kubernetes.getNamespace()).withName(topicName).get() == null
+        );
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/StUtils.java
@@ -137,7 +137,7 @@ public class StUtils {
                     return false;
                 }
             });
-        StUtils.waitForAllStatefulSetPodsReady(namespace, name);
+        StUtils.waitForAllStatefulSetPodsReady(name);
         return ssSnapshot(namespace, name);
     }
 
@@ -145,7 +145,7 @@ public class StUtils {
         long timeLeft = TestUtils.waitFor("Deployment roll of " + name,
             1_000, 300_000, () -> depHasRolled(namespace, name, snapshot));
         StUtils.waitForDeploymentReady(name);
-        StUtils.waitForPodsReady(namespace, kubernetes.getDeploymentSelectors(name), true);
+        StUtils.waitForPodsReady(kubernetes.getDeploymentSelectors(name), true);
         return depSnapshot(namespace, name);
     }
 
@@ -176,16 +176,16 @@ public class StUtils {
     /**
      * Wait until the SS is ready and all of its Pods are also ready
      */
-    public static void waitForAllStatefulSetPodsReady(String namespace, String name) {
+    public static void waitForAllStatefulSetPodsReady(String name) {
         LOGGER.info("Waiting for StatefulSet {} to be ready", name);
         TestUtils.waitFor("statefulset " + name, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubernetes.getStatefulSetStatus(name));
         LOGGER.info("StatefulSet {} is ready", name);
         LOGGER.info("Waiting for Pods of StatefulSet {} to be ready", name);
-        waitForPodsReady(namespace, kubernetes.getStatefulSetSelectors(name), true);
+        waitForPodsReady(kubernetes.getStatefulSetSelectors(name), true);
     }
 
-    public static void waitForPodsReady(String namespace, LabelSelector selector, boolean containers) {
+    public static void waitForPodsReady(LabelSelector selector, boolean containers) {
         TestUtils.waitFor("All pods matching " + selector + "to be ready", Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS, () -> {
             List<Pod> pods = kubernetes.listPods(selector);
             if (pods.isEmpty()) {

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>kubernetes-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/test/src/main/java/io/strimzi/test/extensions/StrimziExtension.java
+++ b/test/src/main/java/io/strimzi/test/extensions/StrimziExtension.java
@@ -11,7 +11,7 @@ import io.strimzi.test.annotations.OpenShiftOnly;
 import io.strimzi.test.annotations.Resources;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.HelmClient;
-import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.KubeExecClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Minishift;
 import io.strimzi.test.k8s.OpenShift;
@@ -396,7 +396,7 @@ public class StrimziExtension implements AfterAllCallback, BeforeAllCallback, Af
         return new HashSet<>(Arrays.asList(commaSeparated.split(",+")));
     }
 
-    protected KubeClient<?> kubeClient() {
+    protected KubeExecClient<?> kubeClient() {
         return clusterResource().client();
     }
 
@@ -669,8 +669,8 @@ public class StrimziExtension implements AfterAllCallback, BeforeAllCallback, Af
                     kubeClient().create(resources.value());
                 }
 
-                private KubeClient kubeClient() {
-                    KubeClient client = StrimziExtension.this.kubeClient();
+                private KubeExecClient kubeClient() {
+                    KubeExecClient client = StrimziExtension.this.kubeClient();
                     if (resources.asAdmin()) {
                         client = client.clientWithAdmin();
                     }

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -42,7 +42,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     public static final String SERVICE = "service";
     public static final String CM = "cm";
     private String namespace = defaultNamespace();
-    private Kubernetes kubernetes;
+    private Kubernetes kubernetes = new Kubernetes();
 
     protected abstract String cmd();
 
@@ -62,9 +62,6 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     private static final Context NOOP = new Context();
 
     public Kubernetes kubeAPIClient() {
-        if (this.kubernetes == null) {
-            this.kubernetes = new Kubernetes();
-        }
         return this.kubernetes;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -43,7 +43,6 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     public static final String SERVICE = "service";
     public static final String CM = "cm";
     private String namespace = defaultNamespace();
-    private Kubernetes kubernetes = getKubernetes(namespace);
 
     protected abstract String cmd();
 
@@ -62,15 +61,11 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
 
     private static final Context NOOP = new Context();
 
-    public Kubernetes kubeAPIClient() {
-        return kubernetes;
-    }
-
     @Override
     public String namespace(String namespace) {
         String previous = this.namespace;
         this.namespace = namespace;
-        kubernetes.namespace(namespace);
+        getKubernetes().namespace(namespace);
         return previous;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -7,8 +7,6 @@ package io.strimzi.test.k8s;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,8 +20,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static io.strimzi.test.k8s.Kubernetes.getKubernetes;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 
@@ -42,7 +43,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     public static final String SERVICE = "service";
     public static final String CM = "cm";
     private String namespace = defaultNamespace();
-    private Kubernetes kubernetes = new Kubernetes();
+    private Kubernetes kubernetes = getKubernetes(namespace);
 
     protected abstract String cmd();
 
@@ -62,14 +63,14 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     private static final Context NOOP = new Context();
 
     public Kubernetes kubeAPIClient() {
-        return this.kubernetes;
+        return kubernetes;
     }
 
     @Override
     public String namespace(String namespace) {
         String previous = this.namespace;
         this.namespace = namespace;
-        this.kubernetes.namespace(namespace);
+        kubernetes.namespace(namespace);
         return previous;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeExecClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeExecClient.java
@@ -29,9 +29,9 @@ import static io.strimzi.test.k8s.Kubernetes.getKubernetes;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 
-public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements KubeClient<K> {
+public abstract class BaseKubeExecClient<K extends BaseKubeExecClient<K>> implements KubeExecClient<K> {
 
-    private static final Logger LOGGER = LogManager.getLogger(BaseKubeClient.class);
+    private static final Logger LOGGER = LogManager.getLogger(BaseKubeExecClient.class);
 
     public static final String CREATE = "create";
     public static final String APPLY = "apply";

--- a/test/src/main/java/io/strimzi/test/k8s/Helm.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Helm.java
@@ -23,10 +23,10 @@ public class Helm implements HelmClient {
     // TODO: configurable?
     private static final String INSTALL_TIMEOUT_SECONDS = "60";
 
-    private KubeClient<?> kubeClient;
+    private KubeExecClient<?> kubeClient;
     private boolean initialized;
 
-    public Helm(KubeClient<?> kubeClient) {
+    public Helm(KubeExecClient<?> kubeClient) {
         this.kubeClient = kubeClient;
         this.initialized = false;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 public interface HelmClient {
-    static HelmClient findClient(KubeClient<?> kubeClient) {
+    static HelmClient findClient(KubeExecClient<?> kubeClient) {
         HelmClient client = new Helm(kubeClient);
         if (!client.clientAvailable()) {
             throw new RuntimeException("No helm client found on $PATH. $PATH=" + System.getenv("PATH"));

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -66,9 +66,6 @@ public interface KubeClient<K extends KubeClient<K>> {
         return delete(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));
     }
 
-    /** Replaces the resources in the given files. */
-    K replace(File... files);
-
     /**
      * Replace with the given YAML.
      * @param yamlContent The replacement YAML.
@@ -173,12 +170,6 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     String describe(String resourceType, String resourceName);
 
-    default String logs(String pod) {
-        return logs(pod, null);
-    }
-
-    String logs(String pod, String container);
-
     /**
      * @param resourceType The type of resource
      * @param resourceName The name of resource
@@ -195,4 +186,6 @@ public interface KubeClient<K extends KubeClient<K>> {
     Date getResourceCreateTimestamp(String pod, String s);
 
     List<String> listResourcesByLabel(String resourceType, String label);
+
+    Kubernetes kubeAPIClient();
 }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -186,6 +186,4 @@ public interface KubeClient<K extends KubeClient<K>> {
     Date getResourceCreateTimestamp(String pod, String s);
 
     List<String> listResourcesByLabel(String resourceType, String label);
-
-    Kubernetes kubeAPIClient();
 }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeCluster.java
@@ -30,7 +30,7 @@ public interface KubeCluster {
     void clusterDown();
 
     /** Return a default client for this kind of cluster. */
-    KubeClient defaultClient();
+    KubeExecClient defaultClient();
 
     /**
      * Returns the cluster named by the TEST_CLUSTER environment variable, if set, otherwise finds a cluster that's

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -21,20 +21,20 @@ public class KubeClusterResource {
 
     private final boolean bootstrap;
     private KubeCluster cluster;
-    private KubeClient client;
+    private KubeExecClient client;
     private HelmClient helmClient;
 
     public KubeClusterResource() {
         bootstrap = true;
     }
 
-    public KubeClusterResource(KubeCluster cluster, KubeClient client) {
+    public KubeClusterResource(KubeCluster cluster, KubeExecClient client) {
         bootstrap = false;
         this.cluster = cluster;
         this.client = client;
     }
 
-    public KubeClusterResource(KubeCluster cluster, KubeClient client, HelmClient helmClient) {
+    public KubeClusterResource(KubeCluster cluster, KubeExecClient client, HelmClient helmClient) {
         bootstrap = false;
         this.cluster = cluster;
         this.client = client;
@@ -46,9 +46,9 @@ public class KubeClusterResource {
         return client().defaultNamespace();
     }
 
-    public KubeClient client() {
+    public KubeExecClient client() {
         if (bootstrap && client == null) {
-            this.client = KubeClient.findClient(cluster());
+            this.client = KubeExecClient.findClient(cluster());
         }
         return client;
     }
@@ -73,7 +73,7 @@ public class KubeClusterResource {
                 this.cluster = KubeCluster.bootstrap();
             }
             if (client == null) {
-                this.client = KubeClient.findClient(cluster);
+                this.client = KubeExecClient.findClient(cluster);
             }
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeExecClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeExecClient.java
@@ -16,12 +16,12 @@ import static java.util.stream.Collectors.toList;
  * Abstraction for a kubernetes client.
  * @param <K> The subtype of KubeClient, for fluency.
  */
-public interface KubeClient<K extends KubeClient<K>> {
+public interface KubeExecClient<K extends KubeExecClient<K>> {
 
-    static KubeClient<?> findClient(KubeCluster cluster) {
-        KubeClient client = null;
-        List<KubeClient> kubeClients = Arrays.asList(cluster.defaultClient(), new Kubectl(), new Oc());
-        for (KubeClient kc: kubeClients) {
+    static KubeExecClient<?> findClient(KubeCluster cluster) {
+        KubeExecClient client = null;
+        List<KubeExecClient> kubeClients = Arrays.asList(cluster.defaultClient(), new Kubectl(), new Oc());
+        for (KubeExecClient kc: kubeClients) {
             if (kc.clientAvailable()) {
                 client = kc;
                 break;

--- a/test/src/main/java/io/strimzi/test/k8s/Kubectl.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubectl.java
@@ -5,9 +5,9 @@
 package io.strimzi.test.k8s;
 
 /**
- * A {@link KubeClient} wrapping {@code kubectl}.
+ * A {@link KubeExecClient} wrapping {@code kubectl}.
  */
-public class Kubectl extends BaseKubeClient<Kubectl> {
+public class Kubectl extends BaseKubeExecClient<Kubectl> {
 
     public static final String KUBECTL = "kubectl";
 

--- a/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
@@ -1,0 +1,233 @@
+package io.strimzi.test.k8s;
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ExecListener;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.strimzi.test.TestUtils;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class Kubernetes<K extends Kubernetes<K>> {
+
+    static final long GLOBAL_TIMEOUT = 300000;
+    static final long GLOBAL_POLL_INTERVAL = 1000;
+    private static final Logger LOGGER = LogManager.getLogger(Kubernetes.class);
+
+    private KubernetesClient client = new DefaultKubernetesClient();
+    private String namespace;
+
+    public String namespace(String namespace) {
+        String previous = this.namespace;
+        this.namespace = namespace;
+        return previous;
+    }
+
+    public K createNameSpace(String name) {
+        Namespace ns = new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build();
+        client.namespaces().createOrReplace(ns);
+        return (K) this;
+    }
+
+    public K deleteNamespace(String name) {
+        client.namespaces().withName(name).delete();
+        return (K) this;
+    }
+
+    public String execInPod(String podName, String... command) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        LOGGER.info("Running command on pod {}: {}", podName, command);
+        CompletableFuture<String> data = new CompletableFuture<>();
+        try (ExecWatch execWatch = client.pods().inNamespace(namespace)
+                .withName(podName)
+                .readingInput(null)
+                .writingOutput(baos)
+                .usingListener(new ExecListener() {
+                    @Override
+                    public void onOpen(Response response) {
+                        LOGGER.info("Reading data...");
+                    }
+
+                    @Override
+                    public void onFailure(Throwable throwable, Response response) {
+                        data.completeExceptionally(throwable);
+                    }
+
+                    @Override
+                    public void onClose(int i, String s) {
+                        data.complete(baos.toString());
+                    }
+                }).exec(command)) {
+            return data.get(1, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            LOGGER.warn("Exception running command {} on pod: {}", command, e.getMessage());
+            return "";
+        }
+    }
+
+    public String execInPodContainer(String podName, String container, String... command) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        LOGGER.info("Running command on pod {}: {}", podName, command);
+        CompletableFuture<String> data = new CompletableFuture<>();
+        try (ExecWatch execWatch = client.pods().inNamespace(namespace)
+                .withName(podName).inContainer(container)
+                .readingInput(null)
+                .writingOutput(baos)
+                .usingListener(new ExecListener() {
+                    @Override
+                    public void onOpen(Response response) {
+                        LOGGER.info("Reading data...");
+                    }
+
+                    @Override
+                    public void onFailure(Throwable throwable, Response response) {
+                        data.completeExceptionally(throwable);
+                    }
+
+                    @Override
+                    public void onClose(int i, String s) {
+                        data.complete(baos.toString());
+                    }
+                }).exec(command)) {
+            return data.get(1, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            LOGGER.warn("Exception running command {} on pod: {}", command, e.getMessage());
+            return "";
+        }
+    }
+
+    public void waitForPodDeletion(String namespace, String name) {
+        LOGGER.info("Waiting when Pod {} will be deleted", name);
+
+        TestUtils.waitFor("pod " + name + " deletion", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
+                () -> client.pods().inNamespace(namespace).withName(name).get() == null);
+    }
+
+    public void waitForPodDeletion(String name) {
+        LOGGER.info("Waiting when Pod {} will be deleted", name);
+
+        TestUtils.waitFor("pod " + name + " deletion", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
+                () -> client.pods().inNamespace(namespace).withName(name).get() == null);
+    }
+
+
+    public void waitForPod(String name) {
+        LOGGER.info("Waiting when Pod {} will be ready", name);
+
+        TestUtils.waitFor("pod " + name + " will be ready", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
+                () -> {
+                    List<ContainerStatus> statuses =  client.pods().inNamespace(namespace).withName(name).get().getStatus().getContainerStatuses();
+                    for (ContainerStatus containerStatus : statuses) {
+                        if (!containerStatus.getReady()) {
+                            return false;
+                        }
+                    }
+                    return true;
+                });
+    }
+
+    public List<Pod> listPods(String namespace, LabelSelector selector) {
+        return client.pods().inNamespace(namespace).withLabelSelector(selector).list().getItems();
+    }
+
+    public List<Pod> listPods(Map<String, String> labelSelector) {
+        return client.pods().withLabels(labelSelector).list().getItems();
+    }
+
+    /**
+     * Gets pod
+     */
+    public Pod getPod(String namespace, String name) {
+        return client.pods().inNamespace(namespace).withName(name).get();
+    }
+
+    /**
+     * Gets stateful set
+     */
+    public StatefulSet getStatefulSet(String namespace, String statefulSetName) {
+        return  client.apps().statefulSets().inNamespace(namespace).withName(statefulSetName).get();
+    }
+
+    /**
+     * Gets stateful set selectors
+     */
+    public LabelSelector getStatefulSetSelectors(String namespace, String statefulSetName) {
+        return client.apps().statefulSets().inNamespace(namespace).withName(statefulSetName).get().getSpec().getSelector();
+    }
+
+    /**
+     * Gets stateful set status
+     */
+    public boolean getStatefulSetStatus(String namespace, String statefulSetName) {
+        return client.apps().statefulSets().inNamespace(namespace).withName(statefulSetName).isReady();
+    }
+
+    /**
+     * Gets deployment
+     */
+    public Deployment getDeployment(String namespace, String deploymentName) {
+        return client.extensions().deployments().inNamespace(namespace).withName(deploymentName).get();
+    }
+
+    /**
+     * Gets deployment status
+     */
+    public LabelSelector getDeploymentSelectors(String namespace, String deploymentName) {
+        return client.extensions().deployments().inNamespace(namespace).withName(deploymentName).get().getSpec().getSelector();
+    }
+
+    /**
+     * Gets deployment status
+     */
+    public boolean getDeploymentStatus(String namespace, String deploymentName) {
+        return client.extensions().deployments().inNamespace(namespace).withName(deploymentName).isReady();
+    }
+
+    /**
+     * Gets deployment config status
+     */
+    public boolean getDeploymentConfigStatus(String namespace, String deploymentCofigName) {
+        return client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(namespace).withName(deploymentCofigName).isReady();
+    }
+
+    public Secret createSecret(Secret secret) {
+        return client.secrets().create(secret);
+    }
+
+    public Secret patchSecret(String secretName, Secret secret) {
+        return client.secrets().withName(secretName).patch(secret);
+    }
+
+
+    public Secret getSecret(String secretName) {
+        return client.secrets().withName(secretName).get();
+    }
+
+    public List<Secret> getListSecrets() {
+        return client.secrets().list().getItems();
+    }
+
+    public String logs(String podName, String containerName) {
+        if (containerName != null) {
+            return client.pods().withName(podName).inContainer(containerName).getLog();
+        } else {
+            return client.pods().withName(podName).getLog();
+        }
+    }
+}

--- a/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
@@ -1,5 +1,6 @@
 package io.strimzi.test.k8s;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -83,6 +84,10 @@ public class Kubernetes {
 
     public void deleteConfigMap (String configMapName) {
         CLIENT.inNamespace(namespace).configMaps().withName(configMapName).delete();
+    }
+
+    public ConfigMap getConfigMap (String configMapName) {
+        return CLIENT.inNamespace(namespace).configMaps().withName(configMapName).get();
     }
 
     public boolean getConfigMapStatus (String configMapName) {

--- a/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
@@ -1,5 +1,6 @@
 package io.strimzi.test.k8s;
 
+import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.Event;
@@ -32,6 +33,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayOutputStream;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -180,6 +185,18 @@ public class Kubernetes {
      */
     public Pod getPod(String name) {
         return client.pods().withName(name).get();
+    }
+
+    public Date getPodCreateTimestamp(String podName) {
+        DateFormat df = new SimpleDateFormat("yyyyMMdd'T'kkmmss'Z'");
+        Pod pod = getPod(podName);
+        Date parsedDate = null;
+        try {
+            df.parse(pod.getMetadata().getCreationTimestamp());
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return parsedDate;
     }
 
     /**

--- a/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
@@ -34,21 +34,15 @@ public class Kubernetes {
     static final long GLOBAL_POLL_INTERVAL = 1000;
     private static final Logger LOGGER = LogManager.getLogger(Kubernetes.class);
 
-    private NamespacedKubernetesClient client;
+    private NamespacedKubernetesClient client = new DefaultKubernetesClient().inNamespace("default");
 
     private static Kubernetes INSTANCE;
 
-    public static Kubernetes getKubernetes(String namespace) {
+    public static Kubernetes getKubernetes() {
         if (INSTANCE == null) {
-            INSTANCE = new Kubernetes(namespace);
-        } else {
-            INSTANCE.namespace(namespace);
+            INSTANCE = new Kubernetes();
         }
         return INSTANCE;
-    }
-
-    private Kubernetes (String namespace) {
-        client = new DefaultKubernetesClient().inNamespace(namespace);
     }
 
     public NamespacedKubernetesClient getInstance() {

--- a/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubernetes.java
@@ -63,7 +63,7 @@ public class Kubernetes {
     }
 
     public String namespace(String namespace) {
-        String previous = CLIENT.getNamespace();
+        String previous = this.namespace;
         this.namespace = namespace;
         return previous;
     }
@@ -81,12 +81,12 @@ public class Kubernetes {
         CLIENT.namespaces().withName(name).delete();
     }
 
-    public void deleteConfigMap (String configManName) {
-        CLIENT.inNamespace(namespace).configMaps().withName(configManName).delete();
+    public void deleteConfigMap (String configMapName) {
+        CLIENT.inNamespace(namespace).configMaps().withName(configMapName).delete();
     }
 
-    public boolean getConfigMapStatus (String configManName) {
-        return CLIENT.inNamespace(namespace).configMaps().withName(configManName).isReady();
+    public boolean getConfigMapStatus (String configMapName) {
+        return CLIENT.inNamespace(namespace).configMaps().withName(configMapName).isReady();
     }
 
 
@@ -171,7 +171,7 @@ public class Kubernetes {
         return CLIENT.inNamespace(namespace).pods().withName(name).get();
     }
 
-    public Date getPodCreateTimestamp(String podName) {
+    public Date getCreationTimestampForPod(String podName) {
         DateFormat df = new SimpleDateFormat("yyyyMMdd'T'kkmmss'Z'");
         Pod pod = getPod(podName);
         Date parsedDate = null;

--- a/test/src/main/java/io/strimzi/test/k8s/Minikube.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Minikube.java
@@ -36,7 +36,7 @@ public class Minikube implements KubeCluster {
     }
 
     @Override
-    public KubeClient defaultClient() {
+    public KubeExecClient defaultClient() {
         return new Kubectl();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Minishift.java
@@ -34,7 +34,7 @@ public class Minishift implements KubeCluster {
     }
 
     @Override
-    public KubeClient defaultClient() {
+    public KubeExecClient defaultClient() {
         return new Oc();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/Oc.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Oc.java
@@ -13,9 +13,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 
 /**
- * A {@link KubeClient} implementation wrapping {@code oc}.
+ * A {@link KubeExecClient} implementation wrapping {@code oc}.
  */
-public class Oc extends BaseKubeClient<Oc> {
+public class Oc extends BaseKubeExecClient<Oc> {
 
     private static final Logger LOGGER = LogManager.getLogger(Oc.class);
 

--- a/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
@@ -22,7 +22,7 @@ public class OpenShift implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            Exec.exec(OC, "cluster", "status");
+//            Exec.exec(OC, "cluster", "status");
             return true;
         } catch (KubeClusterException e) {
             if (e.result.exitStatus() == 1) {
@@ -31,7 +31,7 @@ public class OpenShift implements KubeCluster {
                     // In this case it is still coming up, so wait for rather than saying it's not up
                     TestUtils.waitFor("oc cluster up", 1_000, 60_000, () -> {
                         try {
-                            Exec.exec(OC, "cluster", "status");
+//                            Exec.exec(OC, "cluster", "status");
                             LOGGER.trace("oc cluster is up");
                             return true;
                         } catch (KubeClusterException e2) {

--- a/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
@@ -58,7 +58,7 @@ public class OpenShift implements KubeCluster {
     }
 
     @Override
-    public KubeClient defaultClient() {
+    public KubeExecClient defaultClient() {
         return new Oc();
     }
 

--- a/test/src/test/java/io/strimzi/test/StrimziExtensionTest.java
+++ b/test/src/test/java/io/strimzi/test/StrimziExtensionTest.java
@@ -7,7 +7,7 @@ package io.strimzi.test;
 import io.strimzi.test.annotations.Namespace;
 import io.strimzi.test.annotations.Resources;
 import io.strimzi.test.extensions.StrimziExtension;
-import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.KubeExecClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 class StrimziExtensionTest {
 
-    private static final KubeClient MOCK_KUBE_CLIENT = mock(KubeClient.class);
+    private static final KubeExecClient MOCK_KUBE_CLIENT = mock(KubeExecClient.class);
 
     StrimziExtensionTest() throws InvocationTargetException {
     }
@@ -49,7 +49,7 @@ class StrimziExtensionTest {
         }
 
         @Override
-        public KubeClient<?> client() {
+        public KubeExecClient<?> client() {
             return MOCK_KUBE_CLIENT;
         }
 

--- a/test/src/test/java/io/strimzi/test/StrimziExtensionTest.java
+++ b/test/src/test/java/io/strimzi/test/StrimziExtensionTest.java
@@ -173,9 +173,6 @@ class StrimziExtensionTest {
         launcher.registerTestExecutionListeners(listener);
         launcher.execute(request);
 
-        when(MOCK_KUBE_CLIENT.logs("pod1")).thenReturn("these\nare\nthe\nlogs\nfrom\npod\n1");
-        when(MOCK_KUBE_CLIENT.logs("pod2")).thenReturn("these\nare\nthe\nlogs\nfrom\npod\n2");
-
         if (!listener.getSummary().getFailures().isEmpty()) {
             listener.getSummary().getFailures().get(0).getException().printStackTrace();
         }


### PR DESCRIPTION
###This PR still in progress

### Type of change
- Refactoring

### Description
After long execution ST we decided that using fabric8 client to emulate ST will be a more stable solution. So it is the main reason for this refactoring.
This PR has implementation fabric8 Kubernetes client for ST. Kubernetes client has all usual methods to create/update/delete all Strizmi entities.
Also, in scope of this PR, all helped methods like `wait` were moved to `StUtils` class to split client and other logic. 

TODO:
- [ ] Remove usage CMD kube client in the remaining system tests
- [ ] Order methods in kude client 
- [ ] Deprecate old methods
- [ ] Add JavaDocs
- [ ] Make sure that Kubernetes works fine without additional configuration
- [ ] Fix check-style issues

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

