### PR TITLE
[DOC] fix broken link

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -64,7 +64,7 @@
 
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 
-:CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.htm[cron expression^]
+:CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html[cron expression^]
 
 // Docker image names
 :DockerTag: {ProductVersion}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -64,7 +64,7 @@
 
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 
-:CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html[cron expression^]
+:CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.htm[cron expression^]
 
 // Docker image names
 :DockerTag: {ProductVersion}


### PR DESCRIPTION
### Type of change
- Documentation

### Description
The [old link](http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html) shows page with this message: `We've recently been heavily re-working the quartz-scheduler.org website, and some links have gone astray.`

