### PR TITLE
Make it possible to set zk timeout in kafka conf

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -22,9 +22,11 @@ public class KafkaConfiguration extends AbstractConfiguration {
     public static final String LOG_MESSAGE_FORMAT_VERSION = "log.message.format.version";
 
     private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> EXCEPTIONS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIXES.split(", "));
+        EXCEPTIONS = asList("zookeeper.connection.timeout.ms");
     }
 
     /**
@@ -45,7 +47,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS);
     }
 
     private KafkaConfiguration(String configuration, List<String> forbiddenOptions) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -16,6 +16,7 @@ import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractConfigurationTest {
@@ -217,6 +218,24 @@ public class AbstractConfigurationTest {
 
         AbstractConfiguration config = new TestConfiguration(configuration);
         assertEquals(expectedConfiguration, config.asOrderedProperties());
+    }
+
+    @Test
+    public void testKafkaZookeeperTimeout() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("valid", "validValue");
+        conf.put("zookeeper.connection.whatever", "invalid");
+        conf.put("security.invalid1", "invalid");
+        conf.put("zookeeper.connection.timeout.ms", "42"); // valid
+        conf.put("zookeeper.connection.timeout", "42"); // invalid
+
+        KafkaConfiguration kc = new KafkaConfiguration(conf.entrySet());
+
+        assertEquals("validValue", kc.asOrderedProperties().asMap().get("valid"));
+        assertNull(kc.asOrderedProperties().asMap().get("zookeeper.connection.whatever"));
+        assertNull(kc.asOrderedProperties().asMap().get("security.invalid1"));
+        assertEquals("42", kc.asOrderedProperties().asMap().get("zookeeper.connection.timeout.ms"));
+        assertNull(kc.asOrderedProperties().asMap().get("zookeeper.connection.timeout"));
     }
 }
 


### PR DESCRIPTION
### Type of change

- Bugfix


### Description
It seems that users cannot configure the `zookeeper.connection.timeout.ms` (https://kafka.apache.org/documentation/#configuration) today, because it starts with `zookeeper.connect` which is forbidden config. However, the connection timeout is something what the users might want / need to configure. We should make sure it is allowed.

### Checklist

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

