### PR TITLE
ST: Fix for ConnectS2IST and fix for Docker Tags 

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -223,3 +223,6 @@ Ex)
 ### Log level
 
 To set the log level of Strimzi for system tests need to add system property `TEST_STRIMZI_LOG_LEVEL` with one of the following values: `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`.
+
+### Execute ST with custom Kafka version
+To set custom Kafka version in system tests need to add system property `ST_KAFKA_VERSION` with one of the following values: `2.0.0`, `2.0.1`, `2.1.0`

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -76,6 +76,7 @@ public class Resources {
     private static final long TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS = Duration.ofMinutes(7).toMillis();
     private static final long TIMEOUT_FOR_RESOURCE_CREATION = Duration.ofMinutes(5).toMillis();
     public static final long TIMEOUT_FOR_RESOURCE_READINESS = Duration.ofMinutes(7).toMillis();
+    private static final String KAFKA_VERSION = "2.1.0";
 
     public static final String STRIMZI_PATH_TO_CO_CONFIG = "../install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml";
     public static final String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
@@ -369,6 +370,7 @@ public class Resources {
         return new KafkaConnectS2IBuilder()
             .withMetadata(new ObjectMetaBuilder().withName(name).withNamespace(client().getNamespace()).build())
             .withNewSpec()
+                .withVersion(KAFKA_VERSION)
                 .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
                 .withReplicas(kafkaConnectS2IReplicas)
             .endSpec();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -147,7 +147,7 @@ public class StUtils {
     }
 
     public static File downloadAndUnzip(String url) throws IOException {
-        InputStream bais = (InputStream) URI.create(url).toURL().getContent();
+        InputStream bais = (InputStream) URI.create(url).toURL().openConnection().getContent();
         File dir = Files.createTempDirectory(StUtils.class.getName()).toFile();
         dir.deleteOnExit();
         ZipInputStream zin = new ZipInputStream(bais);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -37,7 +37,7 @@ class ConnectS2IST extends AbstractST {
     @OpenShiftOnly
     @Tag(FLAKY)
     void testDeployS2IWithMongoDBPlugin() throws IOException {
-        classResources().kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1)
+        testClassResources.kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
             .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -37,7 +37,7 @@ class ConnectS2IST extends AbstractST {
     @OpenShiftOnly
     @Tag(FLAKY)
     void testDeployS2IWithMongoDBPlugin() throws IOException {
-        resources().kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1)
+        classResources().kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
             .endMetadata()
@@ -45,15 +45,12 @@ class ConnectS2IST extends AbstractST {
 
         File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.3.0/debezium-connector-mongodb-0.3.0-plugin.zip");
 
-        String connectS2IPodName = KUBE_CLIENT.listResourcesByLabel("pod", "type=kafka-connect-s2i").get(0);
-
         // Start a new image build using the plugins directory
         KUBE_CLIENT.exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
-        KUBE_CLIENT.waitForResourceDeletion("pod", connectS2IPodName);
 
         KUBE_CLIENT.waitForDeploymentConfig(CONNECT_DEPLOYMENT_NAME);
 
-        connectS2IPodName = KUBE_CLIENT.listResourcesByLabel("pod", "type=kafka-connect-s2i").get(0);
+        String connectS2IPodName = KUBE_CLIENT.listResourcesByLabel("pod", "type=kafka-connect-s2i").get(0);
         String plugins = KUBE_CLIENT.execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins").out();
 
         assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -71,7 +71,7 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_MIRROR_MAKER = "../install/cluster-operator/045-Crd-kafkamirrormaker.yaml";
 
-    private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile(":([^:]*?)-kafka-([0-9.]+)$");
+    private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile(":([^:]*?)-kafka-(?<version>[0-9.])");
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
 
     private TestUtils() {
@@ -148,12 +148,12 @@ public final class TestUtils {
         return "";
     }
 
-    public static String changeOrgAndTag(String image, String newOrg, String newTag, String kafkaVersion) {
+    public static String changeOrgAndTag(String image, String newOrg, String newTag) {
         image = image.replaceFirst("^strimzi/", newOrg + "/");
         Matcher m = KAFKA_COMPONENT_PATTERN.matcher(image);
         StringBuffer sb = new StringBuffer();
         if (m.find()) {
-            m.appendReplacement(sb, ":" + newTag + "-kafka-" + kafkaVersion);
+            m.appendReplacement(sb, ":" + newTag + "-kafka-" + m.group("version"));
             m.appendTail(sb);
             image = sb.toString();
         } else {
@@ -165,11 +165,9 @@ public final class TestUtils {
     public static String changeOrgAndTag(String image) {
         String strimziOrg = "strimzi";
         String strimziTag = "latest";
-        String kafkaVersion = "2.1.0";
         String dockerOrg = System.getenv().getOrDefault("DOCKER_ORG", strimziOrg);
         String dockerTag = System.getenv().getOrDefault("DOCKER_TAG", strimziTag);
-        kafkaVersion = System.getenv().getOrDefault("KAFKA_VERSION", kafkaVersion);
-        return changeOrgAndTag(image, dockerOrg, dockerTag, kafkaVersion);
+        return changeOrgAndTag(image, dockerOrg, dockerTag);
     }
 
     public static String changeOrgAndTagInImageMap(String imageMap) {


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
1. Fixed issue with an incorrect instance of resources in ConnectS2IST. We need to use class resources to deploy Kafka ConnectS2I
2. Fixed issue with wrong Docker Tags during the deploying of CO. The problem here, that we hardcoded Kafka version and as result, we had hardcode in Docker Tags.
```
        - name: STRIMZI_KAFKA_IMAGES
          value: |
            2.0.0=strimzi/kafka:latest-kafka-2.1.0 <- wrong, correct Tag -> latest-kafka-2.0.0
            2.0.1=strimzi/kafka:latest-kafka-2.1.0 <- wrong, correct Tag -> latest-kafka-2.0.1
            2.1.0=strimzi/kafka:latest-kafka-2.1.0
```
3. Added Kafka version for Kafka ConnectS2I default builder


### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

