### PR TITLE
Fix NPE in log message - Closes #1336

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1678,8 +1678,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             final int podGeneration = StatefulSetOperator.getPodGeneration(pod);
 
             if (pod == null)    {
-                log.debug("Rolling update of {}/{}: pod doesn't exist",
-                        ss.getMetadata().getNamespace(), ss.getMetadata().getName());
+                log.debug("Rolling update of {}/{}: pod doesn't exist; ss has {}={}",
+                        ss.getMetadata().getNamespace(), ss.getMetadata().getName(),
+                        StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, ssGeneration);
             } else {
                 log.debug("Rolling update of {}/{}: pod {} has {}={}; ss has {}={}",
                         ss.getMetadata().getNamespace(), ss.getMetadata().getName(), pod.getMetadata().getName(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1674,6 +1674,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         private boolean isPodUpToDate(StatefulSet ss, Pod pod) {
+            if (pod == null)    {
+                log.debug("Rolling update of {}/{}: pod doesn't exist",
+                        ss.getMetadata().getNamespace(), ss.getMetadata().getName());
+                return false;
+            }
+
             final int ssGeneration = StatefulSetOperator.getSsGeneration(ss);
             final int podGeneration = StatefulSetOperator.getPodGeneration(pod);
             log.debug("Rolling update of {}/{}: pod {} has {}={}; ss has {}={}",

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1674,18 +1674,19 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         private boolean isPodUpToDate(StatefulSet ss, Pod pod) {
+            final int ssGeneration = StatefulSetOperator.getSsGeneration(ss);
+            final int podGeneration = StatefulSetOperator.getPodGeneration(pod);
+
             if (pod == null)    {
                 log.debug("Rolling update of {}/{}: pod doesn't exist",
                         ss.getMetadata().getNamespace(), ss.getMetadata().getName());
-                return false;
+            } else {
+                log.debug("Rolling update of {}/{}: pod {} has {}={}; ss has {}={}",
+                        ss.getMetadata().getNamespace(), ss.getMetadata().getName(), pod.getMetadata().getName(),
+                        StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, podGeneration,
+                        StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, ssGeneration);
             }
 
-            final int ssGeneration = StatefulSetOperator.getSsGeneration(ss);
-            final int podGeneration = StatefulSetOperator.getPodGeneration(pod);
-            log.debug("Rolling update of {}/{}: pod {} has {}={}; ss has {}={}",
-                    ss.getMetadata().getNamespace(), ss.getMetadata().getName(), pod.getMetadata().getName(),
-                    StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, podGeneration,
-                    StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, ssGeneration);
             return ssGeneration == podGeneration;
         }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the Pod doesn't exist and we are checking for its generation and the need of rolling update we check it for null when extracting the generation but not when logging the debug message. This causes the NPE described in #1336.