### PR TITLE
Adding helm hook to pre-load strimzi crds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for JBOD storage for Kafka brokers
 * Allow users to configure the default ImagePullPolicy
+* Helm chart deploys CRDs before other resources via `crd-install` helm/hook.sh annotation
 
 ## 0.10.0
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkas.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkaconnects.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkaconnects2is.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkatopics.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkausers.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -8,6 +8,8 @@ metadata:
     component: kafkamirrormakers.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: kafka.strimzi.io
   version: v1alpha1


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Utilizes the helm/hook: crd-install to pre-load custom resources strimzi uses to define
a kafka cluster before other resources that might rely on those definitions are attempted to be loaded.
This is a requirement for adding the strimzi-kafka-operator helm chart as a dependency of other charts in their requirements.yaml file if they attempt to deploy a kafka cluster as part of their application or are using a kubernetes-deployed cluster for integration testing an app that will interact with a kafka cluster.

### Checklist

- [X] Update CHANGELOG.md

