### PR TITLE
Proper handling of immutable fields during PVC reconciliation

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -59,7 +59,9 @@ public class PvcOperator extends AbstractResourceOperator<KubernetesClient, Pers
     }
 
     /**
-     * Reverts the changes to immutable fields in PVCs spec section
+     * Reverts the changes to immutable fields in PVCs spec section. The values for these fields in the current resource
+     * are often not set by us but by Kubernetes alone (e.g. volume ID, default storage class etc.). So our Model
+     * classes are nto aware of them and cannot set them properly. Therefore we are reverting these values here.
      *
      * @param current   Existing PVC
      * @param desired   Desired PVC

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
@@ -28,5 +29,46 @@ public class PvcOperator extends AbstractResourceOperator<KubernetesClient, Pers
     @Override
     protected MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> operation() {
         return client.persistentVolumeClaims();
+    }
+
+    /**
+     * Patches the resource with the given namespace and name to match the given desired resource
+     * and completes the given future accordingly.
+     *
+     * PvcOperator needs to patch the volumeName field in spec which is immutable and which should contain the same value as the existing resource.
+     *
+     * @param namespace Namespace of the pvc
+     * @param name      Name of the pvc
+     * @param current   Current pvc
+     * @param desired   Desired pvc
+     *
+     * @return  Future with reconciliation result
+     */
+    @Override
+    protected Future<ReconcileResult<PersistentVolumeClaim>> internalPatch(String namespace, String name, PersistentVolumeClaim current, PersistentVolumeClaim desired) {
+        try {
+            if (current.getSpec() != null && desired.getSpec() != null)   {
+                revertImmutableChanges(current, desired);
+            }
+
+            return super.internalPatch(namespace, name, current, desired);
+        } catch (Exception e) {
+            log.error("Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    /**
+     * Reverts the changes to immutable fields in PVCs spec section
+     *
+     * @param current   Existing PVC
+     * @param desired   Desired PVC
+     */
+    protected void revertImmutableChanges(PersistentVolumeClaim current, PersistentVolumeClaim desired)   {
+        desired.getSpec().setVolumeName(current.getSpec().getVolumeName());
+        desired.getSpec().setStorageClassName(current.getSpec().getStorageClassName());
+        desired.getSpec().setAccessModes(current.getSpec().getAccessModes());
+        desired.getSpec().setSelector(current.getSpec().getSelector());
+        desired.getSpec().setDataSource(current.getSpec().getDataSource());
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
@@ -5,14 +5,21 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
+import org.junit.Test;
 
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PvcOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> {
@@ -40,5 +47,44 @@ public class PvcOperatorTest extends AbstractResourceOperatorTest<KubernetesClie
     @Override
     protected PvcOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new PvcOperator(vertx, mockClient);
+    }
+
+    @Test
+    public void testRevertingImmutableFields()   {
+        PersistentVolumeClaim desired = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                    .withName("my-pvc")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewResources()
+                        .withRequests(Collections.singletonMap("storage", new Quantity("100", null)))
+                    .endResources()
+                .endSpec()
+                .build();
+
+        PersistentVolumeClaim current = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                    .withName("my-pvc")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                        .withRequests(Collections.singletonMap("storage", new Quantity("10", null)))
+                    .endResources()
+                    .withStorageClassName("my-storage-class")
+                    .withSelector(new LabelSelector(null, Collections.singletonMap("key", "label")))
+                    .withVolumeName("pvc-ce9ebf52-435a-11e9-8fbc-06b5ff7c7748")
+                .endSpec()
+                .build();
+
+        PvcOperator op = createResourceOperations(vertx, mock(KubernetesClient.class));
+        op.revertImmutableChanges(current, desired);
+
+        assertEquals(current.getSpec().getStorageClassName(), desired.getSpec().getStorageClassName());
+        assertEquals(current.getSpec().getAccessModes(), desired.getSpec().getAccessModes());
+        assertEquals(current.getSpec().getSelector(), desired.getSpec().getSelector());
+        assertEquals(current.getSpec().getVolumeName(), desired.getSpec().getVolumeName());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Strimzi has the `PvcOperator` class for operating of PVCs (Persistent Volume Claims). However , this class seems to be currently used only for deletion of PVCs and not any reconciliation of existing PVCs. the reconciliation seems to not work properly right now, because we are trying to change immutable fields assigned after the PVC creation (such as `volumeName`). This PR makes sure the immutable field changes are reverted and we can successfully reconcile PVCs. This will be needed later for further changes to how we handle storage.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally