### PR TITLE
Do not use some Fluent classes which cause problems in builds

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -411,7 +411,6 @@ public class KafkaConnectClusterTest {
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
                     .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
-                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -440,7 +439,6 @@ public class KafkaConnectClusterTest {
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
-                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -583,10 +581,8 @@ public class KafkaConnectClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
-                //.withNewConfigMapKeyRef("my-map", "my-key", false)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
                     .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
-                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -13,6 +14,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -408,7 +410,8 @@ public class KafkaConnectClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                    .withNewSecretKeyRef("my-secret", "my-key", false)
+                    .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
+                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -436,7 +439,8 @@ public class KafkaConnectClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                    .withNewConfigMapKeyRef("my-map", "my-key", false)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
+                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -579,8 +583,10 @@ public class KafkaConnectClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef("my-map", "my-key", false)
-                .withNewSecretKeyRef("my-secret", "my-key", false)
+                .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
+                //.withNewConfigMapKeyRef("my-map", "my-key", false)
+                    .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
+                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -13,6 +14,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -494,7 +496,8 @@ public class KafkaConnectS2IClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withNewSecretKeyRef("my-secret", "my-key", false)
+                .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
+                //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -521,7 +524,8 @@ public class KafkaConnectS2IClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef("my-map", "my-key", false)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
+                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -664,8 +668,10 @@ public class KafkaConnectS2IClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withNewConfigMapKeyRef("my-map", "my-key", false)
-                .withNewSecretKeyRef("my-secret", "my-key", false)
+                    .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
+                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
+                    .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
+                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -496,8 +496,7 @@ public class KafkaConnectS2IClusterTest {
         ExternalConfigurationEnv env = new ExternalConfigurationEnvBuilder()
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
-                .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
-                //.withNewSecretKeyRef("my-secret", "my-key", false)
+                    .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
                 .endValueFrom()
                 .build();
 
@@ -525,7 +524,6 @@ public class KafkaConnectS2IClusterTest {
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
-                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
                 .endValueFrom()
                 .build();
 
@@ -669,9 +667,7 @@ public class KafkaConnectS2IClusterTest {
                 .withName("MY_ENV_VAR")
                 .withNewValueFrom()
                     .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-map").withKey("my-key").withOptional(false).build())
-                    //.withNewConfigMapKeyRef("my-map", "my-key", false)
                     .withSecretKeyRef(new SecretKeySelectorBuilder().withName("my-secret").withKey("my-key").withOptional(false).build())
-                    //.withNewSecretKeyRef("my-secret", "my-key", false)
                 .endValueFrom()
                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR slightly modifies some tests which seem to break the build in certain environments with following errors:

```
[INFO] ------------------------------------------------------------------------
[INFO] Building cluster-operator 0.10.0.RC1-redhat-00001
[INFO] ------------------------------------------------------------------------
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.pom (7.2 kB at 326 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.jar
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.jar (32 kB at 2.4 MB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz/2.2.1.redhat-1/quartz-2.2.1.redhat-1.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz/2.2.1.redhat-1/quartz-2.2.1.redhat-1.pom (9.6 kB at 3.9 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz-parent/2.2.1.redhat-1/quartz-parent-2.2.1.redhat-1.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz-parent/2.2.1.redhat-1/quartz-parent-2.2.1.redhat-1.pom (14 kB at 6.1 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/c3p0/c3p0/0.9.1.1/c3p0-0.9.1.1.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/c3p0/c3p0/0.9.1.1/c3p0-0.9.1.1.pom (856 B at 147 B/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz/2.2.1.redhat-1/quartz-2.2.1.redhat-1.jar
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/c3p0/c3p0/0.9.1.1/c3p0-0.9.1.1.jar
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/c3p0/c3p0/0.9.1.1/c3p0-0.9.1.1.jar (608 kB at 5.0 MB/s)
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/quartz-scheduler/quartz/2.2.1.redhat-1/quartz-2.2.1.redhat-1.jar (692 kB at 4.0 MB/s)
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cluster-operator ---
[INFO] 
[INFO] --- maven-checkstyle-plugin:3.0.0:check (validate) @ cluster-operator ---
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-banned-dependencies) @ cluster-operator ---
[INFO] 
[INFO] --- jacoco-maven-plugin:0.7.9:prepare-agent (default) @ cluster-operator ---
[INFO] surefireArgLine set to -javaagent:/tmp/.m2/repository/org/jacoco/org.jacoco.agent/0.7.9/org.jacoco.agent-0.7.9-runtime.jar=destfile=/tmp/strimzi-0.10.0/cluster-operator/target/jacoco.exec
[INFO] 
[INFO] --- project-sources-maven-plugin:1.0:archive (project-sources-archive) @ cluster-operator ---
[INFO] Skipping the assembly in this project because it's not the Execution Root
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ cluster-operator ---
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.pom (5.7 kB at 258 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom (3.2 kB at 246 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/spice/spice-parent/15/spice-parent-15.pom
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/spice/spice-parent/15/spice-parent-15.pom (8.4 kB at 492 kB/s)
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.jar
[INFO] Downloading from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.jar (155 kB at 2.1 MB/s)
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar (51 kB at 678 kB/s)
[INFO] Downloaded from indy-mvn: http://indy.newcastle.svc.cluster.local/api/folo/track/build-12144/maven/group/build-12144/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar (8.5 kB at 110 kB/s)
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 13 resources
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ cluster-operator ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 38 source files to /tmp/strimzi-0.10.0/cluster-operator/target/classes
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java: Some input files use or override a deprecated API.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java: Recompile with -Xlint:deprecation for details.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java: Some input files use unchecked or unsafe operations.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ cluster-operator ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 30 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ cluster-operator ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 33 source files to /tmp/strimzi-0.10.0/cluster-operator/target/test-classes
[INFO] -------------------------------------------------------------
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java: Some input files use or override a deprecated API.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java: Recompile with -Xlint:deprecation for details.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java: Some input files use unchecked or unsafe operations.
[WARNING] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MockKube.java: Recompile with -Xlint:unchecked for details.
[INFO] 4 warnings 
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[497,17] cannot find symbol
  symbol:   method withNewSecretKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[524,17] cannot find symbol
  symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[667,17] cannot find symbol
  symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[411,21] cannot find symbol
  symbol:   method withNewSecretKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[439,21] cannot find symbol
  symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[582,17] cannot find symbol
  symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
  location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[INFO] 6 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Strimzi - Apache Kafka on Kubernetes and OpenShift . SUCCESS [26:08 min]
[INFO] test ............................................... SUCCESS [03:55 min]
[INFO] crd-generator ...................................... SUCCESS [ 57.112 s]
[INFO] api ................................................ SUCCESS [01:53 min]
[INFO] certificate-manager ................................ SUCCESS [  3.975 s]
[INFO] operator-common .................................... SUCCESS [ 49.634 s]
[INFO] topic-operator ..................................... SUCCESS [ 56.707 s]
[INFO] cluster-operator ................................... FAILURE [ 17.449 s]
[INFO] user-operator ...................................... SKIPPED
[INFO] kafka-init ......................................... SKIPPED
[INFO] systemtest ......................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35:02 min
[INFO] Finished at: 2019-01-30T10:59:21Z
[INFO] Final Memory: 83M/953M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project cluster-operator: Compilation failure: Compilation failure: 
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[497,17] cannot find symbol
[ERROR]   symbol:   method withNewSecretKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[524,17] cannot find symbol
[ERROR]   symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java:[667,17] cannot find symbol
[ERROR]   symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[411,21] cannot find symbol
[ERROR]   symbol:   method withNewSecretKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[439,21] cannot find symbol
[ERROR]   symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] /tmp/strimzi-0.10.0/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java:[582,17] cannot find symbol
[ERROR]   symbol:   method withNewConfigMapKeyRef(java.lang.String,java.lang.String,boolean)
[ERROR]   location: interface io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvFluent.ValueFromNested<io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder>
[ERROR] -> [Help 1]
```