### PR TITLE
ST: CO watches all namespaces

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
@@ -10,6 +10,12 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -89,4 +95,13 @@ abstract class AbstractResources {
     MixedOperation<Deployment, DeploymentList, DoneableDeployment, Resource<Deployment, DoneableDeployment>> clusterOperator() {
         return customResourcesWithCascading(Deployment.class, DeploymentList.class, DoneableDeployment.class);
     }
+
+    MixedOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> kubernetesClusterRoleBinding() {
+        return customResourcesWithCascading(KubernetesClusterRoleBinding.class, KubernetesClusterRoleBindingList.class, DoneableKubernetesClusterRoleBinding.class);
+    }
+
+    MixedOperation<KubernetesRoleBinding, KubernetesRoleBindingList, DoneableKubernetesRoleBinding, Resource<KubernetesRoleBinding, DoneableKubernetesRoleBinding>> kubernetesRoleBinding() {
+        return customResourcesWithCascading(KubernetesRoleBinding.class, KubernetesRoleBindingList.class, DoneableKubernetesRoleBinding.class);
+    }
+
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -17,10 +17,8 @@ import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding
 import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
-import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
-import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -78,14 +78,6 @@ public class Resources extends AbstractResources {
         super(client);
     }
 
-    private MixedOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> kubernetesClusterRoleBinding() {
-        return customResourcesWithCascading(KubernetesClusterRoleBinding.class, KubernetesClusterRoleBindingList.class, DoneableKubernetesClusterRoleBinding.class);
-    }
-
-    private MixedOperation<KubernetesRoleBinding, KubernetesRoleBindingList, DoneableKubernetesRoleBinding, Resource<KubernetesRoleBinding, DoneableKubernetesRoleBinding>> kubernetesRoleBinding() {
-        return customResourcesWithCascading(KubernetesRoleBinding.class, KubernetesRoleBindingList.class, DoneableKubernetesRoleBinding.class);
-    }
-
     private List<Runnable> resources = new ArrayList<>();
 
     private <T extends HasMetadata> T deleteLater(MixedOperation<T, ?, ?, ?> x, T resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -738,6 +739,70 @@ public class Resources {
                 .editFirstSubject()
                     .withNamespace(namespace)
                 .endSubject();
+    }
+
+    List<KubernetesClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespace) {
+        LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all OpenShift projects");
+
+        List<KubernetesClusterRoleBinding> kCRBList = new ArrayList<>();
+
+        kCRBList.add(
+            new KubernetesClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName("strimzi-cluster-operator-namespaced")
+                .endMetadata()
+                .withNewRoleRef()
+                    .withApiGroup("rbac.authorization.k8s.io")
+                    .withKind("ClusterRole")
+                    .withName("strimzi-cluster-operator-namespaced")
+                .endRoleRef()
+                .withSubjects(new KubernetesSubjectBuilder()
+                    .withKind("ServiceAccount")
+                    .withName("strimzi-cluster-operator")
+                    .withNamespace(namespace)
+                    .build()
+                )
+                .build()
+        );
+
+        kCRBList.add(
+            new KubernetesClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName("strimzi-entity-operator")
+                .endMetadata()
+                .withNewRoleRef()
+                    .withApiGroup("rbac.authorization.k8s.io")
+                    .withKind("ClusterRole")
+                    .withName("strimzi-entity-operator")
+                .endRoleRef()
+                .withSubjects(new KubernetesSubjectBuilder()
+                    .withKind("ServiceAccount")
+                    .withName("strimzi-cluster-operator")
+                    .withNamespace(namespace)
+                    .build()
+                )
+                .build()
+        );
+
+        kCRBList.add(
+            new KubernetesClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName("strimzi-topic-operator")
+                .endMetadata()
+                .withNewRoleRef()
+                    .withApiGroup("rbac.authorization.k8s.io")
+                    .withKind("ClusterRole")
+                    .withName("strimzi-topic-operator")
+                .endRoleRef()
+                .withSubjects(new KubernetesSubjectBuilder()
+                    .withKind("ServiceAccount")
+                    .withName("strimzi-cluster-operator")
+                    .withNamespace(namespace)
+                    .build()
+                )
+                .build()
+        );
+        return kCRBList;
     }
 
     DoneableKubernetesClusterRoleBinding kubernetesClusterRoleBinding(KubernetesClusterRoleBinding clusterRoleBinding, String clientNamespace) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -4,16 +4,13 @@
  */
 package io.strimzi.systemtest;
 
-import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding;
@@ -25,20 +22,10 @@ import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.strimzi.api.kafka.Crds;
-import io.strimzi.api.kafka.KafkaAssemblyList;
-import io.strimzi.api.kafka.KafkaConnectAssemblyList;
-import io.strimzi.api.kafka.KafkaConnectS2IAssemblyList;
-import io.strimzi.api.kafka.KafkaMirrorMakerList;
-import io.strimzi.api.kafka.KafkaTopicList;
-import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
@@ -71,7 +58,7 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
-public class Resources {
+public class Resources extends AbstractResources {
 
     private static final Logger LOGGER = LogManager.getLogger(Resources.class);
     private static final long POLL_INTERVAL_FOR_RESOURCE_CREATION = Duration.ofSeconds(3).toMillis();
@@ -87,57 +74,8 @@ public class Resources {
     public static final String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
     public static final String STRIMZI_DEFAULT_LOG_LEVEL = "DEBUG";
 
-    private final NamespacedKubernetesClient client;
-
     Resources(NamespacedKubernetesClient client) {
-        this.client = client;
-    }
-
-    private NamespacedKubernetesClient client() {
-        return client;
-    }
-
-    private MixedOperation<Kafka, KafkaAssemblyList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafka() {
-        return customResourcesWithCascading(Kafka.class, KafkaAssemblyList.class, DoneableKafka.class);
-    }
-
-    // This logic is necessary only for the deletion of resources with `cascading: true`
-    private <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResourcesWithCascading(Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
-        return new CustomResourceOperationsImpl<T, L, D>(((DefaultKubernetesClient) client()).getHttpClient(), client().getConfiguration(), Crds.kafka().getSpec().getGroup(), Crds.kafka().getSpec().getVersion(), "kafkas", true, client().getNamespace(), null, true, null, null, false, resourceType, listClass, doneClass);
-    }
-
-    private MixedOperation<KafkaConnect, KafkaConnectAssemblyList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnect() {
-        return client()
-                .customResources(Crds.kafkaConnect(),
-                        KafkaConnect.class, KafkaConnectAssemblyList.class, DoneableKafkaConnect.class);
-    }
-
-    private MixedOperation<KafkaConnectS2I, KafkaConnectS2IAssemblyList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> kafkaConnectS2I() {
-        return client()
-                .customResources(Crds.kafkaConnectS2I(),
-                        KafkaConnectS2I.class, KafkaConnectS2IAssemblyList.class, DoneableKafkaConnectS2I.class);
-    }
-
-    private MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> kafkaMirrorMaker() {
-        return client()
-                .customResources(Crds.mirrorMaker(),
-                        KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class);
-    }
-
-    private MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> kafkaTopic() {
-        return client()
-                .customResources(Crds.topic(),
-                        KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
-    }
-
-    private MixedOperation<KafkaUser, KafkaUserList, DoneableKafkaUser, Resource<KafkaUser, DoneableKafkaUser>> kafkaUser() {
-        return client()
-                .customResources(Crds.kafkaUser(),
-                        KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
-    }
-
-    private MixedOperation<Deployment, DeploymentList, DoneableDeployment, Resource<Deployment, DoneableDeployment>> clusterOperator() {
-        return customResourcesWithCascading(Deployment.class, DeploymentList.class, DoneableDeployment.class);
+        super(client);
     }
 
     private MixedOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> kubernetesClusterRoleBinding() {
@@ -455,7 +393,7 @@ public class Resources {
         return kafka;
     }
 
-    KafkaConnect waitFor(KafkaConnect kafkaConnect) {
+    private KafkaConnect waitFor(KafkaConnect kafkaConnect) {
         LOGGER.info("Waiting for Kafka Connect {}", kafkaConnect.getMetadata().getName());
         String namespace = kafkaConnect.getMetadata().getNamespace();
         waitForDeployment(namespace, kafkaConnect.getMetadata().getName() + "-connect");
@@ -486,7 +424,7 @@ public class Resources {
     /**
      * Wait until the SS is ready and all of its Pods are also ready
      */
-    public void waitForStatefulSet(String namespace, String name) {
+    private void waitForStatefulSet(String namespace, String name) {
         StUtils.waitForAllStatefulSetPodsReady(client(), namespace, name);
     }
 
@@ -613,7 +551,7 @@ public class Resources {
         });
     }
 
-    Deployment getDeploymentFromYaml(String yamlPath) {
+    private Deployment getDeploymentFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, Deployment.class);
     }
 
@@ -698,11 +636,11 @@ public class Resources {
         });
     }
 
-    KubernetesRoleBinding getRoleBindingFromYaml(String yamlPath) {
+    private KubernetesRoleBinding getRoleBindingFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, KubernetesRoleBinding.class);
     }
 
-    KubernetesClusterRoleBinding getClusterRoleBindingFromYaml(String yamlPath) {
+    private KubernetesClusterRoleBinding getClusterRoleBindingFromYaml(String yamlPath) {
         return TestUtils.configFromYaml(yamlPath, KubernetesClusterRoleBinding.class);
     }
 
@@ -710,7 +648,7 @@ public class Resources {
         return kubernetesRoleBinding(defaultKubernetesRoleBinding(yamlPath, namespace).build(), clientNamespace);
     }
 
-    KubernetesRoleBindingBuilder defaultKubernetesRoleBinding(String yamlPath, String namespace) {
+    private KubernetesRoleBindingBuilder defaultKubernetesRoleBinding(String yamlPath, String namespace) {
         LOGGER.info("Creating RoleBinding from {} in namespace {}", yamlPath, namespace);
 
         return new KubernetesRoleBindingBuilder(getRoleBindingFromYaml(yamlPath))
@@ -720,7 +658,7 @@ public class Resources {
                 .endSubject();
     }
 
-    DoneableKubernetesRoleBinding kubernetesRoleBinding(KubernetesRoleBinding roleBinding, String clientNamespace) {
+    private DoneableKubernetesRoleBinding kubernetesRoleBinding(KubernetesRoleBinding roleBinding, String clientNamespace) {
         LOGGER.info("Apply RoleBinding in namespace {}", clientNamespace);
         client.inNamespace(clientNamespace).rbac().kubernetesRoleBindings().createOrReplace(roleBinding);
         deleteLater(roleBinding);
@@ -731,7 +669,7 @@ public class Resources {
         return kubernetesClusterRoleBinding(defaultKubernetesClusterRoleBinding(yamlPath, namespace).build(), clientNamespace);
     }
 
-    KubernetesClusterRoleBindingBuilder defaultKubernetesClusterRoleBinding(String yamlPath, String namespace) {
+    private KubernetesClusterRoleBindingBuilder defaultKubernetesClusterRoleBinding(String yamlPath, String namespace) {
         LOGGER.info("Creating ClusterRoleBinding from {} in namespace {}", yamlPath, namespace);
 
         return new KubernetesClusterRoleBindingBuilder(getClusterRoleBindingFromYaml(yamlPath))

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.File;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+
+public abstract class AbstractNamespaceST extends AbstractST {
+
+    private static final Logger LOGGER = LogManager.getLogger(AbstractNamespaceST.class);
+
+    static final String CO_NAMESPACE = "multiple-namespace-test";
+    static final String SECOND_NAMESPACE = "second-multiply-namespace-test";
+    static final String TOPIC_NAME = "my-topic";
+    static final String TOPIC_INSTALL_DIR = "../examples/topic/kafka-topic.yaml";
+
+    private static Resources secondNamespaceResources;
+    static Resources classResources;
+
+    void checkTOInDiffNamespaceThanCO() {
+        List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
+        assertThat(topics, not(hasItems(TOPIC_NAME)));
+
+        deployNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
+        deleteNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
+    }
+
+    void checkKafkaInDiffNamespaceThanCO() {
+        String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
+
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3).done();
+
+        LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
+        kubeClient.namespace(SECOND_NAMESPACE);
+        kubeClient.waitForStatefulSet(kafkaName, 3);
+    }
+
+    void checkMirrorMakerForKafkaInDifNamespaceThanCO() {
+        String kafkaName = CLUSTER_NAME + "-target";
+        String kafkaSourceName = kafkaClusterName(CLUSTER_NAME);
+        String kafkaTargetName = kafkaClusterName(kafkaName);
+
+        secondNamespaceResources.kafkaEphemeral(kafkaName, 3).done();
+        secondNamespaceResources.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
+
+        LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
+        kubeClient.namespace(SECOND_NAMESPACE);
+        kubeClient.waitForDeployment(CLUSTER_NAME + "-mirror-maker", 1);
+    }
+
+    void deployNewTopic(String namespace, String topic) {
+        LOGGER.info("Creating topic {} in namespace {}", topic, namespace);
+        kubeClient.namespace(namespace);
+        kubeClient.create(new File(TOPIC_INSTALL_DIR));
+        TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", 5000, 120000, () -> {
+            kubeClient.namespace(CO_NAMESPACE);
+            List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
+            return topics2.contains(topic);
+        });
+    }
+
+    void deleteNewTopic(String namespace, String topic) {
+        LOGGER.info("Deleting topic {} in namespace {}", topic, namespace);
+        kubeClient.namespace(namespace);
+        kubeClient.deleteByName("KafkaTopic", topic);
+        kubeClient.namespace(CO_NAMESPACE);
+    }
+
+    @BeforeEach
+    void createSecondNamespaceResources() {
+        kubeClient.namespace(SECOND_NAMESPACE);
+        secondNamespaceResources = new Resources(namespacedClient());
+        kubeClient.namespace(CO_NAMESPACE);
+    }
+
+    @AfterEach
+    void deleteSecondNamespaceResources() throws Exception {
+        secondNamespaceResources.deleteResources();
+        waitForDeletion(TEARDOWN_GLOBAL_WAIT, SECOND_NAMESPACE, CO_NAMESPACE, SECOND_NAMESPACE);
+        kubeClient.namespace(CO_NAMESPACE);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -23,11 +23,10 @@ public abstract class AbstractNamespaceST extends AbstractST {
 
     static final String CO_NAMESPACE = "multiple-namespace-test";
     static final String SECOND_NAMESPACE = "second-multiply-namespace-test";
-    static final String TOPIC_NAME = "my-topic";
-    static final String TOPIC_INSTALL_DIR = "../examples/topic/kafka-topic.yaml";
+    private static final String TOPIC_NAME = "my-topic";
+    private static final String TOPIC_INSTALL_DIR = "../examples/topic/kafka-topic.yaml";
 
     private static Resources secondNamespaceResources;
-    static Resources classResources;
 
     void checkTOInDiffNamespaceThanCO() {
         List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -13,28 +13,16 @@ import org.junit.jupiter.api.BeforeEach;
 import java.io.File;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.not;
-
 public abstract class AbstractNamespaceST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(AbstractNamespaceST.class);
 
-    static final String CO_NAMESPACE = "multiple-namespace-test";
-    static final String SECOND_NAMESPACE = "second-multiply-namespace-test";
-    private static final String TOPIC_NAME = "my-topic";
+    static final String CO_NAMESPACE = "co-namespace-test";
+    static final String SECOND_NAMESPACE = "second-namespace-test";
+    static final String TOPIC_NAME = "my-topic";
     private static final String TOPIC_INSTALL_DIR = "../examples/topic/kafka-topic.yaml";
 
     private static Resources secondNamespaceResources;
-
-    void checkTOInDiffNamespaceThanCO() {
-        List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
-        assertThat(topics, not(hasItems(TOPIC_NAME)));
-
-        deployNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
-        deleteNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
-    }
 
     void checkKafkaInDiffNamespaceThanCO() {
         String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
@@ -59,12 +47,12 @@ public abstract class AbstractNamespaceST extends AbstractST {
         kubeClient.waitForDeployment(CLUSTER_NAME + "-mirror-maker", 1);
     }
 
-    void deployNewTopic(String namespace, String topic) {
-        LOGGER.info("Creating topic {} in namespace {}", topic, namespace);
-        kubeClient.namespace(namespace);
+    void deployNewTopic(String topicNamespace, String clusterNamespace, String topic) {
+        LOGGER.info("Creating topic {} in namespace {}", topic, topicNamespace);
+        kubeClient.namespace(topicNamespace);
         kubeClient.create(new File(TOPIC_INSTALL_DIR));
         TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", 5000, 120000, () -> {
-            kubeClient.namespace(CO_NAMESPACE);
+            kubeClient.namespace(clusterNamespace);
             List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
             return topics2.contains(topic);
         });

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -31,8 +31,8 @@ public abstract class AbstractNamespaceST extends AbstractST {
         secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
-        kubeClient.namespace(SECOND_NAMESPACE);
-        kubeClient.waitForStatefulSet(kafkaName, 3);
+        KUBE_CLIENT.namespace(SECOND_NAMESPACE);
+        KUBE_CLIENT.waitForStatefulSet(kafkaName, 3);
     }
 
     void checkMirrorMakerForKafkaInDifNamespaceThanCO() {
@@ -44,16 +44,16 @@ public abstract class AbstractNamespaceST extends AbstractST {
         secondNamespaceResources.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
-        kubeClient.namespace(SECOND_NAMESPACE);
-        kubeClient.waitForDeployment(CLUSTER_NAME + "-mirror-maker", 1);
+        KUBE_CLIENT.namespace(SECOND_NAMESPACE);
+        KUBE_CLIENT.waitForDeployment(CLUSTER_NAME + "-mirror-maker", 1);
     }
 
     void deployNewTopic(String topicNamespace, String clusterNamespace, String topic) {
         LOGGER.info("Creating topic {} in namespace {}", topic, topicNamespace);
-        kubeClient.namespace(topicNamespace);
-        kubeClient.create(new File(TOPIC_EXAMPLES_DIR));
+        KUBE_CLIENT.namespace(topicNamespace);
+        KUBE_CLIENT.create(new File(TOPIC_EXAMPLES_DIR));
         TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", 5000, 120000, () -> {
-            kubeClient.namespace(clusterNamespace);
+            KUBE_CLIENT.namespace(clusterNamespace);
             List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
             return topics2.contains(topic);
         });
@@ -61,22 +61,22 @@ public abstract class AbstractNamespaceST extends AbstractST {
 
     void deleteNewTopic(String namespace, String topic) {
         LOGGER.info("Deleting topic {} in namespace {}", topic, namespace);
-        kubeClient.namespace(namespace);
-        kubeClient.deleteByName("KafkaTopic", topic);
-        kubeClient.namespace(CO_NAMESPACE);
+        KUBE_CLIENT.namespace(namespace);
+        KUBE_CLIENT.deleteByName("KafkaTopic", topic);
+        KUBE_CLIENT.namespace(CO_NAMESPACE);
     }
 
     @BeforeEach
     void createSecondNamespaceResources() {
-        kubeClient.namespace(SECOND_NAMESPACE);
+        KUBE_CLIENT.namespace(SECOND_NAMESPACE);
         secondNamespaceResources = new Resources(namespacedClient());
-        kubeClient.namespace(CO_NAMESPACE);
+        KUBE_CLIENT.namespace(CO_NAMESPACE);
     }
 
     @AfterEach
     void deleteSecondNamespaceResources() throws Exception {
         secondNamespaceResources.deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, SECOND_NAMESPACE, CO_NAMESPACE, SECOND_NAMESPACE);
-        kubeClient.namespace(CO_NAMESPACE);
+        waitForDeletion(TEARDOWN_GLOBAL_WAIT, SECOND_NAMESPACE);
+        KUBE_CLIENT.namespace(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -20,9 +20,10 @@ public abstract class AbstractNamespaceST extends AbstractST {
     static final String CO_NAMESPACE = "co-namespace-test";
     static final String SECOND_NAMESPACE = "second-namespace-test";
     static final String TOPIC_NAME = "my-topic";
-    private static final String TOPIC_INSTALL_DIR = "../examples/topic/kafka-topic.yaml";
+    static final String USER_NAME = "my-user";
+    private static final String TOPIC_EXAMPLES_DIR = "../examples/topic/kafka-topic.yaml";
 
-    private static Resources secondNamespaceResources;
+    static Resources secondNamespaceResources;
 
     void checkKafkaInDiffNamespaceThanCO() {
         String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
@@ -50,7 +51,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void deployNewTopic(String topicNamespace, String clusterNamespace, String topic) {
         LOGGER.info("Creating topic {} in namespace {}", topic, topicNamespace);
         kubeClient.namespace(topicNamespace);
-        kubeClient.create(new File(TOPIC_INSTALL_DIR));
+        kubeClient.create(new File(TOPIC_EXAMPLES_DIR));
         TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", 5000, 120000, () -> {
             kubeClient.namespace(clusterNamespace);
             List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -28,11 +28,11 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void checkKafkaInDiffNamespaceThanCO() {
         String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
 
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 1).done();
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
         KUBE_CLIENT.namespace(SECOND_NAMESPACE);
-        KUBE_CLIENT.waitForStatefulSet(kafkaName, 1);
+        KUBE_CLIENT.waitForStatefulSet(kafkaName, 3);
     }
 
     void checkMirrorMakerForKafkaInDifNamespaceThanCO() {
@@ -40,7 +40,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
         String kafkaSourceName = kafkaClusterName(CLUSTER_NAME);
         String kafkaTargetName = kafkaClusterName(kafkaName);
 
-        secondNamespaceResources.kafkaEphemeral(kafkaName, 1).done();
+        secondNamespaceResources.kafkaEphemeral(kafkaName, 3).done();
         secondNamespaceResources.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -28,11 +28,11 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void checkKafkaInDiffNamespaceThanCO() {
         String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
 
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3).done();
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 1).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
         KUBE_CLIENT.namespace(SECOND_NAMESPACE);
-        KUBE_CLIENT.waitForStatefulSet(kafkaName, 3);
+        KUBE_CLIENT.waitForStatefulSet(kafkaName, 1);
     }
 
     void checkMirrorMakerForKafkaInDifNamespaceThanCO() {
@@ -40,7 +40,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
         String kafkaSourceName = kafkaClusterName(CLUSTER_NAME);
         String kafkaTargetName = kafkaClusterName(kafkaName);
 
-        secondNamespaceResources.kafkaEphemeral(kafkaName, 3).done();
+        secondNamespaceResources.kafkaEphemeral(kafkaName, 1).done();
         secondNamespaceResources.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractResources.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractResources.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaAssemblyList;
+import io.strimzi.api.kafka.KafkaConnectAssemblyList;
+import io.strimzi.api.kafka.KafkaConnectS2IAssemblyList;
+import io.strimzi.api.kafka.KafkaMirrorMakerList;
+import io.strimzi.api.kafka.KafkaTopicList;
+import io.strimzi.api.kafka.KafkaUserList;
+import io.strimzi.api.kafka.model.DoneableKafka;
+import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
+import io.strimzi.api.kafka.model.DoneableKafkaTopic;
+import io.strimzi.api.kafka.model.DoneableKafkaUser;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
+
+abstract class AbstractResources {
+
+    final NamespacedKubernetesClient client;
+
+    AbstractResources(NamespacedKubernetesClient client) {
+        this.client = client;
+    }
+
+    NamespacedKubernetesClient client() {
+        return client;
+    }
+
+    MixedOperation<Kafka, KafkaAssemblyList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafka() {
+        return customResourcesWithCascading(Kafka.class, KafkaAssemblyList.class, DoneableKafka.class);
+    }
+
+    // This logic is necessary only for the deletion of resources with `cascading: true`
+    <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResourcesWithCascading(Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+        return new CustomResourceOperationsImpl<T, L, D>(((DefaultKubernetesClient) client()).getHttpClient(), client().getConfiguration(), Crds.kafka().getSpec().getGroup(), Crds.kafka().getSpec().getVersion(), "kafkas", true, client().getNamespace(), null, true, null, null, false, resourceType, listClass, doneClass);
+    }
+
+    MixedOperation<KafkaConnect, KafkaConnectAssemblyList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnect() {
+        return client()
+                .customResources(Crds.kafkaConnect(),
+                        KafkaConnect.class, KafkaConnectAssemblyList.class, DoneableKafkaConnect.class);
+    }
+
+    MixedOperation<KafkaConnectS2I, KafkaConnectS2IAssemblyList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> kafkaConnectS2I() {
+        return client()
+                .customResources(Crds.kafkaConnectS2I(),
+                        KafkaConnectS2I.class, KafkaConnectS2IAssemblyList.class, DoneableKafkaConnectS2I.class);
+    }
+
+    MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> kafkaMirrorMaker() {
+        return client()
+                .customResources(Crds.mirrorMaker(),
+                        KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class);
+    }
+
+    MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> kafkaTopic() {
+        return client()
+                .customResources(Crds.topic(),
+                        KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+    }
+
+    MixedOperation<KafkaUser, KafkaUserList, DoneableKafkaUser, Resource<KafkaUser, DoneableKafkaUser>> kafkaUser() {
+        return client()
+                .customResources(Crds.kafkaUser(),
+                        KafkaUser.class, KafkaUserList.class, DoneableKafkaUser.class);
+    }
+
+    MixedOperation<Deployment, DeploymentList, DoneableDeployment, Resource<Deployment, DoneableDeployment>> clusterOperator() {
+        return customResourcesWithCascading(Deployment.class, DeploymentList.class, DoneableDeployment.class);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -24,7 +24,7 @@ import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
 @Namespace(MultipleNamespaceST.CO_NAMESPACE)
 @Namespace(value = MultipleNamespaceST.SECOND_NAMESPACE, use = false)
 @ClusterOperator
-public class AllNamespaceST extends AbstractNamespaceST {
+class AllNamespaceST extends AbstractNamespaceST {
 
     private static final Logger LOGGER = LogManager.getLogger(AllNamespaceST.class);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.strimzi.test.annotations.ClusterOperator;
+import io.strimzi.test.annotations.Namespace;
+import io.strimzi.test.extensions.StrimziExtension;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
+
+@ExtendWith(StrimziExtension.class)
+@Namespace(MultipleNamespaceST.CO_NAMESPACE)
+@Namespace(value = MultipleNamespaceST.SECOND_NAMESPACE, use = false)
+@ClusterOperator
+public class AllNamespaceST extends AbstractNamespaceST {
+
+    private static final Logger LOGGER = LogManager.getLogger(AllNamespaceST.class);
+
+    /**
+     * Test the case where the TO is configured to watch a different namespace that it is deployed in
+     */
+    @Test
+    @Tag(REGRESSION)
+    void testTopicOperatorWatchingOtherNamespace() {
+        LOGGER.info("Deploying TO in different namespace than CO when CO watches all namespaces");
+        checkTOInDiffNamespaceThanCO();
+    }
+
+    /**
+     * Test the case when Kafka will be deployed in different namespace than CO
+     */
+    @Test
+    @Tag(REGRESSION)
+    void testKafkaInDifferentNsThanClusterOperator() throws InterruptedException {
+        LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
+        checkKafkaInDiffNamespaceThanCO();
+    }
+
+    /**
+     * Test the case when MirrorMaker will be deployed in different namespace across multiple namespaces
+     */
+    @Test
+    @Tag(REGRESSION)
+    void testDeployMirrorMakerAcrossMultipleNamespace() throws InterruptedException {
+        LOGGER.info("Deploying Kafka MirrorMaker in different namespace than CO when CO watches all namespaces");
+        checkMirrorMakerForKafkaInDifNamespaceThanCO();
+    }
+
+    @BeforeAll
+    static void createClassResources(TestInfo testInfo) {
+        // Apply role bindings in CO namespace
+        applyRoleBindings(CO_NAMESPACE);
+
+        // Create ClusterRoleBindings that grant cluster-wide access to all OpenShift projects
+        List<KubernetesClusterRoleBinding> clusterRoleBindingList = testClassResources.clusterRoleBindingsForAllNamespaces(CO_NAMESPACE);
+        clusterRoleBindingList.forEach(kubernetesClusterRoleBinding ->
+            testClassResources.kubernetesClusterRoleBinding(kubernetesClusterRoleBinding, CO_NAMESPACE));
+
+        LOGGER.info("Deploying CO to watch all namespaces");
+        testClassResources.clusterOperator("*").done();
+
+        classResources = new Resources(namespacedClient());
+        classResources().kafkaEphemeral(CLUSTER_NAME, 3)
+            .editSpec()
+                .editEntityOperator()
+                    .editTopicOperator()
+                        .withWatchedNamespace(SECOND_NAMESPACE)
+                    .endTopicOperator()
+                .endEntityOperator()
+            .endSpec()
+            .done();
+
+        testClass = testInfo.getTestClass().get().getSimpleName();
+    }
+
+    private static Resources classResources() {
+        return classResources;
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -71,8 +71,7 @@ class AllNamespaceST extends AbstractNamespaceST {
         LOGGER.info("Deploying CO to watch all namespaces");
         testClassResources.clusterOperator("*").done();
 
-        classResources = new Resources(namespacedClient());
-        classResources().kafkaEphemeral(CLUSTER_NAME, 3)
+        testClassResources.kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()
                     .editTopicOperator()
@@ -83,9 +82,5 @@ class AllNamespaceST extends AbstractNamespaceST {
             .done();
 
         testClass = testInfo.getTestClass().get().getSimpleName();
-    }
-
-    private static Resources classResources() {
-        return classResources;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -90,7 +90,8 @@ class AllNamespaceST extends AbstractNamespaceST {
         secondNamespaceResources.tlsUser(CLUSTER_NAME, USER_NAME).done();
 
         String previousNamespace = kubeClient.namespace(SECOND_NAMESPACE);
-        kubeClient.waitForResourceCreation("KafkaUser", USER_NAME);
+        // Check that UO created a secret for new user
+        kubeClient.waitForResourceCreation("Secret", USER_NAME);
 
         kubeClient.namespace(previousNamespace);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -71,7 +71,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectInOtherNamespaceThanCO() {
         String previousNamespace = KUBE_CLIENT.namespace(SECOND_NAMESPACE);
         // Deploy Kafka in other namespace than CO
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME, 3).done();
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME, 1).done();
         // Deploy Kafka Connect in other namespace than CO
         secondNamespaceResources.kafkaConnect(CLUSTER_NAME, 1).done();
         // Check that Kafka Connect was deployed

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -71,7 +71,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectInOtherNamespaceThanCO() {
         String previousNamespace = KUBE_CLIENT.namespace(SECOND_NAMESPACE);
         // Deploy Kafka in other namespace than CO
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME, 1).done();
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME, 3).done();
         // Deploy Kafka Connect in other namespace than CO
         secondNamespaceResources.kafkaConnect(CLUSTER_NAME, 1).done();
         // Check that Kafka Connect was deployed

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -31,7 +31,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     @Test
     @Tag(REGRESSION)
     void testTopicOperatorWatchingOtherNamespace() {
-        LOGGER.info("Deploying TO in different namespace than CO when CO watches multiple namespaces");
+        LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
 
         List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
         assertThat(topics, not(hasItems(TOPIC_NAME)));

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -12,7 +12,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.List;
+
 import static io.strimzi.test.extensions.StrimziExtension.REGRESSION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 
 @ExtendWith(StrimziExtension.class)
 @ClusterOperator
@@ -27,7 +32,12 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     @Tag(REGRESSION)
     void testTopicOperatorWatchingOtherNamespace() {
         LOGGER.info("Deploying TO in different namespace than CO when CO watches multiple namespaces");
-        checkTOInDiffNamespaceThanCO();
+
+        List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
+        assertThat(topics, not(hasItems(TOPIC_NAME)));
+
+        deployNewTopic(SECOND_NAMESPACE, CO_NAMESPACE, TOPIC_NAME);
+        deleteNewTopic(SECOND_NAMESPACE, TOPIC_NAME);
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -58,7 +58,6 @@ class MultipleNamespaceST extends AbstractNamespaceST {
         LOGGER.info("Deploying CO to watch multiple namespaces");
         testClassResources.clusterOperator(String.join(",", CO_NAMESPACE, SECOND_NAMESPACE)).done();
 
-    private void deployTestSpecificResources() {
         testClassResources.kafkaEphemeral(CLUSTER_NAME, 3)
             .editSpec()
                 .editEntityOperator()
@@ -66,6 +65,9 @@ class MultipleNamespaceST extends AbstractNamespaceST {
                         .withWatchedNamespace(SECOND_NAMESPACE)
                     .endTopicOperator()
                 .endEntityOperator()
-            .endSpec().done();
+            .endSpec()
+            .done();
+
+        testClass = testInfo.getTestClass().get().getSimpleName();
     }
 }


### PR DESCRIPTION
### Type of change
- New ST

### Description
One more pre-condition step was added as deploying CO to watch all namespaces for namespaces STs.
Also was created an abstract class for Namespaces because of possible code duplicate in new ST. 

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

