### PR TITLE
Fix NPE when only bootstrap overrides are specified for an external listener

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1187,19 +1187,19 @@ public class KafkaCluster extends AbstractModel {
         if (isExposedWithNodePort()) {
             NodePortListenerOverride overrides = ((KafkaListenerExternalNodePort) listeners.getExternal()).getOverrides();
 
-            if (overrides != null) {
+            if (overrides != null && overrides.getBrokers() != null) {
                 brokerOverride.addAll(overrides.getBrokers());
             }
         } else if (isExposedWithLoadBalancer()) {
             LoadBalancerListenerOverride overrides = ((KafkaListenerExternalLoadBalancer) listeners.getExternal()).getOverrides();
 
-            if (overrides != null) {
+            if (overrides != null && overrides.getBrokers() != null) {
                 brokerOverride.addAll(overrides.getBrokers());
             }
         } else if (isExposedWithRoute()) {
             RouteListenerOverride overrides = ((KafkaListenerExternalRoute) listeners.getExternal()).getOverrides();
 
-            if (overrides != null) {
+            if (overrides != null && overrides.getBrokers() != null) {
                 brokerOverride.addAll(overrides.getBrokers());
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When external listener has `overrides` property with only `bootstrap` configured, it would run onto NPEs. This PR adds additional null checks and fixes this.