### PR TITLE
Added missing Kafka Mirror Maker to the CO overview

### DIFF
--- a/documentation/book/con-what-the-cluster-operator-does.adoc
+++ b/documentation/book/con-what-the-cluster-operator-does.adoc
@@ -14,7 +14,7 @@ On {OpenShiftName} such a cluster can be deployed using the Source2Image feature
 .Example Architecture diagram of the Cluster Operator.
 image::cluster_operator.png[Cluster Operator]
 
-When the Cluster Operator is up, it starts to _watch_ for certain {ProductPlatformName} resources containing the desired Kafka or Kafka Connect cluster configuration.
+When the Cluster Operator is up, it starts to _watch_ for certain {ProductPlatformName} resources containing the desired Kafka, Kafka Connect, or Kafka Mirror Maker cluster configuration.
 By default, it watches only in the same namespace or project where it is installed.
 The Cluster Operator can be configured to watch for more {Namespaces}.
 Cluster Operator watches the following resources:
@@ -22,11 +22,12 @@ Cluster Operator watches the following resources:
 * A `Kafka` resource for the Kafka cluster.
 * A `KafkaConnect` resource for the Kafka Connect cluster.
 * A `KafkaConnectS2I` resource for the Kafka Connect cluster with Source2Image support.
+* A `KafkaMirrorMaker` resource for the Kafka Mirror Maker instance.
 
-When a new `Kafka`, `KafkaConnect`, or `KafkaConnectS2I` resource is created in the {ProductPlatformName} cluster, the operator gets the cluster description from the desired resource and starts creating a new Kafka or Kafka Connect cluster by creating the necessary other {ProductPlatformName} resources, such as StatefulSets, Services, ConfigMaps, and so on.
+When a new `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, or `Kafka Mirror Maker` resource is created in the {ProductPlatformName} cluster, the operator gets the cluster description from the desired resource and starts creating a new Kafka, Kafka Connect, or Kafka Mirror Maker cluster by creating the necessary other {ProductPlatformName} resources, such as StatefulSets, Services, ConfigMaps, and so on.
 
-Every time the desired resource is updated by the user, the operator performs corresponding updates on the {ProductPlatformName} resources which make up the Kafka or Kafka Connect cluster.
-Resources are either patched or deleted and then re-created in order to make the Kafka or Kafka Connect cluster reflect the state of the desired cluster resource.
+Every time the desired resource is updated by the user, the operator performs corresponding updates on the {ProductPlatformName} resources which make up the Kafka, Kafka Connect, or Kafka Mirror Maker cluster.
+Resources are either patched or deleted and then re-created in order to make the Kafka, Kafka Connect, or Kafka Mirror Maker cluster reflect the state of the desired cluster resource.
 This might cause a rolling update which might lead to service disruption.
 
 Finally, when the desired resource is deleted, the operator starts to undeploy the cluster and delete all the related {ProductPlatformName} resources.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The current Cluster Operator overview doesn't mention Kafka Mirror Maker as a possible resource.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

