### PR TITLE
Fix the deployment and docs of the standalone UO - Closes #903

### DIFF
--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -16,8 +16,10 @@ For instance it can operate _with_ any Kafka cluster, not only the one deployed 
 
 . Edit the `install/user-operator/05-Deployment-strimzi-user-operator.yaml` resource. You will need to change the following
 +
-.. The `STRIMZI_CA_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} `Secret` which should contain the Certificate Authority for signing new user certificates for TLS Client Authentication.
-The `Secret` should contain the public key of the Certificate Authority under the key `clients-ca.crt` and the private key under `clients-ca.key`.
+.. The `STRIMZI_CA_CERT_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} `Secret` which should contain the public key of the Certificate Authority for signing new user certificates for TLS Client Authentication.
+The `Secret` should contain the public key of the Certificate Authority under the key `ca.crt`.
+.. The `STRIMZI_CA_KEY_NAME` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to point to an {ProductPlatformName} `Secret` which should contain the private key of the Certificate Authority for signing new user certificates for TLS Client Authentication.
+The `Secret` should contain the private key of the Certificate Authority under the key `ca.key`.
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
 

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -22,7 +22,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: STRIMZI_LABELS
               value: "strimzi.io/cluster=my-cluster"
-            - name: STRIMZI_CA_NAME
+            - name: STRIMZI_CA_CERT_NAME
+              value: my-cluster-clients-ca-cert
+            - name: STRIMZI_CA_KEY_NAME
               value: my-cluster-clients-ca
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
@@ -32,6 +34,12 @@ spec:
               value: "20000"
             - name: STRIMZI_LOG_LEVEL
               value: INFO
+            - name: STRIMZI_GC_LOG_ENABLED
+              value: "true"
+            - name: STRIMZI_CA_VALIDITY
+              value: "365"
+            - name: STRIMZI_CA_RENEWAL
+              value: "30"
           livenessProbe:
             httpGet:
               path: /healthy


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The standalone deployment of the User Operator seems to use some old environment variables. In particular `STRIMZI_CA_NAME` with name of a secret containing both public and private key doesn't exist anymore. Instead we use `STRIMZI_CA_KEY_NAME` and `STRIMZI_CA_CERT_NAME`. This PR updates the deployment in installation files and the docs. This should close #903.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally