### PR TITLE
Fix typo in Connect external configuration example

### DIFF
--- a/documentation/book/con-kafka-connect-external-configuration.adoc
+++ b/documentation/book/con-kafka-connect-external-configuration.adoc
@@ -83,9 +83,9 @@ spec:
       - name: connector1
         configMap:
           name: connector1-configuration
-    - name: connector1-certificates
-      secret:
-        secretName: connector1-certificates
+      - name: connector1-certificates
+        secret:
+          secretName: connector1-certificates
 ----
 
 The volumes will be mounted inside the Kafka Connect containers in the path `/opt/kafka/external-configuration/_<volume-name>_`.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

There seems to be a simple typo in alignment in the example with Kafka Connect external configuration