### PR TITLE
Add explanation about NodePort hostname verification to FAQ

### DIFF
--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -74,7 +74,7 @@ restart the cluster operator.
 === Hostname verification fails when connecting to NodePorts using TLS
 
 Currently, off-cluster access using NodePorts with TLS encryption enabled does not support TLS hostname verification.
-As a result, the clients which verify the hostname will fail to connect.
+As a result, the clients that verify the hostname will fail to connect.
 For example the Java client will fail with following exception:
 
 [source,java]

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -75,7 +75,7 @@ restart the cluster operator.
 
 Off cluster access using NodePorts with enabled TLS encryption currently does not support TLS hostname verification.
 As a result, the clients which verify the hostname will fail to connect.
-For examle the Java client will fail with following exception:
+For example the Java client will fail with following exception:
 
 [source,java]
 Caused by: java.security.cert.CertificateException: No subject alternative names matching IP address 168.72.15.231 found

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -88,7 +88,7 @@ Caused by: java.security.cert.CertificateException: No subject alternative names
     at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1501)
     ... 17 more
 
-In odrer to connect, you have to disable the hostname verification.
+To connect, you must disable hostname verification.
 In the Java client you can do it using the configuration option `ssl.endpoint.identification.algorithm`.
 To disable hostname verification, set this option to empty string.
 

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -92,7 +92,7 @@ To connect, you must disable hostname verification.
 In the Java client, you can do this by setting the configuration option `ssl.endpoint.identification.algorithm` to an empty string.
 To disable hostname verification, set this option to empty string.
 
-When configuring the client using properties file, it can be done like this:
+When configuring the client using a properties file, you can do it this way:
 
 [source,properties]
 ssl.endpoint.identification.algorithm=

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -90,7 +90,6 @@ Caused by: java.security.cert.CertificateException: No subject alternative names
 
 To connect, you must disable hostname verification.
 In the Java client, you can do this by setting the configuration option `ssl.endpoint.identification.algorithm` to an empty string.
-To disable hostname verification, set this option to empty string.
 
 When configuring the client using a properties file, you can do it this way:
 

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -71,5 +71,33 @@ Should this message appear periodically even in situations when there should be 
 cluster, it might indicate that due to some error the lock was not properly released. In such cases it is recommended to
 restart the cluster operator.
 
+=== Hostname verification fails when connecting to NodePorts using TLS
 
+Off cluster access using NodePorts with enabled TLS encryption currently does not support TLS hostname verification.
+As a result, the clients which verify the hostname will fail to connect.
+For examle the Java client will fail with following exception:
 
+[source,java]
+Caused by: java.security.cert.CertificateException: No subject alternative names matching IP address 168.72.15.231 found
+    at sun.security.util.HostnameChecker.matchIP(HostnameChecker.java:168)
+    at sun.security.util.HostnameChecker.match(HostnameChecker.java:94)
+    at sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:455)
+    at sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:436)
+    at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:252)
+    at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:136)
+    at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1501)
+    ... 17 more
+
+In odrer to connect, you have to disable the hostname verification.
+In the Java client you can do it using the configuration option `ssl.endpoint.identification.algorithm`.
+To disable hostname verification, set this option to empty string.
+
+When configuring the client using properties file, it can be done like this:
+
+[source,properties]
+ssl.endpoint.identification.algorithm=
+
+When configuring the client directly in Java, set it to empty string:
+
+[source,java]
+props.put("ssl.endpoint.identification.algorithm", "");

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -89,7 +89,7 @@ Caused by: java.security.cert.CertificateException: No subject alternative names
     ... 17 more
 
 To connect, you must disable hostname verification.
-In the Java client you can do it using the configuration option `ssl.endpoint.identification.algorithm`.
+In the Java client, you can do this by setting the configuration option `ssl.endpoint.identification.algorithm` to an empty string.
 To disable hostname verification, set this option to empty string.
 
 When configuring the client using properties file, it can be done like this:

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -97,7 +97,7 @@ When configuring the client using a properties file, you can do it this way:
 [source,properties]
 ssl.endpoint.identification.algorithm=
 
-When configuring the client directly in Java, set it to empty string:
+When configuring the client directly in Java, set the configuration option to an empty string:
 
 [source,java]
 props.put("ssl.endpoint.identification.algorithm", "");

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -75,7 +75,7 @@ restart the cluster operator.
 
 Currently, off-cluster access using NodePorts with TLS encryption enabled does not support TLS hostname verification.
 As a result, the clients that verify the hostname will fail to connect.
-For example the Java client will fail with following exception:
+For example, the Java client will fail with the following exception:
 
 [source,java]
 Caused by: java.security.cert.CertificateException: No subject alternative names matching IP address 168.72.15.231 found

--- a/documentation/book/faq.adoc
+++ b/documentation/book/faq.adoc
@@ -73,7 +73,7 @@ restart the cluster operator.
 
 === Hostname verification fails when connecting to NodePorts using TLS
 
-Off cluster access using NodePorts with enabled TLS encryption currently does not support TLS hostname verification.
+Currently, off-cluster access using NodePorts with TLS encryption enabled does not support TLS hostname verification.
 As a result, the clients which verify the hostname will fail to connect.
 For example the Java client will fail with following exception:
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

After several questions I decided to add to the FAQ in our documentation a new section about hostname verification on node ports (which is not supported) and describe how to disable it.

### Checklist

- [x] Update documentation