### PR TITLE
Update com.puppycrawl.tools checkstyle dependency to 8.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.8</version>
+                        <version>8.18</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

GitHub reports the com.puppycrawl.tools:checkstyle dependency as containing CVE. This PR updates it to version 8.18 where this CVE should be fixed.