### PR TITLE
Fix Docs: Kafka Version Table for Upgrade

### DIFF
--- a/documentation/book/proc-upgrading-brokers-newer-kafka.adoc
+++ b/documentation/book/proc-upgrading-brokers-newer-kafka.adoc
@@ -18,7 +18,7 @@ This procedure describes how to upgrade a {ProductName} Kafka cluster from one v
 
 . Consult the table below and determine whether the new Kafka version has a different log message format version than the previous version. 
 +
-{blank}include::snip-kafka-versions.adoc[leveloffset=+1]
+include::snip-kafka-versions.adoc[leveloffset=+1]
 +
 If the log message format versions are the same proceed to the next step. 
 Otherwise, ensure the `Kafka.spec.kafka.config` has the `log.message.format.version` configured to the default for the previous version.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_
The  Kafka Version Table for Upgrade Process is not visible correctly in the latest documentation, it was visible correctly for 0.10.0 release though. This PR fixes this.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

