### PR TITLE
Fix wrong Linux assumption which doesn't skip tests

### DIFF
--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public final class TestUtils {
 

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -338,10 +338,6 @@ public final class TestUtils {
         }
     }
 
-    public static void assumeLinux() {
-        assumeTrue(System.getProperty("os.name").contains("nux"));
-    }
-
     /** Map Streams utility methods */
     public static <K, V> Map.Entry<K, V> entry(K key, V value) {
         return new AbstractMap.SimpleEntry<>(key, value);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.topic;
 
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
@@ -10,6 +10,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -110,7 +111,7 @@ public class TopicOperatorAssignedKafkaImplTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        TestUtils.assumeLinux();
+        Assume.assumeTrue(System.getProperty("os.name").contains("nux") || System.getProperty("os.name").contains("Mac OS X"));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The TO tests seem to be using the `TestUtils.assumeLinux()` method. But since the `test` module is JUnit5 now it does work and it reports the tests as failed. (see #1319)

This PR removes `TestUtils.assumeLinux()` method to avoid this in the future (it is not used anywhere else) and replaces it with local code. Additionally, this actually works on MacOS X, so I enabled this on MacOs X as well.