### PR TITLE
java.util.regex.Pattern is thread-safe and should be compiled only once

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -43,6 +43,8 @@ public class ExamplesTest {
         Crds.registerCustomKinds();
     }
 
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\$\\{\\{(.+?)\\}?\\}");
+
     /**
      * Recurse through the examples directory looking for resources of the right type
      * and validating them.
@@ -169,8 +171,7 @@ public class ExamplesTest {
         }
         for (JsonNode object : rootNode.get("objects")) {
             String s = new YAMLMapper().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES).enable(SerializationFeature.INDENT_OUTPUT).writeValueAsString(object);
-            Pattern p = Pattern.compile("\\$\\{\\{(.+?)\\}?\\}");
-            Matcher matcher = p.matcher(s);
+            Matcher matcher = PARAMETER_PATTERN.matcher(s);
             StringBuilder sb = new StringBuilder();
             int last = 0;
             while (matcher.find()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -100,6 +100,7 @@ public abstract class AbstractModel {
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "/delete-claim";
     @Deprecated
     public static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = "cluster.operator.strimzi.io/delete-claim";
+    private static final Pattern LOGGER_PATTERN = Pattern.compile("\\$\\{(.*)\\}, ([A-Z]+)");
 
     protected static final String DEFAULT_KAFKA_GC_LOG_ENABLED = String.valueOf(true);
     protected static final String DEFAULT_STRIMZI_GC_LOG_ENABED = String.valueOf(true);
@@ -354,8 +355,7 @@ public abstract class AbstractModel {
                 if ((asList(validLoggerValues).contains(tmpEntry.replaceAll(",[ ]+CONSOLE", ""))) || (asList(validLoggerValues).contains(tmpEntry))) {
                     // correct value
                 } else {
-                    Pattern p = Pattern.compile("\\$\\{(.*)\\}, ([A-Z]+)");
-                    Matcher m = p.matcher(tmpEntry);
+                    Matcher m = LOGGER_PATTERN.matcher(tmpEntry);
 
                     String logger = "";
                     String value = "";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -22,6 +22,13 @@ import java.util.regex.Pattern;
  */
 public class KafkaVersion implements Comparable<KafkaVersion> {
 
+    private static final Pattern KAFKA_VERSION_PATTERN = Pattern.compile(
+        "(?<version>[0-9.]+)\\s+" +
+        "(?<default>default)?\\s+" +
+        "(?<proto>[0-9.]+)\\s+" +
+        "(?<msg>[0-9.]+)\\s+" +
+        "(?<sha>[0-9A-Za-z]+)");
+
     /**
      * Parse the version information present in the {@code /kafka-versions} classpath resource.
      * @param reader A leader for the version info.
@@ -35,13 +42,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         String line = reader.readLine();
         while (line != null) {
             if (!line.isEmpty() && !line.startsWith("#")) {
-                Pattern pattern = Pattern.compile(
-                        "(?<version>[0-9.]+)\\s+" +
-                                "(?<default>default)?\\s+" +
-                                "(?<proto>[0-9.]+)\\s+" +
-                                "(?<msg>[0-9.]+)\\s+" +
-                                "(?<sha>[0-9A-Za-z]+)");
-                Matcher matcher = pattern.matcher(line);
+                Matcher matcher = KAFKA_VERSION_PATTERN.matcher(line);
                 if (matcher.matches()) {
                     String version = matcher.group("version");
                     KafkaVersion kafkaVersion = new KafkaVersion(version,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -64,6 +64,7 @@ import java.util.regex.Pattern;
 public class ZookeeperSetOperator extends StatefulSetOperator {
 
     private static final Logger log = LogManager.getLogger(ZookeeperSetOperator.class);
+    private static final Pattern CA_KEY_PATTERN = Pattern.compile("^---*BEGIN.*---*$(.*)^---*END.*---*$.*", Pattern.MULTILINE | Pattern.DOTALL);
 
     /**
      * Constructor
@@ -159,8 +160,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
             keyStore.load(null, password);
 
             String keyText = new String(decoder.decode(clusterSecretKey.getData().get("ca.key")), StandardCharsets.ISO_8859_1);
-            Pattern parse = Pattern.compile("^---*BEGIN.*---*$(.*)^---*END.*---*$.*", Pattern.MULTILINE | Pattern.DOTALL);
-            Matcher matcher = parse.matcher(keyText);
+            Matcher matcher = CA_KEY_PATTERN.matcher(keyText);
             if (!matcher.find()) {
                 throw new RuntimeException("Bad client (CO) key. Key misses BEGIN or END markers");
             }
@@ -175,7 +175,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
             X509Certificate coCert = (X509Certificate) x509.generateCertificate(new ByteArrayInputStream(coCertKey.cert()));
 
             String coCertKeyText = new String(coCertKey.key(), StandardCharsets.ISO_8859_1);
-            Matcher matcher2 = parse.matcher(coCertKeyText);
+            Matcher matcher2 = CA_KEY_PATTERN.matcher(coCertKeyText);
             if (!matcher2.find()) {
                 throw new RuntimeException("Bad client (CO) key. Key misses BEGIN or END markers");
             }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -114,6 +114,7 @@ public abstract class AbstractST {
     static final long GLOBAL_TIMEOUT = 300000;
     static final long GLOBAL_POLL_INTERVAL = 1000;
     static final long TEARDOWN_GLOBAL_WAIT = 10000;
+    private static final Pattern BRACE_PATTERN = Pattern.compile("^\\{.*\\}$", Pattern.MULTILINE);
 
     public static KubeClusterResource cluster = new KubeClusterResource();
     protected static DefaultKubernetesClient client = new DefaultKubernetesClient();
@@ -488,8 +489,7 @@ public abstract class AbstractST {
     void checkPings(int messagesCount, Job job) {
         String podName = jobPodName(job);
         String log = podLog(podName);
-        Pattern p = Pattern.compile("^\\{.*\\}$", Pattern.MULTILINE);
-        Matcher m = p.matcher(log);
+        Matcher m = BRACE_PATTERN.matcher(log);
         boolean producerSuccess = false;
         boolean consumerSuccess = false;
         while (m.find()) {
@@ -820,8 +820,7 @@ public abstract class AbstractST {
     void checkRecordsForConsumer(int messagesCount, Job job) {
         String podName = jobPodName(job);
         String log = podLog(podName);
-        Pattern p = Pattern.compile("^\\{.*\\}$", Pattern.MULTILINE);
-        Matcher m = p.matcher(log);
+        Matcher m = BRACE_PATTERN.matcher(log);
         boolean consumerSuccess = false;
         while (m.find()) {
             String json = m.group();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -86,6 +86,7 @@ class KafkaST extends AbstractST {
 
     public static final String NAMESPACE = "kafka-cluster-test";
     private static final String TOPIC_NAME = "test-topic";
+    private static final Pattern ZK_SERVER_STATE = Pattern.compile("zk_server_state\\s+(leader|follower)");
 
     static KubernetesClient client = new DefaultKubernetesClient();
 
@@ -205,7 +206,7 @@ class KafkaST extends AbstractST {
 
         waitForZkPods(newZkPodNames);
         // check the new node is either in leader or follower state
-        waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2, 3, 4, 5, 6);
+        waitForZkMntr(ZK_SERVER_STATE, 0, 1, 2, 3, 4, 5, 6);
         checkZkPodsLog(newZkPodNames);
 
         //Test that CO doesn't have any exceptions in log
@@ -222,7 +223,7 @@ class KafkaST extends AbstractST {
         }
 
         // Wait for one zk pods will became leader and others follower state
-        waitForZkMntr(Pattern.compile("zk_server_state\\s+(leader|follower)"), 0, 1, 2);
+        waitForZkMntr(ZK_SERVER_STATE, 0, 1, 2);
 
         //Test that the second pod has event 'Killing'
         assertThat(getEvents("Pod", newZkPodNames.get(4)), hasAllOfReasons(Killing));

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -71,6 +71,9 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_MIRROR_MAKER = "../install/cluster-operator/045-Crd-kafkamirrormaker.yaml";
 
+    private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile(":([^:]*?)-kafka-([0-9.]+)$");
+    private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
+
     private TestUtils() {
         // All static methods
     }
@@ -147,8 +150,7 @@ public final class TestUtils {
 
     public static String changeOrgAndTag(String image, String newOrg, String newTag, String kafkaVersion) {
         image = image.replaceFirst("^strimzi/", newOrg + "/");
-        Pattern p = Pattern.compile(":([^:]*?)-kafka-([0-9.]+)$");
-        Matcher m = p.matcher(image);
+        Matcher m = KAFKA_COMPONENT_PATTERN.matcher(image);
         StringBuffer sb = new StringBuffer();
         if (m.find()) {
             m.appendReplacement(sb, ":" + newTag + "-kafka-" + kafkaVersion);
@@ -171,8 +173,7 @@ public final class TestUtils {
     }
 
     public static String changeOrgAndTagInImageMap(String imageMap) {
-        java.util.regex.Pattern p = java.util.regex.Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
-        Matcher m = p.matcher(imageMap);
+        Matcher m = VERSION_IMAGE_PATTERN.matcher(imageMap);
         StringBuffer sb = new StringBuffer();
         while (m.find()) {
             m.appendReplacement(sb, m.group("version") + "=" + TestUtils.changeOrgAndTag(m.group("image")));

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/OperatorAssignedKafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/OperatorAssignedKafkaImpl.java
@@ -47,6 +47,10 @@ import java.util.regex.Pattern;
  */
 public class OperatorAssignedKafkaImpl extends BaseKafkaImpl {
 
+    private static final Pattern REASSIGN_FAILED = Pattern.compile("Reassignment of partition .* failed");
+    private static final Pattern REASSIGN_COMPLETE = Pattern.compile("Reassignment of partition .* completed successfully");
+    private static final Pattern REASSIGN_INPROGRESS = Pattern.compile("Reassignment of partition .* is still in progress");
+
     private final static Logger LOGGER = LogManager.getLogger(OperatorAssignedKafkaImpl.class);
     private final Config config;
 
@@ -192,11 +196,11 @@ public class OperatorAssignedKafkaImpl extends BaseKafkaImpl {
         @Override
         public Void apply(String line) {
             if (line.contains("Partitions reassignment failed due to")
-                    || Pattern.matches("Reassignment of partition .* failed", line)) {
+                    || REASSIGN_FAILED.matcher(line).matches()) {
                 throw new OperatorException("Reassigment failed: " + line);
-            } else if (Pattern.matches("Reassignment of partition .* completed successfully", line)) {
+            } else if (REASSIGN_COMPLETE.matcher(line).matches()) {
                 complete++;
-            } else if (Pattern.matches("Reassignment of partition .* is still in progress", line)) {
+            } else if (REASSIGN_INPROGRESS.matcher(line).matches()) {
                 inProgress++;
             }
             return null;


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

java.util.regex.Pattern is immutable and thread-safe.  Since compiling a Pattern is an expensive operation, it should be done once if possible.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

