### PR TITLE
unify periodic/periodical reconciliation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -113,7 +113,7 @@ public class ClusterOperator extends AbstractVerticle {
                     log.info("Started operator for {} kind", "KafkaConnectS2I");
                     watchByKind.put("KafkaS2IConnect", w);
                 }
-                log.info("Setting up periodical reconciliation for namespace {}", namespace);
+                log.info("Setting up periodic reconciliation for namespace {}", namespace);
                 this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
                     log.info("Triggering periodic reconciliation for namespace {}...", namespace);
                     reconcileAll("timer");

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -78,7 +78,7 @@ public class UserOperator extends AbstractVerticle {
                 log.info("Started operator for {} kind", "KafkaUser");
                 watch = w;
 
-                log.info("Setting up periodical reconciliation for namespace {}", namespace);
+                log.info("Setting up periodic reconciliation for namespace {}", namespace);
                 this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
                     log.info("Triggering periodic reconciliation for namespace {}...", namespace);
                     reconcileAll("timer");


### PR DESCRIPTION
### Type of change
- Trivial

### Description
While looking into CO logs I noticed we use these messages 
```
Setting up periodical reconciliation for namespace myproject
Triggering periodic reconciliation for namespace myproject
```
It would be good to use a unified word for `periodic`/`periodical`. It helps to orientate better in the logs while searching for the phrase `periodic reconciliation`.
