### PR TITLE
Added autorefresh every 5 secs on Grafana dashboards

### DIFF
--- a/metrics/examples/grafana/strimzi-kafka-connect.json
+++ b/metrics/examples/grafana/strimzi-kafka-connect.json
@@ -663,7 +663,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -1700,7 +1700,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],

--- a/metrics/examples/grafana/strimzi-zookeeper.json
+++ b/metrics/examples/grafana/strimzi-zookeeper.json
@@ -1242,7 +1242,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The current dashboards have "refresh" parameter set to false which means no auto-refresh enabled but the user has to click every time to refresh the dashboard.
This PR adds a more useful autorefresh every 5 seconds.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

