### PR TITLE
Check for include:

### DIFF
--- a/.travis/check_docs.sh
+++ b/.travis/check_docs.sh
@@ -44,6 +44,9 @@ grep_check '[[]id=(["'"'"'])[[:alnum:]_-]+(?!-[{]context[}])\1' "[id=...] should
 # leveloffset=+
 grep_check 'leveloffset+=[0-9]+'  "It should be leveloffset=+... not +="
 
+# include: should be include::
+grep_check 'include:[^:[ ]+[[]'  "It should be include::...[] (two colons) not include:...[]"
+
 if [ $fatal -gt 0 ]; then
   echo "ERROR: ${fatal} docs problems found."
   exit 1


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Prevent people from accidentally trying to use `include:` when they meant `include::`.
