### PR TITLE
Fix rolling updates during maintenance window

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -945,9 +945,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 isPodToRestart(zkDiffs.resource(), pod, zkAncillaryCmChange, dateSupplier, this.clusterCa)
             ));
         }
-
-        /* test */
-        public void setZkAncillaryCmChange(boolean zkAncillaryCmChange) {
+        
+        /* test */ void setZkAncillaryCmChange(boolean zkAncillaryCmChange) {
             this.zkAncillaryCmChange = zkAncillaryCmChange;
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -946,6 +946,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             ));
         }
 
+        /* test */
+        public void setZkAncillaryCmChange(boolean zkAncillaryCmChange) {
+            this.zkAncillaryCmChange = zkAncillaryCmChange;
+        }
+
         /**
          * Scale up is divided by scaling up Zookeeper cluster in steps.
          * Scaling up from N to M (N > 0 and M>N) replicas is done in M-N steps.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -945,9 +945,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 isPodToRestart(zkDiffs.resource(), pod, zkAncillaryCmChange, dateSupplier, this.clusterCa)
             ));
         }
-        
+
         /* test */ void setZkAncillaryCmChange(boolean zkAncillaryCmChange) {
             this.zkAncillaryCmChange = zkAncillaryCmChange;
+        }
+
+        /* test */ void setKafkaAncillaryCmChange(boolean kafkaAncillaryCmChange) {
+            this.kafkaAncillaryCmChange = kafkaAncillaryCmChange;
         }
 
         /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -185,7 +185,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -201,7 +201,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
                 context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, false, false);
 
         async.await();
     }
@@ -217,7 +217,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -233,7 +233,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -440,7 +440,8 @@ public class MaintenanceTimeWindowsTest {
     }
 
     private void doZkRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
-                                   Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+                                   Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler, boolean caCertChanged,
+                                   boolean crChanged) {
 
         this.init(maintenanceTimeWindows);
 
@@ -453,7 +454,7 @@ public class MaintenanceTimeWindowsTest {
 
             @Override
             public boolean certRenewed() {
-                return true;
+                return caCertChanged;
             }
         };
 
@@ -461,6 +462,8 @@ public class MaintenanceTimeWindowsTest {
         z.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "1");
         this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperClusterName(NAME)).patch(z);
 
+
+        this.reconciliationState.setZkAncillaryCmChange(crChanged);
         this.reconciliationState.zkRollingUpdate(dateSupplier).setHandler(handler);
     }
 
@@ -550,5 +553,69 @@ public class MaintenanceTimeWindowsTest {
         };
 
         this.reconciliationState.topicOperatorDeployment(dateSupplier).setHandler(handler);
+    }
+
+    @Test
+    public void testZkRollingUpdateMaintenanceNotSatisfiedCertNotChangedSomethingElseIs(TestContext context) {
+
+        Async async = context.async();
+
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, false, true);
+
+        async.await();
+    }
+
+    @Test
+    public void testZkRollingUpdateMaintenanceNotSatisfiedCertChangedSomethingElseIs(TestContext context) {
+
+        Async async = context.async();
+
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, true);
+
+        async.await();
+    }
+
+    @Test
+    public void testZkRollingUpdateMaintenanceNotSatisfiedCertChangedSomethingElseIsNot(TestContext context) {
+
+        Async async = context.async();
+
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, false);
+
+        async.await();
+    }
+
+    @Test
+    public void testZkRollingUpdateMaintenanceSatisfiedCertChangedSomethingElseIsNot(TestContext context) {
+
+        Async async = context.async();
+
+        doZkRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(ZookeeperCluster.zookeeperPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, false);
+
+        async.await();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -627,12 +627,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                }, false, true);
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, false, true);
 
         async.await();
     }
@@ -643,12 +643,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                }, true, true);
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, true);
 
         async.await();
     }
@@ -659,12 +659,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
-                    context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                }, true, false);
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, false);
 
         async.await();
     }
@@ -675,12 +675,12 @@ public class MaintenanceTimeWindowsTest {
         Async async = context.async();
 
         doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
-                () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
-                r -> {
-                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
-                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
-                    async.complete();
-                }, true, false);
+            () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+            r -> {
+                String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                async.complete();
+            }, true, false);
 
         async.await();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -249,7 +249,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -265,7 +265,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
                 context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -281,7 +281,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -297,7 +297,7 @@ public class MaintenanceTimeWindowsTest {
                 String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
-            });
+            }, true, false);
 
         async.await();
     }
@@ -468,7 +468,8 @@ public class MaintenanceTimeWindowsTest {
     }
 
     private void doKafkaRollingUpdate(List<String> maintenanceTimeWindows, Supplier<Date> dateSupplier,
-                                      Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler) {
+                                      Handler<AsyncResult<KafkaAssemblyOperator.ReconciliationState>> handler,
+                                      boolean caCertChanged, boolean crChanged) {
 
         this.init(maintenanceTimeWindows);
 
@@ -482,14 +483,14 @@ public class MaintenanceTimeWindowsTest {
 
             @Override
             public boolean certRenewed() {
-                return true;
+                return caCertChanged;
             }
         };
         this.reconciliationState.clientsCa = new ClientsCa(null, null, this.clientsCaSecret, null, null, 0, 0, true, null) {
 
             @Override
             public boolean certRenewed() {
-                return false;
+                return caCertChanged;
             }
         };
 
@@ -497,6 +498,7 @@ public class MaintenanceTimeWindowsTest {
         k.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "1");
         k.getSpec().getTemplate().getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0");
         this.mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(NAME)).patch(k);
+        this.reconciliationState.setKafkaAncillaryCmChange(crChanged);
 
         this.reconciliationState.kafkaRollingUpdate(dateSupplier).setHandler(handler);
     }
@@ -615,6 +617,70 @@ public class MaintenanceTimeWindowsTest {
                 context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
                 async.complete();
             }, true, false);
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceNotSatisfiedCertNotChangedSomethingElseIs(TestContext context) {
+
+        Async async = context.async();
+
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+                r -> {
+                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                    async.complete();
+                }, false, true);
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceNotSatisfiedCertChangedSomethingElseIs(TestContext context) {
+
+        Async async = context.async();
+
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+                r -> {
+                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                    async.complete();
+                }, true, true);
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceNotSatisfiedCertChangedSomethingElseIsNot(TestContext context) {
+
+        Async async = context.async();
+
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+                () -> Date.from(LocalDateTime.of(2018, 11, 26, 11, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+                r -> {
+                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                    context.assertEquals("0", generation, "Pod had unexpected generation " + generation);
+                    async.complete();
+                }, true, false);
+
+        async.await();
+    }
+
+    @Test
+    public void testKafkaRollingUpdateMaintenanceSatisfiedCertChangedSomethingElseIsNot(TestContext context) {
+
+        Async async = context.async();
+
+        doKafkaRollingUpdate(Collections.singletonList("* * 8-10 * * ?"),
+                () -> Date.from(LocalDateTime.of(2018, 11, 26, 9, 00, 0).atZone(ZoneId.of("GMT")).toInstant()),
+                r -> {
+                    String generation = getClusterCaGenerationPod(KafkaCluster.kafkaPodName(NAME, 0));
+                    context.assertEquals("1", generation, "Pod had unexpected generation " + generation);
+                    async.complete();
+                }, true, false);
 
         async.await();
     }


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
As we agreed, during the maintenance window is opened every rolling update oxcept of CA renewal related should be performed.
Changing behaviour from 
```
+------------------+---------------+---------------+
| Rolling update?  | Widnow opened | Window closed |
+------------------+---------------+---------------+
| change CA        | yes           | no            |
| change whatever  | yes           | no            |
| change both      | yes           | no            |
+------------------+---------------+---------------+
```
to 
```
+------------------+---------------+---------------+
| Rolling update?  | Widnow opened | Window closed |
+------------------+---------------+---------------+
| change CA        | yes           | no            |
| change whatever  | yes           | yes           |
| change both      | yes           | yes           |
+------------------+---------------+---------------+
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

