### PR TITLE
ST: Make image name more configurable

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -226,3 +226,5 @@ To set the log level of Strimzi for system tests need to add system property `TE
 ### Docker image names in ST
 
 To set specific prefix or suffix to the image name need to add system property `DOCKER_IMAGE_PREFIX` or `DOCKER_IMAGE_SUFFIX`
+For example, `image strimzi/cluster-operator:latest` will have following update:
+If add `DOCKER_IMAGE_PREFIX=custom-prefix-` and `DOCKER_IMAGE_SUFFIX-custom-suffix` as a result will be `strimzi/custom-prefix-cluster-operator-custom-suffix:latest`

--- a/HACKING.md
+++ b/HACKING.md
@@ -196,9 +196,8 @@ It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositor
 
 To execute an expected group of system tests need to add system property `junitTags` with following value:
 
-`-DjunitTags=integration` - to execute one test group
+`-DjunitTags=acceptance` - to execute one test group
 `-DjunitTags=acceptance,regression` - to execute many test groups
-`-DjunitTags=all` - to execute all test groups
 
 If `junitTags` system property isn't defined, all tests without an explicitly declared test group will be executed.
 
@@ -223,3 +222,7 @@ Ex)
 ### Log level
 
 To set the log level of Strimzi for system tests need to add system property `TEST_STRIMZI_LOG_LEVEL` with one of the following values: `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`.
+
+### Docker image names in ST
+
+To set specific prefix or suffix to the image name need to add system property `DOCKER_IMAGE_PREFIX` or `DOCKER_IMAGE_SUFFIX`

--- a/HACKING.md
+++ b/HACKING.md
@@ -226,5 +226,5 @@ To set the log level of Strimzi for system tests need to add system property `TE
 ### Docker image names in ST
 
 To set specific prefix or suffix to the image name need to add system property `DOCKER_IMAGE_PREFIX` or `DOCKER_IMAGE_SUFFIX`
-For example, `image strimzi/cluster-operator:latest` will have following update:
-If add `DOCKER_IMAGE_PREFIX=custom-prefix-` and `DOCKER_IMAGE_SUFFIX-custom-suffix` as a result will be `strimzi/custom-prefix-cluster-operator-custom-suffix:latest`
+An example with image `image strimzi/cluster-operator:latest`:
+If add `DOCKER_IMAGE_PREFIX=custom-prefix-` and `DOCKER_IMAGE_SUFFIX=-custom-suffix` as a result will be `strimzi/custom-prefix-clusteroperator-custom-suffix:latest`

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -402,11 +402,16 @@ public final class TestUtils {
             ObjectNode containerNode = (ObjectNode) node.at("/spec/template/spec/containers").get(0);
             for (JsonNode envVar : containerNode.get("env")) {
                 String varName = envVar.get("name").textValue();
+                String varValue = envVar.get("value").textValue();
                 if (varName.matches("STRIMZI_NAMESPACE")) {
-                    // Replace all the default images with ones from the $DOCKER_ORG org and with the $DOCKER_TAG tag
                     ((ObjectNode) envVar).remove("valueFrom");
                     ((ObjectNode) envVar).put("value", namespace);
                 }
+                // Replace all the default images with ones from the $DOCKER_ORG org and with the $DOCKER_TAG tag
+                if (varName.contains("IMAGE")) {
+                    ((ObjectNode) envVar).put("value", changeOrgAndTag(varValue));
+                }
+
             }
             return mapper.writeValueAsString(node);
         } catch (IOException e) {

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -152,15 +152,19 @@ public final class TestUtils {
     public static String changeOrgAndTag(String image, String newOrg, String newTag, String kafkaVersion, String imagePrefix, String imageSuffix) {
         // Update image name with prefix and suffix if needed
         if (imagePrefix != null || imageSuffix != null) {
-            Matcher imageNameMatcher = IMAGE_NAME_PATTERN.matcher(image);
-            if (imageNameMatcher.find()) {
-                String imageName = imageNameMatcher.group(1);
+            Matcher m = IMAGE_NAME_PATTERN.matcher(image);
+            StringBuffer sb = new StringBuffer();
+            if (m.find()) {
+                String imageName = m.group(1);
                 String processedImageName = ((imagePrefix == null) ? "" : imagePrefix)
                         + imageName.replaceAll("-", "")
                         + ((imageSuffix == null) ? "" : imageSuffix);
-                image = image.replaceAll(imageName, processedImageName);
+                m.appendReplacement(sb, m.group(0).replaceFirst(Pattern.quote(m.group(1)), processedImageName));
+                m.appendTail(sb);
+                image = sb.toString();
             }
         }
+        // Update image org and image tag
         image = image.replaceFirst("^strimzi/", newOrg + "/");
         Matcher m = KAFKA_COMPONENT_PATTERN.matcher(image);
         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
In some cases, we need to have custom prefix and suffix for image name and this is a reason of changes in this PR. So now we have two system properties `DOCKER_IMAGE_PREFIX` or `DOCKER_IMAGE_SUFFIX` which we can use to configure the image name.
Also in this PR was fixed hardcoded image name during CO deployment process.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

