### PR TITLE
Zk roll

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -182,12 +182,16 @@ public class ZookeeperLeaderFinderTest {
         }
     }
 
+    Secret coKeySecret() {
+        return new Secret();
+    }
+
     @Test
     public void test0Pods() {
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
         assertEquals(Integer.valueOf(-1),
                 finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        emptyList()).result());
+                        emptyList(), coKeySecret()).result());
     }
 
     BackOff backoff() {
@@ -199,40 +203,15 @@ public class ZookeeperLeaderFinderTest {
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
         assertEquals(Integer.valueOf(0),
                 finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0))).result());
+                        asList(getPod(0)), coKeySecret()).result());
     }
 
     @Test
     public void testSecretsNotFound() {
         SecretOperator mock = mock(SecretOperator.class);
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, mock, this::backoff);
-        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(null));
-        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(null));
-        assertEquals("Secret testns/testcluster-cluster-operator-certs does not exist",
-                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0), getPod(1))).cause().getMessage());
 
         Mockito.reset(mock);
-        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(new SecretBuilder().build()));
-        when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(null));
-        assertEquals("Secret testns/testcluster-cluster-operator-certs does not exist",
-                finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0), getPod(1))).cause().getMessage());
-
-        Mockito.reset(mock);
-        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(
-                        new SecretBuilder()
-                                .withNewMetadata()
-                                    .withName(ClusterOperator.secretName(CLUSTER))
-                                    .withNamespace(NAMESPACE)
-                                .endMetadata()
-                                .withData(emptyMap())
-                        .build()));
         when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
                 .thenReturn(Future.succeededFuture(
                         new SecretBuilder()
@@ -244,7 +223,13 @@ public class ZookeeperLeaderFinderTest {
                                 .build()));
         assertEquals("The Secret testns/testcluster-cluster-operator-certs is missing the key cluster-operator.key",
                 finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0), getPod(1))).cause().getMessage());
+                        asList(getPod(0), getPod(1)), new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(ClusterOperator.secretName(CLUSTER))
+                                .withNamespace(NAMESPACE)
+                                .endMetadata()
+                                .withData(emptyMap())
+                                .build()).cause().getMessage());
     }
 
     @Test
@@ -252,16 +237,6 @@ public class ZookeeperLeaderFinderTest {
         SecretOperator mock = mock(SecretOperator.class);
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, mock, this::backoff);
 
-        when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(
-                        new SecretBuilder()
-                                .withNewMetadata()
-                                .withName(ClusterOperator.secretName(CLUSTER))
-                                .withNamespace(NAMESPACE)
-                                .endMetadata()
-                                .withData(map("cluster-operator.key", "notacert",
-                                        "cluster-operator.crt", "notacert"))
-                                .build()));
         when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
                 .thenReturn(Future.succeededFuture(
                         new SecretBuilder()
@@ -272,7 +247,14 @@ public class ZookeeperLeaderFinderTest {
                                 .withData(map(Ca.CA_CRT, "notacert"))
                                 .build()));
         Throwable cause = finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                asList(getPod(0), getPod(1))).cause();
+                asList(getPod(0), getPod(1)), new SecretBuilder()
+                        .withNewMetadata()
+                        .withName(ClusterOperator.secretName(CLUSTER))
+                        .withNamespace(NAMESPACE)
+                        .endMetadata()
+                        .withData(map("cluster-operator.key", "notacert",
+                                "cluster-operator.crt", "notacert"))
+                        .build()).cause();
         assertTrue(cause instanceof RuntimeException);
         assertEquals("Bad/corrupt certificate found in data.cluster-operator\\.crt of Secret testcluster-cluster-operator-certs in namespace testns", cause.getMessage());
     }
@@ -307,7 +289,7 @@ public class ZookeeperLeaderFinderTest {
 
         Async a = context.async();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                    asList(getPod(0), getPod(1)))
+                    asList(getPod(0), getPod(1)), coKeySecret())
             .setHandler(ar -> {
                 if (ar.succeeded()) {
                     context.assertEquals(-1, ar.result());
@@ -353,7 +335,7 @@ public class ZookeeperLeaderFinderTest {
 
         Async a = context.async();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                asList(getPod(0), getPod(1)))
+                asList(getPod(0), getPod(1)), coKeySecret())
                 .setHandler(result -> {
                     context.assertEquals(ZookeeperLeaderFinder.UNKNOWN_LEADER, result.result());
                     for (FakeZk zk : zks) {
@@ -394,7 +376,7 @@ public class ZookeeperLeaderFinderTest {
 
         Async a = context.async();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                asList(getPod(0), getPod(1)))
+                asList(getPod(0), getPod(1)), coKeySecret())
                 .setHandler(ar -> {
                     if (ar.succeeded()) {
                         context.assertEquals(leader, ar.result());
@@ -438,7 +420,7 @@ public class ZookeeperLeaderFinderTest {
         ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
 
         Async a = context.async();
-        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(getPod(0), getPod(1)))
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(getPod(0), getPod(1)), coKeySecret())
                 .setHandler(asyncResult -> {
                     if (asyncResult.failed()) {
                         asyncResult.cause().printStackTrace();

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -254,6 +254,7 @@ class SecurityST extends AbstractST {
             () -> LOGGER.error("Couldn't find user secret {}", CLIENT.secrets().inNamespace(NAMESPACE).list().getItems()));
 
         AvailabilityVerifier mp = waitForInitialAvailability(aliceUserName);
+        mp.stop(30_000);
 
         // Get all pods, and their resource versions
         Map<String, String> zkPods = StUtils.ssSnapshot(CLIENT, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME));
@@ -285,9 +286,6 @@ class SecurityST extends AbstractST {
         LOGGER.info("Wait for EO to rolling restart (1)...");
         eoPod = StUtils.waitTillDepHasRolled(CLIENT, NAMESPACE, KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), eoPod);
 
-        //mp.stop(30_000);
-        //mp = waitForInitialAvailability(aliceUserName);
-
         LOGGER.info("Wait for zk to rolling restart (2)...");
         zkPods = StUtils.waitTillSsHasRolled(CLIENT, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME), zkPods);
         LOGGER.info("Wait for kafka to rolling restart (2)...");
@@ -305,9 +303,8 @@ class SecurityST extends AbstractST {
             assertNotEquals("CA key in " + secretName + " should have changed",
                     initialCaKeys.get(secretName), value);
         }
-        //mp.stop(30_000);
-        //mp = waitForInitialAvailability(aliceUserName);
-        waitForAvailability(mp);
+
+        mp = waitForInitialAvailability(aliceUserName);
 
         AvailabilityVerifier.Result result = mp.stop(30_000);
         LOGGER.info("Producer/consumer stats during cert renewal {}", result);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Cluster CA key replacement requires a ZK roll (so that ZK nodes trust new ZK peer certs, and new Kafka certs). When rolling ZK the CO now needs to know the leader. In KAO `clusterOperatorSecret()` is called immediately after CA reconciliation and before `rollingUpdateForNewCaKey()`. This meant that the ZookeeperLeaderFinding didn't trust the old ZK certs (because it was only trusting the new certs, which we were rolling ZK in order to start using). Fix this by having the ZLF trust both old and new certs.

Also fix the test which was timing out when closing the AvailabilityVerifier. This is done by initially checking we can produce and consume, and then again (with different client instances) after the CA replacement+rolls. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

