### PR TITLE
Add verison property to Kafka Connect example in metrics

### DIFF
--- a/metrics/examples/kafka/kafka-connect-metrics.yaml
+++ b/metrics/examples/kafka/kafka-connect-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: my-connect-cluster
 spec:
+  version: 2.1.1
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9092
   metrics:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The KafkaConnect example in metrics does not specify Kafka version. This PR adds it there.