### PR TITLE
Provided clients CA cert namespace to the UO

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -43,6 +43,7 @@ public class EntityUserOperator extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
     public static final String ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
+    public static final String ENV_VAR_CLIENTS_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
     public static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
     public static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
 
@@ -224,6 +225,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Long.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCaKeySecretName(cluster)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsCaCertSecretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_NAMESPACE, namespace));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -76,6 +76,7 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(uoZookeeperSessionTimeout * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME).withValue(KafkaCluster.clientsCaKeySecretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaCertSecretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAMESPACE).withValue(namespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(KafkaCluster.DEFAULT_STRIMZI_GC_LOG_ENABED).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_VALIDITY).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS)).build());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If the UO is deployed in a namespace (where all certificates live) but it's configured to watch for users in a different one, when a new user is created in that namespace the following exception is raised:

```
io.strimzi.operator.user.model.NoCertificateSecretException: The Clients CA Cert Secret is missing
        at io.strimzi.operator.user.model.KafkaUserModel.maybeGenerateCertificates(KafkaUserModel.java:135) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.strimzi.operator.user.model.KafkaUserModel.fromCrd(KafkaUserModel.java:89) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.strimzi.operator.user.operator.KafkaUserOperator.createOrUpdate(KafkaUserOperator.java:120) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.strimzi.operator.user.operator.KafkaUserOperator.lambda$reconcile$2(KafkaUserOperator.java:190) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.vertx.core.shareddata.impl.LocalAsyncLocks$LockWaiter.lambda$acquireLock$1(LocalAsyncLocks.java:65) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339) ~[user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463) [user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [user-operator-0.11.0-SNAPSHOT.jar:0.11.0-SNAPSHOT]
```

It's due to the missing namespace env var where the clients CA can be found by the UO.
This PR fixes the bug.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

