### PR TITLE
Fix NPE which breaks reconciliation when overrides are used without NodePorts

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -536,7 +536,7 @@ public class KafkaCluster extends AbstractModel {
                 KafkaListenerExternalNodePort externalNodePort = (KafkaListenerExternalNodePort) listeners.getExternal();
                 if (externalNodePort.getOverrides() != null &&  externalNodePort.getOverrides().getBrokers() != null) {
                     nodePort = externalNodePort.getOverrides().getBrokers().stream()
-                        .filter(broker -> broker != null && broker.getBroker() != null && broker.getBroker() == pod)
+                        .filter(broker -> broker != null && broker.getBroker() != null && broker.getBroker() == pod && broker.getNodePort() != null)
                         .map(NodePortListenerBrokerOverride::getNodePort)
                         .findAny().orElse(null);
                 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the external listener is set to `nodeport` and overrides are used without actually overriding the node port numbers, the `findAny()` call when looking for the node port configuration will fire an NPE and break the reconciliation. We need to add an additional check whether the node port is set or not.

See the following example resource which triggers the original bug:
``` yaml
apiVersion: kafka.strimzi.io/v1alpha1
kind: Kafka
metadata:
  name: my-cluster
spec:
  kafka:
    version: 2.1.0
    replicas: 3
    listeners:
      plain: {}
      tls: {}
      external:
        type: nodeport
        tls: false    
        overrides:
          brokers:
          - broker: 0
            advertisedHost: 192.168.99.103
          - broker: 1
            advertisedHost: 192.168.99.103
          - broker: 2
            advertisedHost: 192.168.99.103
    config:
      offsets.topic.replication.factor: 3
      transaction.state.log.replication.factor: 3
      transaction.state.log.min.isr: 2
      log.message.format.version: "2.1"
    storage:
      type: persistent-claim
      size: 100Gi
      deleteClaim: false
  zookeeper:
    replicas: 3
    storage:
      type: persistent-claim
      size: 100Gi
      deleteClaim: false
  entityOperator:
    topicOperator: {}
    userOperator: {}
```

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally