### PR TITLE
Set metrics appendix up in the index

### DIFF
--- a/documentation/book/master.adoc
+++ b/documentation/book/master.adoc
@@ -28,6 +28,10 @@ ifdef::InstallationAppendix[]
 include::appendix_deploying_kubernetes_openshift_cluster.adoc[]
 endif::InstallationAppendix[]
 
+ifdef::MetricsAppendix[]
+include::appendix_metrics.adoc[]
+endif::MetricsAppendix[]
+
 [appendix]
 [id='api_reference-{context}']
 :parent-context: {context}
@@ -35,7 +39,3 @@ endif::InstallationAppendix[]
 ## Custom Resource API Reference
 include::appendix_crds.adoc[]
 :context: {parent-context}
-
-ifdef::MetricsAppendix[]
-include::appendix_metrics.adoc[]
-endif::MetricsAppendix[]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This is a proposal for setting the metrics appendix before the CR API reference.
While searching for something related to metrics in the index, the CR API reference is really long and could be even longer when we'll add more stuff to the api so that metrics chapters are really "far".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

