### PR TITLE
Stop blocking the vertx context thread during start up

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkWatcher.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic;
 
 import io.strimzi.operator.topic.zk.Zk;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,7 +83,10 @@ public abstract class ZkWatcher {
                 log.error("While getting or watching znode {}", path, dataResult.cause());
             }
         };
-        zk.watchData(path, handler).getData(path, handler);
+        zk.watchData(path, handler).compose(zk2 -> {
+            zk.getData(path, handler);
+            return Future.succeededFuture();
+        });
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -7,6 +7,8 @@ package io.strimzi.operator.topic.zk;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
 
@@ -17,8 +19,18 @@ import java.util.List;
  */
 public interface Zk {
 
-    public static Zk create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
-        return new ZkImpl(vertx, zkConnectionString, sessionTimeout, connectionTimeout);
+    public static void create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout,
+                              Handler<AsyncResult<Zk>> handler) {
+        vertx.executeBlocking(f -> {
+            try {
+                f.complete(new ZkImpl(vertx,
+                        new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout,
+                                new BytesPushThroughSerializer())));
+            } catch (Throwable t) {
+                f.fail(t);
+            }
+        },
+                handler);
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -23,14 +23,18 @@ public interface Zk {
                               Handler<AsyncResult<Zk>> handler) {
         vertx.executeBlocking(f -> {
             try {
-                f.complete(new ZkImpl(vertx,
-                        new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout,
-                                new BytesPushThroughSerializer())));
+                f.complete(createSync(vertx, zkConnectionString, sessionTimeout, connectionTimeout));
             } catch (Throwable t) {
                 f.fail(t);
             }
         },
                 handler);
+    }
+
+    public static Zk createSync(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
+        return new ZkImpl(vertx,
+                new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout,
+                        new BytesPushThroughSerializer()));
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -69,7 +69,8 @@ public interface Zk {
     Zk children(String path, Handler<AsyncResult<List<String>>> handler);
 
     /**
-     * Set given the children {@code watcher} on the given {@code path}.
+     * Asynchronously set given the children {@code watcher} on the given {@code path},
+     * returning a future which completes when the watcher is subscribed.
      * A subsequent call to {@link #children(String, Handler)} with the same path will register the child {@code watcher}
      * for the given {@code path} current at that time with zookeeper so
      * that that {@code watcher} is called when the children of the given {@code path} change.
@@ -88,12 +89,13 @@ public interface Zk {
     Zk getData(String path, Handler<AsyncResult<byte[]>> handler);
 
     /**
-     * Set given the data {@code watcher} on the given {@code path}.
+     * Asynchronously set given the data {@code watcher} on the given {@code path},
+     * returning a future which completes when the watcher is subscribed.
      * A subsequent call to {@link #getData(String, Handler)} with the same path will register the data {@code watcher}
      * for the given {@code path} current at that time with zookeeper so
      * that that {@code watcher} is called when the data of the given {@code path} changes.
      */
-    Zk watchData(String path, Handler<AsyncResult<byte[]>> watcher);
+    Future<Zk> watchData(String path, Handler<AsyncResult<byte[]>> watcher);
 
     /**
      * Remove the data watcher, if any, for the given {@code path}.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.topic.zk;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.I0Itec.zkclient.ZkClient;
@@ -73,7 +74,7 @@ public interface Zk {
      * for the given {@code path} current at that time with zookeeper so
      * that that {@code watcher} is called when the children of the given {@code path} change.
      */
-    Zk watchChildren(String path, Handler<AsyncResult<List<String>>> watcher);
+    Future<Zk> watchChildren(String path, Handler<AsyncResult<List<String>>> watcher);
 
     /**
      * Remove the children watcher, if any, for the given {@code path}.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
@@ -13,7 +13,6 @@ import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
-import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
@@ -41,9 +40,9 @@ public class ZkImpl implements Zk {
     private final ConcurrentHashMap<String, IZkDataListener> dataWatches = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, IZkChildListener> childWatches = new ConcurrentHashMap<>();
 
-    public ZkImpl(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
+    public ZkImpl(Vertx vertx, ZkClient zkClient) {
         this.vertx = vertx;
-        this.zookeeper = new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout, new BytesPushThroughSerializer());
+        this.zookeeper = zkClient;
     }
 
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
@@ -198,7 +198,8 @@ public class ZkImpl implements Zk {
     }
 
     @Override
-    public Zk watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
+    public Future<Zk> watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
+        Future<Zk> result = Future.future();
         workerPool().executeBlocking(
             future -> {
                 try {
@@ -210,8 +211,15 @@ public class ZkImpl implements Zk {
                     future.fail(t);
                 }
             },
-            log("watchChildren"));
-        return this;
+            ar -> {
+                log("watchChildren").handle(ar);
+                if (ar.succeeded()) {
+                    result.complete(this);
+                } else {
+                    result.fail(ar.cause());
+                }
+            });
+        return result;
     }
 
     @Override

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
@@ -81,9 +81,9 @@ class MockZk implements Zk {
     }
 
     @Override
-    public Zk watchData(String path, Handler<AsyncResult<byte[]>> watcher) {
+    public Future<Zk> watchData(String path, Handler<AsyncResult<byte[]>> watcher) {
         dataHandlers.put(path, watcher);
-        return this;
+        return Future.succeededFuture(this);
     }
 
     @Override

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
@@ -63,9 +63,9 @@ class MockZk implements Zk {
     }
 
     @Override
-    public Zk watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
+    public Future<Zk> watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
         childrenHandler = watcher;
-        return this;
+        return Future.succeededFuture(this);
     }
 
     @Override

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -11,6 +11,8 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -20,7 +22,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -37,10 +38,10 @@ public class ZkTopicStoreTest {
 
     @Before
     public void setup()
-            throws IOException, InterruptedException,
-            TimeoutException, ExecutionException {
+            throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
-        zk = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
+        zk = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
+                new BytesPushThroughSerializer()));
         this.store = new ZkTopicStore(zk);
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -4,15 +4,13 @@
  */
 package io.strimzi.operator.topic;
 
-import io.strimzi.operator.topic.zk.ZkImpl;
+import io.strimzi.operator.topic.zk.Zk;
 import io.strimzi.test.EmbeddedZooKeeper;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -34,14 +32,13 @@ public class ZkTopicStoreTest {
     private Vertx vertx = Vertx.vertx();
 
     private ZkTopicStore store;
-    private ZkImpl zk;
+    private Zk zk;
 
     @Before
     public void setup()
             throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
-        zk = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
-                new BytesPushThroughSerializer()));
+        zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
         this.store = new ZkTopicStore(zk);
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -9,6 +9,8 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.junit.After;
 import org.junit.Before;
@@ -18,8 +20,6 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -30,15 +30,14 @@ public class ZkImplTest {
     private EmbeddedZooKeeper zkServer;
 
     private Vertx vertx = Vertx.vertx();
-    private ZkImpl zk;
+    private Zk zk;
 
     @Before
     public void setup()
-            throws IOException, InterruptedException,
-            TimeoutException, ExecutionException {
+            throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
-
-        zk = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
+        zk = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
+                new BytesPushThroughSerializer()));
     }
 
     @After
@@ -55,7 +54,8 @@ public class ZkImplTest {
     @Ignore
     @Test
     public void testReconnectOnBounce(TestContext context) throws IOException, InterruptedException {
-        ZkImpl zkImpl = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
+        ZkImpl zkImpl = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
+                new BytesPushThroughSerializer()));
         zkServer.restart();
         Async async = context.async();
         zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -9,8 +9,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.junit.After;
 import org.junit.Before;
@@ -36,8 +34,7 @@ public class ZkImplTest {
     public void setup()
             throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
-        zk = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
-                new BytesPushThroughSerializer()));
+        zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
     }
 
     @After
@@ -54,8 +51,7 @@ public class ZkImplTest {
     @Ignore
     @Test
     public void testReconnectOnBounce(TestContext context) throws IOException, InterruptedException {
-        ZkImpl zkImpl = new ZkImpl(vertx, new ZkClient(zkServer.getZkConnectString(), 60_000, 10_000,
-                new BytesPushThroughSerializer()));
+        Zk zkImpl = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
         zkServer.restart();
         Async async = context.async();
         zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -116,12 +116,15 @@ public class ZkImplTest {
         byte[] data2 = {2};
         zk.watchData("/foo", dataWatch -> {
             context.assertTrue(Arrays.equals(data2, dataWatch.result()));
-        }).getData("/foo", dataResult -> {
-            context.assertTrue(Arrays.equals(data1, dataResult.result()));
+        }).compose(zk2 -> {
+            zk.getData("/foo", dataResult -> {
+                context.assertTrue(Arrays.equals(data1, dataResult.result()));
 
-            zk.setData("/foo", data2, -1, setResult -> {
-                done.complete();
+                zk.setData("/foo", data2, -1, setResult -> {
+                    done.complete();
+                });
             });
+            return Future.succeededFuture();
         });
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This avoids an ugly warning message being printed in the log.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

