### PR TITLE
Disable TopicOperatorAssignedKafkaImplTest on travis

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
@@ -111,6 +111,7 @@ public class TopicOperatorAssignedKafkaImplTest {
     @BeforeClass
     public static void setUp() throws Exception {
         Assume.assumeTrue(System.getProperty("os.name").contains("nux") || System.getProperty("os.name").contains("Mac OS X"));
+        Assume.assumeTrue(System.getenv("TRAVIS") == null);
     }
 
     @Test


### PR DESCRIPTION


### Type of change

- Refactoring


### Description

Disable TopicOperatorAssignedKafkaImplTest on travis. TopicOperatorAssignedKafkaImplTest seems to be very flaky when run on Travis (it runs reliably locally for me). I believe this is acceptable because in practice the TO doesn't support RF change anyway, so not running the test for this not-yet-used functionality does not really represent a reduction of test coverage.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

