### PR TITLE
Make it possible to run Kafka Connect against our single node Kafka broker

### DIFF
--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -1,0 +1,16 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnectS2I
+metadata:
+  name: my-connect-cluster
+spec:
+  version: 2.1.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  config:
+    config.storage.replication.factor: 1
+    offset.storage.replication.factor: 1
+    status.storage.replication.factor: 1

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -1,0 +1,17 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  version: 2.1.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  config:
+    config.storage.replication.factor: 1
+    offset.storage.replication.factor: 1
+    status.storage.replication.factor: 1
+


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We have now in example single node Kafka broker deployment. But we do not have a matching Kafka Connect example. The examples we have require 3+ Kafka brokers. Since the examples can be easily used as a URL (`kubectl apply -f httpt://...`), it would be handy to have a Kafka Connect and Kafka Connect S2I deployments in the examples which would work with single node Kafka. These examples can be used by 3rd party tutorials and examples where single node Kafka is used (e.g. Debezium)