### PR TITLE
Remove default Kafka Connect configs which are not needed anymore

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -30,10 +30,6 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
         DEFAULTS.put("status.storage.topic", "connect-cluster-status");
         DEFAULTS.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         DEFAULTS.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULTS.put("internal.key.converter.schemas.enable", "false");
-        DEFAULTS.put("internal.value.converter.schemas.enable", "false");
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -68,15 +68,11 @@ public class KafkaConnectClusterTest {
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
-            .addPair("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter")
             .addPair("config.storage.topic", "connect-cluster-configs")
             .addPair("group.id", "connect-cluster")
             .addPair("status.storage.topic", "connect-cluster-status")
-            .addPair("internal.value.converter.schemas.enable", "false")
-            .addPair("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter")
             .addPair("offset.storage.topic", "connect-cluster-offsets")
             .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .addPair("internal.key.converter.schemas.enable", "false")
             .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
     private final OrderedProperties expectedConfiguration = new OrderedProperties()
             .addMapPairs(defaultConfiguration.asMap())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -75,15 +75,11 @@ public class KafkaConnectS2IClusterTest {
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
-            .addPair("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter")
             .addPair("config.storage.topic", "connect-cluster-configs")
             .addPair("group.id", "connect-cluster")
             .addPair("status.storage.topic", "connect-cluster-status")
-            .addPair("internal.value.converter.schemas.enable", "false")
-            .addPair("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter")
             .addPair("offset.storage.topic", "connect-cluster-offsets")
             .addPair("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .addPair("internal.key.converter.schemas.enable", "false")
             .addPair("key.converter", "org.apache.kafka.connect.json.JsonConverter");
     private final OrderedProperties expectedConfiguration = new OrderedProperties()
             .addMapPairs(defaultConfiguration.asMap())

--- a/documentation/book/proc-configuring-kafka-connect.adoc
+++ b/documentation/book/proc-configuring-kafka-connect.adoc
@@ -32,10 +32,6 @@ spec:
     value.converter: org.apache.kafka.connect.json.JsonConverter
     key.converter.schemas.enable: true
     value.converter.schemas.enable: true
-    internal.key.converter: org.apache.kafka.connect.json.JsonConverter
-    internal.value.converter: org.apache.kafka.connect.json.JsonConverter
-    internal.key.converter.schemas.enable: false
-    internal.value.converter.schemas.enable: false
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3

--- a/documentation/book/ref-kafka-connect-configuration.adoc
+++ b/documentation/book/ref-kafka-connect-configuration.adoc
@@ -39,10 +39,6 @@ Selected options have default values:
 * `status.storage.topic` with default value `connect-cluster-status`
 * `key.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
 * `value.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
-* `internal.key.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
-* `internal.value.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
-* `internal.key.converter.schemas.enable` with default value `false`
-* `internal.value.converter.schemas.enable` with default value `false`
 
 These options will be automatically configured in case they are not present in the `KafkaConnect.spec.config` or `KafkaConnectS2I.spec.config` properties.
 
@@ -64,10 +60,6 @@ spec:
     value.converter: org.apache.kafka.connect.json.JsonConverter
     key.converter.schemas.enable: true
     value.converter.schemas.enable: true
-    internal.key.converter: org.apache.kafka.connect.json.JsonConverter
-    internal.value.converter: org.apache.kafka.connect.json.JsonConverter
-    internal.key.converter.schemas.enable: false
-    internal.value.converter.schemas.enable: false
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -55,14 +55,10 @@ class ConnectST extends AbstractST {
     public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KafkaResources.plainBootstrapAddress(KAFKA_CLUSTER_NAME);
     private static final Map EXPECTED_CONFIG = loadProperties("group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.key.converter.schemas.enable=false\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "config.storage.topic=connect-cluster-configs\n" +
             "status.storage.topic=connect-cluster-status\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "internal.value.converter.schemas.enable=false\n" +
-            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n");
+            "offset.storage.topic=connect-cluster-offsets\n");
 
     @Test
     @Tag(ACCEPTANCE)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Since [Kafka 2.0](http://kafka.apache.org/documentation/#upgrade_200_notable) it is not needed anymore to configure some of the Kafka Connect options which used to be mandatory anymore since they have now defaults directly in Kafka and the default values are the same as our own default values. I would suggest to remove these from our configuration.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally