### PR TITLE
Fix wrong title in the procedure for accessing Kafka using loadbalancers

### DIFF
--- a/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/book/proc-accessing-kafka-using-loadbalancers.adoc
@@ -3,7 +3,7 @@
 // assembly-configuring-kafka-listeners.adoc
 
 [id='proc-accessing-kafka-using-loadbalancers-{context}']
-= Accessing Kafka using loadbalancers routes
+= Accessing Kafka using loadbalancers
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes a trivial bug in the documentation where the procedure is incorrectly named. 

