### PR TITLE
Make sure that TO and UO role bindings are using the watched namespace where needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -253,7 +253,7 @@ public class EntityTopicOperator extends AbstractModel {
             createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }
 
-    public KubernetesRoleBinding generateRoleBinding(String namespace) {
+    public KubernetesRoleBinding generateRoleBinding(String namespace, String watchedNamespace) {
         KubernetesSubject ks = new KubernetesSubjectBuilder()
                 .withKind("ServiceAccount")
                 .withName(EntityOperator.entityOperatorServiceAccountName(cluster))
@@ -269,7 +269,7 @@ public class EntityTopicOperator extends AbstractModel {
         KubernetesRoleBinding rb = new KubernetesRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(roleBindingName(cluster))
-                    .withNamespace(namespace)
+                    .withNamespace(watchedNamespace)
                     .withOwnerReferences(createOwnerReference())
                     .withLabels(labels.toMap())
                 .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -244,7 +244,7 @@ public class EntityUserOperator extends AbstractModel {
         return singletonList(createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
     }
 
-    public KubernetesRoleBinding generateRoleBinding(String namespace) {
+    public KubernetesRoleBinding generateRoleBinding(String namespace, String watchedNamespace) {
         KubernetesSubject ks = new KubernetesSubjectBuilder()
                 .withKind("ServiceAccount")
                 .withName(EntityOperator.entityOperatorServiceAccountName(cluster))
@@ -260,7 +260,7 @@ public class EntityUserOperator extends AbstractModel {
         KubernetesRoleBinding rb = new KubernetesRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(roleBindingName(cluster))
-                    .withNamespace(namespace)
+                    .withNamespace(watchedNamespace)
                     .withOwnerReferences(createOwnerReference())
                     .withLabels(labels.toMap())
                 .endMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -317,7 +317,7 @@ public class TopicOperator extends AbstractModel {
         return topicOperatorServiceAccountName(cluster);
     }
 
-    public KubernetesRoleBinding generateRoleBinding(String namespace) {
+    public KubernetesRoleBinding generateRoleBinding(String namespace, String watchedNamespace) {
         KubernetesSubject ks = new KubernetesSubjectBuilder()
                 .withKind("ServiceAccount")
                 .withName(getServiceAccountName())
@@ -335,7 +335,7 @@ public class TopicOperator extends AbstractModel {
                     .withName(roleBindingName(cluster))
                     .withOwnerReferences(createOwnerReference())
                     .withLabels(labels.toMap())
-                    .withNamespace(namespace)
+                    .withNamespace(watchedNamespace)
                 .endMetadata()
                 .withRoleRef(roleRef)
                 .withSubjects(ks)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1588,12 +1588,18 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> topicOperatorRoleBinding() {
-            String watchedNamespace = topicOperator != null ? topicOperator.getWatchedNamespace() : null;
-            return withVoid(roleBindingOperator.reconcile(
-                    watchedNamespace != null && !watchedNamespace.isEmpty() ?
-                            watchedNamespace : namespace,
-                    TopicOperator.roleBindingName(name),
-                    toDeployment != null ? topicOperator.generateRoleBinding(namespace) : null));
+            if (topicOperator != null) {
+                String watchedNamespace = namespace;
+
+                if (topicOperator.getWatchedNamespace() != null
+                        && !topicOperator.getWatchedNamespace().isEmpty()) {
+                    watchedNamespace = topicOperator.getWatchedNamespace();
+                }
+
+                return withVoid(roleBindingOperator.reconcile(watchedNamespace, TopicOperator.roleBindingName(name), topicOperator.generateRoleBinding(namespace, watchedNamespace)));
+            } else {
+                return withVoid(roleBindingOperator.reconcile(namespace, TopicOperator.roleBindingName(name), null));
+            }
         }
 
         Future<ReconciliationState> topicOperatorAncillaryCm() {
@@ -1691,43 +1697,49 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityOperatorTopicOpRoleBinding() {
-            String watchedNamespace = entityOperator != null && entityOperator.getTopicOperator() != null ?
-                    entityOperator.getTopicOperator().getWatchedNamespace() : null;
-            return withVoid(roleBindingOperator.reconcile(
-                    watchedNamespace != null && !watchedNamespace.isEmpty() ?
-                            watchedNamespace : namespace,
-                    EntityTopicOperator.roleBindingName(name),
-                    eoDeployment != null && entityOperator.getTopicOperator() != null ?
-                            entityOperator.getTopicOperator().generateRoleBinding(namespace) : null));
+            if (eoDeployment != null && entityOperator.getTopicOperator() != null) {
+                String watchedNamespace = namespace;
+
+                if (entityOperator.getTopicOperator().getWatchedNamespace() != null
+                        && !entityOperator.getTopicOperator().getWatchedNamespace().isEmpty()) {
+                    watchedNamespace = entityOperator.getTopicOperator().getWatchedNamespace();
+                }
+
+                return withVoid(roleBindingOperator.reconcile(
+                        watchedNamespace,
+                        EntityTopicOperator.roleBindingName(name),
+                        entityOperator.getTopicOperator().generateRoleBinding(namespace, watchedNamespace)));
+            } else  {
+                return withVoid(roleBindingOperator.reconcile(namespace, EntityTopicOperator.roleBindingName(name), null));
+            }
         }
 
         Future<ReconciliationState> entityOperatorUserOpRoleBinding() {
-            Future ownNamespaceFuture;
-            Future watchedNamespaceFuture;
+            if (eoDeployment != null && entityOperator.getTopicOperator() != null) {
+                Future ownNamespaceFuture;
+                Future watchedNamespaceFuture;
 
-            // Create role binding for the watched namespace
-            String watchedNamespace = entityOperator != null && entityOperator.getUserOperator() != null ?
-                    entityOperator.getUserOperator().getWatchedNamespace() : null;
+                String watchedNamespace = namespace;
 
-            if (watchedNamespace != null && !watchedNamespace.isEmpty() && !namespace.equals(watchedNamespace))    {
-                watchedNamespaceFuture = roleBindingOperator.reconcile(
-                        watchedNamespace,
-                        EntityUserOperator.roleBindingName(name),
-                        eoDeployment != null && entityOperator.getUserOperator() != null ?
-                                entityOperator.getUserOperator().generateRoleBinding(namespace) : null);
+                if (entityOperator.getUserOperator().getWatchedNamespace() != null
+                        && !entityOperator.getUserOperator().getWatchedNamespace().isEmpty()) {
+                    watchedNamespace = entityOperator.getUserOperator().getWatchedNamespace();
+                }
+
+                if (!namespace.equals(watchedNamespace)) {
+                    watchedNamespaceFuture = roleBindingOperator.reconcile(watchedNamespace, EntityUserOperator.roleBindingName(name), entityOperator.getUserOperator().generateRoleBinding(namespace, watchedNamespace));
+                } else {
+                    watchedNamespaceFuture = Future.succeededFuture();
+                }
+
+                // Create role binding for the the UI runs in (it needs to access the CA etc.)
+                ownNamespaceFuture = roleBindingOperator.reconcile(namespace, EntityUserOperator.roleBindingName(name), entityOperator.getUserOperator().generateRoleBinding(namespace, namespace));
+
+
+                return withVoid(CompositeFuture.join(ownNamespaceFuture, watchedNamespaceFuture));
             } else {
-                watchedNamespaceFuture = Future.succeededFuture();
+                return withVoid(roleBindingOperator.reconcile(namespace, EntityUserOperator.roleBindingName(name), null));
             }
-
-            // Create role binding for the the UI runs in (it needs to access the CA etc.)
-            ownNamespaceFuture = roleBindingOperator.reconcile(
-                    namespace,
-                    EntityUserOperator.roleBindingName(name),
-                    eoDeployment != null && entityOperator.getUserOperator() != null ?
-                            entityOperator.getUserOperator().generateRoleBinding(namespace) : null);
-
-
-            return withVoid(CompositeFuture.join(ownNamespaceFuture, watchedNamespaceFuture));
         }
 
         Future<ReconciliationState> entityOperatorTopicOpAncillaryCm() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
@@ -176,4 +177,11 @@ public class EntityTopicOperatorTest {
                 EntityOperatorTest.volumeMounts(container.getVolumeMounts()));
     }
 
+    @Test
+    public void testRoleBinding()   {
+        KubernetesRoleBinding binding = entityTopicOperator.generateRoleBinding(namespace, toWatchedNamespace);
+
+        assertEquals(namespace, binding.getSubjects().get(0).getNamespace());
+        assertEquals(toWatchedNamespace, binding.getMetadata().getNamespace());
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
@@ -225,5 +226,13 @@ public class EntityUserOperatorTest {
         List<EnvVar> envvar = f.getEnvVars();
         assertEquals(validity, Integer.parseInt(envvar.stream().filter(a -> a.getName().equals(EntityUserOperator.ENV_VAR_CLIENTS_CA_VALIDITY)).findFirst().get().getValue()));
         assertEquals(renewal, Integer.parseInt(envvar.stream().filter(a -> a.getName().equals(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL)).findFirst().get().getValue()));
+    }
+
+    @Test
+    public void testRoleBinding()   {
+        KubernetesRoleBinding binding = entityUserOperator.generateRoleBinding(namespace, uoWatchedNamespace);
+
+        assertEquals(namespace, binding.getSubjects().get(0).getNamespace());
+        assertEquals(uoWatchedNamespace, binding.getMetadata().getNamespace());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
 import io.strimzi.api.kafka.model.EphemeralStorage;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
@@ -226,6 +227,14 @@ public class TopicOperatorTest {
         dep = tc.generateDeployment(true, ImagePullPolicy.IFNOTPRESENT);
         assertEquals(ImagePullPolicy.IFNOTPRESENT.toString(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
         assertEquals(ImagePullPolicy.IFNOTPRESENT.toString(), dep.getSpec().getTemplate().getSpec().getContainers().get(1).getImagePullPolicy());
+    }
+
+    @Test
+    public void testRoleBinding()   {
+        KubernetesRoleBinding binding = tc.generateRoleBinding(namespace, tcWatchedNamespace);
+
+        assertEquals(namespace, binding.getSubjects().get(0).getNamespace());
+        assertEquals(tcWatchedNamespace, binding.getMetadata().getNamespace());
     }
 
     @AfterClass


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Since the update around Cluster Role Bindings and Role Bindings, the CO seems to ignore the watched namespace when creating the binding. This is wrong - it has to place the role binding into the watched namespace and use the cluster namespace in the subject. This PR should fix this for UO and TO in EO and for the TO deployed through CO.

This should close the issue #1442 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging