### PR TITLE
Removed reference to kind=topic as label for TO watcher

### DIFF
--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -16,8 +16,8 @@ spec:
         - name: strimzi-topic-operator
           image: strimzi/topic-operator:latest
           env:
-            - name: STRIMZI_CONFIGMAP_LABELS
-              value: "strimzi.io/kind=topic"
+            - name: STRIMZI_RESOURCE_LABELS
+              value: "strimzi.io/cluster=my-cluster"
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_ZOOKEEPER_CONNECT

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -109,7 +109,7 @@ public class Config {
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
     /** A comma-separated list of key=value pairs for selecting Resources that describe topics. */
-    public static final Value<LabelPredicate> LABELS = new Value<>(TC_RESOURCE_LABELS, LABEL_PREDICATE, "strimzi.io/kind=topic");
+    public static final Value<LabelPredicate> LABELS = new Value<>(TC_RESOURCE_LABELS, LABEL_PREDICATE, "strimzi.io/cluster=my-cluster");
 
     /** A comma-separated list of kafka bootstrap servers. */
     public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value<>(TC_KAFKA_BOOTSTRAP_SERVERS, STRING, true);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -109,7 +109,7 @@ public class Config {
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
     /** A comma-separated list of key=value pairs for selecting Resources that describe topics. */
-    public static final Value<LabelPredicate> LABELS = new Value<>(TC_RESOURCE_LABELS, LABEL_PREDICATE, "strimzi.io/cluster=my-cluster");
+    public static final Value<LabelPredicate> LABELS = new Value<>(TC_RESOURCE_LABELS, LABEL_PREDICATE, "");
 
     /** A comma-separated list of kafka bootstrap servers. */
     public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value<>(TC_KAFKA_BOOTSTRAP_SERVERS, STRING, true);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -75,7 +75,7 @@ public class TopicOperatorIT extends BaseITST {
     private static String oldNamespace;
 
     private final LabelPredicate resourcePredicate = LabelPredicate.fromString(
-            "strimzi.io/kind=topic");
+            "strimzi.io/cluster=my-cluster");
 
     public static final String NAMESPACE = "topic-operator-it";
 
@@ -597,7 +597,7 @@ public class TopicOperatorIT extends BaseITST {
         operation().inNamespace(NAMESPACE).create(topicResource);
 
         waitForEvent(context, topicResource,
-                "Failure processing KafkaTopic watch event ADDED on resource two-resources-one-topic with labels {strimzi.io/kind=topic}: " +
+                "Failure processing KafkaTopic watch event ADDED on resource two-resources-one-topic with labels {strimzi.io/cluster=my-cluster}: " +
                         "Topic 'two-resources-one-topic' is already managed via KafkaTopic 'two-resources-one-topic-1' it cannot also be managed via the KafkaTopic 'two-resources-one-topic'",
                 TopicOperator.EventType.WARNING);
     }


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

It's not actually a bug but the TO still has a reference to use `strimzi.io/kind=topic` as default value for the `STRIMZI_RESOURCE_LABELS` env var while with CRD this label doesn't exist anymore.
It's a bug instead for the standalone deployment of the TO where the old `STRIMZI_CONFIGMAP_LABELS` is still used.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

