### PR TITLE
change all /bin/sh to /bin/bash

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 export PULL_REQUEST=${PULL_REQUEST:-true}

--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 fatal=0
 GREP=grep

--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 rm -rf ~/.kube

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # path were the Secret with EO certificates is mounted
 EO_CERTS_KEYS=/etc/tls-sidecar/eo-certs

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_pre_stop.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_pre_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GRACE_PERIOD=$1
 TIMER="0"

--- a/docker-images/entity-operator-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/entity-operator-stunnel/scripts/stunnel_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generate and print the config file
 echo "Starting Stunnel with configuration:"

--- a/docker-images/java-base/scripts/dynamic_resources.sh
+++ b/docker-images/java-base/scripts/dynamic_resources.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 function get_heap_size {
   CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`

--- a/docker-images/java-base/scripts/launch_java.sh
+++ b/docker-images/java-base/scripts/launch_java.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -x
 JAR=$1
 shift

--- a/docker-images/kafka-base/scripts/dynamic_resources.sh
+++ b/docker-images/kafka-base/scripts/dynamic_resources.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 function get_heap_size {
   FRACTION=$1

--- a/docker-images/kafka-base/scripts/set_kafka_gc_options.sh
+++ b/docker-images/kafka-base/scripts/set_kafka_gc_options.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # expand gc options based upon java version
 function get_gc_opts {

--- a/docker-images/kafka-connect/s2i/scripts/assemble
+++ b/docker-images/kafka-connect/s2i/scripts/assemble
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # S2I assemble script for extending the strimzi/kafka-connect image with additional Kafka Connect plugins

--- a/docker-images/kafka-connect/s2i/scripts/run
+++ b/docker-images/kafka-connect/s2i/scripts/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # S2I run script for extending the strimzi/kafka-connect image with additional Kafka Connect plugins

--- a/docker-images/kafka-connect/s2i/scripts/usage
+++ b/docker-images/kafka-connect/s2i/scripts/usage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cat <<EOF

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SECURITY_PROTOCOL=PLAINTEXT
 

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set +x
 
 if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then

--- a/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_tls_prepare_certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parameters:
 # $1: Path to the new truststore

--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_consumer_config_generator.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_consumer_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SECURITY_PROTOCOL=PLAINTEXT
 

--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_producer_config_generator.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_producer_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SECURITY_PROTOCOL=PLAINTEXT
 

--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set +x
 
 if [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER" ] || [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER" ]; then

--- a/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
+++ b/docker-images/kafka-mirror-maker/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parameters:
 # $1: Path to the new truststore

--- a/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # path were the Secret with broker certificates is mounted
 KAFKA_CERTS_KEYS=/etc/tls-sidecar/kafka-brokers

--- a/docker-images/kafka-stunnel/scripts/stunnel_pre_stop.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_pre_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GRACE_PERIOD=$1
 TIMER="0"

--- a/docker-images/kafka-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/kafka-stunnel/scripts/stunnel_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export BASE_HOSTNAME=$(hostname | rev | cut -d "-" -f2- | rev)
 export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #####
 # PLAIN listener

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set +x
 
 # volume for saving Kafka server logs

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parameters:
 # $1: Path to the new truststore

--- a/docker-images/stunnel-base/scripts/stunnel_healthcheck.sh
+++ b/docker-images/stunnel-base/scripts/stunnel_healthcheck.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 netstat -ntl | grep -q :$1

--- a/docker-images/test-client/scripts/consumer.sh
+++ b/docker-images/test-client/scripts/consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 . ./set_kafka_gc_options.sh

--- a/docker-images/test-client/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/test-client/scripts/kafka_tls_prepare_certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/docker-images/test-client/scripts/ping.sh
+++ b/docker-images/test-client/scripts/ping.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 ./producer.sh

--- a/docker-images/test-client/scripts/producer.sh
+++ b/docker-images/test-client/scripts/producer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # path were the Secret with ZK nodes certificates is mounted
 NODE_CERTS_KEYS=/etc/tls-sidecar/zookeeper-nodes

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_pre_stop.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_pre_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GRACE_PERIOD=$1
 TIMER="0"

--- a/docker-images/zookeeper-stunnel/scripts/stunnel_run.sh
+++ b/docker-images/zookeeper-stunnel/scripts/stunnel_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export BASE_HOSTNAME=$(hostname | rev | cut -d "-" -f2- | rev)
 export BASE_FQDN=$(hostname -f | cut -d "." -f2-)

--- a/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Write the config file
 cat <<EOF

--- a/docker-images/zookeeper/scripts/zookeeper_healthcheck.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ZOOKEEPER_ID=$(hostname | awk -F'-' '{print $NF+1}')
 CLIENT_PORT=$(expr 21810 + $ZOOKEEPER_ID - 1)

--- a/docker-images/zookeeper/scripts/zookeeper_run.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # volume for saving Zookeeper server logs
 export ZOOKEEPER_VOLUME="/var/lib/zookeeper/"

--- a/metrics/examples/grafana/grafana-openshift/run.sh
+++ b/metrics/examples/grafana/grafana-openshift/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /etc/sysconfig/grafana-server
 

--- a/systemtest/scripts/run_tests.sh
+++ b/systemtest/scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 TESTCASE=$1
 
 if [ -n "$TESTCASE" ]; then

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set +x
 
 if [ -f /opt/topic-operator/custom-config/log4j2.properties ];

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -f /opt/user-operator/custom-config/log4j2.properties ];
 then


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Use bash for all scripts.  java-base/dynamic-resources.sh requires bash for arithmetic expansion.  Probably ought to be consistent to eliminate confusion. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

