### PR TITLE
Use OrderedProperties to create logging annotation

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -21,6 +21,12 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -66,12 +67,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -148,7 +147,7 @@ public abstract class AbstractModel {
     private Affinity userAffinity;
     private List<Toleration> tolerations;
 
-    protected Map validLoggerFields;
+    protected final Map<String, String> validLoggerFields;
     private final String[] validLoggerValues = new String[]{"INFO", "ERROR", "WARN", "TRACE", "DEBUG", "FATAL", "OFF" };
     private Logging logging;
     protected boolean gcLoggingEnabled = true;
@@ -186,6 +185,7 @@ public abstract class AbstractModel {
         this.cluster = cluster;
         this.namespace = namespace;
         this.labels = labels.withCluster(cluster);
+        this.validLoggerFields = getDefaultLogConfig().asMap();
     }
 
     public Labels getLabels() {
@@ -277,50 +277,35 @@ public abstract class AbstractModel {
      * Returns map with all available loggers for current pod and default values.
      * @return
      */
-    protected Properties getDefaultLogConfig() {
-        Properties properties = new Properties();
-        String defaultLogConfigFileName = getDefaultLogConfigFileName();
-        try {
-            properties = getDefaultLoggingProperties(defaultLogConfigFileName);
-        } catch (IOException e) {
-            log.warn("Unable to read default log config from '{}'", defaultLogConfigFileName);
+    protected OrderedProperties getDefaultLogConfig() {
+        return getOrderedProperties(getDefaultLogConfigFileName());
+    }
+
+    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION") // InputStream is closed by properties.addStringPairs
+    public static OrderedProperties getOrderedProperties(String configFileName) {
+        OrderedProperties properties = new OrderedProperties();
+        if (configFileName != null && !configFileName.isEmpty()) {
+            InputStream is = AbstractModel.class.getResourceAsStream("/" + configFileName);
+            if (is == null) {
+                log.warn("Cannot find resource '{}'", configFileName);
+            } else {
+                try {
+                    properties.addStringPairs(is);
+                } catch (IOException e) {
+                    log.warn("Unable to read default log config from '{}'", configFileName);
+                }
+            }
         }
         return properties;
     }
 
     /**
-     * Takes resource file containing default log4j properties and returns it as a Properties.
-     * @param defaultConfigResourceFileName name of file, where default log4j properties are stored
-     * @return
-     */
-    protected Properties getDefaultLoggingProperties(String defaultConfigResourceFileName) throws IOException {
-        Properties defaultSettings = new Properties();
-        InputStream is = null;
-        try {
-            is = AbstractModel.class.getResourceAsStream("/" + defaultConfigResourceFileName);
-            defaultSettings.load(is);
-        } finally {
-            if (is != null) {
-                is.close();
-            }
-        }
-        return defaultSettings;
-    }
-
-    /**
      * Transforms map to log4j properties file format
-     * @param newSettings map with properties
+     * @param properties map with properties
      * @return
      */
-    protected static String createPropertiesString(Properties newSettings) {
-        StringWriter sw = new StringWriter();
-        try {
-            newSettings.store(sw, "Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
-        } catch (IOException e) {
-            log.warn("Error creating properties", e);
-        }
-        // remove date comment, because it is updated with each reconciliation which leads to restarting pods
-        return sw.toString().replaceAll("#[A-Za-z]+ [A-Za-z]+ [0-9]+ [0-9]+:[0-9]+:[0-9]+ [A-Z]+ [0-9]+", "");
+    protected static String createPropertiesString(OrderedProperties properties) {
+        return properties.asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
     }
 
     public Logging getLogging() {
@@ -381,8 +366,8 @@ public abstract class AbstractModel {
                 }
             });
             // update fields otherwise use default values
-            Properties newSettings = getDefaultLogConfig();
-            newSettings.putAll(((InlineLogging) logging).getLoggers());
+            OrderedProperties newSettings = getDefaultLogConfig();
+            newSettings.addMapPairs(((InlineLogging) logging).getLoggers());
             return createPropertiesString(newSettings);
         } else if (logging instanceof ExternalLogging) {
             if (externalCm != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -83,7 +83,6 @@ public class EntityTopicOperator extends AbstractModel {
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-topic-operator-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/topic-operator/custom-config/";
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
     public void setWatchedNamespace(String watchedNamespace) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -75,7 +75,6 @@ public class EntityUserOperator extends AbstractModel {
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-user-operator-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/user-operator/custom-config/";
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
     public void setWatchedNamespace(String watchedNamespace) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -191,7 +191,6 @@ public class KafkaCluster extends AbstractModel {
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
 
         this.initImage = KafkaClusterSpec.DEFAULT_INIT_IMAGE;
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
     public static String kafkaClusterName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -96,7 +96,6 @@ public class KafkaConnectCluster extends AbstractModel {
         super(namespace, cluster, labels);
         this.name = kafkaConnectClusterName(cluster);
         this.serviceName = serviceName(cluster);
-        this.validLoggerFields = getDefaultLogConfig();
         this.ancillaryConfigName = logAndMetricsConfigName(cluster);
         this.replicas = DEFAULT_REPLICAS;
         this.readinessPath = "/";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -47,7 +47,6 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
      */
     private KafkaConnectS2ICluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
     public static KafkaConnectS2ICluster fromCrd(KafkaConnectS2I kafkaConnectS2I, KafkaVersion.Lookup versions) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -95,7 +95,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         super(namespace, cluster, labels);
         this.name = kafkaMirrorMakerClusterName(cluster);
         this.serviceName = serviceName(cluster);
-        this.validLoggerFields = getDefaultLogConfig();
         this.ancillaryConfigName = logAndMetricsConfigName(cluster);
         this.replicas = DEFAULT_REPLICAS;
         this.readinessPath = "/";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -107,7 +107,6 @@ public class TopicOperator extends AbstractModel {
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "topic-operator-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/topic-operator/custom-config/";
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -144,7 +144,6 @@ public class ZookeeperCluster extends AbstractModel {
 
         this.logAndMetricsConfigVolumeName = "zookeeper-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
-        this.validLoggerFields = getDefaultLogConfig();
     }
 
     public static ZookeeperCluster fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
@@ -180,4 +180,21 @@ public class OrderedPropertiesTest {
             .addPair("unicode", "\u0123X\uAbBa");
         Assert.assertEquals(expected.asMap(), actual);
     }
+
+    @Test
+    public void pairsWithComment() {
+        Assert.assertEquals("# this is a comment\n" +
+                "first=1\n" +
+                "second=2\n" +
+                "third=3\n" +
+                "FOURTH=4\n", createTestKeyValues().asPairsWithComment("this is a comment"));
+    }
+
+    @Test
+    public void pairsWithMultineComment() {
+        Assert.assertEquals("# this\n" +
+                "# is\n" +
+                "# a\n" +
+                "# comment\\\n", new OrderedProperties().asPairsWithComment("this\nis\n\ra\rcomment\\"));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -67,17 +67,9 @@ public class KafkaConnectAssemblyOperatorTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             emptyMap(), singletonMap("2.0.0", "strimzi/kafka-connect:latest-kafka-2.0.0"), emptyMap(), emptyMap()) { };
     protected static Vertx vertx;
-    public static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
-    public static final String LOGGING_CONFIG = "#Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.\n" +
-            "\n" +
-            "log4j.rootLogger=${connect.root.logger.level}, CONSOLE\n" +
-            "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
-            "log4j.logger.org.reflections=ERROR\n" +
-            "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-            "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-            "connect.root.logger.level=INFO\n" +
-            "log4j.logger.org.apache.zookeeper=ERROR\n" +
-            "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n";
+    private static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
+    private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
+            .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
     @BeforeClass
     public static void before() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -71,17 +71,9 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             emptyMap(), emptyMap(), singletonMap("2.0.0", "strimzi/kafka-connect:latest-kafka-2.0.0"),
             emptyMap()) { };
     protected static Vertx vertx;
-    public static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
-    public static final String LOGGING_CONFIG = "#Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.\n" +
-            "\n" +
-            "log4j.rootLogger=${connect.root.logger.level}, CONSOLE\n" +
-            "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
-            "log4j.logger.org.reflections=ERROR\n" +
-            "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-            "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-            "connect.root.logger.level=INFO\n" +
-            "log4j.logger.org.apache.zookeeper=ERROR\n" +
-            "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n";
+    private static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
+    private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
+            .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
     @BeforeClass
     public static void before() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -66,14 +66,10 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.singletonMap("2.0.0", "strimzi/kafka-mirror-maker:latest-kafka-2.0.0"));
     protected static Vertx vertx;
-    public static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
-    public static final String LOGGING_CONFIG = "#Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.\n" +
-            "\n" +
-            "log4j.rootLogger=${mirrormaker.root.logger}, CONSOLE\n" +
-            "mirrormaker.root.logger=INFO\n" +
-            "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
-            "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-            "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n";
+    private static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
+    private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("mirrorMakerDefaultLoggingProperties")
+            .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
+
     private final String producerBootstrapServers = "foo-kafka:9092";
     private final String consumerBootstrapServers = "bar-kafka:9092";
     private final String groupId = "my-group-id";


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
Log properties should be ordered in the same fashion as other properties.  This removes last use of Properties class.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

