### PR TITLE
Fix issues with OpenShift detection on 4.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -37,12 +37,12 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_KAFKA_CONNECT_S2I_IMAGES = "STRIMZI_KAFKA_CONNECT_S2I_IMAGES";
     public static final String STRIMZI_KAFKA_MIRROR_MAKER_IMAGES = "STRIMZI_KAFKA_MIRROR_MAKER_IMAGES";
     public static final String STRIMZI_IMAGE_PULL_POLICY = "STRIMZI_IMAGE_PULL_POLICY";
-    public static final String STRIMZI_FORCE_OPENSHIFT = "STRIMZI_FORCE_OPENSHIFT";
+    public static final String STRIMZI_ASSUME_OPENSHIFT = "STRIMZI_ASSUME_OPENSHIFT";
 
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
     public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
-    public static final Boolean DEFAULT_STRIMZI_FORCE_OPENSHIFT = null;
+    public static final Boolean DEFAULT_STRIMZI_ASSUME_OPENSHIFT = null;
 
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;
@@ -50,7 +50,7 @@ public class ClusterOperatorConfig {
     private final boolean createClusterRoles;
     private final KafkaVersion.Lookup versions;
     private final ImagePullPolicy imagePullPolicy;
-    private final Boolean forceOpenShift;
+    private final Boolean assumeOpenShift;
 
     /**
      * Constructor
@@ -61,15 +61,16 @@ public class ClusterOperatorConfig {
      * @param createClusterRoles true to create the cluster roles
      * @param versions The configured Kafka versions
      * @param imagePullPolicy Image pull policy configured by the user
+     * @param assumeOpenShift Assumes whether we are on Kubernetes on OPenShift and skips autodetection
      */
-    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs, boolean createClusterRoles, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy, Boolean forceOpenShift) {
+    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs, boolean createClusterRoles, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy, Boolean assumeOpenShift) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
         this.createClusterRoles = createClusterRoles;
         this.versions = versions;
         this.imagePullPolicy = imagePullPolicy;
-        this.forceOpenShift = forceOpenShift;
+        this.assumeOpenShift = assumeOpenShift;
     }
 
     /**
@@ -152,13 +153,13 @@ public class ClusterOperatorConfig {
             }
         }
 
-        Boolean forceOpenShift = DEFAULT_STRIMZI_FORCE_OPENSHIFT;
-        String forceOpenShiftEnvVar = map.get(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT);
-        if (forceOpenShiftEnvVar != null) {
-            forceOpenShift = Boolean.parseBoolean(forceOpenShiftEnvVar);
+        Boolean assumeOpenShift = DEFAULT_STRIMZI_ASSUME_OPENSHIFT;
+        String assumeOpenShiftEnvVar = map.get(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT);
+        if (assumeOpenShiftEnvVar != null) {
+            assumeOpenShift = Boolean.parseBoolean(assumeOpenShiftEnvVar);
         }
 
-        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles, lookup, imagePullPolicy, forceOpenShift);
+        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles, lookup, imagePullPolicy, assumeOpenShift);
     }
 
 
@@ -204,8 +205,8 @@ public class ClusterOperatorConfig {
     /**
      * @return  Whether we should assume that we are on OPenShift without the autodetection
      */
-    public Boolean isForceOpenShift() {
-        return forceOpenShift;
+    public Boolean isAssumeOpenShift() {
+        return assumeOpenShift;
     }
 
     @Override
@@ -217,7 +218,7 @@ public class ClusterOperatorConfig {
                 ",createClusterRoles=" + createClusterRoles +
                 ",versions=" + versions +
                 ",imagePullPolicy=" + imagePullPolicy +
-                ",forceOpenShift=" + forceOpenShift +
+                ",assumeOpenShift=" + assumeOpenShift +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -194,9 +194,9 @@ public class Main {
     }
 
     static Future<Boolean> isOnOpenShift(Vertx vertx, KubernetesClient client, ClusterOperatorConfig config)  {
-        if (config.isForceOpenShift() != null)  {
-            log.debug("OpenShift has been set to {} through {}.", config.isForceOpenShift(), ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT);
-            return Future.succeededFuture(config.isForceOpenShift());
+        if (config.isAssumeOpenShift() != null)  {
+            log.debug("OpenShift has been set to {} through {}.", config.isAssumeOpenShift(), ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT);
+            return Future.succeededFuture(config.isAssumeOpenShift());
         } else if (client.isAdaptable(OkHttpClient.class)) {
             OkHttpClient ok = client.adapt(OkHttpClient.class);
             Future<Boolean> fut = Future.future();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -19,6 +19,8 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class ClusterOperatorConfigTest {
 
@@ -47,7 +49,7 @@ public class ClusterOperatorConfigTest {
     @Test
     public void testReconciliationInterval() {
 
-        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null);
+        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null, null);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(60_000, config.getReconciliationIntervalMs());
@@ -173,5 +175,34 @@ public class ClusterOperatorConfigTest {
         envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "Sometimes");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
+    }
+
+    @Test
+    public void testForceOpenShift() {
+        ClusterOperatorConfig config;
+        Map<String, String> envVars;
+
+        envVars = new HashMap<>(1);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
+        config = ClusterOperatorConfig.fromMap(envVars);
+        assertNull(config.isForceOpenShift());
+
+        envVars = new HashMap<>(2);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "TRUE");
+        config = ClusterOperatorConfig.fromMap(envVars);
+        assertTrue(config.isForceOpenShift());
+
+        envVars = new HashMap<>(2);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "FALSE");
+        config = ClusterOperatorConfig.fromMap(envVars);
+        assertFalse(config.isForceOpenShift());
+
+        envVars = new HashMap<>(2);
+        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "something");
+        config = ClusterOperatorConfig.fromMap(envVars);
+        assertFalse(config.isForceOpenShift());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -185,24 +185,24 @@ public class ClusterOperatorConfigTest {
         envVars = new HashMap<>(1);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
         config = ClusterOperatorConfig.fromMap(envVars);
-        assertNull(config.isForceOpenShift());
+        assertNull(config.isAssumeOpenShift());
 
         envVars = new HashMap<>(2);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "TRUE");
+        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "TRUE");
         config = ClusterOperatorConfig.fromMap(envVars);
-        assertTrue(config.isForceOpenShift());
+        assertTrue(config.isAssumeOpenShift());
 
         envVars = new HashMap<>(2);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "FALSE");
+        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "FALSE");
         config = ClusterOperatorConfig.fromMap(envVars);
-        assertFalse(config.isForceOpenShift());
+        assertFalse(config.isAssumeOpenShift());
 
         envVars = new HashMap<>(2);
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_FORCE_OPENSHIFT, "something");
+        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "something");
         config = ClusterOperatorConfig.fromMap(envVars);
-        assertFalse(config.isForceOpenShift());
+        assertFalse(config.isAssumeOpenShift());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our OpenShift detection is broker on OpenShift 4. It seems the last version of OpenShift 4 deprecated the `/oapi` API endpoint. This PR changes the detection endpoint to `/apis/route.openshift.io/v1`. 

It additionally adds a new environment variable for CO called `STRIMZI_FORCE_OPENSHIFT`. When this environment variable is not set OpenShift will be autodetected. If it is set to `TRUE`, we will assume OpenShift and if it is set to `FALSE` we will assume Kubernetes.

### Checklist

- [x] Write tests
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally