### PR TITLE
Add test for and fix #1221 and #472

### DIFF
--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>mockkube</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
         </dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -33,14 +33,14 @@ public class Session extends AbstractVerticle {
     private final Config config;
     private final KubernetesClient kubeClient;
 
-    OperatorAssignedKafkaImpl kafka;
-    AdminClient adminClient;
-    K8sImpl k8s;
-    TopicOperator topicOperator;
-    Watch topicWatch;
-    ZkTopicsWatcher topicsWatcher;
-    TopicConfigsWatcher topicConfigsWatcher;
-    ZkTopicWatcher topicWatcher;
+    /*test*/ OperatorAssignedKafkaImpl kafka;
+    /*test*/ AdminClient adminClient;
+    /*test*/ K8sImpl k8s;
+    /*test*/ TopicOperator topicOperator;
+    /*test*/ Watch topicWatch;
+    /*test*/ ZkTopicsWatcher topicsWatcher;
+    /*test*/ TopicConfigsWatcher topicConfigsWatcher;
+    /*test*/ ZkTopicWatcher topicWatcher;
     /** The id of the periodic reconciliation timer. This is null during a periodic reconciliation. */
     private volatile Long timerId;
     private volatile boolean stopped = false;
@@ -157,7 +157,8 @@ public class Session extends AbstractVerticle {
 
         Thread resourceThread = new Thread(() -> {
             LOGGER.debug("Watching KafkaTopics matching {}", resourcePredicate);
-            Session.this.topicWatch = kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class).inNamespace(namespace).watch(new K8sTopicWatcher(topicOperator, resourcePredicate));
+            Session.this.topicWatch = kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
+                    .inNamespace(namespace).watch(new K8sTopicWatcher(topicOperator, resourcePredicate));
             LOGGER.debug("Watching setup");
 
             // start the HTTP server for healthchecks

--- a/topic-operator/src/main/resources/log4j2.properties
+++ b/topic-operator/src/main/resources/log4j2.properties
@@ -3,9 +3,9 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -164,7 +164,7 @@ public class TopicOperatorIT {
         });
         async.await();
 
-        waitFor(context, () -> this.topicsWatcher.started(), timeout, "Topics watcher not started");
+        waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
         waitFor(context, () -> this.topicsConfigWatcher.started(), timeout, "Topic configs watcher not started");
         waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.kafka.ZookeeperServer;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaTopicList;
+import io.strimzi.api.kafka.model.DoneableKafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.test.mockkube.MockKube;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+import static io.strimzi.test.TestUtils.waitFor;
+import static java.util.Arrays.asList;
+
+@RunWith(VertxUnitRunner.class)
+public class TopicOperatorMockTest {
+
+    private static final Logger LOGGER = LogManager.getLogger(TopicOperatorMockTest.class);
+
+    private KubernetesClient kubeClient;
+    private Session session;
+    private KafkaCluster kafkaCluster;
+    private Vertx vertx;
+    private String deploymentId;
+    private AdminClient adminClient;
+    private TopicConfigsWatcher topicsConfigWatcher;
+    private ZkTopicWatcher topicWatcher;
+    private ZkTopicsWatcher topicsWatcher;
+
+    // TODO this is all in common with TOIT, so factor out a common base class
+
+    @Before
+    public void createMockKube(TestContext context) throws Exception {
+        vertx = Vertx.vertx();
+        MockKube mockKube = new MockKube();
+        mockKube.withCustomResourceDefinition(Crds.topic(),
+                        KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+        kubeClient = mockKube.build();
+
+        kafkaCluster = new KafkaCluster();
+        kafkaCluster.addBrokers(1);
+        kafkaCluster.deleteDataPriorToStartup(true);
+        kafkaCluster.deleteDataUponShutdown(true);
+        kafkaCluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
+        kafkaCluster.startup();
+
+        Map<String, String> m = new HashMap();
+        m.put(io.strimzi.operator.topic.Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
+        m.put(io.strimzi.operator.topic.Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
+        m.put(io.strimzi.operator.topic.Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
+        m.put(io.strimzi.operator.topic.Config.NAMESPACE.key, "myproject");
+        session = new Session(kubeClient, new io.strimzi.operator.topic.Config(m));
+
+        Async async = context.async();
+        vertx.deployVerticle(session, ar -> {
+            if (ar.succeeded()) {
+                deploymentId = ar.result();
+                adminClient = session.adminClient;
+                topicsConfigWatcher = session.topicConfigsWatcher;
+                topicWatcher = session.topicWatcher;
+                topicsWatcher = session.topicsWatcher;
+                async.complete();
+            } else {
+                ar.cause().printStackTrace();
+                context.fail("Failed to deploy session");
+            }
+        });
+        async.await();
+
+        int timeout = 30_000;
+
+        waitFor("Topic watcher not started",  1_000, timeout,
+            () -> this.topicWatcher.started());
+        waitFor("Topic configs watcher not started", 1_000, timeout,
+            () -> this.topicsConfigWatcher.started());
+        waitFor("Topic watcher not started", 1_000, timeout,
+            () -> this.topicsWatcher.started());
+        //waitFor(context, () -> this.topicsConfigWatcher.started(), timeout, "Topic configs watcher not started");
+        //waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
+    }
+
+    private static int zkPort(KafkaCluster cluster) {
+        // TODO Method was added in DBZ-540, so no need for reflection once
+        // dependency gets upgraded
+        try {
+            Field zkServerField = KafkaCluster.class.getDeclaredField("zkServer");
+            zkServerField.setAccessible(true);
+            return ((ZookeeperServer) zkServerField.get(cluster)).getPort();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createInKube(KafkaTopic topic) {
+        Crds.topicOperation(kubeClient).create(topic);
+    }
+
+    private void updateInKube(KafkaTopic topic) {
+        Crds.topicOperation(kubeClient).withName(topic.getMetadata().getName()).patch(topic);
+    }
+
+    @Test
+    public void testCreatedWithoutTopicNameInKube(TestContext context) {
+        LOGGER.info("Test started");
+
+        int retention = 100_000_000;
+        KafkaTopic kt = new KafkaTopicBuilder()
+                .withNewMetadata()
+                .withName("my-topic")
+                .addToLabels("strimzi.io/kind", "topic")
+                .endMetadata()
+                .withNewSpec()
+                .withPartitions(1)
+                .withReplicas(1)
+                .addToConfig("retention.bytes", retention)
+                .endSpec().build();
+
+        testCreatedInKube(context, kt);
+    }
+
+    void testCreatedInKube(TestContext context, KafkaTopic kt) {
+        String kubeName = kt.getMetadata().getName();
+        String kafkaName = kt.getSpec().getTopicName() != null ? kt.getSpec().getTopicName() : kubeName;
+        int retention = (Integer) kt.getSpec().getConfig().get("retention.bytes");
+
+        createInKube(kt);
+
+        // Check created in Kafka
+        waitUntilTopicExistsInKafka(kafkaName);
+        LOGGER.info("Topic has been created");
+        Topic fromKafka = getFromKafka(context, kafkaName);
+        context.assertEquals(kafkaName, fromKafka.getTopicName().toString());
+        //context.assertEquals(kubeName, fromKafka.getResourceName().toString());
+        // Reconcile after no changes
+        reconcile(context);
+        // Check things still the same
+        Topic fromKafka2 = getFromKafka(context, kafkaName);
+        context.assertEquals(fromKafka, fromKafka2);
+
+        // Config change + reconcile
+        updateInKube(new KafkaTopicBuilder(kt).editSpec().addToConfig("retention.bytes", retention + 1).endSpec().build());
+        waitUntilTopicInKafka(kafkaName, config -> Integer.toString(retention + 1).equals(config.get("retention.bytes").value()));
+        reconcile(context);
+
+        // Check things still the same
+        fromKafka2 = getFromKafka(context, kafkaName);
+        context.assertEquals(new Topic.Builder(fromKafka)
+                            .withConfigEntry("retention.bytes", Integer.toString(retention + 1))
+                        .build(),
+                fromKafka2);
+
+        // Reconcile after change #partitions change
+        // Check things still the same
+        // Try to add a matching spec.topicName
+        // Check things still the same
+        // Try to change spec.topicName
+        // Check error
+        // Try to change spec.topicName back
+        // Check things still the same (recover from error)
+        // Try to remove spec.topicName
+        // Check things still the same
+    }
+
+    Topic getFromKafka(TestContext context, String topicName) {
+        AtomicReference<Topic> ref = new AtomicReference<>();
+        Async async = context.async();
+        Future<TopicMetadata> kafkaMetadata = Future.future();
+        session.kafka.topicMetadata(new TopicName(topicName), kafkaMetadata.completer());
+        kafkaMetadata.map(metadata -> TopicSerialization.fromTopicMetadata(metadata)).setHandler(fromKafka -> {
+            if (fromKafka.succeeded()) {
+                ref.set(fromKafka.result());
+            } else {
+                context.fail(fromKafka.cause());
+            }
+            async.complete();
+        });
+        async.await();
+        return ref.get();
+    }
+
+    private Config waitUntilTopicExistsInKafka(String topicName) {
+        return waitUntilTopicInKafka(topicName, desc -> desc != null);
+    }
+
+    private Config waitUntilTopicInKafka(String topicName, Predicate<Config> p) {
+        ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+        AtomicReference<Config> ref = new AtomicReference<>();
+        waitFor("Creation of topic " + topicName, 1_000, 10_000, () -> {
+            try {
+                Map<ConfigResource, Config> descriptionMap = adminClient.describeConfigs(asList(configResource)).all().get();
+                Config desc = descriptionMap.get(configResource);
+                if (p.test(desc)) {
+                    ref.set(desc);
+                    return true;
+                }
+                return false;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+        return ref.get();
+    }
+
+    void reconcile(TestContext context) {
+        Async async = context.async();
+        session.topicOperator.reconcileAllTopics("test").setHandler(ar -> {
+            if (!ar.succeeded()) {
+                context.fail(ar.cause());
+            }
+            async.complete();
+        });
+        async.await();
+    }
+
+
+    @Test
+    public void testCreatedWithSameTopicNameInKube(TestContext context) {
+
+        int retention = 100_000_000;
+        KafkaTopic kt = new KafkaTopicBuilder()
+                .withNewMetadata()
+                .withName("my-topic")
+                .addToLabels("strimzi.io/kind", "topic")
+                .endMetadata()
+                .withNewSpec()
+                .withTopicName("my-topic") // the same as metadata.name
+                .withPartitions(1)
+                .withReplicas(1)
+                .addToConfig("retention.bytes", retention)
+                .endSpec().build();
+
+        testCreatedInKube(context, kt);
+    }
+
+    @Test
+    public void testCreatedWithDifferentTopicNameInKube(TestContext context) {
+        int retention = 100_000_000;
+        KafkaTopic kt = new KafkaTopicBuilder()
+                .withNewMetadata()
+                .withName("my-topic")
+                .addToLabels("strimzi.io/kind", "topic")
+                .endMetadata()
+                .withNewSpec()
+                    .withTopicName("DIFFERENT") // different to metadata.name
+                    .withPartitions(1)
+                    .withReplicas(1)
+                    .addToConfig("retention.bytes", retention)
+                .endSpec().build();
+
+        testCreatedInKube(context, kt);
+    }
+    /*
+    @Test
+    public void testCreatedInKafka() {
+
+    }
+
+    @Test
+    public void testCreatedInKafkaWhenAKafkaTopicExists() {
+
+    }
+    */
+}

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -274,15 +274,5 @@ public class TopicOperatorMockTest {
 
         testCreatedInKube(context, kt);
     }
-    /*
-    @Test
-    public void testCreatedInKafka() {
 
-    }
-
-    @Test
-    public void testCreatedInKafkaWhenAKafkaTopicExists() {
-
-    }
-    */
 }

--- a/topic-operator/src/test/resources/log4j2-test.properties
+++ b/topic-operator/src/test/resources/log4j2-test.properties
@@ -10,3 +10,5 @@ rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
+logger.strimzi.name = io.strimzi
+logger.strimzi.level = debug


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Use the private topic store as a mapping between the topic name in Kafka and
the KafkaTopic metadata.name. Previously we were incorrectly just using the
Kafka name assuming it must come from a KafkaTopic with that metadata.name.

This complicates the reconcileAll algorithm, because we cope with the
possibility that the private topic does not exist, so we have to pass that
undetermined state through to where we have to reconcile the KafkaTopics
present in kube.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

