### PR TITLE
[DOC] Repeated information in the Kafka Broker Listeners section

### DIFF
--- a/documentation/book/con-mutual-tls-authentication.adoc
+++ b/documentation/book/con-mutual-tls-authentication.adoc
@@ -10,9 +10,7 @@
 
 Mutual authentication or two-way authentication is when both the server and the client present certificates. {ProductName} can configure Kafka to use TLS (Transport Layer Security) to provide encrypted communication between Kafka brokers and clients either with or without mutual authentication. When you configure mutual authentication, the broker authenticates the client and the client authenticates the broker. Mutual TLS authentication is always used for the communication between Kafka brokers and Zookeeper pods.
 
-NOTE: In many common uses of TLS (such as the HTTPS protocol used between a web browser and a web server) the authentication is not mutual: Only one party to the communication gets proof of the identity of the other party.
-
-TLS authentication is more commonly one-way, where only one party authenticates to another. For example, when the HTTPS protocol is used between a web browser and a web server, the authentication is not usually mutual and only the server  gets proof of the identity of the browser.
+NOTE: TLS authentication is more commonly one-way, with one party authenticating the identity of another. For example, when HTTPS is used between a web browser and a web server, the server obtains proof of the identity of the browser.
 
 == When to use mutual TLS authentication for clients
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Update to remove repeated information on HTTPS non-mutual authentication and have all the information in a note.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

