### PR TITLE
Rename asMapName → asKubeName, since we're no longer using CMs

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
@@ -45,7 +45,7 @@ public class Topic {
         }
 
         public Builder(TopicName topicName, int numPartitions, short numReplicas, Map<String, String> config) {
-            this(topicName, topicName.asMapName(), numPartitions, numReplicas, config, null);
+            this(topicName, topicName.asKubeName(), numPartitions, numReplicas, config, null);
         }
 
         public Builder(String topicName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
@@ -53,7 +53,7 @@ public class Topic {
         }
 
         public Builder(TopicName topicName, int numPartitions, short numReplicas, Map<String, String> config, ObjectMeta metadata) {
-            this(topicName, topicName.asMapName(), numPartitions, numReplicas, config, metadata);
+            this(topicName, topicName.asKubeName(), numPartitions, numReplicas, config, metadata);
         }
 
         public Builder(String topicName, int numPartitions, Map<String, String> config, ObjectMeta metadata) {
@@ -160,11 +160,11 @@ public class Topic {
         return resourceName;
     }
 
-    public ResourceName getOrAsMapName() {
+    public ResourceName getOrAsKubeName() {
         if (resourceName != null) {
             return resourceName;
         } else {
-            return topicName.asMapName();
+            return topicName.asKubeName();
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
@@ -54,12 +54,12 @@ class TopicName {
     public static final String SEP = "---";
 
     /**
-     * Return a valid map name for the given topic name. If the topic name is already valid as a resource name
+     * Return a valid resource name for the given topic name. If the topic name is already valid as a resource name
      * then it is used as the returned resource name, otherwise a "best effort" prefix is
      * constructed (with invalid characters removed or changed) and a disambiguating hash is appended to that
      * prefix and the concatenation of the prefix and hash is returned.
      */
-    public ResourceName asMapName() {
+    public ResourceName asKubeName() {
         ResourceName mname;
         if (ResourceName.isValidResourceName(this.name)) {
             mname = new ResourceName(this.name);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -128,7 +128,7 @@ public class TopicSerialization {
      * Create a resource to reflect the given Topic.
      */
     public static KafkaTopic toTopicResource(Topic topic, LabelPredicate resourcePredicate) {
-        ResourceName resourceName = topic.getOrAsMapName();
+        ResourceName resourceName = topic.getOrAsKubeName();
         ObjectMeta om = topic.getMetadata();
         if (om != null) {
             om.setName(resourceName.toString());
@@ -237,7 +237,7 @@ public class TopicSerialization {
         ObjectMapper mapper = objectMapper();
         ObjectNode root = mapper.createObjectNode();
         // TODO Do we store the k8s uid here?
-        root.put(JSON_KEY_MAP_NAME, topic.getOrAsMapName().toString());
+        root.put(JSON_KEY_MAP_NAME, topic.getOrAsKubeName().toString());
         root.put(JSON_KEY_TOPIC_NAME, topic.getTopicName().toString());
         root.put(JSON_KEY_PARTITIONS, topic.getNumPartitions());
         root.put(JSON_KEY_REPLICAS, topic.getNumReplicas());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicNameTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicNameTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 public class TopicNameTest {
 
     private void checkMappedName(String name, String expect) {
-        assertEquals(expect, new TopicName(name).asMapName().toString());
+        assertEquals(expect, new TopicName(name).asKubeName().toString());
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -254,7 +254,7 @@ public class TopicOperatorIT {
     private String createTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
         LOGGER.info("Creating topic {}", topicName);
         // Create a topic
-        String resourceName = new TopicName(topicName).asMapName().toString();
+        String resourceName = new TopicName(topicName).asKubeName().toString();
         CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicName, 1, (short) 1)));
         crt.all().get();
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -40,7 +40,7 @@ public class TopicOperatorTest {
     private final LabelPredicate resourcePredicate = LabelPredicate.fromString("app=strimzi");
 
     private final TopicName topicName = new TopicName("my-topic");
-    private final ResourceName resourceName = topicName.asMapName();
+    private final ResourceName resourceName = topicName.asKubeName();
     private Vertx vertx = Vertx.vertx();
     private MockKafka mockKafka = new MockKafka();
     private MockTopicStore mockTopicStore = new MockTopicStore();
@@ -378,7 +378,7 @@ public class TopicOperatorTest {
         mockKafka.setCreateTopicResponse(topicName.toString(), null);
 
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockK8s.createResource(TopicSerialization.toTopicResource(kubeTopic, resourcePredicate), ar -> async0.countDown());
 
         Async async = context.async(1);
@@ -438,7 +438,7 @@ public class TopicOperatorTest {
 
         Async async0 = context.async();
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
         mockKafka.createTopic(kafkaTopic, ar -> async0.complete());
         async0.await();
@@ -447,7 +447,7 @@ public class TopicOperatorTest {
         topicOperator.reconcile(null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
-            mockK8s.assertExists(context, topicName.asMapName());
+            mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
             mockK8s.assertNoEvents(context);
             mockTopicStore.read(topicName, readResult -> {
@@ -455,7 +455,7 @@ public class TopicOperatorTest {
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asMapName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -486,7 +486,7 @@ public class TopicOperatorTest {
         topicOperator.reconcile(null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertNotExists(context, topicName);
-            mockK8s.assertNotExists(context, topicName.asMapName());
+            mockK8s.assertNotExists(context, topicName.asKubeName());
             mockKafka.assertNotExists(context, topicName);
             mockK8s.assertNoEvents(context);
             async.complete();
@@ -506,7 +506,7 @@ public class TopicOperatorTest {
         Async async0 = context.async(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
         mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockK8s.createResource(TopicSerialization.toTopicResource(kubeTopic, resourcePredicate), ar -> async0.countDown());
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
@@ -515,7 +515,7 @@ public class TopicOperatorTest {
         topicOperator.reconcile(null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
-            mockK8s.assertExists(context, topicName.asMapName());
+            mockK8s.assertExists(context, topicName.asKubeName());
             mockK8s.assertNoEvents(context);
             mockKafka.assertExists(context, topicName);
             mockTopicStore.read(topicName, readResult -> {
@@ -545,9 +545,9 @@ public class TopicOperatorTest {
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, resourcePredicate);
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockK8s.createResource(topic, ar -> async0.countDown());
-        mockK8s.setModifyResponse(topicName.asMapName(), null);
+        mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
 
@@ -555,14 +555,14 @@ public class TopicOperatorTest {
         topicOperator.reconcile(topic, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
-            mockK8s.assertExists(context, topicName.asMapName());
+            mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
             mockTopicStore.read(topicName, readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(mergedTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asMapName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(mergedTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -586,9 +586,9 @@ public class TopicOperatorTest {
         mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, resourcePredicate);
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockK8s.createResource(topic, ar -> async0.countDown());
-        mockK8s.setModifyResponse(topicName.asMapName(), null);
+        mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
 
@@ -599,14 +599,14 @@ public class TopicOperatorTest {
                     e.getMessage().contains("KafkaTopic is incompatible with the topic metadata. " +
                             "The topic metadata will be treated as canonical."));
             mockTopicStore.assertExists(context, topicName);
-            mockK8s.assertExists(context, topicName.asMapName());
+            mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
             mockTopicStore.read(topicName, readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asMapName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -632,9 +632,9 @@ public class TopicOperatorTest {
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, resourcePredicate);
-        mockK8s.setCreateResponse(topicName.asMapName(), null);
+        mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockK8s.createResource(resource, ar -> async0.countDown());
-        mockK8s.setModifyResponse(topicName.asMapName(), null);
+        mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         mockTopicStore.create(privateTopic, ar -> async0.countDown());
         async0.await();
@@ -648,7 +648,7 @@ public class TopicOperatorTest {
                 context.assertEquals(resultTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asMapName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(resultTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

When I refactored the TO to use CRs I missed a couple of places, which were still using "map" in the name. This PR changes these "map" names.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

