### PR TITLE
The big storage refactoring

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -449,24 +449,25 @@ public abstract class AbstractModel {
     protected void setStorage(Storage storage) {
         if (storage instanceof PersistentClaimStorage) {
             PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) storage;
-
-            if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
-                throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
-            }
+            checkPersistentStorageSize(persistentClaimStorage);
         } else if (storage instanceof JbodStorage)  {
             JbodStorage jbodStorage = (JbodStorage) storage;
 
             for (Storage jbodVolume : jbodStorage.getVolumes()) {
                 if (jbodVolume instanceof PersistentClaimStorage) {
                     PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) jbodVolume;
-                    if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
-                        throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
-                    }
+                    checkPersistentStorageSize(persistentClaimStorage);
                 }
             }
         }
 
         this.storage = storage;
+    }
+
+    private void checkPersistentStorageSize(PersistentClaimStorage storage)   {
+        if (storage.getSize() == null || storage.getSize().isEmpty()) {
+            throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
+        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -55,6 +55,7 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.JbodStorage;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
@@ -69,6 +70,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -98,6 +100,7 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_STRIMZI_GC_LOG_ENABLED = "STRIMZI_GC_LOG_ENABLED";
 
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "/delete-claim";
+    public static final String ANNO_STRIMZI_IO_STORAGE = Annotations.STRIMZI_DOMAIN + "/storage";
     @Deprecated
     public static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = "cluster.operator.strimzi.io/delete-claim";
     private static final Pattern LOGGER_PATTERN = Pattern.compile("\\$\\{(.*)\\}, ([A-Z]+)");
@@ -240,7 +243,7 @@ public abstract class AbstractModel {
     }
 
 
-    protected Map<String, String> getSelectorLabels() {
+    public Map<String, String> getSelectorLabels() {
         return labels.withName(name).strimziLabels().toMap();
     }
 
@@ -444,6 +447,25 @@ public abstract class AbstractModel {
     }
 
     protected void setStorage(Storage storage) {
+        if (storage instanceof PersistentClaimStorage) {
+            PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) storage;
+
+            if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
+                throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
+            }
+        } else if (storage instanceof JbodStorage)  {
+            JbodStorage jbodStorage = (JbodStorage) storage;
+
+            for (Storage jbodVolume : jbodStorage.getVolumes()) {
+                if (jbodVolume instanceof PersistentClaimStorage) {
+                    PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) jbodVolume;
+                    if (persistentClaimStorage.getSize() == null || persistentClaimStorage.getSize().isEmpty()) {
+                        throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
+                    }
+                }
+            }
+        }
+
         this.storage = storage;
     }
 
@@ -582,15 +604,16 @@ public abstract class AbstractModel {
         return servicePort;
     }
 
-    protected PersistentVolumeClaim createPersistentVolumeClaim(String name, PersistentClaimStorage storage) {
+    protected PersistentVolumeClaim createPersistentVolumeClaimTemplate(String name, PersistentClaimStorage storage) {
         Map<String, Quantity> requests = new HashMap<>();
         requests.put("storage", new Quantity(storage.getSize(), null));
+
         LabelSelector selector = null;
         if (storage.getSelector() != null && !storage.getSelector().isEmpty()) {
             selector = new LabelSelector(null, storage.getSelector());
         }
 
-        PersistentVolumeClaimBuilder pvcb = new PersistentVolumeClaimBuilder()
+        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
                     .withName(name)
                 .endMetadata()
@@ -601,9 +624,43 @@ public abstract class AbstractModel {
                     .endResources()
                     .withStorageClassName(storage.getStorageClass())
                     .withSelector(selector)
-                .endSpec();
+                .endSpec()
+                .build();
 
-        return pvcb.build();
+        return pvc;
+    }
+
+    protected PersistentVolumeClaim createPersistentVolumeClaim(String name, PersistentClaimStorage storage) {
+        Map<String, Quantity> requests = new HashMap<>();
+        requests.put("storage", new Quantity(storage.getSize(), null));
+
+        LabelSelector selector = null;
+        if (storage.getSelector() != null && !storage.getSelector().isEmpty()) {
+            selector = new LabelSelector(null, storage.getSelector());
+        }
+
+        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withLabels(getLabelsWithName(templateStatefulSetLabels))
+                    .withAnnotations(Collections.singletonMap(ANNO_STRIMZI_IO_DELETE_CLAIM, Boolean.toString(storage.isDeleteClaim())))
+                .endMetadata()
+                .withNewSpec()
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                        .withRequests(requests)
+                    .endResources()
+                    .withStorageClassName(storage.getStorageClass())
+                    .withSelector(selector)
+                .endSpec()
+                .build();
+
+        if (storage.isDeleteClaim())    {
+            pvc.getMetadata().setOwnerReferences(Collections.singletonList(createOwnerReference()));
+        }
+
+        return pvc;
     }
 
     protected Volume createEmptyDirVolume(String name) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -100,6 +100,7 @@ public abstract class AbstractModel {
     public static final String ENV_VAR_STRIMZI_GC_LOG_ENABLED = "STRIMZI_GC_LOG_ENABLED";
 
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "/delete-claim";
+    /** Annotation on PVCs storing the original configuration (so we can revert changes). */
     public static final String ANNO_STRIMZI_IO_STORAGE = Annotations.STRIMZI_DOMAIN + "/storage";
     @Deprecated
     public static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = "cluster.operator.strimzi.io/delete-claim";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -792,10 +792,10 @@ public class KafkaCluster extends AbstractModel {
         if (storage != null) {
             if (storage instanceof PersistentClaimStorage) {
                 Integer id = ((PersistentClaimStorage) storage).getId();
-                String pvcName = ModelUtils.getVolumePrefix(id) + "-" + name;
+                String pvcBaseName = ModelUtils.getVolumePrefix(id) + "-" + name;
 
                 for (int i = 0; i < replicas; i++)  {
-                    pvcs.add(createPersistentVolumeClaim(pvcName + "-" + i, (PersistentClaimStorage) storage));
+                    pvcs.add(createPersistentVolumeClaim(pvcBaseName + "-" + i, (PersistentClaimStorage) storage));
                 }
             } else if (storage instanceof JbodStorage) {
                 for (SingleVolumeStorage volume : ((JbodStorage) storage).getVolumes()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -742,7 +742,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Fill the with volumes, persistent volume claims and related volume mount paths for the storage
+     * Fill the StatefulSet with volumes, persistent volume claims and related volume mount paths for the storage
      * It's called recursively on the related inner volumes if the storage is of {@link Storage#TYPE_JBOD} type
      *
      * @param storage the Storage instance from which building volumes, persistent volume claims and
@@ -780,8 +780,8 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Fill the with volumes, persistent volume claims and related volume mount paths for the storage
-     * It's called recursively on the related inner volumes if the storage is of {@link Storage#TYPE_JBOD} type
+     * Generate the persistent volume claims for the storage It's called recursively on the related inner volumes if the
+     * storage is of {@link Storage#TYPE_JBOD} type
      *
      * @param storage the Storage instance from which building volumes, persistent volume claims and
      *                related volume mount paths

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -267,5 +269,21 @@ public class ModelUtils {
      */
     public static String getVolumePrefix(Integer id) {
         return id == null ? AbstractModel.VOLUME_NAME : AbstractModel.VOLUME_NAME + "-" + id;
+    }
+
+    public static Storage decodeStorageFromJson(String json) {
+        try {
+            return new ObjectMapper().readValue(json, Storage.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String encodeStorageToJson(Storage storage) {
+        try {
+            return new ObjectMapper().writeValueAsString(storage);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -63,18 +63,26 @@ public class StorageDiff extends AbstractResourceDiff {
     /**
      * Returns whether the Diff is empty or not
      *
-     * @return
+     * @return true when the storage configurations are the same
      */
     public boolean isEmpty() {
         return isEmpty;
     }
 
-    /** Returns true if there's a difference in {@code /type} */
+    /**
+     * Returns true if there's a difference in {@code /type}
+     *
+     * @return true when the storage configurations have different type
+     */
     public boolean changesType() {
         return changesType;
     }
 
-    /** Returns true if there's a difference in {@code /size} */
+    /**
+     * Returns true if there's a difference in {@code /size}
+     *
+     * @return true when the size of the volumes changed
+     */
     public boolean changesSize() {
         return changesSize;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.zjsonpatch.JsonDiff;
+import io.strimzi.api.kafka.model.Storage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.regex.Pattern;
+
+import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
+import static java.lang.Integer.parseInt;
+
+public class StorageDiff {
+
+    private static final Logger log = LogManager.getLogger(StorageDiff.class.getName());
+
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
+        "^(/deleteClaim"
+        + "|/volumes/[0-9]+/deleteClaim)$");
+
+    private final boolean isEmpty;
+    private final boolean changesType;
+    private final boolean changesSize;
+
+    public StorageDiff(Storage current, Storage desired) {
+        JsonNode diff = JsonDiff.asJson(patchMapper().valueToTree(current), patchMapper().valueToTree(desired));
+        int num = 0;
+        boolean changesType = false;
+        boolean changesSize = false;
+
+        for (JsonNode d : diff) {
+            String pathValue = d.get("path").asText();
+            if (IGNORABLE_PATHS.matcher(pathValue).matches()) {
+                log.debug("Ignoring Storage diff {}", d);
+                continue;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Storage differs: {}", d);
+                log.debug("Current Storage path {} has value {}", pathValue, getFromPath(current, pathValue));
+                log.debug("Desired Storage path {} has value {}", pathValue, getFromPath(desired, pathValue));
+            }
+
+            num++;
+            changesType |= pathValue.endsWith("/type");
+            changesSize |= pathValue.endsWith("/size");
+        }
+
+        this.isEmpty = num == 0;
+        this.changesType = changesType;
+        this.changesSize = changesSize;
+    }
+
+    private JsonNode getFromPath(Storage current, String pathValue) {
+        JsonNode node1 = patchMapper().valueToTree(current);
+        for (String field : pathValue.replaceFirst("^/", "").split("/")) {
+            JsonNode node2 = node1.get(field);
+            if (node2 == null) {
+                try {
+                    int index = parseInt(field);
+                    node2 = node1.get(index);
+                } catch (NumberFormatException e) {
+                }
+            }
+            if (node2 == null) {
+                node1 = null;
+                break;
+            } else {
+                node1 = node2;
+            }
+        }
+        return node1;
+    }
+
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+
+    /** Returns true if there's a difference in {@code /type} */
+    public boolean changesType() {
+        return changesType;
+    }
+
+    /** Returns true if there's a difference in {@code /size} */
+    public boolean changesSize() {
+        return changesSize;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -62,7 +62,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
     protected static final int LOCK_TIMEOUT_MS = 10000;
 
-
     protected final Vertx vertx;
     protected final boolean isOpenShift;
     protected final ResourceType assemblyType;
@@ -125,11 +124,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     protected abstract Future<Void> createOrUpdate(Reconciliation reconciliation, T assemblyResource);
 
     /**
-     * Subclasses implement this method to delete the cluster.
-     */
-    protected abstract Future<Void> delete(Reconciliation reconciliation);
-
-    /**
      * The name of the given {@code resource}, as read from its metadata.
      * @param resource The resource
      */
@@ -146,10 +140,10 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     /**
      * Reconcile assembly resources in the given namespace having the given {@code name}.
      * Reconciliation works by getting the assembly resource (e.g. {@code KafkaAssembly}) in the given namespace with the given name and
-     * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
+     * comparing with the corresponding resources}.
      * <ul>
-     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created or updated} if ConfigMap is without same-named resources</li>
-     * <li>An assembly will be {@linkplain #delete(Reconciliation) deleted} if resources without same-named ConfigMap</li>
+     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created or updated} if CustomResource is without same-named resources</li>
+     * <li>An assembly will be deleted automatically by garbage collection when the custom resoruce is deleted</li>
      * </ul>
      */
     public final void reconcileAssembly(Reconciliation reconciliation, Handler<AsyncResult<Void>> handler) {
@@ -183,17 +177,10 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                 }
                             });
                     } else {
-                        log.info("{}: Assembly {} should be deleted", reconciliation, assemblyName);
-                        delete(reconciliation).setHandler(deleteResult -> {
-                            lock.release();
-                            log.debug("{}: Lock {} released", reconciliation, lockName);
-                            if (deleteResult.succeeded())   {
-                                log.info("{}: Assembly {} deleted", reconciliation, assemblyName);
-                            } else {
-                                log.error("{}: Deletion of assembly {} failed", reconciliation, assemblyName, deleteResult.cause());
-                            }
-                            handler.handle(deleteResult);
-                        });
+                        log.info("{}: Assembly {} should be deleted by garbage collection", reconciliation, assemblyName);
+                        lock.release();
+                        log.debug("{}: Lock {} released", reconciliation, lockName);
+                        handler.handle(Future.succeededFuture());
                     }
                 } catch (Throwable ex) {
                     lock.release();
@@ -222,10 +209,10 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
     /**
      * Reconcile assembly resources in the given namespace having the given selector.
      * Reconciliation works by getting the assembly ConfigMaps in the given namespace with the given selector and
-     * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
+     * comparing with the corresponding resources}.
      * <ul>
-     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created} for all ConfigMaps without same-named resources</li>
-     * <li>An assembly will be {@linkplain #delete(Reconciliation) deleted} for all resources without same-named ConfigMaps</li>
+     * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created} for all Custom Resource without same-named resources</li>
+     * <li>An assembly will be deleted automatically by the garbage collection when the Custom Resource is deleted</li>
      * </ul>
      *
      * @param trigger A description of the triggering event (timer or watch), used for logging
@@ -233,29 +220,12 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      */
     public final CountDownLatch reconcileAll(String trigger, String namespace) {
 
-        // get ConfigMaps with kind=cluster&type=kafka (or connect, or connect-s2i) for the corresponding cluster type
+        // get Kafka CustomResources (or Connect, Connect-s2i, or Mirror Maker)
         List<T> desiredResources = resourceOperator.list(namespace, Labels.EMPTY);
         Set<NamespaceAndName> desiredNames = desiredResources.stream()
                 .map(cr -> new NamespaceAndName(cr.getMetadata().getNamespace(), cr.getMetadata().getName()))
                 .collect(Collectors.toSet());
         log.debug("reconcileAll({}, {}): desired resources with labels {}: {}", assemblyType, trigger, Labels.EMPTY, desiredNames);
-
-        // get resources with kind=cluster&type=kafka (or connect, or connect-s2i)
-        Labels resourceSelector = Labels.EMPTY.withKind(assemblyType.name);
-        List<? extends HasMetadata> resources = getResources(namespace, resourceSelector);
-        // now extract the cluster name from those
-        Set<NamespaceAndName> resourceNames = resources.stream()
-                .filter(r -> !r.getKind().equals(kind)) // exclude desired resource
-                .map(resource ->
-                        new NamespaceAndName(
-                                resource.getMetadata().getNamespace(),
-                                resource.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL)
-                        )
-                )
-                .collect(Collectors.toSet());
-        log.debug("reconcileAll({}, {}): Other resources with labels {}: {}", assemblyType, trigger, resourceSelector, resourceNames);
-
-        desiredNames.addAll(resourceNames);
 
         // We use a latch so that callers (specifically, test callers) know when the reconciliation is complete
         // Using futures would be more complex for no benefit
@@ -271,14 +241,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
         return latch;
     }
-
-    /**
-     * Gets all the assembly resources (for all assemblies) in the given namespace.
-     * Assembly resources (e.g. the {@code KafkaAssembly} resource) may be included in the result.
-     * @param namespace The namespace
-     * @return The matching resources.
-     */
-    protected abstract List<HasMetadata> getResources(String namespace, Labels selector);
 
     public Future<Watch> createWatch(String watchNamespace, Consumer<KubernetesClientException> onClose) {
         Future<Watch> result = Future.future();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -20,7 +19,6 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
@@ -37,9 +35,7 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -119,17 +115,6 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                 .compose(i -> deploymentOperations.reconcile(namespace, connect.getName(), connect.generateDeployment(annotations, isOpenShift, imagePullPolicy)))
                 .compose(i -> deploymentOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()).map((Void) null));
     }
-
-    @Override
-    protected Future<Void> delete(Reconciliation reconciliation) {
-        return Future.succeededFuture();
-    }
-
-    @Override
-    protected List<HasMetadata> getResources(String namespace, Labels selector) {
-        return Collections.EMPTY_LIST;
-    }
-
 
     Future<ReconcileResult<ServiceAccount>> connectServiceAccount(String namespace, KafkaConnectCluster connect) {
         return serviceAccountOperations.reconcile(namespace,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -21,7 +20,6 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
@@ -40,9 +38,7 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 /**
  * <p>Assembly operator for a "Kafka Connect S2I" assembly, which manages:</p>
@@ -136,16 +132,6 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
         } else {
             return Future.failedFuture("S2I only available on OpenShift");
         }
-    }
-
-    @Override
-    protected Future<Void> delete(Reconciliation reconciliation) {
-        return Future.succeededFuture();
-    }
-
-    @Override
-    protected List<HasMetadata> getResources(String namespace, Labels selector) {
-        return Collections.EMPTY_LIST;
     }
 
     Future<ReconcileResult<ServiceAccount>> connectServiceAccount(String namespace, KafkaConnectCluster connect) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -20,7 +19,6 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
@@ -37,9 +35,7 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -119,20 +115,6 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> podDisruptionBudgetOperator.reconcile(namespace, mirror.getName(), mirror.generatePodDisruptionBudget()))
                 .compose(i -> deploymentOperations.reconcile(namespace, mirror.getName(), mirror.generateDeployment(annotations, isOpenShift, imagePullPolicy)))
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirror.getName(), mirror.getReplicas()).map((Void) null));
-    }
-
-    @Override
-    protected Future<Void> delete(Reconciliation reconciliation) {
-        return Future.succeededFuture();
-    }
-
-    @Override
-    protected List<HasMetadata> getResources(String namespace, Labels selector) {
-        List<HasMetadata> result = new ArrayList<>();
-        result.addAll(deploymentOperations.list(namespace, selector));
-        result.addAll(resourceOperator.list(namespace, selector));
-        
-        return result;
     }
 
     Future<ReconcileResult<ServiceAccount>> mirrorMakerServiceAccount(String namespace, KafkaMirrorMakerCluster mirror) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceDiff.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+public abstract class AbstractResourceDiff {
+    protected JsonNode lookupPath(JsonNode source, String path) {
+        JsonNode s = source;
+        for (String component : path.substring(1).split("/")) {
+            if (s.isArray()) {
+                try {
+                    s = s.path(Integer.parseInt(component));
+                } catch (NumberFormatException e) {
+                    return MissingNode.getInstance();
+                }
+            } else {
+                s = s.path(component);
+            }
+        }
+        return s;
+    }
+
+    /**
+     * Returns whether the Diff is empty or not
+     *
+     * @return
+     */
+    public abstract boolean isEmpty();
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -4,21 +4,10 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 
 /**
  * Specialization of {@link StatefulSetOperator} for StatefulSets of Kafka brokers
@@ -38,12 +27,7 @@ public class KafkaSetOperator extends StatefulSetOperator {
     }
 
     @Override
-    protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
-        StatefulSetDiff diff = new StatefulSetDiff(current, desired);
-        if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Changing Kafka storage type or size is not possible. The changes will be ignored.");
-            diff = revertStorageChanges(current, desired);
-        }
+    protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
         return !diff.isEmpty() && needsRollingUpdate(diff);
     }
 
@@ -56,74 +40,10 @@ public class KafkaSetOperator extends StatefulSetOperator {
             log.debug("Changed template spec => needs rolling update");
             return true;
         }
+        if (diff.changesVolumeClaimTemplates()) {
+            log.debug("Changed volume claim template => needs rolling update");
+            return true;
+        }
         return false;
-    }
-
-    private void revertVolumeChanges(StatefulSet current, StatefulSet desired) {
-
-        Container currentKafka =
-                current.getSpec().getTemplate().getSpec().getContainers().stream().filter(c -> c.getName().equals("kafka")).findFirst().get();
-        Container desiredKafka =
-                desired.getSpec().getTemplate().getSpec().getContainers().stream().filter(c -> c.getName().equals("kafka")).findFirst().get();
-
-        desiredKafka.setVolumeMounts(currentKafka.getVolumeMounts());
-
-        // the external listener changed from nodeport, we need to remove rack-volume
-        if (currentKafka.getEnv().stream().anyMatch(a -> a.getName().equals(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED) && a.getValue().equals("nodeport")) &&
-                desiredKafka.getEnv().stream().noneMatch(a -> a.getName().equals(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED) && a.getValue().equals("nodeport"))) {
-            desiredKafka.getVolumeMounts().remove(desiredKafka.getVolumeMounts().stream().filter(a -> a.getName().equals("rack-volume")).findFirst().get());
-        }
-
-        StatefulSet updated = new StatefulSetBuilder(desired)
-                .editSpec()
-                    .editTemplate()
-                        .editSpec()
-                            .editFirstContainer()
-                                .editMatchingEnv(e -> e.getName().equals(KafkaCluster.ENV_VAR_KAFKA_LOG_DIRS))
-                                    .withValue(desiredKafka.getVolumeMounts().stream()
-                                        .filter(vm -> vm.getMountPath().contains(AbstractModel.VOLUME_NAME))
-                                        .map(vm -> vm.getMountPath())
-                                        .collect(Collectors.joining(",")))
-                                .endEnv()
-                            .endContainer()
-                        .endSpec()
-                    .endTemplate()
-                .endSpec()
-                .build();
-
-        desired.setSpec(updated.getSpec());
-    }
-
-    @Override
-    protected StatefulSetDiff revertStorageChanges(StatefulSet current, StatefulSet desired) {
-
-        List<PersistentVolumeClaim> currentPvcs = current.getSpec().getVolumeClaimTemplates();
-        List<PersistentVolumeClaim> desiredPvcs = desired.getSpec().getVolumeClaimTemplates();
-
-        if (desiredPvcs.size() != currentPvcs.size()) {
-            log.warn("Adding or removing Kafka persistent storage is not possible. The changes will be ignored.");
-            revertVolumeChanges(current, desired);
-        } else {
-
-            for (PersistentVolumeClaim currentPvc : currentPvcs) {
-
-                Optional<PersistentVolumeClaim> pvc =
-                        desiredPvcs.stream()
-                                .filter(desiredPvc -> desiredPvc.getMetadata().getName().equals(currentPvc.getMetadata().getName()))
-                                .findFirst();
-
-                if (!pvc.isPresent()) {
-                    log.warn("Changing Kafka persistent storage ids is not possible. The changes will be ignored.");
-                    revertVolumeChanges(current, desired);
-
-                } else if (!pvc.get().getSpec().getResources().getRequests().get("storage").getAmount()
-                        .equals(currentPvc.getSpec().getResources().getRequests().get("storage").getAmount())) {
-
-                    log.warn("Changing Kafka storage size is not possible. The changes will be ignored.");
-                }
-            }
-        }
-
-        return super.revertStorageChanges(current, desired);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
@@ -40,6 +41,7 @@ public class ResourceOperatorSupplier {
     public final CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> kafkaOperator;
     public final NetworkPolicyOperator networkPolicyOperator;
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
+    public final PodOperator podOperations;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, boolean isOpenShift, long operationTimeoutMs) {
         this(vertx, client, new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
@@ -62,6 +64,7 @@ public class ResourceOperatorSupplier {
                 new ClusterRoleBindingOperator(vertx, client),
                 new NetworkPolicyOperator(vertx, client),
                 new PodDisruptionBudgetOperator(vertx, client),
+                new PodOperator(vertx, client),
                 new CrdOperator<>(vertx, client, Kafka.class, KafkaList.class, DoneableKafka.class));
     }
 
@@ -78,6 +81,7 @@ public class ResourceOperatorSupplier {
                                     ClusterRoleBindingOperator clusterRoleBindingOperator,
                                     NetworkPolicyOperator networkPolicyOperator,
                                     PodDisruptionBudgetOperator podDisruptionBudgetOperator,
+                                    PodOperator podOperations,
                                     CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> kafkaOperator) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
@@ -93,5 +97,6 @@ public class ResourceOperatorSupplier {
         this.networkPolicyOperator = networkPolicyOperator;
         this.podDisruptionBudgetOperator = podDisruptionBudgetOperator;
         this.kafkaOperator = kafkaOperator;
+        this.podOperations = podOperations;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -136,7 +136,7 @@ public class StatefulSetDiff extends AbstractResourceDiff {
     /**
      * Returns whether the Diff is empty or not
      *
-     * @return
+     * @return true when the StatefulSets are identical
      */
     public boolean isEmpty() {
         return isEmpty;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 
 import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
 
-public class StatefulSetDiff {
+public class StatefulSetDiff extends AbstractResourceDiff {
 
     private static final Logger log = LogManager.getLogger(StatefulSetDiff.class.getName());
 
@@ -113,22 +113,6 @@ public class StatefulSetDiff {
         this.changesVolumeClaimTemplate = changesVolumeClaimTemplate;
     }
 
-    JsonNode lookupPath(JsonNode source, String path) {
-        JsonNode s = source;
-        for (String component : path.substring(1).split("/")) {
-            if (s.isArray()) {
-                try {
-                    s = s.path(Integer.parseInt(component));
-                } catch (NumberFormatException e) {
-                    return MissingNode.getInstance();
-                }
-            } else {
-                s = s.path(component);
-            }
-        }
-        return s;
-    }
-
     boolean compareMemoryAndCpuResources(JsonNode source, JsonNode target, String pathValue, Matcher resourceMatchers) {
         JsonNode s = lookupPath(source, pathValue);
         JsonNode t = lookupPath(target, pathValue);
@@ -150,6 +134,11 @@ public class StatefulSetDiff {
         return false;
     }
 
+    /**
+     * Returns whether the Diff is empty or not
+     *
+     * @return
+     */
     public boolean isEmpty() {
         return isEmpty;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.MissingNode;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.zjsonpatch.JsonDiff;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -40,12 +40,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
     }
 
     @Override
-    protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
-        StatefulSetDiff diff = new StatefulSetDiff(current, desired);
-        if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Changing Zookeeper storage type or size is not possible. The changes will be ignored.");
-            diff = revertStorageChanges(current, desired);
-        }
+    protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
         return !diff.isEmpty() && needsRollingUpdate(diff);
     }
 
@@ -61,6 +56,10 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         }
         if (diff.changesSpecTemplate()) {
             log.debug("Changed template spec => needs rolling update");
+            return true;
+        }
+        if (diff.changesVolumeClaimTemplates()) {
+            log.debug("Changed volume claim template => needs rolling update");
             return true;
         }
         return false;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -55,6 +55,7 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
@@ -490,7 +491,7 @@ public class ResourceUtils {
                 mock(KafkaSetOperator.class), mock(ConfigMapOperator.class), mock(SecretOperator.class),
                 mock(PvcOperator.class), mock(DeploymentOperator.class),
                 mock(ServiceAccountOperator.class), mock(RoleBindingOperator.class), mock(ClusterRoleBindingOperator.class),
-                mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(CrdOperator.class));
+                mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class), mock(CrdOperator.class));
         when(supplier.serviceAccountOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
@@ -28,6 +29,7 @@ import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.openshift.api.model.Route;
+import io.strimzi.api.kafka.model.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.Kafka;
@@ -36,6 +38,7 @@ import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.RackBuilder;
+import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
@@ -73,6 +76,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings({
+        "checkstyle:ClassDataAbstractionCoupling",
+        "checkstyle:ClassFanOutComplexity"
+})
 public class KafkaClusterTest {
 
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(new StringReader(
@@ -1493,5 +1500,192 @@ public class KafkaClusterTest {
 
         assertEquals("0://some-host.com:12345", kc.getExternalAdvertisedUrl(0, "some-host.com", "12345"));
         assertEquals("0://:12345", kc.getExternalAdvertisedUrl(0, "", "12345"));
+    }
+
+    @Test
+    public void testGeneratePersistentVolumeClaims()    {
+
+        /**********
+         * Persistent storage with claim deletion
+         */
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewPersistentClaimStorage().withStorageClass("gp2-ssd").withDeleteClaim(true).withSize("100Gi").endPersistentClaimStorage()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage()), kc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims(kc.getStorage());
+
+        assertEquals(3, pvcs.size());
+
+        for (PersistentVolumeClaim pvc : pvcs) {
+            assertEquals(new Quantity("100Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-ssd", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME));
+            assertEquals(1, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("true", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        /**********
+         * Persistent storage without claim deletion
+         */
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewPersistentClaimStorage().withStorageClass("gp2-ssd").withDeleteClaim(false).withSize("100Gi").endPersistentClaimStorage()
+                    .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage()), kc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        pvcs = kc.generatePersistentVolumeClaims(kc.getStorage());
+
+        assertEquals(3, pvcs.size());
+
+        for (PersistentVolumeClaim pvc : pvcs) {
+            assertEquals(new Quantity("100Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-ssd", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME));
+            assertEquals(0, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("false", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        /**********
+         * JBOD storage without claim deletion
+         */
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withStorage(new JbodStorageBuilder().withVolumes(
+                            new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
+                            new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                            .build())
+                    .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage()), kc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        pvcs = kc.generatePersistentVolumeClaims(kc.getStorage());
+
+        assertEquals(6, pvcs.size());
+
+        for (int i = 0; i < 3; i++) {
+            PersistentVolumeClaim pvc = pvcs.get(i);
+            assertEquals(new Quantity("100Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-ssd", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME));
+            assertEquals(0, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("false", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        for (int i = 3; i < 6; i++) {
+            PersistentVolumeClaim pvc = pvcs.get(i);
+            assertEquals(new Quantity("1000Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-st1", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME));
+            assertEquals(1, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("true", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        /**********
+         * Ephemeral storage
+         */
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewEphemeralStorage().endEphemeralStorage()
+                    .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage()), kc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        pvcs = kc.generatePersistentVolumeClaims(kc.getStorage());
+
+        assertEquals(0, pvcs.size());
+    }
+
+    @Test
+    public void testStorageReverting() {
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                .build();
+
+        Storage ephemeral = new EphemeralStorageBuilder().build();
+
+        Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+
+        // Test Storage changes and how the are reverted
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withStorage(jbod)
+                .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, ephemeral);
+        assertEquals(ephemeral, kc.getStorage());
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withStorage(jbod)
+                .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, persistent);
+        assertEquals(persistent, kc.getStorage());
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withStorage(ephemeral)
+                .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod);
+        assertEquals(jbod, kc.getStorage());
+
+        kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withStorage(persistent)
+                .endKafka()
+                .endSpec()
+                .build();
+        kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod);
+        assertEquals(jbod, kc.getStorage());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -7,6 +7,10 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.strimzi.api.kafka.model.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplateBuilder;
 import io.strimzi.api.kafka.model.template.PodTemplate;
@@ -125,5 +129,21 @@ public class ModelUtilsTest {
         protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
             return null;
         }
+    }
+
+    @Test
+    public void testStorageSerializationAndDeserialization()    {
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                .build();
+
+        Storage ephemeral = new EphemeralStorageBuilder().build();
+
+        Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+
+        assertEquals(jbod, ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(jbod)));
+        assertEquals(ephemeral, ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(ephemeral)));
+        assertEquals(persistent, ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(persistent)));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.Storage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StorageDiffTest {
+    @Test
+    public void testJbodDiff()    {
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                .build();
+
+        Storage jbod2 = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                .build();
+
+        assertFalse(new StorageDiff(jbod, jbod).changesType());
+        assertTrue(new StorageDiff(jbod, jbod).isEmpty());
+        assertFalse(new StorageDiff(jbod, jbod).changesSize());
+
+        assertFalse(new StorageDiff(jbod, jbod2).changesType());
+        assertFalse(new StorageDiff(jbod, jbod2).isEmpty());
+        assertTrue(new StorageDiff(jbod, jbod2).changesSize());
+    }
+
+    @Test
+    public void testPersistentDiff()    {
+        Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+        Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
+
+        assertFalse(new StorageDiff(persistent, persistent).changesType());
+        assertTrue(new StorageDiff(persistent, persistent).isEmpty());
+        assertFalse(new StorageDiff(persistent, persistent).changesSize());
+
+        assertFalse(new StorageDiff(persistent, persistent2).changesType());
+        assertFalse(new StorageDiff(persistent, persistent2).isEmpty());
+        assertTrue(new StorageDiff(persistent, persistent2).changesSize());
+    }
+
+    @Test
+    public void testEphemeralDiff()    {
+        Storage ephemeral = new EphemeralStorageBuilder().build();
+
+        assertFalse(new StorageDiff(ephemeral, ephemeral).changesType());
+        assertTrue(new StorageDiff(ephemeral, ephemeral).isEmpty());
+        assertFalse(new StorageDiff(ephemeral, ephemeral).changesSize());
+    }
+
+    @Test
+    public void testCrossDiff()    {
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build(),
+                new PersistentClaimStorageBuilder().withStorageClass("gp2-st1").withDeleteClaim(true).withId(1).withSize("1000Gi").build())
+                .build();
+
+        Storage ephemeral = new EphemeralStorageBuilder().build();
+
+        Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+
+        assertTrue(new StorageDiff(jbod, ephemeral).changesType());
+        assertTrue(new StorageDiff(persistent, ephemeral).changesType());
+        assertTrue(new StorageDiff(jbod, persistent).changesType());
+
+        assertFalse(new StorageDiff(jbod, ephemeral).isEmpty());
+        assertFalse(new StorageDiff(persistent, ephemeral).isEmpty());
+        assertFalse(new StorageDiff(jbod, persistent).isEmpty());
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
@@ -21,11 +22,14 @@ import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
+import io.strimzi.api.kafka.model.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.RackBuilder;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
@@ -658,5 +662,116 @@ public class ZookeeperClusterTest {
         podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
         assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(3));
+    }
+
+    @Test
+    public void testGeneratePersistentVolumeClaims()    {
+
+        /**********
+         * Persistent storage with claim deletion
+         */
+
+        Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withNewPersistentClaimStorage().withStorageClass("gp2-ssd").withDeleteClaim(true).withSize("100Gi").endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(ka.getSpec().getZookeeper().getStorage()), zc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        List<PersistentVolumeClaim> pvcs = zc.generatePersistentVolumeClaims();
+
+        assertEquals(3, pvcs.size());
+
+        for (PersistentVolumeClaim pvc : pvcs) {
+            assertEquals(new Quantity("100Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-ssd", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(zc.VOLUME_NAME));
+            assertEquals(1, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("true", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        /**********
+         * Persistent storage without claim deletion
+         */
+
+        ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withNewPersistentClaimStorage().withStorageClass("gp2-ssd").withDeleteClaim(false).withSize("100Gi").endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+        zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(ka.getSpec().getZookeeper().getStorage()), zc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        pvcs = zc.generatePersistentVolumeClaims();
+
+        assertEquals(3, pvcs.size());
+
+        for (PersistentVolumeClaim pvc : pvcs) {
+            assertEquals(new Quantity("100Gi"), pvc.getSpec().getResources().getRequests().get("storage"));
+            assertEquals("gp2-ssd", pvc.getSpec().getStorageClassName());
+            assertTrue(pvc.getMetadata().getName().startsWith(zc.VOLUME_NAME));
+            assertEquals(0, pvc.getMetadata().getOwnerReferences().size());
+            assertEquals("false", pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+        }
+
+        /**********
+         * Ephemeral storage
+         */
+
+        ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withNewEphemeralStorage().endEphemeralStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+        zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
+
+        // Check Storage annotation on STS
+        assertEquals(ModelUtils.encodeStorageToJson(ka.getSpec().getZookeeper().getStorage()), zc.generateStatefulSet(true, ImagePullPolicy.NEVER).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE));
+
+        // Check PVCs
+        pvcs = zc.generatePersistentVolumeClaims();
+
+        assertEquals(0, pvcs.size());
+    }
+
+    @Test
+    public void testStorageReverting() {
+        SingleVolumeStorage ephemeral = new EphemeralStorageBuilder().build();
+        SingleVolumeStorage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
+
+        // Test Storage changes and how the are reverted
+
+        Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withStorage(ephemeral)
+                .endZookeeper()
+                .endSpec()
+                .build();
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS, persistent);
+        assertEquals(persistent, zc.getStorage());
+
+        ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withStorage(persistent)
+                .endZookeeper()
+                .endSpec()
+                .build();
+        zc = ZookeeperCluster.fromCrd(ka, VERSIONS, ephemeral);
+        assertEquals(ephemeral, zc.getStorage());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -100,7 +100,7 @@ public class CertificateRenewalTest {
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
                 new ResourceOperatorSupplier(null, null, null,
                         null, null, secretOps, null, null,
-                        null, null, null, null, null, null),
+                        null, null, null, null, null, null, null),
                 new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 
 import static io.strimzi.api.kafka.model.Storage.deleteClaim;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -586,8 +585,6 @@ public class KafkaAssemblyOperatorMockTest {
         kco.reconcileAssembly(new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, CLUSTER_NAME), ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.assertTrue(ar.succeeded());
-            assertPvcs(context, !originalKafkaDeleteClaim ? deleteClaim(zkStorage) ? emptySet() : zkPvcs :
-                    deleteClaim(zkStorage) ? kafkaPvcs : allPvcs);
             deleteAsync.complete();
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -389,6 +389,11 @@ public class KafkaAssemblyOperatorTest {
                     return null;
                 });
 
+        when(mockPvcOps.listAsync(eq(clusterCmNamespace), ArgumentMatchers.any(Labels.class)))
+                .thenAnswer(invocation -> {
+                    return Future.succeededFuture(Collections.EMPTY_LIST);
+                });
+
         Set<String> expectedPvcs = new HashSet<>(zkPvcs.keySet());
         expectedPvcs.addAll(kafkaPvcs.keySet());
         ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
@@ -737,6 +742,19 @@ public class KafkaAssemblyOperatorTest {
                     }
                     return null;
                 });
+
+        when(mockPvcOps.listAsync(eq(clusterNamespace), ArgumentMatchers.any(Labels.class)))
+                .thenAnswer(invocation -> {
+                    Labels labels = invocation.getArgument(1);
+                    if (labels.toMap().get(Labels.STRIMZI_NAME_LABEL).contains("kafka")) {
+                        return Future.succeededFuture(new ArrayList<PersistentVolumeClaim>(kafkaPvcs.values()));
+                    } else if (labels.toMap().get(Labels.STRIMZI_NAME_LABEL).contains("zookeeper")) {
+                        return Future.succeededFuture(new ArrayList<PersistentVolumeClaim>(zkPvcs.values()));
+                    }
+                    return Future.succeededFuture(Collections.EMPTY_LIST);
+                });
+
+        when(mockPvcOps.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
         // Mock CM get
         when(mockKafkaOps.get(clusterNamespace, clusterName)).thenReturn(updatedAssembly);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -152,7 +152,7 @@ public class KafkaUpdateTest {
                 new MockCertManager(),
                 new ResourceOperatorSupplier(null, null, null,
                         kso, null, null, null, null,
-                        null, null, null, null, null, null),
+                        null, null, null, null, null, null, null),
                 lookup, null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -7,14 +7,18 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
+import io.strimzi.api.kafka.model.JbodStorage;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -129,34 +133,4 @@ public class KafkaSetOperatorTest {
                 "foo", null));
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
     }
-
-    /*@Test
-    public void testChangeStorageType() {
-        Kafka kafkaa = getResource();
-        Kafka kafkab = getResource();
-        PersistentClaimStorage pcs = new PersistentClaimStorage();
-        pcs.setSize("100Gi");
-
-        JbodStorage jbod = new JbodStorage();
-        SingleVolumeStorage volume = new PersistentClaimStorage() {
-            @Override
-            public String getType() {
-                return null;
-            }
-        };
-        volume.setId(0);
-        jbod.setVolumes(Arrays.asList(volume));
-
-        kafkaa.getSpec().getKafka().setStorage(pcs);
-        kafkab.getSpec().getKafka().setStorage(jbod);
-        KafkaVersion.Lookup versions = new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap());
-        a = KafkaCluster.fromCrd(kafkaa, versions).generateStatefulSet(true, null);
-        b = KafkaCluster.fromCrd(kafkab, versions).generateStatefulSet(true, null);
-        b.getMetadata().getLabels().put("new", "label");
-
-        KafkaSetOperator kso = new KafkaSetOperator(null, null, 0);
-        assertTrue(kso.shouldIncrementGeneration(a, b));
-        assertTrue(kso.revertStorageChanges(a, b).changesLabels());
-        assertFalse(kso.revertStorageChanges(a, b).changesVolumeClaimTemplates());
-    }*/
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -7,18 +7,14 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
-import io.strimzi.api.kafka.model.JbodStorage;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.PersistentClaimStorage;
-import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -134,7 +130,7 @@ public class KafkaSetOperatorTest {
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
     }
 
-    @Test
+    /*@Test
     public void testChangeStorageType() {
         Kafka kafkaa = getResource();
         Kafka kafkab = getResource();
@@ -162,5 +158,5 @@ public class KafkaSetOperatorTest {
         assertTrue(kso.shouldIncrementGeneration(a, b));
         assertTrue(kso.revertStorageChanges(a, b).changesLabels());
         assertFalse(kso.revertStorageChanges(a, b).changesVolumeClaimTemplates());
-    }
+    }*/
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -7,18 +7,14 @@ package io.strimzi.operator.cluster.operator.resource;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.api.kafka.model.InlineLogging;
-import io.strimzi.api.kafka.model.JbodStorage;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.PersistentClaimStorage;
-import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -79,7 +79,7 @@ public class StatefulSetOperatorTest
     protected StatefulSetOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new StatefulSetOperator(vertx, mockClient, 60_000L) {
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
         };
@@ -94,7 +94,7 @@ public class StatefulSetOperatorTest
             }
 
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
 
@@ -140,7 +140,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
         };
@@ -184,7 +184,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
         };
@@ -223,7 +223,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
         };
@@ -262,7 +262,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
                 return true;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -4,13 +4,17 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.apps.DoneableStatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -23,9 +27,12 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 
@@ -33,8 +40,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class StatefulSetOperatorTest
@@ -270,5 +279,97 @@ public class StatefulSetOperatorTest
         Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
         assertTrue(result.failed());
         assertTrue(result.cause().getMessage().equals("reconcile failed"));
+    }
+
+    @Test
+    public void testInternalReplace(TestContext context)   {
+        StatefulSet sts1 = new StatefulSetBuilder()
+                .withNewMetadata()
+                    .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
+                    .withName(AbstractResourceOperatorTest.RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(3)
+                    .withNewTemplate()
+                        .withNewMetadata()
+                        .endMetadata()
+                    .endTemplate()
+                .endSpec()
+                .build();
+
+        Map<String, Quantity> requests = new HashMap<>();
+        requests.put("storage", new Quantity("100Gi"));
+
+        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                    .withName("data")
+                .endMetadata()
+                .withNewSpec()
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                        .withRequests(requests)
+                    .endResources()
+                    .withStorageClassName("gp2")
+                .endSpec()
+                .build();
+
+        StatefulSet sts2 = new StatefulSetBuilder()
+                .withNewMetadata()
+                    .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
+                    .withName(AbstractResourceOperatorTest.RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(3)
+                    .withNewTemplate()
+                        .withNewMetadata()
+                        .endMetadata()
+                    .endTemplate()
+                    .withVolumeClaimTemplates(pvc)
+                .endSpec()
+                .build();
+
+        EditReplacePatchDeletable mockERPD = mock(EditReplacePatchDeletable.class);
+
+        Resource mockResource = mock(resourceType());
+        when(mockResource.get()).thenReturn(sts1);
+        when(mockResource.cascading(eq(false))).thenReturn(mockERPD);
+
+        PodOperator podOperator = mock(PodOperator.class);
+        when(podOperator.waitFor(anyString(), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture());
+        when(podOperator.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(podOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+        when(podOperator.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(new PodBuilder().withNewMetadata().withName("my-pod-0").endMetadata().build()));
+
+        PvcOperator pvcOperator = mock(PvcOperator.class);
+        when(pvcOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+        mocker(mockClient, mockCms);
+
+        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
+            @Override
+            protected boolean shouldIncrementGeneration(StatefulSetDiff diff) {
+                return true;
+            }
+
+            @Override
+            public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+                return Future.succeededFuture();
+            }
+        };
+
+        Async async = context.async();
+        op.reconcile(sts1.getMetadata().getNamespace(), sts1.getMetadata().getName(), sts2).setHandler(ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            assertTrue(ar.succeeded());
+            verify(mockERPD).delete();
+            async.complete();
+        });
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -49,6 +49,12 @@ public class Annotations {
         return str != null ? parseInt(str) : defaultValue;
     }
 
+    public static String stringAnnotation(HasMetadata resource, String annotation, String defaultValue, String... deprecatedAnnotations) {
+        ObjectMeta metadata = resource.getMetadata();
+        String str = annotation(annotation, null, metadata, deprecatedAnnotations);
+        return str != null ? str : defaultValue;
+    }
+
     public static int intAnnotation(PodTemplateSpec podSpec, String annotation, int defaultValue, String... deprecatedAnnotations) {
         ObjectMeta metadata = podSpec.getMetadata();
         String str = annotation(annotation, null, metadata, deprecatedAnnotations);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -264,6 +264,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
 
     /**
      * Asynchronously lists the resource with the given {@code selector} in the given {@code namespace}.
+     *
      * @param namespace The namespace.
      * @param selector The selector.
      * @return A Future with a list of matching resources.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -112,12 +112,31 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
     }
 
     /**
-     * Deletes the resource with the given namespace and name
-     * and completes the given future accordingly
+     * Deletes the resource with the given namespace and name and completes the given future accordingly.
+     * This method will do a cascading delete.
+     *
+     * @param namespace Namespace of the resource which should be deleted
+     * @param name Name of the resource which should be deleted
+     *
+     * @return Future with result of the reconciliation
      */
     protected Future<ReconcileResult<T>> internalDelete(String namespace, String name) {
+        return internalDelete(namespace, name, true);
+    }
+
+    /**
+     * Deletes the resource with the given namespace and name and completes the given future accordingly
+     *
+     * @param namespace Namespace of the resource which should be deleted
+     * @param name Name of the resource which should be deleted
+     * @param cascading Defines whether the delete should be cascading or not (e.g. whether a STS deletion should delete pods etc.)
+     *
+     * @return Future with result of the reconciliation
+     */
+
+    protected Future<ReconcileResult<T>> internalDelete(String namespace, String name, boolean cascading) {
         try {
-            operation().inNamespace(namespace).withName(name).delete();
+            operation().inNamespace(namespace).withName(name).cascading(cascading).delete();
             log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);
             return Future.succeededFuture(ReconcileResult.deleted());
         } catch (Exception e) {
@@ -145,7 +164,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
         }
     }
 
-    private boolean wasChanged(T oldVersion, T newVersion) {
+    protected boolean wasChanged(T oldVersion, T newVersion) {
         if (oldVersion != null
                 && oldVersion.getMetadata() != null
                 && newVersion != null


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR does the refactoring of the storage handling in CO to give us more flexibility for other changes such as storage resizing, adding / removing volumes in JBOD etc. It does following main changes:
* Reworked reconciliation of PVCs and their cleanup (our method during scaledown, garbage collection after cluster deletion)
* Possibility to _replace_ Statefulset after changes to immutable fields (non-cascading delete + create)
* Improvements to Pod cleanup to handle race conditions between PVC deletion and pod restart
* Storing old storage configuration as JSON in annotation to make it easy to revert changes which are not allowed.
* Removal of the old code for deleting clusters (replaced by garbage collection)

+ probably something ore what was standing in the way.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally