### PR TITLE
fix misplaced tag parameter in backup command

### DIFF
--- a/documentation/book/proc-upgrading-the-cluster-operator-0-10-0-to-0-11-0.adoc
+++ b/documentation/book/proc-upgrading-the-cluster-operator-0-10-0-to-0-11-0.adoc
@@ -27,7 +27,7 @@ endif::Kubernetes[]
 On {OpenShiftName} use `oc get`:
 +
 ----
-oc get -l all app=strimzi -o yaml > strimzi-backup.yaml
+oc get all -l app=strimzi -o yaml > strimzi-backup.yaml
 ----
 
 . Update the Cluster Operator. 


### PR DESCRIPTION
### Type of change

Documentation

### Description

After #1408 got merged I just noticed that the `-l` tag was misplaced in one of the `oc` backup commands.
