### PR TITLE
ST: KubernetesClientException was added to the whitelist of ST matcher

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -38,7 +38,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
     enum LogWhiteList {
         CO_TIMEOUT_EXCEPTION("io.strimzi.operator.cluster.operator.resource.TimeoutException"),
         // "NO_ERROR" is necessary because DnsNameResolver prints debug information `QUERY(0), NoError(0), RD RA` after `recived` operation
-        NO_ERROR("NoError(0)"),
+        NO_ERROR("NoError\\(0\\)"),
         // This is necessary for OCP 3.10 or less because of having exception handling during the patching of NetworkPolicy
         CAUGHT_EXCEPTION_FOR_NETWORK_POLICY("Caught exception while patching NetworkPolicy"
                 + "(?s)(.*?)"

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -7,6 +7,9 @@ package io.strimzi.systemtest.matchers;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * <p>A LogHasNoUnexpectedErrors is custom matcher to check log form kubernetes client
  * doesn't have any unexpected errors. </p>
@@ -17,7 +20,8 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
     public boolean matches(Object actualValue) {
         if (!"".equals(actualValue)) {
             for (LogWhiteList value : LogWhiteList.values()) {
-                if (((String) actualValue).contains(value.name)) {
+                Matcher m = Pattern.compile(value.name).matcher((String) actualValue);
+                if (m.find()) {
                     return true;
                 }
             }
@@ -34,7 +38,11 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
     enum LogWhiteList {
         CO_TIMEOUT_EXCEPTION("io.strimzi.operator.cluster.operator.resource.TimeoutException"),
         // "NO_ERROR" is necessary because DnsNameResolver prints debug information `QUERY(0), NoError(0), RD RA` after `recived` operation
-        NO_ERROR("NoError(0)");
+        NO_ERROR("NoError(0)"),
+        // This is necessary for OCP 3.10 or less because of having exception handling during the patching of NetworkPolicy
+        CAUGHT_EXCEPTION_FOR_NETWORK_POLICY("Caught exception while patching NetworkPolicy"
+                + "(?s)(.*?)"
+                + "io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH");
 
         final String name;
 

--- a/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -414,7 +414,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     public String searchInLog(String resourceType, String resourceName, long sinceSeconds, String... grepPattern) {
         try {
             return Exec.exec("bash", "-c", join(" ", namespacedCommand("logs", resourceType + "/" + resourceName, "--since=" + String.valueOf(sinceSeconds) + "s",
-                    "|", "grep", " -e " + join(" -e ", grepPattern)))).out();
+                    "|", "grep", " -e " + join(" -e ", grepPattern), "-B", "1"))).out();
         } catch (KubeClusterException e) {
             if (e.result != null && e.result.exitStatus() == 1) {
                 LOGGER.info("{} not found", grepPattern);


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
After merging PR #1402, CO started to print a message about the caught exception while patching in logs. We have this message in the DEBUG level and message is expected for OCP 3.10 or less. So this is a reason why whitelist for log matcher has been expanded by a new error message.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

