### PR TITLE
Make sure that EO and TO deployments are deleted when needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1505,27 +1505,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> topicOperatorDeployment(Supplier<Date> dateSupplier) {
-
             if (this.topicOperator != null) {
-
                 Future<Deployment> future = deploymentOperations.getAsync(namespace, this.topicOperator.getName());
-                if (future != null) {
-                    return future.compose(dep -> {
-                        // getting the current cluster CA generation from the current deployment, if exists
-                        int caCertGeneration = getDeploymentCaCertGeneration(dep, this.clusterCa);
-                        // if maintenance windows are satisfied, the cluster CA generation could be changed
-                        // and EO needs a rolling update updating the related annotation
-                        boolean isSatisfiedBy = isMaintenanceTimeWindowsSatisfied(dateSupplier);
-                        if (isSatisfiedBy) {
-                            caCertGeneration = getCaCertGeneration(this.clusterCa);
-                        }
-                        Annotations.annotations(toDeployment.getSpec().getTemplate()).put(
-                                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
-                        return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment));
-                    }).map(i -> this);
-                }
+                return future.compose(dep -> {
+                    // getting the current cluster CA generation from the current deployment, if exists
+                    int caCertGeneration = getDeploymentCaCertGeneration(dep, this.clusterCa);
+                    // if maintenance windows are satisfied, the cluster CA generation could be changed
+                    // and EO needs a rolling update updating the related annotation
+                    boolean isSatisfiedBy = isMaintenanceTimeWindowsSatisfied(dateSupplier);
+                    if (isSatisfiedBy) {
+                        caCertGeneration = getCaCertGeneration(this.clusterCa);
+                    }
+                    Annotations.annotations(toDeployment.getSpec().getTemplate()).put(
+                            Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+                    return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), toDeployment));
+                }).map(i -> this);
+            } else  {
+                return withVoid(deploymentOperations.reconcile(namespace, TopicOperator.topicOperatorName(name), null));
             }
-            return Future.succeededFuture(this);
         }
 
         Future<ReconciliationState> topicOperatorSecret() {
@@ -1622,30 +1619,28 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityOperatorDeployment(Supplier<Date> dateSupplier) {
-
             if (this.entityOperator != null) {
                 Future<Deployment> future = deploymentOperations.getAsync(namespace, this.entityOperator.getName());
-                if (future != null) {
-                    return future.compose(dep -> {
-                        // getting the current cluster CA generation from the current deployment, if exists
-                        int clusterCaCertGeneration = getDeploymentCaCertGeneration(dep, this.clusterCa);
-                        int clientsCaCertGeneration = getDeploymentCaCertGeneration(dep, this.clientsCa);
-                        // if maintenance windows are satisfied, the cluster CA generation could be changed
-                        // and EO needs a rolling update updating the related annotation
-                        boolean isSatisfiedBy = isMaintenanceTimeWindowsSatisfied(dateSupplier);
-                        if (isSatisfiedBy) {
-                            clusterCaCertGeneration = getCaCertGeneration(this.clusterCa);
-                            clientsCaCertGeneration = getCaCertGeneration(this.clientsCa);
-                        }
-                        Annotations.annotations(eoDeployment.getSpec().getTemplate()).put(
-                                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(clusterCaCertGeneration));
-                        Annotations.annotations(eoDeployment.getSpec().getTemplate()).put(
-                                Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(clientsCaCertGeneration));
-                        return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment));
-                    }).map(i -> this);
-                }
+                return future.compose(dep -> {
+                    // getting the current cluster CA generation from the current deployment, if exists
+                    int clusterCaCertGeneration = getDeploymentCaCertGeneration(dep, this.clusterCa);
+                    int clientsCaCertGeneration = getDeploymentCaCertGeneration(dep, this.clientsCa);
+                    // if maintenance windows are satisfied, the cluster CA generation could be changed
+                    // and EO needs a rolling update updating the related annotation
+                    boolean isSatisfiedBy = isMaintenanceTimeWindowsSatisfied(dateSupplier);
+                    if (isSatisfiedBy) {
+                        clusterCaCertGeneration = getCaCertGeneration(this.clusterCa);
+                        clientsCaCertGeneration = getCaCertGeneration(this.clientsCa);
+                    }
+                    Annotations.annotations(eoDeployment.getSpec().getTemplate()).put(
+                            Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(clusterCaCertGeneration));
+                    Annotations.annotations(eoDeployment.getSpec().getTemplate()).put(
+                            Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(clientsCaCertGeneration));
+                    return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment));
+                }).map(i -> this);
+            } else  {
+                return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), null));
             }
-            return Future.succeededFuture(this);
         }
 
         Future<ReconciliationState> entityOperatorSecret() {

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -102,6 +102,7 @@ rules:
   - deployments/scale
   - deployments/status
   - statefulsets
+  - replicasets
   verbs:
   - get
   - list

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -373,6 +373,9 @@ public class KafkaAssemblyOperatorTest {
             }
             return Future.succeededFuture(ReconcileResult.created(desired));
         });
+        when(mockDepOps.getAsync(anyString(), anyString())).thenReturn(
+                Future.succeededFuture()
+        );
 
         when(mockSecretOps.list(anyString(), any())).thenReturn(
                 secrets
@@ -727,10 +730,17 @@ public class KafkaAssemblyOperatorTest {
             when(mockDepOps.get(clusterNamespace, TopicOperator.topicOperatorName(clusterName))).thenReturn(
                     originalTopicOperator.generateDeployment(true)
             );
+            when(mockDepOps.getAsync(clusterNamespace, TopicOperator.topicOperatorName(clusterName))).thenReturn(
+                    Future.succeededFuture(originalTopicOperator.generateDeployment(true))
+            );
         }
+
         if (originalEntityOperator != null) {
             when(mockDepOps.get(clusterNamespace, EntityOperator.entityOperatorName(clusterName))).thenReturn(
                     originalEntityOperator.generateDeployment(true, Collections.EMPTY_MAP)
+            );
+            when(mockDepOps.getAsync(clusterNamespace, EntityOperator.entityOperatorName(clusterName))).thenReturn(
+                    Future.succeededFuture(originalEntityOperator.generateDeployment(true, Collections.EMPTY_MAP))
             );
         }
 

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -106,6 +106,7 @@ rules:
   - deployments/scale
   - deployments/status
   - statefulsets
+  - replicasets
   verbs:
   - get
   - list

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -102,6 +102,7 @@ rules:
   - deployments/scale
   - deployments/status
   - statefulsets
+  - replicasets
   verbs:
   - get
   - list


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When EO or TO configuration are removed from the CO, the deployments are not deleted. This PR makes sure they are.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally