### PR TITLE
Fix skipping of certificate-manager tests on non-Linux platforms

### DIFF
--- a/certificate-manager/pom.xml
+++ b/certificate-manager/pom.xml
@@ -38,10 +38,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.strimzi</groupId>
-      <artifactId>test</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.certs;
 
-import io.strimzi.test.TestUtils;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -34,14 +34,13 @@ public class OpenSslCertManagerTest {
 
     @BeforeClass
     public static void before() throws CertificateException {
-        TestUtils.assumeLinux();
+        Assume.assumeTrue(System.getProperty("os.name").contains("nux"));
         certFactory = CertificateFactory.getInstance("X.509");
         ssl = new OpenSslCertManager();
     }
 
     @Test
     public void testGenerateSelfSignedCert() throws Exception {
-
         File key = File.createTempFile("key-", ".key");
         File cert = File.createTempFile("crt-", ".crt");
 

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -7,7 +7,7 @@ package io.strimzi.certs;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.strimzi.test.TestUtils;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ public class SecretCertProviderTest {
 
     @BeforeClass
     public static void before() {
-        TestUtils.assumeLinux();
+        Assume.assumeTrue(System.getProperty("os.name").contains("nux"));
         ssl = new OpenSslCertManager();
         secretCertProvider = new SecretCertProvider();
         ownerReference = new OwnerReferenceBuilder()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The tests in `certificate-manager` module should be executed only on Linux platforms. But as pointed out in #1318 they are not. The problem seems to be that the TestUtils have moved to JUnit5 which the unit tests are still JUnit 4. And the `assumeTrue` from JUnit 5 doesn't work. I changed this to use the `Assume.assumeTrue` from JUnit 4 and now the tests seem to be fix and ignored on MacOS.