### PR TITLE
Fix handling of metrics when the metrics field is not specified

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -71,7 +71,7 @@ public class KafkaClusterSpec implements Serializable {
     private Probe livenessProbe;
     private Probe readinessProbe;
     private JvmOptions jvmOptions;
-    private Map<String, Object> metrics = new HashMap<>(0);
+    private Map<String, Object> metrics;
     private Affinity affinity;
     private List<Toleration> tolerations;
     private KafkaListeners listeners;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -48,7 +48,7 @@ public class KafkaConnectSpec implements Serializable {
     private Probe livenessProbe;
     private Probe readinessProbe;
     private JvmOptions jvmOptions;
-    private Map<String, Object> metrics = new HashMap<>(0);
+    private Map<String, Object> metrics;
     private Affinity affinity;
     private List<Toleration> tolerations;
     private String bootstrapServers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -48,7 +48,7 @@ public class KafkaMirrorMakerSpec implements Serializable {
     private List<Toleration> tolerations;
     private JvmOptions jvmOptions;
     private Logging logging;
-    private Map<String, Object> metrics = new HashMap<>(0);
+    private Map<String, Object> metrics;
     private KafkaMirrorMakerTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -62,7 +62,7 @@ public class ZookeeperClusterSpec implements Serializable {
     private Probe livenessProbe;
     private Probe readinessProbe;
     private JvmOptions jvmOptions;
-    private Map<String, Object> metrics = new HashMap<>(0);
+    private Map<String, Object> metrics;
     private Affinity affinity;
     private List<Toleration> tolerations;
     private ZookeeperClusterTemplate template;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `metrics` field should not be initialised to empty map because that means that metrics will be always enabled.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally