### PR TITLE
Change storage + anything else causes error

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -101,7 +101,7 @@ public class KafkaCluster extends AbstractModel {
     private static final String ENV_VAR_KAFKA_CLIENTTLS_ENABLED = "KAFKA_CLIENTTLS_ENABLED";
     /** The authentication to configure for the CLIENTTLS listener (TLS transport) . */
     private static final String ENV_VAR_KAFKA_CLIENTTLS_AUTHENTICATION = "KAFKA_CLIENTTLS_AUTHENTICATION";
-    protected static final String ENV_VAR_KAFKA_EXTERNAL_ENABLED = "KAFKA_EXTERNAL_ENABLED";
+    public static final String ENV_VAR_KAFKA_EXTERNAL_ENABLED = "KAFKA_EXTERNAL_ENABLED";
     protected static final String ENV_VAR_KAFKA_EXTERNAL_ADDRESSES = "KAFKA_EXTERNAL_ADDRESSES";
     protected static final String ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION = "KAFKA_EXTERNAL_AUTHENTICATION";
     protected static final String ENV_VAR_KAFKA_EXTERNAL_TLS = "KAFKA_EXTERNAL_TLS";
@@ -725,7 +725,7 @@ public class KafkaCluster extends AbstractModel {
                 }
                 return;
             } else {
-                throw new IllegalStateException("The declared storage is not supported");
+                throw new IllegalStateException("The declared storage '" + storage.getType() + "' is not supported");
             }
 
             String name = ModelUtils.getVolumePrefix(id);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -68,6 +68,12 @@ public class KafkaSetOperator extends StatefulSetOperator {
 
         desiredKafka.setVolumeMounts(currentKafka.getVolumeMounts());
 
+        // the external listener changed from nodeport, we need to remove rack-volume
+        if (currentKafka.getEnv().stream().anyMatch(a -> a.getName().equals(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED) && a.getValue().equals("nodeport")) &&
+                desiredKafka.getEnv().stream().noneMatch(a -> a.getName().equals(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED) && a.getValue().equals("nodeport"))) {
+            desiredKafka.getVolumeMounts().remove(desiredKafka.getVolumeMounts().stream().filter(a -> a.getName().equals("rack-volume")).findFirst().get());
+        }
+
         StatefulSet updated = new StatefulSetBuilder(desired)
                 .editSpec()
                     .editTemplate()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -324,7 +324,6 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
      */
     protected StatefulSetDiff revertStorageChanges(StatefulSet current, StatefulSet desired) {
         desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
-        desired.getSpec().getTemplate().getSpec().setInitContainers(current.getSpec().getTemplate().getSpec().getInitContainers());
         desired.getSpec().getTemplate().getSpec().setSecurityContext(current.getSpec().getTemplate().getSpec().getSecurityContext());
 
         if (current.getSpec().getVolumeClaimTemplates().isEmpty()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -7,14 +7,18 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.JbodStorage;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -128,5 +132,35 @@ public class KafkaSetOperatorTest {
         a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
                 "foo", null));
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
+    }
+
+    @Test
+    public void testChangeStorageType() {
+        Kafka kafkaa = getResource();
+        Kafka kafkab = getResource();
+        PersistentClaimStorage pcs = new PersistentClaimStorage();
+        pcs.setSize("100Gi");
+
+        JbodStorage jbod = new JbodStorage();
+        SingleVolumeStorage volume = new PersistentClaimStorage() {
+            @Override
+            public String getType() {
+                return null;
+            }
+        };
+        volume.setId(0);
+        jbod.setVolumes(Arrays.asList(volume));
+
+        kafkaa.getSpec().getKafka().setStorage(pcs);
+        kafkab.getSpec().getKafka().setStorage(jbod);
+        KafkaVersion.Lookup versions = new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap());
+        a = KafkaCluster.fromCrd(kafkaa, versions).generateStatefulSet(true, null);
+        b = KafkaCluster.fromCrd(kafkab, versions).generateStatefulSet(true, null);
+        b.getMetadata().getLabels().put("new", "label");
+
+        KafkaSetOperator kso = new KafkaSetOperator(null, null, 0);
+        assertTrue(kso.shouldIncrementGeneration(a, b));
+        assertTrue(kso.revertStorageChanges(a, b).changesLabels());
+        assertFalse(kso.revertStorageChanges(a, b).changesVolumeClaimTemplates());
     }
 }


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
Changing storage type + external listener type (nodeport->route) causes Kafka pod's death with this message in the Kafka SS: 
`create Pod my-cluster-kafka-0 in StatefulSet my-cluster-kafka failed error: Pod "my-cluster-kafka-0" is invalid: [spec.containers[0].volumeMounts[5].name: Not found: "rack-volume", spec.initContainers[0].volumeMounts[0].name: Not found: "rack-volume"]`

I am opening to begin a discussion. I have a few questions.
1. Why we do copy `initContainers`?
2. How to properly remove incorrect `volumeMounts`?

I think the most experienced people in this are @ppatierno and @scholzj 

Thanks for any comment!

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

