### PR TITLE
Update Kafka related dependencies - Kafka, Debezium and Scala

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,17 @@
                 <version>${quartz.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
@@ -350,6 +361,19 @@
                 <version>${gson.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!--<dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>-->
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,14 +83,15 @@
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
-        <kafka.version>2.0.0</kafka.version>
+        <kafka.version>2.1.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
-        <scala-library.version>2.12.6</scala-library.version>
+        <scala-library.version>2.12.7</scala-library.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <mockito.version>2.23.4</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.2.1</quartz.version>
+        <debezium.version>0.9.0.Final</debezium.version>
 
         <jupiter.version>5.3.2</jupiter.version>
         <junit.platform.version>1.3.2</junit.platform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -361,19 +361,6 @@
                 <version>${gson.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!--<dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-core</artifactId>
-                <version>${debezium.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-core</artifactId>
-                <version>${debezium.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>-->
         </dependencies>
     </dependencyManagement>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>compile</scope>
         </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -39,13 +39,11 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>compile</scope>
         </dependency>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -77,13 +77,11 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -77,13 +77,13 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
@@ -56,6 +56,8 @@ import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.RenewDelegationTokenOptions;
 import org.apache.kafka.clients.admin.RenewDelegationTokenResult;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionReplica;
@@ -203,6 +205,11 @@ class MockAdminClient extends AdminClient {
 
     @Override
     public DeleteConsumerGroupsResult deleteConsumerGroups(Collection<String> collection, DeleteConsumerGroupsOptions deleteConsumerGroupsOptions) {
+        return null;
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
         return null;
     }
 }

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -87,13 +87,11 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -87,13 +87,13 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>0.8.1.Final</version>
+            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates some of the dependencies. In particular:
* Kafka to 2.1.0
* Debezium to 0.9.0
* Scala to 2.12.7
