### PR TITLE
Fix StackOverFlow error when the tlsSidecar object is used - Closes #1421

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -71,7 +71,7 @@ public class ResourceVisitor {
         ArrayList<String> path = new ArrayList<>();
         try {
             visit(path, resource, visitor);
-        } catch (RuntimeException | ReflectiveOperationException e) {
+        } catch (RuntimeException | ReflectiveOperationException | StackOverflowError e) {
             LOGGER.error("Error while visiting {}", path, e);
             if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -150,7 +150,8 @@ public class ResourceVisitor {
                 }
                 path.remove(path.size() - 1);
             } else if (!isScalar(returnType)
-                    && !Map.class.isAssignableFrom(returnType)) {
+                    && !Map.class.isAssignableFrom(returnType)
+                    && !returnType.isEnum()) {
                 path.add(propertyName);
                 visit(path, propertyValue, visitor);
                 path.remove(path.size() - 1);

--- a/operator-common/src/test/resources/example.yaml
+++ b/operator-common/src/test/resources/example.yaml
@@ -26,6 +26,7 @@ spec:
     storage:
       type: ephemeral
     version: 2.1.0
+    tlsSidecar: {}
   topicOperator: {}
   zookeeper:
     replicas: 3


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems the ResourceVisitor introduced in #1340 has problem with handling Enums where it runs in cycle. This error is triggered when the `tlsSidecar` object is used which contains Enum for the sidecar log level. This should fix #1421.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally