### PR TITLE
Fix network policies between Zookeeper and CO

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -276,9 +276,18 @@ public class ZookeeperCluster extends AbstractModel {
         labelSelector3.setMatchLabels(expressions3);
         entityOperatorPeer.setPodSelector(labelSelector3);
 
+        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
+        LabelSelector labelSelector4 = new LabelSelector();
+        Map<String, String> expressions4 = new HashMap<>();
+        expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
+        labelSelector4.setMatchLabels(expressions4);
+        clusterOperatorPeer.setPodSelector(labelSelector4);
+        // This is a hack because we have no guarantee that the CO namespace has some particular labels
+        clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
+
         NetworkPolicyIngressRule networkPolicyIngressRule = new NetworkPolicyIngressRuleBuilder()
                 .withPorts(port1, port2, port3)
-                .withFrom(kafkaClusterPeer, zookeeperClusterPeer, entityOperatorPeer)
+                .withFrom(kafkaClusterPeer, zookeeperClusterPeer, entityOperatorPeer, clusterOperatorPeer)
                 .build();
 
         rules.add(networkPolicyIngressRule);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -243,7 +243,7 @@ public class ZookeeperCluster extends AbstractModel {
         return cluster + NETWORK_POLICY_KEY_SUFFIX + NAME_SUFFIX;
     }
 
-    public NetworkPolicy generateNetworkPolicy() {
+    public NetworkPolicy generateNetworkPolicy(boolean coInAllNamespaces) {
         List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
 
         NetworkPolicyPort port1 = new NetworkPolicyPort();
@@ -282,8 +282,11 @@ public class ZookeeperCluster extends AbstractModel {
         expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
         labelSelector4.setMatchLabels(expressions4);
         clusterOperatorPeer.setPodSelector(labelSelector4);
-        // This is a hack because we have no guarantee that the CO namespace has some particular labels
-        clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
+
+        if (coInAllNamespaces) {
+            // This is a hack because we have no guarantee that the CO namespace has some particular labels
+            clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
+        }
 
         NetworkPolicyIngressRule networkPolicyIngressRule = new NetworkPolicyIngressRuleBuilder()
                 .withPorts(port1, port2, port3)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -933,7 +933,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             Future future = networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(true)).recover(
                 cause -> {
                     if (cause instanceof KubernetesClientException && cause.getMessage() != null && cause.getMessage().contains("Forbidden: may not specify more than 1 from type"))  {
-                        log.debug("Network policy creation failed - we will retry without namespace");
+                        log.debug("Network policy creation failed - retrying without namespace");
                         return networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(false));
                     } else {
                         return Future.failedFuture(cause);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -40,11 +40,9 @@ import java.io.IOException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
@@ -15,6 +16,9 @@ import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
@@ -36,9 +40,11 @@ import java.io.IOException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
@@ -503,5 +509,52 @@ public class ZookeeperClusterTest {
         sts = zc.generateStatefulSet(true, ImagePullPolicy.IFNOTPRESENT);
         assertEquals(ImagePullPolicy.IFNOTPRESENT.toString(), sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
         assertEquals(ImagePullPolicy.IFNOTPRESENT.toString(), sts.getSpec().getTemplate().getSpec().getContainers().get(1).getImagePullPolicy());
+    }
+
+    @Test
+    public void testNetworkPolicy() {
+        Kafka kafkaAssembly = ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCmJson, configurationJson, emptyMap());
+        kafkaAssembly.getSpec().getKafka().setRack(new RackBuilder().withTopologyKey("topology-key").build());
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check Network Policies
+        NetworkPolicy np = zc.generateNetworkPolicy();
+
+        LabelSelector podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        assertEquals(podSelector, np.getSpec().getPodSelector());
+
+        List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress();
+        assertEquals(2, rules.size());
+
+        NetworkPolicyIngressRule metricsRule = rules.get(1);
+        assertEquals(1, metricsRule.getPorts().size());
+        assertEquals(new IntOrString(9404), metricsRule.getPorts().get(0).getPort());
+        assertEquals(0, metricsRule.getFrom().size());
+
+        NetworkPolicyIngressRule zooRule = rules.get(0);
+        assertEquals(3, zooRule.getPorts().size());
+        assertEquals(new IntOrString(2181), zooRule.getPorts().get(0).getPort());
+        assertEquals(new IntOrString(2888), zooRule.getPorts().get(1).getPort());
+        assertEquals(new IntOrString(3888), zooRule.getPorts().get(2).getPort());
+
+        assertEquals(4, zooRule.getFrom().size());
+
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(zc.getCluster())));
+        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(0));
+
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(1));
+
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(zc.getCluster())));
+        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(2));
+
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
+        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(new LabelSelector()).build(), zooRule.getFrom().get(3));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -803,7 +803,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock NetworkPolicy get
         when(mockPolicyOps.get(clusterNamespace, KafkaCluster.policyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy());
-        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy());
+        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(true));
 
         // Mock PodDisruptionBudget get
         when(mockPdbOps.get(clusterNamespace, KafkaCluster.kafkaClusterName(clusterName))).thenReturn(originalKafkaCluster.generatePodDisruptionBudget());

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
     spec:
       serviceAccountName: strimzi-cluster-operator
       containers:

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       labels:
         name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
     spec:
       serviceAccountName: strimzi-cluster-operator
       containers:

--- a/olm/strimzi-cluster-operator.clusterserviceversion.yaml
+++ b/olm/strimzi-cluster-operator.clusterserviceversion.yaml
@@ -425,6 +425,7 @@ spec:
             metadata:
               labels:
                 name: strimzi-cluster-operator
+                strimzi.io/kind: cluster-operator
             spec:
               serviceAccountName: strimzi-cluster-operator
               containers:

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -120,7 +120,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
             log.debug("{} {} has been deleted", resourceKind, name);
             return Future.succeededFuture(ReconcileResult.deleted());
         } catch (Exception e) {
-            log.error("Caught exception while deleting {} {}", resourceKind, name, e);
+            log.debug("Caught exception while deleting {} {}", resourceKind, name, e);
             return Future.failedFuture(e);
         }
     }
@@ -140,7 +140,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
             return Future.succeededFuture(wasChanged(current, result) ?
                     ReconcileResult.patched(result) : ReconcileResult.noop(result));
         } catch (Exception e) {
-            log.error("Caught exception while patching {} {}", resourceKind, name, e);
+            log.debug("Caught exception while patching {} {}", resourceKind, name, e);
             return Future.failedFuture(e);
         }
     }
@@ -166,7 +166,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
             log.debug("{} {} has been created", resourceKind, name);
             return Future.succeededFuture(result);
         } catch (Exception e) {
-            log.error("Caught exception while creating {} {}", resourceKind, name, e);
+            log.debug("Caught exception while creating {} {}", resourceKind, name, e);
             return Future.failedFuture(e);
         }
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -121,7 +121,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
             log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);
             return Future.succeededFuture(ReconcileResult.deleted());
         } catch (Exception e) {
-            log.error("Caught exception while deleting {} {} in namespace {}", resourceKind, name, namespace, e);
+            log.debug("Caught exception while deleting {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
         }
     }
@@ -140,7 +140,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
             log.debug("{} {} in namespace {} has been patched", resourceKind, name, namespace);
             return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
         } catch (Exception e) {
-            log.error("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
+            log.debug("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
         }
     }
@@ -166,7 +166,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
             log.debug("{} {} in namespace {} has been created", resourceKind, name, namespace);
             return Future.succeededFuture(result);
         } catch (Exception e) {
-            log.error("Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, e);
+            log.debug("Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);
         }
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Cluster Operator is currently connecting to Zookeeper. But this is not reflected in the Zookeeper network policies.

```
2019-03-04 13:39:07 INFO  AbstractAssemblyOperator:299 - Reconciliation #1(watch) Kafka(my-kafka/my-cluster): Kafka my-cluster in namespace my-kafka was MODIFIED
2019-03-04 13:39:07 INFO  AbstractAssemblyOperator:170 - Reconciliation #1(watch) Kafka(my-kafka/my-cluster): Assembly my-cluster should be created or updated
2019-03-04 13:39:18 WARN  ZookeeperLeaderFinder:252 - ZK my-cluster-zookeeper-0.my-cluster-zookeeper-nodes.my-kafka.svc.cluster.local:2181: failed to connect to zookeeper:
2019-03-04 13:39:18 INFO  ZookeeperLeaderFinder:225 - Pod my-cluster-zookeeper-0 is not a leader
2019-03-04 13:39:28 WARN  ZookeeperLeaderFinder:252 - ZK my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.my-kafka.svc.cluster.local:2181: failed to connect to zookeeper:
2019-03-04 13:39:28 INFO  ZookeeperLeaderFinder:225 - Pod my-cluster-zookeeper-1 is not a leader
2019-03-04 13:39:38 WARN  ZookeeperLeaderFinder:252 - ZK my-cluster-zookeeper-2.my-cluster-zookeeper-nodes.my-kafka.svc.cluster.local:2181: failed to connect to zookeeper:
2019-03-04 13:39:38 INFO  ZookeeperLeaderFinder:225 - Pod my-cluster-zookeeper-2 is not a leader
2019-03-04 13:39:38 INFO  ZookeeperLeaderFinder:191 - No leader found for cluster my-cluster in namespace my-kafka; backing off for 0ms (cumulative 0ms)
```

So this PR adds a new `strimzi.io/kind=cluster-operator` label to the CO deployment and the CO it self adds new `from` section to the network policy role which allows to connect pod with this label from all namespaces.

### Checklist

- [x] Write tests
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally