### PR TITLE
Support for more informative deprecation in docs, logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)
 endif
 
-SUBDIRS=mockkube test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples metrics
+SUBDIRS=mockkube crd-annotations test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples metrics
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -66,6 +67,9 @@ public class KafkaSpec implements UnknownPropertyPreserving, Serializable {
     }
 
     @Deprecated
+    @DeprecatedProperty(
+            movedToPath = "spec.entityOerator.topicOperator"
+    )
     @Description("Configuration of the Topic Operator")
     public TopicOperatorSpec getTopicOperator() {
         return topicOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -214,9 +214,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      */
     protected void validate(T resource) {
         if (resource != null) {
-            String context = kind + " resource " + resource.getMetadata().getName()
-                    + " in namespace " + resource.getMetadata().getNamespace();
-            ResourceVisitor.visit(resource, new ValidationVisitor(context, log));
+            ResourceVisitor.visit(resource, new ValidationVisitor(resource, log));
         }
     }
 

--- a/crd-annotations/Makefile
+++ b/crd-annotations/Makefile
@@ -1,0 +1,11 @@
+PROJECT_NAME=crd-annotations
+
+docker_build: java_install
+docker_push:
+docker_tag:
+all: docker_build docker_push
+clean: java_clean
+
+include ../Makefile.maven
+
+.PHONY: build clean release

--- a/crd-annotations/pom.xml
+++ b/crd-annotations/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>strimzi</artifactId>
+        <groupId>io.strimzi</groupId>
+        <version>0.12.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>crd-annotations</artifactId>
+
+
+</project>

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeprecatedProperty {
+
+    /** The API version in which this property is scheduled to be removed. */
+    String removalVersion() default "";
+
+    /**
+     * If this property has moved to a different location in the Custom Resource this is
+     * the path it has moved to.
+     */
+    String movedToPath() default "";
+
+    /**
+     * If this property has <strong>not</strong> moved to a different location in the Custom Resource this is
+     * a description of how the functionality can now be configured.
+     */
+    String description() default "";
+}

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -19,6 +19,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.strimzi</groupId>
+      <artifactId>crd-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -41,6 +45,12 @@
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.strimzi</groupId>
+      <artifactId>crd-annotations</artifactId>
+      <version>0.12.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -49,8 +49,6 @@
     <dependency>
       <groupId>io.strimzi</groupId>
       <artifactId>crd-annotations</artifactId>
-      <version>0.12.0-SNAPSHOT</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -25,7 +25,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |zookeeper               1.2+<.<|Configuration of the Zookeeper cluster.
 |xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
-|topicOperator           1.2+<.<|Configuration of the Topic Operator.
+|topicOperator           1.2+<.<|*The property `topicOperator` has been deprecated. This feature should now be configured at path `spec.entityOerator.topicOperator`.* Configuration of the Topic Operator.
 |xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`]
 |entityOperator          1.2+<.<|Configuration of the Entity Operator.
 |xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -19,6 +19,10 @@
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>
+            <artifactId>crd-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
 
     <modules>
         <module>test</module>
+        <module>crd-annotations</module>
         <module>crd-generator</module>
         <module>api</module>
         <module>mockkube</module>
@@ -125,6 +126,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.strimzi</groupId>
+                <artifactId>crd-annotations</artifactId>
+                <version>${project.version}</version>
+                <scope>compile</scope>
+            </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>
                 <artifactId>test</artifactId>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Fixes #1460 by adding a new annotation for deprecating properties in CRs which is consumed by the DocGenerator and by the validation at runtime. Unfortunately a new module is necessary because (unlike existing annotations) the annotation's .class needs to be on both the doc-generation-time and runtime classpaths, but this seemed simpler than the alternatives.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

