### PR TITLE
Changed title for online partitions in Kafka dashboard

### DIFF
--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -386,7 +386,7 @@
         }
       ],
       "thresholds": "0,0",
-      "title": "Online Partitions",
+      "title": "Online Partitions Replicas",
       "type": "singlestat",
       "valueFontSize": "200%",
       "valueMaps": [

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -327,7 +327,7 @@
         "#299c46"
       ],
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Partitions that are online",
+      "description": "Replicas that are online",
       "format": "none",
       "gauge": {
         "maxValue": 100,

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -386,7 +386,7 @@
         }
       ],
       "thresholds": "0,0",
-      "title": "Online Partitions Replicas",
+      "title": "Online Replicas",
       "type": "singlestat",
       "valueFontSize": "200%",
       "valueMaps": [


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Taking a look at Grafana Kafka dashboard the "Online Partitions" metric is not right talking about "partitions". I had a cluster with 2 topics, each one with 1 partition and 1 replica. Having a consumer running, the value showed was 152.
Thinking about that the reason is that there is the __consumer_offset with 50 partitions and replication factor of 3.
It means that the "Online Partitions" is really showing the "Online Partitions Replicas" actually not "partitions". So in our case (50 x 3) + (1 x 1) + (1 x 1).
The metrics come from the sum of this "kafka.server:type=ReplicaManager,name=PartitionCount" which counts the partitions ... as replicas which is not wrong "per se", but the "Online Partitions" title sounds wrong to me.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

