### PR TITLE
Revert changes to the storage subdirectories which were removed - Clo…

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -167,7 +167,7 @@ zookeeper.connect=localhost:2181
 zookeeper.connection.timeout.ms=6000
 
 # Logs
-log.dirs=${KAFKA_LOG_DIRS}
+log.dirs=${KAFKA_LOG_DIRS_WITH_PATH}
 
 # TLS / SSL
 ssl.keystore.password=${CERTS_STORE_PASSWORD}

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -5,7 +5,15 @@ export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')
 echo "KAFKA_BROKER_ID=$KAFKA_BROKER_ID"
 
 # Kafka server data dirs
-echo "KAFKA_LOG_DIRS=$KAFKA_LOG_DIRS"
+export KAFKA_LOG_DIR_PATH="kafka-log${KAFKA_BROKER_ID}"
+
+for DIR in $(echo $KAFKA_LOG_DIRS | tr ',' ' ')  ; do
+  export KAFKA_LOG_DIRS_WITH_PATH="${KAFKA_LOG_DIRS_WITH_PATH},${DIR}/${KAFKA_LOG_DIR_PATH}"
+done
+
+export KAFKA_LOG_DIRS_WITH_PATH="${KAFKA_LOG_DIRS_WITH_PATH:1}"
+
+echo "KAFKA_LOG_DIRS=$KAFKA_LOG_DIRS_WITH_PATH"
 
 # Disable Kafka's GC logging (which logs to a file)...
 export GC_LOG_ENABLED="false"


### PR DESCRIPTION
…ses #1307

### Type of change

- Bugfix

### Description

In the JBOD PR, we removed the subdirectory which was automatically created in the mounted volume. However looking back that seems to be a bad choice:
* It breaks backwards compatibility. Everyone updating from previous versions would not only loose the data but would get also Kafka complaining about incorrect directory structure because it would not recognize the directory in there.
* It causes problem with the `lost+found` directory (see #1307) which we didn't had before.
* Having it can be in theory helpful on shared storage. Although I guess we currently don't support that anyway and as I sad in #1320 it is in my personal opinion not good choice for Kafka.

This PR is non in conflict with #1320 - they can compliment each other. I would like to have both things merged.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging