### PR TITLE
Factor out ZookeeperLeaderFinder, use BackOff and vertx net client

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -15,6 +15,8 @@
         <property name="fileExtensions" value="java"/>
     </module>
 
+    <module name="SuppressWarningsFilter" />
+
     <module name="TreeWalker">
 
         <!-- code cleanup -->
@@ -119,6 +121,8 @@
         <module name="IllegalToken">
             <property name="tokens" value="LITERAL_ASSERT"/>
         </module>
+
+        <module name="SuppressWarningsHolder" />
     </module>
 
     <module name="SuppressionFilter">

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -21,10 +21,6 @@ import java.util.regex.Pattern;
 
 public class ClusterCa extends Ca {
 
-    // the Kubernetes service DNS domain is customizable on cluster creation but it's "cluster.local" by default
-    // there is no clean way to get it from a running application so we are passing it through an env var
-    public static final String KUBERNETES_SERVICE_DNS_DOMAIN =
-            System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
     private final String clusterName;
     private Secret entityOperatorSecret;
     private Secret topicOperatorSecret;
@@ -114,8 +110,8 @@ public class ClusterCa extends Ca {
             sbjAltNames.put("DNS.1", ZookeeperCluster.serviceName(cluster));
             sbjAltNames.put("DNS.2", String.format("%s.%s", ZookeeperCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.3", String.format("%s.%s.svc", ZookeeperCluster.serviceName(cluster), namespace));
-            sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", ZookeeperCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-            sbjAltNames.put("DNS.5", String.format("%s.%s.%s.svc.%s", ZookeeperCluster.zookeeperPodName(cluster, i), ZookeeperCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", ZookeeperCluster.serviceName(cluster), namespace, ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.5", ZookeeperCluster.podDnsName(namespace, cluster, i));
 
             Subject subject = new Subject();
             subject.setOrganizationName("io.strimzi");
@@ -141,8 +137,8 @@ public class ClusterCa extends Ca {
             sbjAltNames.put("DNS.1", KafkaCluster.serviceName(cluster));
             sbjAltNames.put("DNS.2", String.format("%s.%s", KafkaCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.3", String.format("%s.%s.svc", KafkaCluster.serviceName(cluster), namespace));
-            sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
-            sbjAltNames.put("DNS.5", String.format("%s.%s.%s.svc.%s", KafkaCluster.kafkaPodName(cluster, i), KafkaCluster.headlessServiceName(cluster), namespace, KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.5", KafkaCluster.podDnsName(namespace, cluster, i));
             int nextDnsId = 6;
             int nextIpId = 1;
             if (externalBootstrapAddress != null)   {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -216,6 +216,14 @@ public class KafkaCluster extends AbstractModel {
         return KafkaResources.bootstrapServiceName(cluster);
     }
 
+    public static String podDnsName(String namespace, String cluster, int podId) {
+        return String.format("%s.%s.%s.svc.%s",
+                KafkaCluster.kafkaPodName(cluster, podId),
+                KafkaCluster.headlessServiceName(cluster),
+                namespace,
+                ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
+    }
+
     /**
      * Generates the name of the service used as bootstrap service for external clients
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -23,11 +23,13 @@ import io.strimzi.api.kafka.model.Resources;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
-import io.strimzi.certs.CertAndKey;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
+import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
 import io.strimzi.operator.common.model.Labels;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,9 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import static io.strimzi.api.kafka.model.Quantities.normalizeCpu;
 import static io.strimzi.api.kafka.model.Quantities.normalizeMemory;
 
@@ -49,6 +48,10 @@ public class ModelUtils {
     private ModelUtils() {}
 
     protected static final Logger log = LogManager.getLogger(ModelUtils.class.getName());
+
+    public static final String KUBERNETES_SERVICE_DNS_DOMAIN =
+            System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
+
     /**
      * Find the first secret in the given secrets with the given name
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -17,13 +17,13 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPort;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
@@ -43,8 +43,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.strimzi.operator.cluster.model.ModelUtils.parseImageMap;
 import static java.util.Arrays.asList;
@@ -106,28 +104,12 @@ public class ZookeeperCluster extends AbstractModel {
         return cluster + ZookeeperCluster.HEADLESS_SERVICE_NAME_SUFFIX;
     }
 
-    private static final Pattern POD_NAME_PATTERN = Pattern.compile("^(.*)-zookeeper-([0-9]+)$");
-
-    private static String podDnsName(String namespace, String cluster, String podName) {
+    public static String podDnsName(String namespace, String cluster, int podId) {
         return String.format("%s.%s.%s.svc.%s",
-                podName,
+                ZookeeperCluster.zookeeperPodName(cluster, podId),
                 ZookeeperCluster.headlessServiceName(cluster),
                 namespace,
                 ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
-    }
-
-    public static String podDnsName(String namespace, String cluster, int podId) {
-        return podDnsName(namespace, cluster, ZookeeperCluster.zookeeperPodName(cluster, podId));
-    }
-
-    public static String podDnsName(String namespace, String podName) {
-        Matcher matcher = POD_NAME_PATTERN.matcher(podName);
-        if (matcher.matches()) {
-            String cluster = matcher.group(1);
-            return podDnsName(namespace, cluster, podName);
-        } else {
-            throw new RuntimeException("Pod name " + podName + " did not match expected pattern for Zookeeper pods");
-        }
     }
 
     public static String zookeeperPodName(String cluster, int pod) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -43,6 +43,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.strimzi.operator.cluster.model.ModelUtils.parseImageMap;
 import static java.util.Arrays.asList;
@@ -102,6 +104,30 @@ public class ZookeeperCluster extends AbstractModel {
 
     public static String headlessServiceName(String cluster) {
         return cluster + ZookeeperCluster.HEADLESS_SERVICE_NAME_SUFFIX;
+    }
+
+    private static final Pattern POD_NAME_PATTERN = Pattern.compile("^(.*)-zookeeper-([0-9]+)$");
+
+    private static String podDnsName(String namespace, String cluster, String podName) {
+        return String.format("%s.%s.%s.svc.%s",
+                podName,
+                ZookeeperCluster.headlessServiceName(cluster),
+                namespace,
+                ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
+    }
+
+    public static String podDnsName(String namespace, String cluster, int podId) {
+        return podDnsName(namespace, cluster, ZookeeperCluster.zookeeperPodName(cluster, podId));
+    }
+
+    public static String podDnsName(String namespace, String podName) {
+        Matcher matcher = POD_NAME_PATTERN.matcher(podName);
+        if (matcher.matches()) {
+            String cluster = matcher.group(1);
+            return podDnsName(namespace, cluster, podName);
+        } else {
+            throw new RuntimeException("Pod name " + podName + " did not match expected pattern for Zookeeper pods");
+        }
     }
 
     public static String zookeeperPodName(String cluster, int pod) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -155,9 +155,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
         createReconciliationState(reconciliation, kafkaAssembly)
                 .reconcileCas()
+                .compose(state -> state.clusterOperatorSecret())
                 // Roll everything if a new CA is added to the trust store.
                 .compose(state -> state.rollingUpdateForNewCaKey())
-                .compose(state -> state.clusterOperatorSecret())
                 .compose(state -> state.zkManualPodCleaning())
                 .compose(state -> state.zkManualRollingUpdate())
                 .compose(state -> state.getZookeeperDescription())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -43,6 +43,7 @@ public class ResourceOperatorSupplier {
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, boolean isOpenShift, long operationTimeoutMs) {
         this(vertx, client, new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
+            // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
             () -> new BackOff(5_000, 2, 4)),
                     isOpenShift, operationTimeoutMs);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.KafkaAssemblyList;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -41,20 +42,26 @@ public class ResourceOperatorSupplier {
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, boolean isOpenShift, long operationTimeoutMs) {
+        this(vertx, client, new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
+            () -> new BackOff(5_000, 2, 4)),
+                    isOpenShift, operationTimeoutMs);
+    }
+
+    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf, boolean isOpenShift, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
-            isOpenShift ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
-            new ZookeeperSetOperator(vertx, client, operationTimeoutMs),
-            new KafkaSetOperator(vertx, client, operationTimeoutMs),
-            new ConfigMapOperator(vertx, client),
-            new SecretOperator(vertx, client),
-            new PvcOperator(vertx, client),
-            new DeploymentOperator(vertx, client),
-            new ServiceAccountOperator(vertx, client),
-            new RoleBindingOperator(vertx, client),
-            new ClusterRoleBindingOperator(vertx, client),
-            new NetworkPolicyOperator(vertx, client),
-            new PodDisruptionBudgetOperator(vertx, client),
-            new CrdOperator<>(vertx, client, Kafka.class, KafkaAssemblyList .class, DoneableKafka.class));
+                isOpenShift ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
+                new ZookeeperSetOperator(vertx, client, zlf, operationTimeoutMs),
+                new KafkaSetOperator(vertx, client, operationTimeoutMs),
+                new ConfigMapOperator(vertx, client),
+                new SecretOperator(vertx, client),
+                new PvcOperator(vertx, client),
+                new DeploymentOperator(vertx, client),
+                new ServiceAccountOperator(vertx, client),
+                new RoleBindingOperator(vertx, client),
+                new ClusterRoleBindingOperator(vertx, client),
+                new NetworkPolicyOperator(vertx, client),
+                new PodDisruptionBudgetOperator(vertx, client),
+                new CrdOperator<>(vertx, client, Kafka.class, KafkaAssemblyList .class, DoneableKafka.class));
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -286,7 +286,7 @@ public class ZookeeperLeaderFinder {
 
     /** The hostname for connecting to zookeeper in the given pod. */
     protected String host(Pod pod) {
-        ZookeeperCluster.podDnsName(pod.getMetadata().getNamespace(), pod.getMetadata().getName());
+        return ZookeeperCluster.podDnsName(pod.getMetadata().getNamespace(), pod.getMetadata().getName());
     }
 
     /** The port number for connecting to zookeeper in the given pod. */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -250,7 +250,13 @@ public class ZookeeperLeaderFinder {
                 } else {
                     log.debug("ZK {}:{}: connected", host, port);
                     NetSocket socket = ar.result();
-                    socket.exceptionHandler(ex -> future.fail(ex));
+                    socket.exceptionHandler(ex -> {
+                        if (!future.isComplete()) {
+                            future.fail(ex);
+                        } else {
+                            log.debug("Ignoring error, since leader status of pod {} is already known", pod.getMetadata().getName());
+                        }
+                    });
                     socket.closeHandler(v -> {
                         if (!future.isComplete()) {
                             log.debug("ZK {}:{}: closing socked, was not leader", host, port);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.cluster.ClusterOperator;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.cert.CertificateFactory;
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class for finding the leader of a ZK cluster
+ */
+public class ZookeeperLeaderFinder {
+
+    private static final Logger log = LogManager.getLogger(ZookeeperLeaderFinder.class);
+
+    static final int UNKNOWN_LEADER = -1;
+
+    private final Vertx vertx;
+    private final SecretOperator secretOperator;
+    private final Supplier<BackOff> backOffSupplier;
+
+    public ZookeeperLeaderFinder(Vertx vertx, SecretOperator secretOperator, Supplier<BackOff> backOffSupplier) {
+        this.vertx = vertx;
+        this.secretOperator = secretOperator;
+        this.backOffSupplier = backOffSupplier;
+    }
+
+    /*test*/ NetClientOptions clientOptions(CertAndKey coCertKey, Secret clusterCaCertificateSecret)
+            throws GeneralSecurityException, IOException {
+
+        CertificateFactory x509 = CertificateFactory.getInstance("X.509");
+        Base64.Decoder decoder = Base64.getDecoder();
+
+        // Validate the certificates are not corrupt
+        //x509.generateCertificate(new ByteArrayInputStream(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT))));
+        //x509.generateCertificate(new ByteArrayInputStream(coCertKey.cert()));
+
+        Buffer coCertBuffer = Buffer.buffer(coCertKey.cert());
+        log.debug("CO cert\n{}", coCertBuffer);
+        Buffer coKeyBuffer = Buffer.buffer(coCertKey.key());
+        //log.debug("CO key\n{}", coKeyBuffer);
+        Buffer clusterCaCertBuffer = Buffer.buffer(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT)));
+        log.debug("Cluster CA cert\n{}", clusterCaCertBuffer);
+        return new NetClientOptions()
+                .setConnectTimeout(10_000)
+                .setSsl(true)
+                //.setHostnameVerificationAlgorithm("HTTPS")
+                .setPemKeyCertOptions(new PemKeyCertOptions()
+                        .setCertValue(coCertBuffer)
+                        .setKeyValue(coKeyBuffer))
+                .setPemTrustOptions(new PemTrustOptions()
+                        .addCertValue(clusterCaCertBuffer));
+    }
+
+    /**
+     * Returns a Future which completes with the the id of the Zookeeper leader.
+     * An exponential backoff is used if no ZK node is leader on the attempt to find it.
+     * If there is no leader after 3 attempts then the returned Future completes with {@link #UNKNOWN_LEADER}.
+     */
+    Future<Integer> findZookeeperLeader(String cluster, String namespace, List<Pod> pods) {
+        if (pods.size() <= 1) {
+            return Future.succeededFuture(pods.size() - 1);
+        }
+        String brokersSecretName = ClusterOperator.secretName(cluster);
+        Future<Secret> brokersSecretFuture = secretOperator.getAsync(namespace, brokersSecretName);
+        String clusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(cluster);
+        Future<Secret> clusterCaKeySecretFuture = secretOperator.getAsync(namespace, clusterCaSecretName);
+        return CompositeFuture.join(brokersSecretFuture, clusterCaKeySecretFuture).compose(c -> {
+            Secret brokersSecret = c.resultAt(0);
+            if (brokersSecret == null) {
+                return missingSecretFuture(namespace, brokersSecretName);
+            }
+            Secret clusterCaCertificateSecret = c.resultAt(1);
+            if (clusterCaCertificateSecret  == null) {
+                return missingSecretFuture(namespace, brokersSecretName);
+            }
+            try {
+                CertAndKey coCertKey = Ca.asCertAndKey(brokersSecret, "cluster-operator.key", "cluster-operator.crt");
+                if (coCertKey == null) {
+                    return missingSecretFuture(namespace, brokersSecretName);
+                }
+                NetClientOptions netClientOptions = clientOptions(coCertKey, clusterCaCertificateSecret);
+                return zookeeperLeader(cluster, namespace, pods, netClientOptions);
+            } catch (Throwable e) {
+                return Future.failedFuture(e);
+            }
+        });
+
+    }
+
+    private Future<Integer> missingSecretFuture(String namespace, String brokersSecretName) {
+        return Future.failedFuture(
+                new RuntimeException("Secret " + namespace + "/" + brokersSecretName + " does not exist"));
+    }
+
+    private Future<Integer> zookeeperLeader(String cluster, String namespace, List<Pod> pods,
+                                            NetClientOptions netClientOptions) {
+        Future<Integer> result = Future.future();
+        BackOff backOff = backOffSupplier.get();
+        Handler<Long> handler = new Handler<Long>() {
+            @Override
+            public void handle(Long tid) {
+                zookeeperLeader(pods, netClientOptions).setHandler(leader -> {
+                    if (leader.succeeded()) {
+                        if (leader.result() != UNKNOWN_LEADER) {
+                            result.complete(leader.result());
+                        } else {
+                            rescheduleOrComplete(tid);
+                        }
+                    } else {
+                        log.debug("Ignoring error", leader.cause());
+                        if (backOff.done()) {
+                            result.fail(leader.cause());
+                        } else {
+                            rescheduleOrComplete(tid);
+                        }
+                        //f.fail(leader.cause());
+                    }
+                });
+            }
+
+            void rescheduleOrComplete(Long tid) {
+                if (backOff.done()) {
+                    log.warn("Giving up trying to find the leader of {}/{} after {} attempts taking {}ms",
+                            namespace, cluster, backOff.maxAttempts(), backOff.totalDelayMs());
+                    result.complete(UNKNOWN_LEADER);
+                } else {
+                    // Schedule ourselves to run again
+                    long delay = backOff.delayMs();
+                    log.info("No leader found for cluster {} in namespace {}; " +
+                                    "backing off for {}ms (cumulative {}ms)",
+                            cluster, namespace, delay, backOff.cumulativeDelayMs());
+                    if (delay < 1) {
+                        this.handle(tid);
+                    } else {
+                        vertx.setTimer(delay, this);
+                    }
+                }
+            }
+        };
+        handler.handle(null);
+        return result;
+    }
+
+    /**
+     * Synchronously find the leader by testing each pod in the given list
+     * using {@link #isLeader(Pod, NetClientOptions)}.
+     */
+    private Future<Integer> zookeeperLeader(List<Pod> pods, NetClientOptions netClientOptions) {
+        try {
+            Future<Integer> f = Future.succeededFuture(UNKNOWN_LEADER);
+            for (int i = 0; i < pods.size(); i++) {
+                final int podNum = i;
+                Pod pod = pods.get(i);
+                String podName = pod.getMetadata().getName();
+                f = f.compose(leader -> {
+                    if (leader == UNKNOWN_LEADER) {
+                        log.debug("Checker whether {} is leader", podName);
+                        return isLeader(pod, netClientOptions).map(isLeader -> {
+                            if (isLeader != null && isLeader) {
+                                log.info("Pod {} is leader", podName);
+                                return podNum;
+                            } else {
+                                log.info("Pod {} is not a leader", podName);
+                                return UNKNOWN_LEADER;
+                            }
+                        });
+                    } else {
+                        return Future.succeededFuture(leader);
+                    }
+                });
+            }
+            return f;
+        } catch (Throwable t) {
+            return Future.failedFuture(t);
+        }
+
+    }
+
+    /**
+     * Returns whether the given pod is the zookeeper leader.
+     */
+    protected Future<Boolean> isLeader(Pod pod, NetClientOptions netClientOptions) {
+        Pattern p = Pattern.compile("^Mode: leader$", Pattern.MULTILINE);
+        Future<Boolean> future = Future.future();
+        String host = host(pod);
+        int port = port(pod);
+        log.debug("Connecting to zookeeper on {}:{}", host, port);
+        vertx.createNetClient(netClientOptions)
+            .connect(port, host, ar -> {
+                if (ar.failed()) {
+                    log.warn("ZK {}:{}: failed to connect to zookeeper:", host, port, ar.cause().getMessage());
+                    future.fail(ar.cause());
+                } else {
+                    log.debug("ZK {}:{}: connected", host, port);
+                    NetSocket socket = ar.result();
+                    socket.exceptionHandler(ex -> future.fail(ex));
+                    socket.closeHandler(v -> {
+                        if (!future.isComplete()) {
+                            log.debug("ZK {}:{}: closing socked, was not leader", host, port);
+                            future.complete(Boolean.FALSE);
+                        }
+                    });
+                    log.debug("ZK {}:{}: upgrading to TLS", host, port);
+                    StringBuilder sb = new StringBuilder();
+                    socket.handler(buffer -> {
+                        log.trace("buffer: {}", buffer);
+                        if (!future.isComplete()) {
+                            String s = buffer.getString(0, buffer.length(), "UTF-8");
+                            sb.append(s);
+                            log.trace("appended: {}", sb);
+                            Matcher m = p.matcher(sb);
+                            if (m.find()) {
+                                log.debug("ZK {}:{}: is leader", host, port);
+                                future.complete(Boolean.TRUE);
+                            }
+                            int i = sb.lastIndexOf("\n");
+                            if (i != -1) {
+                                sb.delete(0, i + 1);
+                            }
+                        }
+                    });
+                    log.debug("ZK {}:{}: sending stat", host, port);
+                    socket.write("stat");
+                }
+
+            });
+        return future;
+    }
+
+    /** The hostname for connecting to zookeeper in the given pod. */
+    protected String host(Pod pod) {
+        return pod.getStatus().getPodIP();
+    }
+
+    /** The port number for connecting to zookeeper in the given pod. */
+    protected int port(Pod pod) {
+        return 2181;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -251,16 +251,13 @@ public class ZookeeperLeaderFinder {
                     log.debug("ZK {}:{}: connected", host, port);
                     NetSocket socket = ar.result();
                     socket.exceptionHandler(ex -> {
-                        if (!future.isComplete()) {
-                            future.fail(ex);
-                        } else {
-                            log.debug("Ignoring error, since leader status of pod {} is already known", pod.getMetadata().getName());
+                        if (!future.tryFail(ex)) {
+                            log.debug("Ignoring error, since leader status of pod {} is already known: {}", pod.getMetadata().getName(), ex);
                         }
                     });
                     socket.closeHandler(v -> {
-                        if (!future.isComplete()) {
+                        if (future.tryComplete(Boolean.FALSE)) {
                             log.debug("ZK {}:{}: closing socked, was not leader", host, port);
-                            future.complete(Boolean.FALSE);
                         }
                     });
                     log.debug("ZK {}:{}: upgrading to TLS", host, port);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -62,21 +62,16 @@ public class ZookeeperLeaderFinder {
         //x509.generateCertificate(new ByteArrayInputStream(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT))));
         //x509.generateCertificate(new ByteArrayInputStream(coCertKey.cert()));
 
-        Buffer coCertBuffer = Buffer.buffer(coCertKey.cert());
-        log.debug("CO cert\n{}", coCertBuffer);
-        Buffer coKeyBuffer = Buffer.buffer(coCertKey.key());
-        //log.debug("CO key\n{}", coKeyBuffer);
-        Buffer clusterCaCertBuffer = Buffer.buffer(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT)));
-        log.debug("Cluster CA cert\n{}", clusterCaCertBuffer);
+        log.debug("Cluster CA cert\n{}", Buffer.buffer(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT))));
         return new NetClientOptions()
                 .setConnectTimeout(10_000)
                 .setSsl(true)
                 //.setHostnameVerificationAlgorithm("HTTPS")
                 .setPemKeyCertOptions(new PemKeyCertOptions()
-                        .setCertValue(coCertBuffer)
-                        .setKeyValue(coKeyBuffer))
+                        .setCertValue(Buffer.buffer(coCertKey.cert()))
+                        .setKeyValue(Buffer.buffer(coCertKey.key())))
                 .setPemTrustOptions(new PemTrustOptions()
-                        .addCertValue(clusterCaCertBuffer));
+                        .addCertValue(Buffer.buffer(decoder.decode(clusterCaCertificateSecret.getData().get(Ca.CA_CRT)))));
     }
 
     /**
@@ -141,7 +136,6 @@ public class ZookeeperLeaderFinder {
                         } else {
                             rescheduleOrComplete(tid);
                         }
-                        //f.fail(leader.cause());
                     }
                 });
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -4,58 +4,18 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.certs.CertAndKey;
-import io.strimzi.operator.cluster.ClusterOperator;
-import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyFactory;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 /**
@@ -64,7 +24,7 @@ import java.util.regex.Pattern;
 public class ZookeeperSetOperator extends StatefulSetOperator {
 
     private static final Logger log = LogManager.getLogger(ZookeeperSetOperator.class);
-    private static final Pattern CA_KEY_PATTERN = Pattern.compile("^---*BEGIN.*---*$(.*)^---*END.*---*$.*", Pattern.MULTILINE | Pattern.DOTALL);
+    private final ZookeeperLeaderFinder leaderFinder;
 
     /**
      * Constructor
@@ -72,8 +32,9 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
      * @param vertx  The Vertx instance
      * @param client The Kubernetes client
      */
-    public ZookeeperSetOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
+    public ZookeeperSetOperator(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
         super(vertx, client, operationTimeoutMs);
+        this.leaderFinder = leaderFinder;
     }
 
     @Override
@@ -114,7 +75,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         String name = ss.getMetadata().getName();
         final int replicas = ss.getSpec().getReplicas();
         log.debug("Considering rolling update of {}/{}", namespace, name);
-        Future<Void> f = Future.succeededFuture();
+
         boolean zkRoll = false;
         ArrayList<Pod> pods = new ArrayList<>();
         String cluster = ss.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
@@ -124,212 +85,41 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
             pods.add(pod);
         }
 
+        final Future<Void> rollFuture;
         if (zkRoll) {
-            Future<Integer> leader = zookeeperLeader(cluster, namespace, pods);
-            f = leader.compose(lead -> { // we know a leader, so we can roll up all other zk pods
-                if (lead == -1) {
-                    return Future.failedFuture("Zookeeper leader could not be found");
-                }
-                log.debug("Zookeeper leader is pod: " + lead);
-                Future<Void> f2 = Future.succeededFuture();
+            // Find the leader
+            rollFuture = Future.future();
+            Future<Integer> leaderFuture = leaderFinder.findZookeeperLeader(cluster, namespace, pods);
+            leaderFuture.compose(leader -> {
+                log.debug("Zookeeper leader is " + (leader == ZookeeperLeaderFinder.UNKNOWN_LEADER ? "unknown" : "pod " + leader));
+                Future<Void> fut = Future.succeededFuture();
+                // Then roll each non-leader pod
                 for (int i = 0; i < replicas; i++) {
                     String podName = KafkaResources.zookeeperPodName(cluster, i);
-                    if (i != lead) {
-                        log.debug("maybe restarting non leader pod " + i);
+                    if (i != leader) {
+                        log.debug("Possibly restarting non-leader pod {}", podName);
                         // roll the pod and wait until it is ready
                         // this prevents rolling into faulty state (note: this applies just for ZK pods)
-                        f2 = f2.compose(ignore -> maybeRestartPod(ss, podName, podRestart));
-                    }
-                }
-                return f2.compose(ar -> {
-                    // the leader is rolled as the last
-                    log.debug("maybe restarting leader pod " + lead);
-                    return maybeRestartPod(ss, KafkaResources.zookeeperPodName(cluster, lead), podRestart);
-                });
-            });
-        }
-        return f;
-    }
-
-    private KeyStore setupKeyStore(Secret clusterSecretKey, CertificateFactory x509, char[] password,
-                                   X509Certificate clientCert, CertAndKey coCertKey) throws CertificateException {
-        Base64.Decoder decoder = Base64.getDecoder();
-        KeyStore keyStore = null;
-        try {
-            keyStore = KeyStore.getInstance("PKCS12");
-            keyStore.load(null, password);
-
-            String keyText = new String(decoder.decode(clusterSecretKey.getData().get("ca.key")), StandardCharsets.ISO_8859_1);
-            Matcher matcher = CA_KEY_PATTERN.matcher(keyText);
-            if (!matcher.find()) {
-                throw new RuntimeException("Bad client (CO) key. Key misses BEGIN or END markers");
-            }
-            PrivateKey clientKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(
-                    Base64.getMimeDecoder().decode(matcher.group(1))));
-
-            keyStore.setEntry("tls-probe",
-                    new KeyStore.PrivateKeyEntry(clientKey,
-                            new Certificate[]{clientCert}),
-                    new KeyStore.PasswordProtection(password));
-
-            X509Certificate coCert = (X509Certificate) x509.generateCertificate(new ByteArrayInputStream(coCertKey.cert()));
-
-            String coCertKeyText = new String(coCertKey.key(), StandardCharsets.ISO_8859_1);
-            Matcher matcher2 = CA_KEY_PATTERN.matcher(coCertKeyText);
-            if (!matcher2.find()) {
-                throw new RuntimeException("Bad client (CO) key. Key misses BEGIN or END markers");
-            }
-            PrivateKey coKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(
-                    Base64.getMimeDecoder().decode(matcher2.group(1))));
-
-            keyStore.setEntry("tls-probe2",
-                    new KeyStore.PrivateKeyEntry(coKey,
-                            new Certificate[]{coCert}),
-                    new KeyStore.PasswordProtection(password));
-        } catch (KeyStoreException
-                | NoSuchAlgorithmException
-                | IOException
-                | InvalidKeySpecException e) {
-            log.error("Error while generator Cluster Operator key store", e);
-        }
-        return keyStore;
-    }
-
-    private KeyStore setupTrustStore(char[] password, X509Certificate caCertCO) {
-        KeyStore trustStore = null;
-        try {
-            trustStore = KeyStore.getInstance("PKCS12");
-            trustStore.load(null, password);
-
-            trustStore.setEntry(caCertCO.getSubjectDN().getName(), new KeyStore.TrustedCertificateEntry(caCertCO), null);
-            ByteArrayOutputStream stream2 = new ByteArrayOutputStream();
-            trustStore.store(stream2, password);
-            trustStore.load(new ByteArrayInputStream(stream2.toByteArray()), password);
-        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
-            log.error("Error while generator Cluster Operator trust store", e);
-        }
-        return trustStore;
-    }
-
-    private SSLSocketFactory socketFactory(String cluster, String namespace) throws CertificateException {
-        SSLSocketFactory factory = null;
-        try {
-            CertificateFactory x509 = CertificateFactory.getInstance("X.509");
-            Base64.Decoder decoder = Base64.getDecoder();
-            char[] password = new char[0];
-            SecretOperator secretOperations = new SecretOperator(vertx, client);
-            Secret brokersSecret = secretOperations.get(namespace, ClusterOperator.secretName(cluster));
-            Secret clusterCaKeySecret = secretOperations.get(namespace, cluster + "-cluster-ca");
-            Secret clusterCaCertificateSecret = secretOperations.get(namespace, cluster + "-cluster-ca-cert");
-            CertAndKey coCertKey = Ca.asCertAndKey(brokersSecret, "cluster-operator.key", "cluster-operator.crt");
-            X509Certificate caCertCO = (X509Certificate) x509.generateCertificate(
-                    new ByteArrayInputStream(decoder.decode(clusterCaCertificateSecret.getData().get("ca.crt"))));
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            kmf.init(setupKeyStore(clusterCaKeySecret, x509, password, caCertCO, coCertKey), password);
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("X509");
-            tmf.init(setupTrustStore(password, caCertCO));
-            SSLContext ctx = SSLContext.getInstance("TLS");
-            ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-            factory = ctx.getSocketFactory();
-        } catch (NoSuchAlgorithmException
-                | UnrecoverableKeyException
-                | KeyStoreException
-                | KeyManagementException e) {
-            log.error("Error while creating Cluster Operator SocketFactory", e);
-        }
-        return factory;
-    }
-
-    private boolean isLeader(Pod pod, SSLSocketFactory factory) {
-        int port = 2181;
-        boolean leader = false;
-        try {
-            if (pod.getStatus() == null) {
-                log.debug("Pod has no status (test run)");
-                return true;
-            }
-            String host = pod.getStatus().getPodIP();
-
-            SSLSocket socket = null;
-            Socket plainSocket = factory.createSocket();
-            if (plainSocket instanceof SSLSocket) {
-                // findbugs plugin does not like direct overtyping
-                socket = (SSLSocket) plainSocket;
-            }
-            if (socket == null) {
-                log.error("Could not create socket for getting Zookeeper data");
-                return false;
-            }
-            log.debug("Connecting client to {}:{}", host, port);
-            try {
-                socket.connect(new InetSocketAddress(host, port), 10_000);
-            } catch (ConnectException | SocketTimeoutException e) {
-                log.error("Could not connect " + e.getMessage());
-            }
-            try {
-                log.debug("Starting handshake with {}", socket.getRemoteSocketAddress());
-                try {
-                    socket.startHandshake();
-                    PrintWriter out = new PrintWriter(
-                            new BufferedWriter(
-                                    new OutputStreamWriter(
-                                            socket.getOutputStream(), StandardCharsets.UTF_8)));
-
-                    out.println("stat");
-                    out.flush();
-
-                    BufferedReader in = new BufferedReader(
-                            new InputStreamReader(
-                                    socket.getInputStream(), StandardCharsets.UTF_8));
-
-                    String inputLine;
-                    while ((inputLine = in.readLine()) != null) {
-                        log.debug(inputLine);
-                        if (inputLine.equals("Mode: leader")) {
-                            leader = true;
-                        }
-                    }
-                    in.close();
-                    out.close();
-                } catch (SSLHandshakeException e) {
-                    log.error("Error while performing TLS handshake with pod {} in namespace {}",
-                            pod.getMetadata().getName(), pod.getMetadata().getNamespace(), e);
-                }
-            } finally {
-                socket.close();
-            }
-        } catch (IOException e) {
-            log.debug("Error while getting Zookeeper leader " + e.getMessage());
-        }
-        return leader;
-    }
-
-    public Future<Integer> zookeeperLeader(String cluster, String namespace, ArrayList<Pod> pods) {
-        Future<Integer> result = Future.future();
-        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(f -> {
-            int leader = -1;
-            if (pods.size() == 1) { // standalone
-                leader = 0;
-            } else {
-                SSLSocketFactory factory = null;
-                try {
-                    factory = socketFactory(cluster, namespace);
-                } catch (CertificateException e) {
-                    leader = -1;
-                }
-                for (int i = 0; i < pods.size(); i++) {
-                    log.debug("Checking ZookeeperLeader " + i);
-                    if (isLeader(pods.get(i), factory)) {
-                        leader = i;
-                        log.info("Zookeeper leader found " + pods.get(i).getMetadata().getName());
-                        break;
+                        fut = fut.compose(ignore -> maybeRestartPod(ss, podName, podRestart));
                     } else {
-                        log.info(pods.get(i).getMetadata().getName() + " is not a leader");
+                        log.debug("Deferring restart of leader {}", podName);
                     }
                 }
-            }
-            f.complete(leader);
-        }, true, result.completer());
-        return result;
+                if (leader == ZookeeperLeaderFinder.UNKNOWN_LEADER) {
+                    return fut;
+                } else {
+                    // Finally roll the leader pod
+                    return fut.compose(ar -> {
+                        // the leader is rolled as the last
+                        log.debug("Possibly restarting leader pod (previously deferred) {}", leader);
+                        return maybeRestartPod(ss, KafkaResources.zookeeperPodName(cluster, leader), podRestart);
+                    });
+                }
+            }).setHandler(rollFuture.completer());
+        } else {
+            rollFuture = Future.succeededFuture();
+        }
+        return rollFuture;
     }
+
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class ResourceUtils {
 
     private ResourceUtils() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
@@ -48,6 +49,8 @@ import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
@@ -253,6 +256,14 @@ public class KafkaAssemblyOperatorMockTest {
             @Override
             protected Future<Boolean> isLeader(Pod pod, NetClientOptions netClientOptions) {
                 return Future.succeededFuture(true);
+            }
+            @Override
+            protected PemTrustOptions trustOptions(Secret s) {
+                return new PemTrustOptions();
+            }
+            @Override
+            protected PemKeyCertOptions keyCertOptions(Secret s) {
+                return new PemKeyCertOptions();
             }
         };
         return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, true, 2_000);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -7,9 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
@@ -39,18 +37,12 @@ import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
-import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.MockCertManager;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
@@ -251,21 +243,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     private ResourceOperatorSupplier supplierWithMocks() {
-        ZookeeperLeaderFinder leaderFinder = new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, mockClient),
-            () -> new BackOff(5_000, 2, 4)) {
-            @Override
-            protected Future<Boolean> isLeader(Pod pod, NetClientOptions netClientOptions) {
-                return Future.succeededFuture(true);
-            }
-            @Override
-            protected PemTrustOptions trustOptions(Secret s) {
-                return new PemTrustOptions();
-            }
-            @Override
-            protected PemKeyCertOptions keyCertOptions(Secret s) {
-                return new PemKeyCertOptions();
-            }
-        };
+        ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, mockClient);
         return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, true, 2_000);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -24,16 +24,10 @@ import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
-import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.MockCertManager;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -152,21 +146,7 @@ public class PartialRollingUpdateTest {
     }
 
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {
-        ZookeeperLeaderFinder leaderFinder = new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, bootstrapClient),
-            () -> new BackOff(5_000, 2, 4)) {
-            @Override
-            protected Future<Boolean> isLeader(Pod pod, NetClientOptions options) {
-                return Future.succeededFuture(true);
-            }
-            @Override
-            protected PemTrustOptions trustOptions(Secret s) {
-                return new PemTrustOptions();
-            }
-            @Override
-            protected PemKeyCertOptions keyCertOptions(Secret s) {
-                return new PemKeyCertOptions();
-            }
-        };
+        ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient);
         return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, true, 60_000L);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -32,6 +32,8 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -155,6 +157,14 @@ public class PartialRollingUpdateTest {
             @Override
             protected Future<Boolean> isLeader(Pod pod, NetClientOptions options) {
                 return Future.succeededFuture(true);
+            }
+            @Override
+            protected PemTrustOptions trustOptions(Secret s) {
+                return new PemTrustOptions();
+            }
+            @Override
+            protected PemKeyCertOptions keyCertOptions(Secret s) {
+                return new PemKeyCertOptions();
             }
         };
         return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, true, 60_000L);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.cluster.ClusterOperator;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.SelfSignedCertificate;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static io.strimzi.test.TestUtils.map;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class ZookeeperLeaderFinderTest {
+
+    private static final Logger log = LogManager.getLogger(ZookeeperLeaderFinderTest.class);
+
+    public static final String NAMESPACE = "testns";
+    public static final String CLUSTER = "testcluster";
+
+    private Vertx vertx = Vertx.vertx();
+    private SecretOperator mock = mock(SecretOperator.class);
+    private SelfSignedCertificate zkCertificate = SelfSignedCertificate.create();
+    private SelfSignedCertificate coCertificate = SelfSignedCertificate.create();
+
+    private static final int MAX_ATTEMPTS = 4;
+
+    class TestingZookeeperLeaderFinder extends ZookeeperLeaderFinder {
+        private final int[] ports;
+
+        public TestingZookeeperLeaderFinder(Supplier<BackOff> backOffSupplier, int[] ports) {
+            super(vertx, mock, backOffSupplier);
+            this.ports = ports;
+        }
+
+        @Override
+        NetClientOptions clientOptions(CertAndKey coCertKey, Secret clusterCaCertificateSecret) {
+            return new NetClientOptions()
+                    .setKeyCertOptions(coCertificate.keyCertOptions())
+                    .setTrustOptions(zkCertificate.trustOptions())
+                    .setSsl(true);
+        }
+
+        @Override
+        protected String host(Pod pod) {
+            return "localhost";
+        }
+
+        @Override
+        protected int port(Pod pod) {
+            String name = pod.getMetadata().getName();
+            int idx = name.lastIndexOf('-');
+            return ports[parseInt(name.substring(idx + 1))];
+        }
+    }
+
+    List<FakeZk> zks = new ArrayList<>();
+
+    class FakeZk {
+        private final int id;
+        private final Function<Integer, Boolean> isLeader;
+        private final AtomicInteger attempts = new AtomicInteger();
+        private final NetServer netServer;
+
+        FakeZk(int id, Function<Integer, Boolean> isLeader) {
+            this.id = id;
+            this.isLeader = isLeader;
+            NetServerOptions nso = new NetServerOptions()
+                    .setSsl(true)
+                    .setKeyCertOptions(zkCertificate.keyCertOptions())
+                    .setTrustOptions(coCertificate.trustOptions());
+            netServer = vertx.createNetServer(nso);
+        }
+
+        public void stop() {
+            netServer.close();
+        }
+
+        public Future<Integer> start() {
+            Future<Integer> future = Future.future();
+
+            netServer.exceptionHandler(ex -> log.error(ex))
+                .connectHandler(socket -> {
+                    log.debug("ZK {}: client connection to {}, from {}", id, socket.localAddress(), socket.remoteAddress());
+                    socket.exceptionHandler(ex -> log.error(ex));
+                    socket.write("vesvsebserb\n");
+                    int attempt = attempts.getAndIncrement();
+                    if (isLeader.apply(attempt)) {
+                        log.debug("ZK {}: is leader on attempt {}", id, attempt);
+                        socket.write("Mode: ");
+                        socket.write("leader\n");
+                    } else {
+                        log.debug("ZK {}: is not leader on attempt {}", id, attempt);
+                    }
+                    socket.write("vesvsebserb\n");
+                    log.debug("ZK {}: Sent response, closing", id);
+                    socket.close();
+                })
+                .listen(ar -> {
+                    if (ar.succeeded()) {
+                        future.complete(ar.result().actualPort());
+                    } else {
+                        future.fail(ar.cause());
+                    }
+                });
+            return future;
+        }
+    }
+
+    private int[] startMockZks(TestContext context, int num, BiFunction<Integer, Integer, Boolean> fn) {
+        int[] result = new int[num];
+        Async async = context.async(num);
+        for (int i = 0; i < num; i++) {
+            final int id = i;
+            FakeZk zk = new FakeZk(id, attempt -> fn.apply(id, attempt));
+            zks.add(zk);
+            zk.start().setHandler(ar -> {
+                if (ar.succeeded()) {
+                    Integer port = ar.result();
+                    log.debug("ZK {} listening on port {}", id, port);
+                    result[id] = port;
+                    async.countDown();
+                } else {
+                    context.fail(ar.cause());
+                    async.complete();
+                }
+            });
+        }
+        async.await();
+        return result;
+    }
+
+    @After
+    public void stopZks() {
+        for (FakeZk zk : zks) {
+            zk.stop();
+        }
+    }
+
+    @Test
+    public void test0Pods() {
+        ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
+        assertEquals(Integer.valueOf(-1),
+                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                        emptyList()).result());
+    }
+
+    BackOff backoff() {
+        return new BackOff(50, 2, MAX_ATTEMPTS);
+    }
+
+    @Test
+    public void test1Pods() {
+        ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
+        assertEquals(Integer.valueOf(0),
+                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                        asList(getPod(0))).result());
+    }
+
+    @Test
+    public void testSecretsNotFound() {
+        SecretOperator mock = mock(SecretOperator.class);
+        ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, mock, this::backoff);
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(null));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(null));
+        assertEquals("Secret testns/testcluster-cluster-operator-certs does not exist",
+                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                        asList(getPod(0), getPod(1))).cause().getMessage());
+
+        Mockito.reset(mock);
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(new SecretBuilder().build()));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(null));
+        assertEquals("Secret testns/testcluster-cluster-operator-certs does not exist",
+                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                        asList(getPod(0), getPod(1))).cause().getMessage());
+
+        Mockito.reset(mock);
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                    .withName(ClusterOperator.secretName(CLUSTER))
+                                    .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(emptyMap())
+                        .build()));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                    .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
+                                    .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(emptyMap())
+                                .build()));
+        assertEquals("The Secret testns/testcluster-cluster-operator-certs is missing the key cluster-operator.key",
+                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                        asList(getPod(0), getPod(1))).cause().getMessage());
+    }
+
+    @Test
+    public void testTimeout(TestContext context) {
+        String coSecretName = ClusterOperator.secretName(CLUSTER);
+        when(mock.getAsync(eq(NAMESPACE), eq(coSecretName)))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(coSecretName)
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map("cluster-operator.key", "notacert",
+                                        "cluster-operator.crt", "notacert"))
+                                .build()));
+        String clusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(CLUSTER);
+        when(mock.getAsync(eq(NAMESPACE), eq(clusterCaSecretName)))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(clusterCaSecretName)
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map(Ca.CA_CRT, "notacert"))
+                                .build()));
+
+        int[] ports = startMockZks(context, 2, (id, attempt) -> {
+            System.err.println("attempt " + attempt + " node " + id);
+            return false;
+        });
+
+        ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
+
+        Async a = context.async();
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                    asList(getPod(0), getPod(1)))
+            .compose(result -> {
+                context.assertEquals(-1, result);
+                for (FakeZk zk : zks) {
+                    context.assertEquals(MAX_ATTEMPTS + 1, zk.attempts.get(),
+                            "Unexpected number of attempts for node " + zk.id);
+                }
+                a.complete();
+                return Future.succeededFuture();
+            });
+    }
+
+    @Test
+    public void testTimeoutDueToNetworkExceptions(TestContext context) {
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(ClusterOperator.secretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map("cluster-operator.key", "notacert",
+                                        "cluster-operator.crt", "notacert"))
+                                .build()));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map(Ca.CA_CRT, "notacert"))
+                                .build()));
+
+        int[] ports = startMockZks(context, 2, (id, attempt) -> false);
+        // Use closed ports
+        stopZks();
+
+        ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
+
+        Async a = context.async();
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                asList(getPod(0), getPod(1)))
+                .setHandler(result -> {
+                    context.assertTrue(result.failed());
+                    for (FakeZk zk : zks) {
+                        context.assertEquals(0, zk.attempts.get(),
+                                "Unexpected number of attempts for node " + zk.id);
+                    }
+                    a.complete();
+                });
+    }
+
+    @Test
+    public void testLeaderFoundThirdAttempt(TestContext context) {
+        int leader = 1;
+        int succeedOnAttempt = 2;
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(ClusterOperator.secretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map("cluster-operator.key", "notacert",
+                                        "cluster-operator.crt", "notacert"))
+                                .build()));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenReturn(Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map(Ca.CA_CRT, "notacert"))
+                                .build()));
+
+        int[] ports = startMockZks(context, 2, (id, attempt) -> attempt == succeedOnAttempt && id == leader);
+
+        TestingZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
+
+        Async a = context.async();
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE,
+                asList(getPod(0), getPod(1)))
+                .compose(result -> {
+                    context.assertEquals(leader, result);
+                    for (FakeZk zk : zks) {
+                        context.assertEquals(succeedOnAttempt + 1, zk.attempts.get(),
+                                "Unexpected number of attempts for node " + zk.id);
+                    }
+                    a.complete();
+                    return Future.succeededFuture();
+                });
+    }
+
+    @Test
+    public void testLeaderFoundFirstAttempt(TestContext context) {
+        int leader = 1;
+        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
+                .thenAnswer(i -> Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(ClusterOperator.secretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map("cluster-operator.key", "notacert",
+                                        "cluster-operator.crt", "notacert"))
+                                .build()));
+        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
+                .thenAnswer(i -> Future.succeededFuture(
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(map(Ca.CA_CRT, "notacert"))
+                                .build()));
+
+        int[] ports = startMockZks(context, 2, (id, attempt) -> id == leader);
+
+        ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
+
+        Async a = context.async();
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(getPod(0), getPod(1)))
+                .setHandler(asyncResult -> {
+                    if (asyncResult.failed()) {
+                        asyncResult.cause().printStackTrace();
+                    }
+                    context.assertTrue(asyncResult.succeeded());
+                    context.assertEquals(leader, asyncResult.result());
+                    for (FakeZk zk : zks) {
+                        context.assertEquals(1, zk.attempts.get(),
+                                "Unexpected number of attempts for node " + zk.id);
+                    }
+                    a.complete();
+                });
+    }
+
+    Pod getPod(int id) {
+        return new PodBuilder().withNewMetadata().withName("my-cluster-kafka-" + id).endMetadata().build();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -13,6 +13,7 @@ import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -462,6 +463,7 @@ public class ZookeeperLeaderFinderTest {
                 .withNewMetadata()
                     .withName(ZookeeperCluster.zookeeperPodName("my-cluster", 3))
                     .withNamespace("myproject")
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster")
                 .endMetadata()
             .build();
         assertEquals("my-cluster-zookeeper-3.my-cluster-zookeeper-nodes.myproject.svc.cluster.local",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
@@ -25,10 +25,6 @@ import static org.junit.Assert.assertTrue;
 
 public class ZookeeperSetOperatorTest {
 
-    //public static final Map<String, Object> METRICS_CONFIG = singletonMap("foo", "bar");
-    //public static final Map<String, Object> LOG_ZOOKEEPER_CONFIG = singletonMap("zookeeper.root.logger", "INFO");
-    //public static final Map<String, Object> LOG_KAFKA_CONFIG = singletonMap("kafka.root.logger.level", "INFO");
-
     private StatefulSet a;
     private StatefulSet b;
 

--- a/cluster-operator/src/test/resources/log4j2.properties
+++ b/cluster-operator/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/cluster-operator/src/test/resources/log4j2.properties
+++ b/cluster-operator/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -194,11 +194,29 @@ public abstract class Ca {
         }
     }
 
+    /**
+     * Returns the given {@code cert} and {@code key} values from the given {@code Secret} as a {@code CertAndKey},
+     * or null if the given {@code secret} is null.
+     * An exception is thrown if the given {@code secret} is non-null, but does not contain the given
+     * entries in its {@code data}.
+     */
     public static CertAndKey asCertAndKey(Secret secret, String key, String cert) {
         Base64.Decoder decoder = Base64.getDecoder();
-        return secret == null ? null : new CertAndKey(
-                decoder.decode(secret.getData().get(key)),
-                decoder.decode(secret.getData().get(cert)));
+        if (secret == null || secret.getData() == null) {
+            return null;
+        } else {
+            String keyData = secret.getData().get(key);
+            if (keyData == null) {
+                throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + key);
+            }
+            String certData = secret.getData().get(cert);
+            if (keyData == null || certData == null) {
+                throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + cert);
+            }
+            return new CertAndKey(
+                    decoder.decode(keyData),
+                    decoder.decode(certData));
+        }
     }
 
     private CertAndKey generateSignedCert(Subject subject,

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -210,7 +210,7 @@ public abstract class Ca {
                 throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + key);
             }
             String certData = secret.getData().get(cert);
-            if (keyData == null || certData == null) {
+            if (certData == null) {
                 throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + cert);
             }
             return new CertAndKey(

--- a/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
@@ -6,16 +6,13 @@ package io.strimzi.operator.common;
 
 /**
  * <p>Encapsulates computing delays for an exponential back-off, when an operation has to be retried.
- * The {@link #delayMs()} method will return an increasing delay to be used between operation attempts.
- * <pre>
- *        |<-- delayMs -->|<-- delayMs -->|
- *     attempt         attempt         attempt
- * </pre>
- * The delays after the 0th attempt is always 0ms and the remaining delays are computed by the formula
- * <pre>
- *     delayMs(n) = scaleMs * base ^ attempt
- * </pre>
- * <p>Thus the delay after the 1st attempt is {@code scaleMs}, and after the 2nd attempt is {@code scaleMs * base}.
+ * The {@link #delayMs()} method will return an increasing delay to be used between operation attempts.</p>
+ * <pre>{@literal
+ *     |<-attempt->    |<-attempt->        |<-attempt->|*fail*
+ *     |<-- delayMs -->|<---- delayMs ---->|           |}</pre>
+ * <p>The delays after the 0th attempt is always 0ms and the remaining delays are computed by the formula:</p>
+ * <pre>  delayMs(n) = scaleMs * base ^ attempt</pre>
+ * <p>Thus the delay after the 1st attempt is {@code scaleMs}, and after the 2nd attempt is {@code scaleMs * base}.</p>
  */
 public class BackOff {
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2018, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.operator.topic;
+package io.strimzi.operator.common;
 
 /**
  * Encapsulates computing delays for an exponential back-off.
@@ -42,21 +42,44 @@ public class BackOff {
     }
 
     /**
+     * The maximum number of attempts
+     */
+    public int maxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * The maximum number of attempts
+     */
+    public int maxNumDelays() {
+        return maxAttempts - 1;
+    }
+
+    /**
      * Return the next delay to use, in milliseconds.
      * The first delay is always zero, the 2nd delay is scaleMs, and the delay increases exponentially from there.
      * @throws MaxAttemptsExceededException if the next attempt would exceed the configured number of attempts.
      */
     public long delayMs() {
-        int n = attempt++;
-        return delay(n);
+        if (attempt == maxAttempts) {
+            throw new MaxAttemptsExceededException();
+        }
+        return delay(attempt++);
     }
 
+    /**
+     * Returns whether the next call to {@link #delayMs()} will throw MaxAttemptsExceededException.
+     */
+    public boolean done() {
+        return attempt >= maxAttempts;
+    }
+
+    /**
+     * How much delay for attempt n?
+     */
     private long delay(int n) {
         if (n == 0) {
             return 0L;
-        }
-        if (n >= maxAttempts) {
-            throw new MaxAttemptsExceededException();
         }
         int pow = 1;
         while (n-- > 1) {
@@ -65,11 +88,29 @@ public class BackOff {
         return scaleMs * pow;
     }
 
-    public long totalDelayMs() {
+    private long cumulativeDelayAttemptMs(int numDelays) {
+        if (numDelays > maxAttempts) {
+            throw new MaxAttemptsExceededException();
+        }
         long total = 0;
-        for (int i = 0; i < maxAttempts; i++) {
+        for (int i = 0; i < numDelays; i++) {
             total += delay(i);
         }
         return total;
+    }
+
+    /**
+     * The cumulative delay issued by {@link #delayMs()} so far.
+     */
+    public long cumulativeDelayMs() {
+        return cumulativeDelayAttemptMs(attempt);
+    }
+
+    /**
+     * The total possible delay for this BackOff.
+     * This does not depend on how much delay has already been issued.
+     */
+    public long totalDelayMs() {
+        return cumulativeDelayAttemptMs(maxAttempts);
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
@@ -5,7 +5,17 @@
 package io.strimzi.operator.common;
 
 /**
- * Encapsulates computing delays for an exponential back-off.
+ * <p>Encapsulates computing delays for an exponential back-off, when an operation has to be retried.
+ * The {@link #delayMs()} method will return an increasing delay to be used between operation attempts.
+ * <pre>
+ *        |<-- delayMs -->|<-- delayMs -->|
+ *     attempt         attempt         attempt
+ * </pre>
+ * The delays after the 0th attempt is always 0ms and the remaining delays are computed by the formula
+ * <pre>
+ *     delayMs(n) = scaleMs * base ^ attempt
+ * </pre>
+ * <p>Thus the delay after the 1st attempt is {@code scaleMs}, and after the 2nd attempt is {@code scaleMs * base}.
  */
 public class BackOff {
 
@@ -18,14 +28,23 @@ public class BackOff {
     private final int maxAttempts;
     private int attempt = 0;
 
+    /**
+     * Computes delays according to {@code 200 * 2^attempt} with a maximum of 6 attempts.
+     */
     public BackOff() {
         this(DEFAULT_SCALE_MS, DEFAULT_BASE, DEFAULT_MAX_ATTEMPTS);
     }
 
+    /**
+     * Computes delays according to {@code 200 * 2^attempt} with the given maximum number of attempts.
+     */
     public BackOff(int maxAttempts) {
         this(DEFAULT_SCALE_MS, DEFAULT_BASE, maxAttempts);
     }
 
+    /**
+     * Computes delays according to {@code scaleMs * base^attempt} with the given maximum number of attempts.
+     */
     public BackOff(long scaleMs, int base, int maxAttempts) {
         if (scaleMs <= 0) {
             throw new IllegalArgumentException();
@@ -42,14 +61,14 @@ public class BackOff {
     }
 
     /**
-     * The maximum number of attempts
+     * The maximum number of attempts.
      */
     public int maxAttempts() {
         return maxAttempts;
     }
 
     /**
-     * The maximum number of attempts
+     * The maximum number of delays.
      */
     public int maxNumDelays() {
         return maxAttempts - 1;

--- a/operator-common/src/main/java/io/strimzi/operator/common/MaxAttemptsExceededException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MaxAttemptsExceededException.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2018, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.operator.topic;
+package io.strimzi.operator.common;
 
 /**
  * Thrown to indicate a {@link BackOff} has exceeded its maximum number of attempts.

--- a/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
@@ -2,12 +2,13 @@
  * Copyright 2017-2018, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.operator.topic;
-
+package io.strimzi.operator.common;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class BackOffTest {
@@ -15,28 +16,49 @@ public class BackOffTest {
     @Test
     public void testDefaultBackoff() {
         BackOff b = new BackOff();
+        assertEquals(6200L, b.totalDelayMs());
+        assertFalse(b.done());
         assertEquals(0L, b.delayMs());
+        assertEquals(0L, b.cumulativeDelayMs());
+        assertFalse(b.done());
         assertEquals(200L, b.delayMs());
+        assertEquals(200L, b.cumulativeDelayMs());
+        assertFalse(b.done());
         assertEquals(400L, b.delayMs());
+        assertEquals(600L, b.cumulativeDelayMs());
+        assertFalse(b.done());
         assertEquals(800L, b.delayMs());
+        assertEquals(1400L, b.cumulativeDelayMs());
+        assertFalse(b.done());
         assertEquals(1600L, b.delayMs());
+        assertEquals(3000L, b.cumulativeDelayMs());
+        assertFalse(b.done());
         assertEquals(3200L, b.delayMs());
+        assertEquals(6200L, b.cumulativeDelayMs());
+        assertTrue(b.done());
         try {
             b.delayMs();
             fail("Should throw");
         } catch (MaxAttemptsExceededException e) {
 
         }
+        assertTrue(b.done());
         assertEquals(6200L, b.totalDelayMs());
     }
 
     @Test
     public void testAnotherBackoff() {
         BackOff b = new BackOff(1, 10, 5);
+        assertEquals(1111L, b.totalDelayMs());
+        //attempt
         assertEquals(0L, b.delayMs());
+        //attempt
         assertEquals(1L, b.delayMs());
+        //attempt
         assertEquals(10L, b.delayMs());
+        //attempt
         assertEquals(100L, b.delayMs());
+        //attempt
         assertEquals(1000L, b.delayMs());
         try {
             b.delayMs();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.topic;
 
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.MaxAttemptsExceededException;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -7,6 +7,8 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.MaxAttemptsExceededException;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.operator.common.MaxAttemptsExceededException;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;


### PR DESCRIPTION
To make the zookeeper rolling algortihm more robust we now use a
retry-with-backoff strategy when finding the zookeeper leader.
In the event that we cannot find the leader we proceed with the
reconciliation anyway (it could be the zookeeper cluster is in a broken state
and needs a restart to resolve it).

Move and reuse the existing BackOff class from the Topic Operator.

Use vertx for the networking, which simplifies certificate and key handling.

### Type of change

- Bugfix
- Refactoring

### Description

Factor out ZookeeperLeaderFinder, use BackOff and vertx net client
    
To make the zookeeper rolling algortihm more robust we now use a retry-with-backoff strategy when finding the zookeeper leader. In the event that we cannot find the leader we proceed with the reconciliation anyway (it could be the zookeeper cluster is in a broken state and needs a restart to resolve it).
    
Move and reuse the existing BackOff class from the Topic Operator.
    
Use vertx for the networking, which simplifies certificate and key handling.

### Checklist

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

