### PR TITLE
Add documentation for all namespaces support

### DIFF
--- a/documentation/book/assembly-cluster-operator.adoc
+++ b/documentation/book/assembly-cluster-operator.adoc
@@ -30,6 +30,8 @@ include::proc-deploying-cluster-operator-openshift.adoc[leveloffset=+1]
 
 include::proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc[leveloffset=+1]
 
+include::proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc[leveloffset=+1]
+
 ifdef::Helm[]
 include::proc-deploying-cluster-operator-helm-chart.adoc[leveloffset=+1]
 endif::Helm[]

--- a/documentation/book/assembly-operators-cluster-operator.adoc
+++ b/documentation/book/assembly-operators-cluster-operator.adoc
@@ -19,6 +19,8 @@ include::proc-deploying-cluster-operator-openshift.adoc[leveloffset=+1]
 
 include::proc-deploying-cluster-operator-kubernetes-to-watch-multiple-namespaces.adoc[leveloffset=+1]
 
+include::proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc[leveloffset=+1]
+
 ifdef::Helm[]
 include::proc-deploying-cluster-operator-helm-chart.adoc[leveloffset=+1]
 endif::Helm[]

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// assembly-cluster-operator.adoc
+// assembly-operators-cluster-operator.adoc
+
+[id='deploying-cluster-operator-kubernetes-to-watch-whole-cluster-{context}']
+= Deploying the Cluster Operator to watch the whole cluster
+
+Cluster Operator can be installed to manage Kafka, Kafka Connect and Kafka Mirror Maker in the whole {ProductPlatformName} cluster across all {Namespaces}.
+
+.Prerequisites
+
+* Running {ProductPlatformName} cluster
+
+.Procedure
+
+. Edit the file `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` and set the value of the environment variable `STRIMZI_NAMESPACE` to `*`.
+For example:
++
+[source,yaml]
+----
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  template:
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      containers:
+      - name: strimzi-cluster-operator
+        image: strimzi/cluster-operator:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: STRIMZI_NAMESPACE
+          value: "*"
+----
+
+. To give the Cluster Operator access to all {Namespaces}, create the `ClusterRoleBindings`.
+Replace the `_my-namespace_` or `_my-project_` with the {Namespace} where the cluster operator will be installed.
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl create`:
+[source,shell,subs=+quotes]
+kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc adm policy`:
++
+[source,shell,subs=+quotes]
+oc adm policy add-cluster-role-to-user strimzi-cluster-operator-namespaced --serviceaccount strimzi-cluster-operator -n _my-project_
+oc adm policy add-cluster-role-to-user strimzi-entity-operator --serviceaccount strimzi-cluster-operator -n _my-project_
+oc adm policy add-cluster-role-to-user strimzi-topic-operator --serviceaccount strimzi-cluster-operator -n _my-project_
+
+. Deploy the Cluster Operator
++
+ifdef::Kubernetes[]
+On {KubernetesName} this can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f install/cluster-operator -n _my-namespace_
++
+endif::Kubernetes[]
+On {OpenShiftName} this can be done using `oc apply`:
++
+[source,shell,subs=+quotes]
+oc apply -f install/cluster-operator -n _my-project_

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
@@ -4,19 +4,21 @@
 // assembly-operators-cluster-operator.adoc
 
 [id='deploying-cluster-operator-kubernetes-to-watch-whole-cluster-{context}']
-= Deploying the Cluster Operator to watch the whole cluster
+= Deploying the Cluster Operator to watch all namespaces
 
-Cluster Operator can be installed to manage Kafka, Kafka Connect and Kafka Mirror Maker in the whole {ProductPlatformName} cluster across all {Namespaces}.
-In this mode, the Cluster Operator will automatically start managing clusters in any new {Namespaces} which will be created while it is running.
+You can configure the Cluster Operator to watch {OpenShiftName} resources across all {Namespaces} in your {ProductPlatformName} cluster. When running in this mode, the Cluster Operator automatically manages clusters in any new projects or namespaces that are created.
 
 .Prerequisites
 
-* A running {ProductPlatformName} cluster
+* Your {ProductPlatformName} cluster is running.
 
 .Procedure
 
-. Edit the file `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` and set the value of the environment variable `STRIMZI_NAMESPACE` to `*`.
-For example:
+. Configure the Cluster Operator to watch all namespaces:
+  
+.. Edit the `050-Deployment-strimzi-cluster-operator.yaml` file.
+
+.. Set the value of the `STRIMZI_NAMESPACE` environment variable to `*`.
 +
 [source,yaml]
 ----
@@ -37,33 +39,43 @@ spec:
         # ...
 ----
 
-. To give the Cluster Operator access to all {Namespaces}, create the `ClusterRoleBindings`.
-Replace the `_my-namespace_` or `_my-project_` with the {Namespace} where the cluster operator will be installed.
+. Create `ClusterRoleBindings` that grant cluster-wide access to all {Namespaces} to the Cluster Operator.
 +
-ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl create`:
-[source,shell,subs=+quotes]
-kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-namespace_:strimzi-cluster-operator
-kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
-kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
-+
-endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc adm policy`:
+On {OpenShiftName}, use the `oc adm policy` command:
 +
 [source,shell,subs=+quotes]
 oc adm policy add-cluster-role-to-user strimzi-cluster-operator-namespaced --serviceaccount strimzi-cluster-operator -n _my-project_
 oc adm policy add-cluster-role-to-user strimzi-entity-operator --serviceaccount strimzi-cluster-operator -n _my-project_
 oc adm policy add-cluster-role-to-user strimzi-topic-operator --serviceaccount strimzi-cluster-operator -n _my-project_
-
-. Deploy the Cluster Operator
 +
+Replace `_my-project_` with the project in which you want to install the Cluster Operator.
++
+// upstream only
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
-[source,shell,subs=+quotes]
-kubectl apply -f install/cluster-operator -n _my-namespace_
+On {KubernetesName}, use the `kubectl create` command:
 +
+[source,shell,subs=+quotes]
+kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-namespace_:strimzi-cluster-operator
++
+Replace `_my-namespace_` with the namespace in which you want to install the Cluster Operator.
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+// end
++
+. Deploy the Cluster Operator to your {ProductPlatformName} cluster.
++
+On {OpenShiftName}, use the `oc apply` command:
 +
 [source,shell,subs=+quotes]
 oc apply -f install/cluster-operator -n _my-project_
++
+// upstream only
+ifdef::Kubernetes[]
+On {KubernetesName}, use the `kubectl apply` command:
++
+[source,shell,subs=+quotes]
+kubectl apply -f install/cluster-operator -n _my-namespace_
+endif::Kubernetes[]
++
+// end

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
@@ -7,7 +7,7 @@
 = Deploying the Cluster Operator to watch the whole cluster
 
 Cluster Operator can be installed to manage Kafka, Kafka Connect and Kafka Mirror Maker in the whole {ProductPlatformName} cluster across all {Namespaces}.
-In this mode, the Cluster Operator will automatically start managing clusters in any new {Namespaces} which will be created while it is running and drop any {Namespaces} which will be deleted.
+In this mode, the Cluster Operator will automatically start managing clusters in any new {Namespaces} which will be created while it is running.
 
 .Prerequisites
 

--- a/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-kubernetes-to-watch-whole-cluster.adoc
@@ -7,10 +7,11 @@
 = Deploying the Cluster Operator to watch the whole cluster
 
 Cluster Operator can be installed to manage Kafka, Kafka Connect and Kafka Mirror Maker in the whole {ProductPlatformName} cluster across all {Namespaces}.
+In this mode, the Cluster Operator will automatically start managing clusters in any new {Namespaces} which will be created while it is running and drop any {Namespaces} which will be deleted.
 
 .Prerequisites
 
-* Running {ProductPlatformName} cluster
+* A running {ProductPlatformName} cluster
 
 .Procedure
 
@@ -24,6 +25,7 @@ kind: Deployment
 spec:
   template:
     spec:
+      # ...
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
@@ -32,6 +34,7 @@ spec:
         env:
         - name: STRIMZI_NAMESPACE
           value: "*"
+        # ...
 ----
 
 . To give the Cluster Operator access to all {Namespaces}, create the `ClusterRoleBindings`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the documentation for the PR #1261 which allows to configure Cluster Operator to listen in all namespaces in the whole cluster.