### PR TITLE
Set default Java version in the Operator Dockerfile

### DIFF
--- a/docker-images/operator/Dockerfile
+++ b/docker-images/operator/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-ARG JAVA_VERSION
+ARG JAVA_VERSION=1.8.0
 
 RUN yum -y install java-${JAVA_VERSION}-openjdk-headless openssl && yum -y clean all
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When developing on the CO, it is often very useful to be able to quickly build a new CO image. For example by doing `make all` in `docker-images/operator`. However that doesn't currently work, because that doesn't define a Java version. Adding a default Java version to the Dockerfile will make that possible.