### PR TITLE
Fixed Strimzi backup command

### DIFF
--- a/documentation/book/proc-upgrading-the-cluster-operator.adoc
+++ b/documentation/book/proc-upgrading-the-cluster-operator.adoc
@@ -29,14 +29,14 @@ ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl get`:
 +
 ----
-kubectl get -l app=strimzi > strimzi-backup.yaml
+kubectl get all -l app=strimzi > strimzi-backup.yaml
 ----
 +
 endif::Kubernetes[]
 On {OpenShiftName} use `oc get`:
 +
 ----
-oc get -l app=strimzi > strimzi-backup.yaml
+oc get all -l app=strimzi > strimzi-backup.yaml
 ----
 
 . Update the Cluster Operator. 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The current command for doing Strimzi backup has the `all` option missing and returns the following error if executed as it is:

```
oc get -l app=strimzi-ephemeral > strimzi-backup.yaml
You must specify the type of resource to get. Use "oc api-resources" for a complete list of supported resources.

error: Required resource not specified.
Use "oc explain <resource>" for a detailed description of that resource (e.g. oc explain pods).
See 'oc get -h' for help and examples.
```

This PR fixes the problem.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

