### PR TITLE
Improve log message when the version field contain unsupported Kafka version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -282,7 +282,7 @@ public class KafkaCluster extends AbstractModel {
         result.setReplicas(kafkaClusterSpec.getReplicas());
         String image = versions.kafkaImage(kafkaClusterSpec.getImage(), kafkaClusterSpec.getVersion());
         if (image == null) {
-            throw new InvalidResourceException("Version is not supported");
+            throw new InvalidResourceException("Version " + kafkaClusterSpec.getVersion() + " is not supported");
         }
         result.setImage(image);
         if (kafkaClusterSpec.getReadinessProbe() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -282,7 +282,7 @@ public class KafkaCluster extends AbstractModel {
         result.setReplicas(kafkaClusterSpec.getReplicas());
         String image = versions.kafkaImage(kafkaClusterSpec.getImage(), kafkaClusterSpec.getVersion());
         if (image == null) {
-            throw new InvalidResourceException("Version " + kafkaClusterSpec.getVersion() + " is not supported");
+            throw new InvalidResourceException("Version " + kafkaClusterSpec.getVersion() + " is not supported. Supported versions are: " + String.join(", ", versions.supportedVersions()) + ".");
         }
         result.setImage(image);
         if (kafkaClusterSpec.getReadinessProbe() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -147,7 +147,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 versions.kafkaConnectS2iVersion(spec.getImage(), spec.getVersion())
                 : versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
         if (image == null) {
-            throw new InvalidResourceException("Version is not supported");
+            throw new InvalidResourceException("Version " + spec.getVersion() + " is not supported");
         }
         kafkaConnect.setImage(image);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -147,7 +147,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 versions.kafkaConnectS2iVersion(spec.getImage(), spec.getVersion())
                 : versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
         if (image == null) {
-            throw new InvalidResourceException("Version " + spec.getVersion() + " is not supported");
+            throw new InvalidResourceException("Version " + spec.getVersion() + " is not supported. Supported versions are: " + String.join(", ", versions.supportedVersions()) + ".");
         }
         kafkaConnect.setImage(image);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -168,7 +168,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
         String image = versions.kafkaMirrorMakerImage(kafkaMirrorMaker.getSpec().getImage(), kafkaMirrorMaker.getSpec().getVersion());
         if (image == null) {
-            throw new InvalidResourceException("Version " + kafkaMirrorMaker.getSpec().getVersion() + " is not supported");
+            throw new InvalidResourceException("Version " + kafkaMirrorMaker.getSpec().getVersion() + " is not supported. Supported versions are: " + String.join(", ", versions.supportedVersions()) + ".");
         }
         kafkaMirrorMakerCluster.setImage(image);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -162,13 +162,16 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
         kafkaMirrorMakerCluster.setReplicas(kafkaMirrorMaker.getSpec() != null && kafkaMirrorMaker.getSpec().getReplicas() > 0 ? kafkaMirrorMaker.getSpec().getReplicas() : DEFAULT_REPLICAS);
 
-
         kafkaMirrorMakerCluster.setWhitelist(kafkaMirrorMaker.getSpec().getWhitelist());
         kafkaMirrorMakerCluster.setProducer(kafkaMirrorMaker.getSpec().getProducer());
         kafkaMirrorMakerCluster.setConsumer(kafkaMirrorMaker.getSpec().getConsumer());
-        kafkaMirrorMakerCluster.setImage(versions.kafkaMirrorMakerImage(
-                kafkaMirrorMaker.getSpec().getImage(),
-                kafkaMirrorMaker.getSpec().getVersion()));
+
+        String image = versions.kafkaMirrorMakerImage(kafkaMirrorMaker.getSpec().getImage(), kafkaMirrorMaker.getSpec().getVersion());
+        if (image == null) {
+            throw new InvalidResourceException("Version " + kafkaMirrorMaker.getSpec().getVersion() + " is not supported");
+        }
+        kafkaMirrorMakerCluster.setImage(image);
+
         kafkaMirrorMakerCluster.setLogging(kafkaMirrorMaker.getSpec().getLogging());
         kafkaMirrorMakerCluster.setGcLoggingEnabled(kafkaMirrorMaker.getSpec().getJvmOptions() == null ? true : kafkaMirrorMaker.getSpec().getJvmOptions().isGcLoggingEnabled());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -174,7 +174,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                 log.debug("{}: Lock {} released", reconciliation, lockName);
                                 if (createResult.failed()) {
                                     if (createResult.cause() instanceof InvalidResourceException) {
-                                        log.error(createResult.cause().getMessage());
+                                        log.error("{}: createOrUpdate failed. {}", reconciliation, createResult.cause().getMessage());
                                     } else {
                                         log.error("{}: createOrUpdate failed", reconciliation, createResult.cause());
                                     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When a user specifies incorrect Kafka version in the `version` field, following message is currently logged:
```
2019-03-01 10:02:15 ERROR AbstractAssemblyOperator:174 - Version is not supported
```

This might be misleading since it might be misunderstood for the `version` field it self not being supported. This PR tries to improve the message by adding the version number into it ... e.g. _Version 2.1.1 is not supported_.