### PR TITLE
[DOC] Added GC logging enable/disable set

### DIFF
--- a/documentation/book/assembly-logging.adoc
+++ b/documentation/book/assembly-logging.adoc
@@ -25,3 +25,5 @@ include::proc-kafka-inline-logging.adoc[leveloffset=+1]
 include::proc-kafka-external-logging.adoc[leveloffset=+1]
 
 include::ref-kafka-logging.adoc[leveloffset=+1]
+
+It is also possible to enable and disable garbage collector (GC) logging, for more information see xref:ref-jvm-options-{context}[]

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -108,7 +108,7 @@ NOTE: When neither of the two options (`-server` and `-XX`) is specified, the de
 
 == Garbage collector logging
 
-The `jvmOptions` section also allows to enable/disable the GC (Garbage Collector) logging.
+The `jvmOptions` section also allows you to enable and disable garbage collector (GC) logging.
 The GC logging is enabled by default.
 In order to disable it, the `gcLoggingEnabled` property has to be set as follow.
 

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -105,3 +105,18 @@ The example configuration above will result in the following JVM options:
 ----
 
 NOTE: When neither of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
+
+== GC logging
+
+The `jvmOptions` section also allows to enable/disable the GC (Garbage Collector) logging.
+The GC logging is enabled by default.
+In order to disable it, the `gcLoggingEnabled` property has to be set as follow.
+
+.Example of disabling the GC logging
+[source,yaml,subs=attributes+]
+----
+# ...
+jvmOptions:
+  gcLoggingEnabled: false
+# ...
+----

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -106,7 +106,7 @@ The example configuration above will result in the following JVM options:
 
 NOTE: When neither of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
 
-== GC logging
+== Garbage collector logging
 
 The `jvmOptions` section also allows to enable/disable the GC (Garbage Collector) logging.
 The GC logging is enabled by default.

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -112,7 +112,7 @@ The `jvmOptions` section also allows you to enable and disable garbage collector
 GC logging is enabled by default.
 To disable it, set the `gcLoggingEnabled` property as follows:
 
-.Example of disabling the GC logging
+.Example of disabling GC logging
 [source,yaml,subs=attributes+]
 ----
 # ...

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -109,7 +109,7 @@ NOTE: When neither of the two options (`-server` and `-XX`) is specified, the de
 == Garbage collector logging
 
 The `jvmOptions` section also allows you to enable and disable garbage collector (GC) logging.
-The GC logging is enabled by default.
+GC logging is enabled by default.
 In order to disable it, the `gcLoggingEnabled` property has to be set as follow.
 
 .Example of disabling the GC logging

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -110,7 +110,7 @@ NOTE: When neither of the two options (`-server` and `-XX`) is specified, the de
 
 The `jvmOptions` section also allows you to enable and disable garbage collector (GC) logging.
 GC logging is enabled by default.
-In order to disable it, the `gcLoggingEnabled` property has to be set as follow.
+To disable it, set the `gcLoggingEnabled` property as follows:
 
 .Example of disabling the GC logging
 [source,yaml,subs=attributes+]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This adds a section about how it's possible to enable/disable GC logging after a quick discussion with the community on Slack; it seems not clear how to do that from the current doc because the `gcLoggingEnable` is referenced only in the appendix section related to the CRDs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

