### PR TITLE
fix Cluster Operator resources backup command in upgrade docs

### DIFF
--- a/documentation/book/proc-upgrading-the-cluster-operator-0-10-0-to-0-11-0.adoc
+++ b/documentation/book/proc-upgrading-the-cluster-operator-0-10-0-to-0-11-0.adoc
@@ -20,14 +20,14 @@ ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl get`:
 +
 ----
-kubectl get all -l app=strimzi > strimzi-backup.yaml
+kubectl get all -l app=strimzi -o yaml > strimzi-backup.yaml
 ----
 +
 endif::Kubernetes[]
 On {OpenShiftName} use `oc get`:
 +
 ----
-oc get -l all app=strimzi > strimzi-backup.yaml
+oc get -l all app=strimzi -o yaml > strimzi-backup.yaml
 ----
 
 . Update the Cluster Operator. 

--- a/documentation/book/proc-upgrading-the-cluster-operator-0-9-0-to-0-10-0.adoc
+++ b/documentation/book/proc-upgrading-the-cluster-operator-0-9-0-to-0-10-0.adoc
@@ -36,14 +36,14 @@ ifdef::Kubernetes[]
 On {KubernetesName} use `kubectl get`:
 +
 ----
-kubectl get all -l app=strimzi > strimzi-backup.yaml
+kubectl get all -l app=strimzi -o yaml > strimzi-backup.yaml
 ----
 +
 endif::Kubernetes[]
 On {OpenShiftName} use `oc get`:
 +
 ----
-oc get all -l app=strimzi > strimzi-backup.yaml
+oc get all -l app=strimzi -o yaml > strimzi-backup.yaml
 ----
 
 . Update the Cluster Operator. 


### PR DESCRIPTION
### Type of change

Documentation

### Description

The command for Cluster Operator resources backup should be called with `-o yaml` as the default output (at least for `kubectl`) is [human readable plain-text format](https://kubernetes.io/docs/reference/kubectl/overview/#formatting-output).
