### PR TITLE
Added label app=strimzi to the strimzi-admin cluster role

### DIFF
--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: strimzi-admin
+  labels:
+    app: strimzi
 rules:
 - apiGroups:
   - "kafka.strimzi.io"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As we have for other cluster roles it's useful having the `app: strimzi` label on the `strimzi-admin` as well.
It's useful when deleting all the stuff related to Strimzi for example filtering by that `app` label value.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

