### PR TITLE
Determine k8s version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -216,9 +216,12 @@ public class Main {
                             isOpenShift = false;
                         }
                     }
+                    /* test */ String major = client.getVersion().getMajor().equals("") ? "1" : client.getVersion().getMajor();
+                    /* test */ String minor = client.getVersion().getMinor().equals("") ? "9" : client.getVersion().getMinor();
+
                     PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift,
-                            new KubernetesVersion(Integer.parseInt(client.getVersion().getMajor().split("\\D")[0]),
-                                    Integer.parseInt(client.getVersion().getMinor().split("\\D")[0])));
+                            new KubernetesVersion(Integer.parseInt(major.split("\\D")[0]),
+                                    Integer.parseInt(minor.split("\\D")[0])));
                     request.complete(pfa);
                 } catch (IOException e) {
                     log.error("OpenShift detection failed", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -219,7 +219,7 @@ public class Main {
 
                     request.complete(isOpenShift);
                 } catch (Exception e) {
-                    log.error("OpenShift detection failed", e);
+                    log.error("OpenShift detection failed. You can use Cluster Operator's `assumeOpenShift` flag.", e);
                     request.fail(e);
                 }
             }, fut.completer());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
 
 public class Main {
     private static final Logger log = LogManager.getLogger(Main.class.getName());
+    private static final int MINIMAL_SUPPORTED_MAJOR = 1;
+    private static final int MINIMAL_SUPPORTED_MINOR = 9;
 
     static {
         try {
@@ -216,8 +218,8 @@ public class Main {
                             isOpenShift = false;
                         }
                     }
-                    /* test */ String major = client.getVersion().getMajor().equals("") ? "1" : client.getVersion().getMajor();
-                    /* test */ String minor = client.getVersion().getMinor().equals("") ? "9" : client.getVersion().getMinor();
+                    /* test */ String major = client.getVersion().getMajor().equals("") ? Integer.toString(MINIMAL_SUPPORTED_MAJOR) : client.getVersion().getMajor();
+                    /* test */ String minor = client.getVersion().getMinor().equals("") ? Integer.toString(MINIMAL_SUPPORTED_MINOR) : client.getVersion().getMinor();
 
                     PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift,
                             new KubernetesVersion(Integer.parseInt(major.split("\\D")[0]),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -216,7 +216,9 @@ public class Main {
                             isOpenShift = false;
                         }
                     }
-                    PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift, new KubernetesVersion(client.getVersion().getMajor(), client.getVersion().getMinor()));
+                    PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift,
+                            new KubernetesVersion(Integer.parseInt(client.getVersion().getMajor().replaceAll("\\D", "")),
+                                    Integer.parseInt(client.getVersion().getMinor().replaceAll("\\D", ""))));
                     request.complete(pfa);
                 } catch (IOException e) {
                     log.error("OpenShift detection failed", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -223,7 +223,7 @@ public class Main {
                             new KubernetesVersion(Integer.parseInt(major.split("\\D")[0]),
                                     Integer.parseInt(minor.split("\\D")[0])));
                     request.complete(pfa);
-                } catch (IOException e) {
+                } catch (Exception e) {
                     log.error("OpenShift detection failed", e);
                     request.fail(e);
                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -217,8 +217,8 @@ public class Main {
                         }
                     }
                     PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift,
-                            new KubernetesVersion(Integer.parseInt(client.getVersion().getMajor().replaceAll("\\D", "")),
-                                    Integer.parseInt(client.getVersion().getMinor().replaceAll("\\D", ""))));
+                            new KubernetesVersion(Integer.parseInt(client.getVersion().getMajor().split("\\D")[0]),
+                                    Integer.parseInt(client.getVersion().getMinor().split("\\D")[0])));
                     request.complete(pfa);
                 } catch (IOException e) {
                     log.error("OpenShift detection failed", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
@@ -215,18 +216,10 @@ public class Main {
                             isOpenShift = false;
                         }
                     }
-                    Response resp2 = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "version").build()).execute();
-                    String versionJsonString = null;
-                    if (resp2.code() >= 200 && resp2.code() < 300) {
-                        versionJsonString = resp2.body().string();
-                    }
-                    PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift, versionJsonString);
+                    PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenShift, new KubernetesVersion(client.getVersion().getMajor(), client.getVersion().getMinor()));
                     request.complete(pfa);
                 } catch (IOException e) {
                     log.error("OpenShift detection failed", e);
-                    request.fail(e);
-                } catch (IllegalArgumentException e) {
-                    log.error("Kubernetes version detection failed", e);
                     request.fail(e);
                 }
             }, fut.completer());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -77,7 +77,7 @@ public class Main {
 
         maybeCreateClusterRoles(vertx, config, client).setHandler(crs -> {
             if (crs.succeeded())    {
-                isOnOpenShift(vertx, client, config).setHandler(os -> {
+                getPlatformFeaturesAvailability(vertx, client, config).setHandler(os -> {
                     if (os.succeeded()) {
                         run(vertx, client, os.result(), config).setHandler(ar -> {
                             if (ar.failed()) {
@@ -193,7 +193,7 @@ public class Main {
         return kafkaConnectS2IClusterOperations;
     }
 
-    static Future<PlatformFeaturesAvailability> isOnOpenShift(Vertx vertx, KubernetesClient client, ClusterOperatorConfig config)  {
+    static Future<PlatformFeaturesAvailability> getPlatformFeaturesAvailability(Vertx vertx, KubernetesClient client, ClusterOperatorConfig config)  {
         if (client.isAdaptable(OkHttpClient.class)) {
             OkHttpClient ok = client.adapt(OkHttpClient.class);
             Future<PlatformFeaturesAvailability> fut = Future.future();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -4,71 +4,32 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.vertx.core.json.Json;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 
-import java.util.Properties;
 
 public class PlatformFeaturesAvailability {
-    private Properties properties;
 
-    static final String MAJORVERSION = "major";
-    static final String MINORVERSION = "minor";
-    static final String ISOPENSHIFT = "isOpenshift";
-    static final String NETWORKPOLICIES_NS_AND_PODSEL = "networkPoliciesNSandPodSel";
+    private boolean isOpenshift;
+    private final KubernetesVersion kubernetesVersion;
 
-    static final String KUBERNETES1_8 = "1.8";
-    static final String KUBERNETES1_9 = "1.9";
-    static final String KUBERNETES1_10 = "1.10";
-    static final String KUBERNETES1_11 = "1.11";
-
-    public PlatformFeaturesAvailability(boolean isOpenshift, String versionResponse) {
-        if (versionResponse == null) {
-            throw new IllegalArgumentException("Kubernetes version could not be determined.");
-        }
-        this.properties = new Properties();
-        Properties versionResponseProperties = Json.decodeValue(versionResponse, Properties.class);
-
-        // we need to get versions first
-        properties.put(MAJORVERSION, versionResponseProperties.get(MAJORVERSION).toString().replaceAll("\\D", ""));
-        properties.put(MINORVERSION, versionResponseProperties.get(MINORVERSION).toString().replaceAll("\\D", ""));
-        properties.put(ISOPENSHIFT, Boolean.toString(isOpenshift));
-
-        // then we can compare
-        properties.put(NETWORKPOLICIES_NS_AND_PODSEL, Boolean.toString(this.isEqualOrNewerVersionThan(KUBERNETES1_11)));
+    public PlatformFeaturesAvailability(boolean isOpenshift, KubernetesVersion kubernetesVersion) {
+        this.isOpenshift = isOpenshift;
+        this.kubernetesVersion = kubernetesVersion;
     }
 
     public boolean isOpenshift() {
-        return Boolean.parseBoolean(this.properties.getProperty(ISOPENSHIFT));
+        return this.isOpenshift;
     }
 
     public int getMinorVersion() {
-        return Integer.parseInt(this.properties.getProperty(MINORVERSION));
+        return kubernetesVersion.getMinor();
     }
 
     public int getMajorVersion() {
-        return Integer.parseInt(this.properties.getProperty(MAJORVERSION));
+        return kubernetesVersion.getMajor();
     }
 
     public boolean isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable() {
-        return Boolean.parseBoolean(this.properties.getProperty(NETWORKPOLICIES_NS_AND_PODSEL));
+        return this.kubernetesVersion.compareTo(KubernetesVersion.V1_11) >= 0;
     }
-
-    public boolean isEqualOrNewerVersionThan(String version) {
-        String[] parts = version.split("\\.");
-        if (parts.length < 2) {
-            throw new IllegalArgumentException("The Kubernetes version has to have format of X.Y where X and Y are integers.");
-        }
-        return this.isEqualOrNewerVersionThan(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
-    }
-
-    public boolean isEqualOrNewerVersionThan(int otherMajor, int otherMinor) {
-        if (otherMajor < this.getMajorVersion()) {
-            return true;
-        } else if (otherMajor == this.getMajorVersion()) {
-            return otherMinor <= this.getMinorVersion();
-        } else {
-            return false;
-        }
-    }
-
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -6,7 +6,9 @@ package io.strimzi.operator.cluster;
 
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
 
-
+/**
+ * Gives a info about certain features availability regarding to kubernetes version
+ */
 public class PlatformFeaturesAvailability {
 
     private boolean isOpenshift;
@@ -21,15 +23,11 @@ public class PlatformFeaturesAvailability {
         return this.isOpenshift;
     }
 
-    public int getMinorVersion() {
-        return kubernetesVersion.getMinor();
-    }
-
-    public int getMajorVersion() {
-        return kubernetesVersion.getMajor();
-    }
-
-    public boolean isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable() {
+    public boolean isNamespaceAndPodSelectorNetworkPolicySupported() {
         return this.kubernetesVersion.compareTo(KubernetesVersion.V1_11) >= 0;
+    }
+
+    public KubernetesVersion getKubernetesVersion() {
+        return this.kubernetesVersion;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -14,7 +14,7 @@ public class PlatformFeaturesAvailability {
     static final String MAJORVERSION = "major";
     static final String MINORVERSION = "minor";
     static final String ISOPENSHIFT = "isOpenshift";
-    static final String NETWORKPOLICIES = "networkPolicies";
+    static final String NETWORKPOLICIES_NS_AND_PODSEL = "networkPoliciesNSandPodSel";
 
     static final String KUBERNETES1_8 = "1.8";
     static final String KUBERNETES1_9 = "1.9";
@@ -29,12 +29,12 @@ public class PlatformFeaturesAvailability {
         Properties versionResponseProperties = Json.decodeValue(versionResponse, Properties.class);
 
         // we need to get versions first
-        properties.put(MAJORVERSION, versionResponseProperties.get(MAJORVERSION));
-        properties.put(MINORVERSION, versionResponseProperties.get(MINORVERSION));
+        properties.put(MAJORVERSION, versionResponseProperties.get(MAJORVERSION).toString().replaceAll("\\D", ""));
+        properties.put(MINORVERSION, versionResponseProperties.get(MINORVERSION).toString().replaceAll("\\D", ""));
         properties.put(ISOPENSHIFT, Boolean.toString(isOpenshift));
 
         // then we can compare
-        properties.put(NETWORKPOLICIES, Boolean.toString(this.isEqualOrNewerVersionThan(KUBERNETES1_11)));
+        properties.put(NETWORKPOLICIES_NS_AND_PODSEL, Boolean.toString(this.isEqualOrNewerVersionThan(KUBERNETES1_11)));
     }
 
     public boolean isOpenshift() {
@@ -49,8 +49,8 @@ public class PlatformFeaturesAvailability {
         return Integer.parseInt(this.properties.getProperty(MAJORVERSION));
     }
 
-    public boolean isNetworkPolicyAvailable() {
-        return Boolean.parseBoolean(this.properties.getProperty(NETWORKPOLICIES));
+    public boolean isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable() {
+        return Boolean.parseBoolean(this.properties.getProperty(NETWORKPOLICIES_NS_AND_PODSEL));
     }
 
     public boolean isEqualOrNewerVersionThan(String version) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster;
+
+import io.vertx.core.json.Json;
+
+import java.util.Properties;
+
+public class PlatformFeaturesAvailability {
+    private Properties properties;
+
+    static final String MAJORVERSION = "major";
+    static final String MINORVERSION = "minor";
+    static final String ISOPENSHIFT = "isOpenshift";
+    static final String NETWORKPOLICIES = "networkPolicies";
+
+    static final String KUBERNETES1_8 = "1.8";
+    static final String KUBERNETES1_9 = "1.9";
+    static final String KUBERNETES1_10 = "1.10";
+    static final String KUBERNETES1_11 = "1.11";
+
+    public PlatformFeaturesAvailability(boolean isOpenshift, String versionResponse) {
+        if (versionResponse == null) {
+            throw new IllegalArgumentException("Kubernetes version could not be determined.");
+        }
+        this.properties = new Properties();
+        Properties versionResponseProperties = Json.decodeValue(versionResponse, Properties.class);
+
+        // we need to get versions first
+        properties.put(MAJORVERSION, versionResponseProperties.get(MAJORVERSION));
+        properties.put(MINORVERSION, versionResponseProperties.get(MINORVERSION));
+        properties.put(ISOPENSHIFT, Boolean.toString(isOpenshift));
+
+        // then we can compare
+        properties.put(NETWORKPOLICIES, Boolean.toString(this.isEqualOrNewerVersionThan(KUBERNETES1_11)));
+    }
+
+    public boolean isOpenshift() {
+        return Boolean.parseBoolean(this.properties.getProperty(ISOPENSHIFT));
+    }
+
+    public int getMinorVersion() {
+        return Integer.parseInt(this.properties.getProperty(MINORVERSION));
+    }
+
+    public int getMajorVersion() {
+        return Integer.parseInt(this.properties.getProperty(MAJORVERSION));
+    }
+
+    public boolean isNetworkPolicyAvailable() {
+        return Boolean.parseBoolean(this.properties.getProperty(NETWORKPOLICIES));
+    }
+
+    public boolean isEqualOrNewerVersionThan(String version) {
+        String[] parts = version.split("\\.");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("The Kubernetes version has to have format of X.Y where X and Y are integers.");
+        }
+        return this.isEqualOrNewerVersionThan(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+    }
+
+    public boolean isEqualOrNewerVersionThan(int otherMajor, int otherMinor) {
+        if (otherMajor < this.getMajorVersion()) {
+            return true;
+        } else if (otherMajor == this.getMajorVersion()) {
+            return otherMinor <= this.getMinorVersion();
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator;
+
+public class KubernetesVersion implements Comparable<KubernetesVersion> {
+
+    private int major;
+    private int minor;
+    private String version;
+    public static final KubernetesVersion V1_8 = new KubernetesVersion("1", "8");
+    public static final KubernetesVersion V1_9 = new KubernetesVersion("1", "9");
+    public static final KubernetesVersion V1_10 = new KubernetesVersion("1", "10");
+    public static final KubernetesVersion V1_11 = new KubernetesVersion("1", "11");
+    public static final KubernetesVersion V1_12 = new KubernetesVersion("1", "12");
+
+    public KubernetesVersion(String major, String minor) {
+        this.major = Integer.parseInt(major.replaceAll("\\D", ""));
+        this.minor = Integer.parseInt(minor.replaceAll("\\D", ""));
+        this.version = major + "." + minor;
+    }
+
+    @Override
+    public int hashCode() {
+        return version.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KubernetesVersion that = (KubernetesVersion) o;
+        return major == that.major && minor == that.minor;
+    }
+
+    @Override
+    public int compareTo(KubernetesVersion o) {
+        int multiplier = 10000; //reasonably large number
+        return (major * multiplier + minor) - (o.major * multiplier + o.minor);
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+}
+

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
@@ -11,11 +11,21 @@ public class KubernetesVersion implements Comparable<KubernetesVersion> {
 
     private int major;
     private int minor;
+
+    // unsupported versions
     public static final KubernetesVersion V1_8 = new KubernetesVersion(1, 8);
+
+    // supported versions
     public static final KubernetesVersion V1_9 = new KubernetesVersion(1, 9);
     public static final KubernetesVersion V1_10 = new KubernetesVersion(1, 10);
     public static final KubernetesVersion V1_11 = new KubernetesVersion(1, 11);
     public static final KubernetesVersion V1_12 = new KubernetesVersion(1, 12);
+    public static final KubernetesVersion V1_13 = new KubernetesVersion(1, 13);
+    public static final KubernetesVersion V1_14 = new KubernetesVersion(1, 14);
+
+    public static final KubernetesVersion MINIMAL_SUPPORTED_VERSION = V1_9;
+    public static final int MINIMAL_SUPPORTED_MAJOR = MINIMAL_SUPPORTED_VERSION.major;
+    public static final int MINIMAL_SUPPORTED_MINOR = MINIMAL_SUPPORTED_VERSION.minor;
 
     public KubernetesVersion(int major, int minor) {
         this.major = major;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/KubernetesVersion.java
@@ -4,26 +4,27 @@
  */
 package io.strimzi.operator.cluster.operator;
 
+/**
+ * Represents Kubernetes version which CO runs on
+ */
 public class KubernetesVersion implements Comparable<KubernetesVersion> {
 
     private int major;
     private int minor;
-    private String version;
-    public static final KubernetesVersion V1_8 = new KubernetesVersion("1", "8");
-    public static final KubernetesVersion V1_9 = new KubernetesVersion("1", "9");
-    public static final KubernetesVersion V1_10 = new KubernetesVersion("1", "10");
-    public static final KubernetesVersion V1_11 = new KubernetesVersion("1", "11");
-    public static final KubernetesVersion V1_12 = new KubernetesVersion("1", "12");
+    public static final KubernetesVersion V1_8 = new KubernetesVersion(1, 8);
+    public static final KubernetesVersion V1_9 = new KubernetesVersion(1, 9);
+    public static final KubernetesVersion V1_10 = new KubernetesVersion(1, 10);
+    public static final KubernetesVersion V1_11 = new KubernetesVersion(1, 11);
+    public static final KubernetesVersion V1_12 = new KubernetesVersion(1, 12);
 
-    public KubernetesVersion(String major, String minor) {
-        this.major = Integer.parseInt(major.replaceAll("\\D", ""));
-        this.minor = Integer.parseInt(minor.replaceAll("\\D", ""));
-        this.version = major + "." + minor;
+    public KubernetesVersion(int major, int minor) {
+        this.major = major;
+        this.minor = minor;
     }
 
     @Override
     public int hashCode() {
-        return version.hashCode();
+        return major << 16 ^ minor;
     }
 
     @Override
@@ -36,16 +37,16 @@ public class KubernetesVersion implements Comparable<KubernetesVersion> {
 
     @Override
     public int compareTo(KubernetesVersion o) {
-        int multiplier = 10000; //reasonably large number
-        return (major * multiplier + minor) - (o.major * multiplier + o.minor);
+        int cmp = Integer.compare(major, o.major);
+        if (cmp == 0) {
+            cmp = Integer.compare(minor, o.minor);
+        }
+        return cmp;
     }
 
-    public int getMajor() {
-        return major;
-    }
-
-    public int getMinor() {
-        return minor;
+    @Override
+    public String toString() {
+        return this.major + "." + this.minor;
     }
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.zjsonpatch.JsonDiff;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.common.model.ResourceVisitor;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.InvalidConfigParameterException;
@@ -64,7 +65,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
 
     protected final Vertx vertx;
-    protected final boolean isOpenShift;
+    protected final PlatformFeaturesAvailability pfa;
     protected final ResourceType assemblyType;
     protected final AbstractWatchableResourceOperator<C, T, L, D, R> resourceOperator;
     protected final SecretOperator secretOperations;
@@ -76,7 +77,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
 
     /**
      * @param vertx The Vertx instance
-     * @param isOpenShift True iff running on OpenShift
+     * @param pfa Properties with features availability
      * @param assemblyType Assembly type
      * @param certManager Certificate manager
      * @param resourceOperator For operating on the desired resource
@@ -85,7 +86,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * @param podDisruptionBudgetOperator For operating PodDisruptionBudgets
      * @param imagePullPolicy The user-configured image pull policy. Null if the user didn't configured it.
      */
-    protected AbstractAssemblyOperator(Vertx vertx, boolean isOpenShift, ResourceType assemblyType,
+    protected AbstractAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, ResourceType assemblyType,
                                        CertManager certManager,
                                        AbstractWatchableResourceOperator<C, T, L, D, R> resourceOperator,
                                        SecretOperator secretOperations,
@@ -93,7 +94,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                        PodDisruptionBudgetOperator podDisruptionBudgetOperator,
                                        ImagePullPolicy imagePullPolicy) {
         this.vertx = vertx;
-        this.isOpenShift = isOpenShift;
+        this.pfa = pfa;
         this.assemblyType = assemblyType;
         this.kind = assemblyType.name;
         this.resourceOperator = resourceOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -35,6 +35,7 @@ import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.ClientsCa;
@@ -130,15 +131,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
     /**
      * @param vertx The Vertx instance
-     * @param isOpenShift Whether we're running with OpenShift
+     * @param pfa Platform features availability properties
      */
-    public KafkaAssemblyOperator(Vertx vertx, boolean isOpenShift,
+    public KafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
                                  long operationTimeoutMs,
                                  CertManager certManager,
                                  ResourceOperatorSupplier supplier,
                                  KafkaVersion.Lookup versions,
                                  ImagePullPolicy imagePullPolicy) {
-        super(vertx, isOpenShift, ResourceType.KAFKA, certManager,
+        super(vertx, pfa, ResourceType.KAFKA, certManager,
                 supplier.kafkaOperator, supplier.secretOperations, supplier.networkPolicyOperator,
                 supplier.podDisruptionBudgetOperator, imagePullPolicy);
         this.operationTimeoutMs = operationTimeoutMs;
@@ -959,7 +960,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkStatefulSet() {
-            StatefulSet zkSs = zkCluster.generateStatefulSet(isOpenShift, imagePullPolicy);
+            StatefulSet zkSs = zkCluster.generateStatefulSet(pfa.isOpenshift(), imagePullPolicy);
             Annotations.annotations(zkSs.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(getCaCertGeneration(this.clusterCa)));
             return withZkDiff(zkSetOperations.reconcile(namespace, zkCluster.getName(), zkSs));
         }
@@ -1491,7 +1492,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         Future<ReconciliationState> kafkaStatefulSet() {
             kafkaCluster.setExternalAddresses(kafkaExternalAddresses);
-            StatefulSet kafkaSs = kafkaCluster.generateStatefulSet(isOpenShift, imagePullPolicy);
+            StatefulSet kafkaSs = kafkaCluster.generateStatefulSet(pfa.isOpenshift(), imagePullPolicy);
             PodTemplateSpec template = kafkaSs.getSpec().getTemplate();
             Annotations.annotations(template).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION,
@@ -1556,7 +1557,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                     topicOperator.getLogging() instanceof ExternalLogging ?
                                             configMapOperations.get(kafkaAssembly.getMetadata().getNamespace(), ((ExternalLogging) topicOperator.getLogging()).getName()) :
                                             null);
-                            this.toDeployment = topicOperator.generateDeployment(isOpenShift, imagePullPolicy);
+                            this.toDeployment = topicOperator.generateDeployment(pfa.isOpenshift(), imagePullPolicy);
                             this.toMetricsAndLogsConfigMap = logAndMetricsConfigMap;
                             Annotations.annotations(this.toDeployment.getSpec().getTemplate()).put(
                                     ANNO_STRIMZI_IO_LOGGING,
@@ -1670,7 +1671,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             annotations.put(ANNO_STRIMZI_IO_LOGGING, configAnnotation);
 
                             this.entityOperator = entityOperator;
-                            this.eoDeployment = entityOperator.generateDeployment(isOpenShift, annotations, imagePullPolicy);
+                            this.eoDeployment = entityOperator.generateDeployment(pfa.isOpenshift(), annotations, imagePullPolicy);
                             this.topicOperatorMetricsAndLogsConfigMap = topicOperatorLogAndMetricsConfigMap;
                             this.userOperatorMetricsAndLogsConfigMap = userOperatorLogAndMetricsConfigMap;
                         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -44,10 +45,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class ClusterOperatorTest {
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
 
@@ -148,7 +145,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = new HashMap<>();
         env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, k8sVersionString), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
+        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });
@@ -226,7 +223,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = new HashMap<>();
         env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, k8sVersionString), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
+        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -45,6 +45,10 @@ import static org.mockito.Mockito.when;
 @RunWith(VertxUnitRunner.class)
 public class ClusterOperatorTest {
 
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
+
     private Vertx vertx;
 
     @Before
@@ -144,7 +148,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = new HashMap<>();
         env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, openShift, ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
+        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, k8sVersionString), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });
@@ -222,7 +226,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = new HashMap<>();
         env.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, openShift, ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
+        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, k8sVersionString), ClusterOperatorConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PlatformFeaturesAvailabilityTest {
+
+    @Test
+    public void basicTest() {
+        boolean isOpenshift = true;
+        String response = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"9\",\n" +
+                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
+                "  \"gitCommit\": \"a0ce1bc\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
+        assertTrue(pfa.isOpenshift());
+        assertEquals(9, pfa.getMinorVersion());
+        assertEquals(1, pfa.getMajorVersion());
+    }
+
+    @Test
+    public void newerVersionTest() {
+        boolean isOpenshift = true;
+        String response = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"9\",\n" +
+                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
+                "  \"gitCommit\": \"a0ce1bc\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
+
+        assertTrue(pfa.isEqualOrNewerVersionThan(0, 8));
+        assertTrue(pfa.isEqualOrNewerVersionThan(0, 9));
+        assertTrue(pfa.isEqualOrNewerVersionThan(0, 10));
+
+        assertTrue(pfa.isEqualOrNewerVersionThan(1, 8));
+        assertTrue(pfa.isEqualOrNewerVersionThan(1, 9));
+        assertFalse(pfa.isEqualOrNewerVersionThan(1, 10));
+
+        assertFalse(pfa.isEqualOrNewerVersionThan(2, 8));
+        assertFalse(pfa.isEqualOrNewerVersionThan(2, 9));
+        assertFalse(pfa.isEqualOrNewerVersionThan(2, 10));
+
+
+        assertTrue(pfa.isEqualOrNewerVersionThan("0.8"));
+        assertTrue(pfa.isEqualOrNewerVersionThan("0.9"));
+        assertTrue(pfa.isEqualOrNewerVersionThan("0.10"));
+
+        assertTrue(pfa.isEqualOrNewerVersionThan("1.8"));
+        assertTrue(pfa.isEqualOrNewerVersionThan("1.9"));
+        assertFalse(pfa.isEqualOrNewerVersionThan("1.10"));
+
+        assertFalse(pfa.isEqualOrNewerVersionThan("2.8"));
+        assertFalse(pfa.isEqualOrNewerVersionThan("2.9"));
+        assertFalse(pfa.isEqualOrNewerVersionThan("2.10"));
+
+
+        try {
+            assertFalse(pfa.isEqualOrNewerVersionThan("2"));
+        } catch (Exception e) {
+            if (e instanceof IllegalArgumentException) {
+            } else {
+                fail();
+            }
+        }
+
+        try {
+            assertFalse(pfa.isEqualOrNewerVersionThan("f.10"));
+        } catch (Exception e) {
+            if (e instanceof NumberFormatException) {
+            } else {
+                fail();
+            }
+        }
+    }
+
+    @Test
+    public void networkPolicyTest() {
+        boolean isOpenshift = true;
+        String response = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"9\",\n" +
+                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
+                "  \"gitCommit\": \"a0ce1bc\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        String response2 = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"11\",\n" +
+                "  \"gitVersion\": \"v1.11.1+deadbeef\",\n" +
+                "  \"gitCommit\": \"deadbeef\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2019-06-24T01:54:00Z\",\n" + // manually edited
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
+        assertFalse(pfa.isNetworkPolicyAvailable());
+        PlatformFeaturesAvailability pfa2 = new PlatformFeaturesAvailability(isOpenshift, response2);
+        assertTrue(pfa2.isNetworkPolicyAvailable());
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -124,8 +124,20 @@ public class PlatformFeaturesAvailabilityTest {
                 "}";
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
-        assertFalse(pfa.isNetworkPolicyAvailable());
+        assertFalse(pfa.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
         PlatformFeaturesAvailability pfa2 = new PlatformFeaturesAvailability(isOpenshift, response2);
-        assertTrue(pfa2.isNetworkPolicyAvailable());
+        assertTrue(pfa2.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
+    }
+
+    @Test
+    public void versionWithSomeChars() {
+        boolean isOpenshift = true;
+
+        String response = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"12+\"\n" +
+                "}";
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
+        assertEquals(12, pfa.getMinorVersion());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -5,139 +5,60 @@
 package io.strimzi.operator.cluster;
 
 
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class PlatformFeaturesAvailabilityTest {
 
     @Test
-    public void basicTest() {
-        boolean isOpenshift = true;
-        String response = "{\n" +
-                "  \"major\": \"1\",\n" +
-                "  \"minor\": \"9\",\n" +
-                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
-                "  \"gitCommit\": \"a0ce1bc\",\n" +
-                "  \"gitTreeState\": \"clean\",\n" +
-                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
-                "  \"goVersion\": \"go1.9\",\n" +
-                "  \"compiler\": \"gc\",\n" +
-                "  \"platform\": \"linux/amd64\"\n" +
-                "}";
+    public void versionTest() {
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
-        assertTrue(pfa.isOpenshift());
-        assertEquals(9, pfa.getMinorVersion());
-        assertEquals(1, pfa.getMajorVersion());
+        KubernetesVersion kv1p9 = new KubernetesVersion("1", "5");
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_8) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_9) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_10) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_11) < 0);
+
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_8) == 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_9) < 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_10) < 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_11) < 0);
+
+
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_8) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_9) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_10) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_11) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_12) == 0);
+
+        KubernetesVersion kv2p9 = new KubernetesVersion("2", "9");
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_8) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_9) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_10) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_11) > 0);
     }
 
     @Test
-    public void newerVersionTest() {
-        boolean isOpenshift = true;
-        String response = "{\n" +
-                "  \"major\": \"1\",\n" +
-                "  \"minor\": \"9\",\n" +
-                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
-                "  \"gitCommit\": \"a0ce1bc\",\n" +
-                "  \"gitTreeState\": \"clean\",\n" +
-                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
-                "  \"goVersion\": \"go1.9\",\n" +
-                "  \"compiler\": \"gc\",\n" +
-                "  \"platform\": \"linux/amd64\"\n" +
-                "}";
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
-
-        assertTrue(pfa.isEqualOrNewerVersionThan(0, 8));
-        assertTrue(pfa.isEqualOrNewerVersionThan(0, 9));
-        assertTrue(pfa.isEqualOrNewerVersionThan(0, 10));
-
-        assertTrue(pfa.isEqualOrNewerVersionThan(1, 8));
-        assertTrue(pfa.isEqualOrNewerVersionThan(1, 9));
-        assertFalse(pfa.isEqualOrNewerVersionThan(1, 10));
-
-        assertFalse(pfa.isEqualOrNewerVersionThan(2, 8));
-        assertFalse(pfa.isEqualOrNewerVersionThan(2, 9));
-        assertFalse(pfa.isEqualOrNewerVersionThan(2, 10));
-
-
-        assertTrue(pfa.isEqualOrNewerVersionThan("0.8"));
-        assertTrue(pfa.isEqualOrNewerVersionThan("0.9"));
-        assertTrue(pfa.isEqualOrNewerVersionThan("0.10"));
-
-        assertTrue(pfa.isEqualOrNewerVersionThan("1.8"));
-        assertTrue(pfa.isEqualOrNewerVersionThan("1.9"));
-        assertFalse(pfa.isEqualOrNewerVersionThan("1.10"));
-
-        assertFalse(pfa.isEqualOrNewerVersionThan("2.8"));
-        assertFalse(pfa.isEqualOrNewerVersionThan("2.9"));
-        assertFalse(pfa.isEqualOrNewerVersionThan("2.10"));
-
-
-        try {
-            assertFalse(pfa.isEqualOrNewerVersionThan("2"));
-        } catch (Exception e) {
-            if (e instanceof IllegalArgumentException) {
-            } else {
-                fail();
-            }
-        }
-
-        try {
-            assertFalse(pfa.isEqualOrNewerVersionThan("f.10"));
-        } catch (Exception e) {
-            if (e instanceof NumberFormatException) {
-            } else {
-                fail();
-            }
-        }
+    public void versionWithCharTest() {
+        KubernetesVersion kv1p9 = new KubernetesVersion("1", "9+");
+        assertEquals(9, kv1p9.getMinor());
     }
 
     @Test
-    public void networkPolicyTest() {
-        boolean isOpenshift = true;
-        String response = "{\n" +
-                "  \"major\": \"1\",\n" +
-                "  \"minor\": \"9\",\n" +
-                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
-                "  \"gitCommit\": \"a0ce1bc\",\n" +
-                "  \"gitTreeState\": \"clean\",\n" +
-                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
-                "  \"goVersion\": \"go1.9\",\n" +
-                "  \"compiler\": \"gc\",\n" +
-                "  \"platform\": \"linux/amd64\"\n" +
-                "}";
-
-        String response2 = "{\n" +
-                "  \"major\": \"1\",\n" +
-                "  \"minor\": \"11\",\n" +
-                "  \"gitVersion\": \"v1.11.1+deadbeef\",\n" +
-                "  \"gitCommit\": \"deadbeef\",\n" +
-                "  \"gitTreeState\": \"clean\",\n" +
-                "  \"buildDate\": \"2019-06-24T01:54:00Z\",\n" + // manually edited
-                "  \"goVersion\": \"go1.9\",\n" +
-                "  \"compiler\": \"gc\",\n" +
-                "  \"platform\": \"linux/amd64\"\n" +
-                "}";
-
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
+    public void networkPoliciesWithFancyCombinationTest() {
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_8);
         assertFalse(pfa.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
-        PlatformFeaturesAvailability pfa2 = new PlatformFeaturesAvailability(isOpenshift, response2);
-        assertTrue(pfa2.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
+        pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_11);
+        assertTrue(pfa.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
     }
 
     @Test
-    public void versionWithSomeChars() {
-        boolean isOpenshift = true;
-
-        String response = "{\n" +
-                "  \"major\": \"1\",\n" +
-                "  \"minor\": \"12+\"\n" +
-                "}";
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(isOpenshift, response);
-        assertEquals(12, pfa.getMinorVersion());
+    public void versionsEqualTest() {
+        KubernetesVersion kv1p9 = new KubernetesVersion("1", "9+");
+        assertEquals(kv1p9, KubernetesVersion.V1_9);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -17,7 +17,7 @@ public class PlatformFeaturesAvailabilityTest {
     @Test
     public void versionTest() {
 
-        KubernetesVersion kv1p9 = new KubernetesVersion("1", "5");
+        KubernetesVersion kv1p9 = new KubernetesVersion(1, 5);
         assertTrue(kv1p9.compareTo(KubernetesVersion.V1_8) < 0);
         assertTrue(kv1p9.compareTo(KubernetesVersion.V1_9) < 0);
         assertTrue(kv1p9.compareTo(KubernetesVersion.V1_10) < 0);
@@ -35,7 +35,7 @@ public class PlatformFeaturesAvailabilityTest {
         assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_11) > 0);
         assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_12) == 0);
 
-        KubernetesVersion kv2p9 = new KubernetesVersion("2", "9");
+        KubernetesVersion kv2p9 = new KubernetesVersion(2, 9);
         assertTrue(kv2p9.compareTo(KubernetesVersion.V1_8) > 0);
         assertTrue(kv2p9.compareTo(KubernetesVersion.V1_9) > 0);
         assertTrue(kv2p9.compareTo(KubernetesVersion.V1_10) > 0);
@@ -43,22 +43,16 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     @Test
-    public void versionWithCharTest() {
-        KubernetesVersion kv1p9 = new KubernetesVersion("1", "9+");
-        assertEquals(9, kv1p9.getMinor());
-    }
-
-    @Test
     public void networkPoliciesWithFancyCombinationTest() {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_8);
-        assertFalse(pfa.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
+        assertFalse(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
         pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_11);
-        assertTrue(pfa.isNetworkPolicyPodSelectorAndNameSpaceInSinglePeerAvailable());
+        assertTrue(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
     }
 
     @Test
     public void versionsEqualTest() {
-        KubernetesVersion kv1p9 = new KubernetesVersion("1", "9+");
+        KubernetesVersion kv1p9 = new KubernetesVersion(1, 9);
         assertEquals(kv1p9, KubernetesVersion.V1_9);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -20,6 +20,7 @@ import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -75,9 +76,6 @@ public class CertificateRenewalTest {
     private Vertx vertx = Vertx.vertx();
     private OpenSslCertManager certManager = new OpenSslCertManager();
     private List<Secret> secrets = new ArrayList();
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     @Before
     public void clearSecrets() {
@@ -101,7 +99,7 @@ public class CertificateRenewalTest {
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaCertSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, k8sVersionString), 1L, certManager,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L, certManager,
                 new ResourceOperatorSupplier(null, null, null,
                         null, null, secretOps, null, null,
                         null, null, null, null, null, null),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.Subject;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
@@ -74,6 +75,9 @@ public class CertificateRenewalTest {
     private Vertx vertx = Vertx.vertx();
     private OpenSslCertManager certManager = new OpenSslCertManager();
     private List<Secret> secrets = new ArrayList();
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     @Before
     public void clearSecrets() {
@@ -97,7 +101,7 @@ public class CertificateRenewalTest {
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaCertSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L, certManager,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, k8sVersionString), 1L, certManager,
                 new ResourceOperatorSupplier(null, null, null,
                         null, null, secretOps, null, null,
                         null, null, null, null, null, null),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -54,10 +55,6 @@ public class JbodStorageTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
     private Kafka kafka;
@@ -110,7 +107,7 @@ public class JbodStorageTest {
 
         this.vertx = Vertx.vertx();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9);
         // creating the Kafka operator
         ResourceOperatorSupplier ros =
                 new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.SingleVolumeStorage;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -53,6 +54,10 @@ public class JbodStorageTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
     private Kafka kafka;
@@ -105,11 +110,12 @@ public class JbodStorageTest {
 
         this.vertx = Vertx.vertx();
 
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, k8sVersionString);
         // creating the Kafka operator
         ResourceOperatorSupplier ros =
-                new ResourceOperatorSupplier(this.vertx, this.mockClient, false, 60_000L);
+                new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);
 
-        this.kao = new KafkaAssemblyOperator(this.vertx, false, 2_000, new MockCertManager(), ros, VERSIONS, null);
+        this.kao = new KafkaAssemblyOperator(this.vertx, pfa, 2_000, new MockCertManager(), ros, VERSIONS, null);
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -91,6 +91,8 @@ public class KafkaAssemblyOperatorMockTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"), emptyMap(), emptyMap(), emptyMap()) { };
 
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;
+
     private final int zkReplicas;
     private final SingleVolumeStorage zkStorage;
 
@@ -241,12 +243,12 @@ public class KafkaAssemblyOperatorMockTest {
 
     private ResourceOperatorSupplier supplierWithMocks() {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, mockClient);
-        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000);
+        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, new PlatformFeaturesAvailability(true, kubernetesVersion), 2_000);
     }
 
     private KafkaAssemblyOperator createCluster(TestContext context) {
         ResourceOperatorSupplier supplier = supplierWithMocks();
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000,
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
 
         LOGGER.info("Reconciling initially -> create");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -27,6 +27,7 @@ import io.strimzi.api.kafka.model.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.operator.cluster.ClusterOperator;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
@@ -88,6 +89,10 @@ public class KafkaAssemblyOperatorMockTest {
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(new StringReader(
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"), emptyMap(), emptyMap(), emptyMap()) { };
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     private final int zkReplicas;
     private final SingleVolumeStorage zkStorage;
@@ -239,12 +244,12 @@ public class KafkaAssemblyOperatorMockTest {
 
     private ResourceOperatorSupplier supplierWithMocks() {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, mockClient);
-        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, true, 2_000);
+        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000);
     }
 
     private KafkaAssemblyOperator createCluster(TestContext context) {
         ResourceOperatorSupplier supplier = supplierWithMocks();
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
 
         LOGGER.info("Reconciling initially -> create");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -35,6 +35,7 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.TopicOperator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
@@ -89,10 +90,6 @@ public class KafkaAssemblyOperatorMockTest {
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(new StringReader(
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"), emptyMap(), emptyMap(), emptyMap()) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private final int zkReplicas;
     private final SingleVolumeStorage zkStorage;
@@ -244,12 +241,12 @@ public class KafkaAssemblyOperatorMockTest {
 
     private ResourceOperatorSupplier supplierWithMocks() {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, mockClient);
-        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000);
+        return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000);
     }
 
     private KafkaAssemblyOperator createCluster(TestContext context) {
         ResourceOperatorSupplier supplier = supplierWithMocks();
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
 
         LOGGER.info("Reconciling initially -> create");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -125,6 +125,9 @@ public class KafkaAssemblyOperatorTest {
         LOG_ZOOKEEPER_CONFIG.setLoggers(singletonMap("zookeeper.root.logger", "INFO"));
         LOG_CONNECT_CONFIG.setLoggers(singletonMap("connect.root.logger.level", "INFO"));
     }
+
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;
+
     private final boolean openShift;
     private final boolean metrics;
     private final KafkaListeners kafkaListeners;
@@ -455,7 +458,7 @@ public class KafkaAssemblyOperatorTest {
             when(mockRotueOps.reconcile(eq(clusterCmNamespace), routeNameCaptor.capture(), routeCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         }
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -897,7 +900,7 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> depCaptor = ArgumentCaptor.forClass(String.class);
         when(mockDepOps.reconcile(anyString(), depCaptor.capture(), any())).thenReturn(Future.succeededFuture());
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1014,7 +1017,7 @@ public class KafkaAssemblyOperatorTest {
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1091,7 +1094,7 @@ public class KafkaAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -44,6 +44,7 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.TopicOperator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetDiff;
@@ -118,10 +119,6 @@ public class KafkaAssemblyOperatorTest {
     public static final InlineLogging LOG_ZOOKEEPER_CONFIG = new InlineLogging();
     public static final InlineLogging LOG_CONNECT_CONFIG = new InlineLogging();
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap());
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     static {
         LOG_KAFKA_CONFIG.setLoggers(singletonMap("kafka.root.logger.level", "INFO"));
@@ -458,7 +455,7 @@ public class KafkaAssemblyOperatorTest {
             when(mockRotueOps.reconcile(eq(clusterCmNamespace), routeNameCaptor.capture(), routeCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         }
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -900,7 +897,7 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> depCaptor = ArgumentCaptor.forClass(String.class);
         when(mockDepOps.reconcile(anyString(), depCaptor.capture(), any())).thenReturn(Future.succeededFuture());
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1017,7 +1014,7 @@ public class KafkaAssemblyOperatorTest {
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1094,7 +1091,7 @@ public class KafkaAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_9),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -33,6 +33,7 @@ import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenersBuilder;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.ClientsCa;
@@ -117,6 +118,10 @@ public class KafkaAssemblyOperatorTest {
     public static final InlineLogging LOG_ZOOKEEPER_CONFIG = new InlineLogging();
     public static final InlineLogging LOG_CONNECT_CONFIG = new InlineLogging();
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap());
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     static {
         LOG_KAFKA_CONFIG.setLoggers(singletonMap("kafka.root.logger.level", "INFO"));
@@ -453,7 +458,7 @@ public class KafkaAssemblyOperatorTest {
             when(mockRotueOps.reconcile(eq(clusterCmNamespace), routeNameCaptor.capture(), routeCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         }
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -895,7 +900,7 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> depCaptor = ArgumentCaptor.forClass(String.class);
         when(mockDepOps.reconcile(anyString(), depCaptor.capture(), any())).thenReturn(Future.succeededFuture());
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1012,7 +1017,7 @@ public class KafkaAssemblyOperatorTest {
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,
@@ -1089,7 +1094,7 @@ public class KafkaAssemblyOperatorTest {
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
-        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, openShift,
+        KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, k8sVersionString),
                 ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 certManager,
                 supplier,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -53,10 +54,6 @@ public class KafkaConnectAssemblyOperatorMockTest {
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(new StringReader(
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             emptyMap(), singletonMap("2.0.0", "strimzi/kafka-connect:latest-kafka-2.0.0"), emptyMap(), emptyMap()) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-connect-cluster";
@@ -101,7 +98,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
         SecretOperator secretops = new SecretOperator(vertx, mockClient);
         NetworkPolicyOperator policyops = new NetworkPolicyOperator(vertx, mockClient);
         PodDisruptionBudgetOperator pdbops = new PodDisruptionBudgetOperator(vertx, mockClient);
-        KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 connectOperator,
                 cmops, depops, svcops, secretops, policyops, pdbops, ResourceUtils.supplierWithMocks(true), VERSIONS, null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -52,6 +53,10 @@ public class KafkaConnectAssemblyOperatorMockTest {
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(new StringReader(
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             emptyMap(), singletonMap("2.0.0", "strimzi/kafka-connect:latest-kafka-2.0.0"), emptyMap(), emptyMap()) { };
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-connect-cluster";
@@ -96,7 +101,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
         SecretOperator secretops = new SecretOperator(vertx, mockClient);
         NetworkPolicyOperator policyops = new NetworkPolicyOperator(vertx, mockClient);
         PodDisruptionBudgetOperator pdbops = new PodDisruptionBudgetOperator(vertx, mockClient);
-        KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 connectOperator,
                 cmops, depops, svcops, secretops, policyops, pdbops, ResourceUtils.supplierWithMocks(true), VERSIONS, null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
@@ -72,6 +73,10 @@ public class KafkaConnectAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -111,7 +116,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -196,7 +201,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -297,7 +302,7 @@ public class KafkaConnectAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -387,7 +392,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -438,7 +443,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -491,7 +496,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -543,7 +548,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, true,
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -74,6 +74,8 @@ public class KafkaConnectAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -113,7 +115,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -198,7 +200,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -299,7 +301,7 @@ public class KafkaConnectAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -389,7 +391,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -440,7 +442,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -493,7 +495,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -545,7 +547,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -73,10 +74,6 @@ public class KafkaConnectAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
-
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -116,7 +113,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -201,7 +198,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -302,7 +299,7 @@ public class KafkaConnectAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -392,7 +389,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -443,7 +440,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -496,7 +493,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null);
@@ -548,7 +545,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString),
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockSecretOps, mockPolicyOps, mockPdbOps, supplier, VERSIONS, null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -17,6 +17,7 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectS2ICluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -77,10 +78,6 @@ public class KafkaConnectS2IAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
-
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -131,7 +128,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -255,7 +252,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -375,7 +372,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -497,7 +494,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -557,7 +554,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -619,7 +616,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -674,7 +671,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -12,6 +12,7 @@ import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectS2ICluster;
@@ -76,6 +77,10 @@ public class KafkaConnectS2IAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -126,7 +131,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -249,7 +255,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -368,7 +375,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -489,7 +497,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -548,7 +557,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -609,7 +619,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null);
@@ -663,7 +674,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, true,
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, k8sVersionString);
+        KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps, mockSecretOps, networkPolicyOperator, mockPdbOps, supplier, VERSIONS, null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -78,6 +78,8 @@ public class KafkaConnectS2IAssemblyOperatorTest {
     private static final String LOGGING_CONFIG = AbstractModel.getOrderedProperties("kafkaConnectDefaultLoggingProperties")
             .asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
 
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -128,7 +130,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -252,7 +254,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -372,7 +374,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -494,7 +496,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -554,7 +556,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -616,7 +618,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,
@@ -671,7 +673,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         Async async = context.async(2);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 new MockCertManager(),
                 mockConnectOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -79,10 +80,6 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
     private final String whitelist = ".*";
     private final String image = "my-image:latest";
 
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
-
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -133,7 +130,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -239,7 +236,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -360,7 +357,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -472,7 +469,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -544,7 +541,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -618,7 +615,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -694,7 +691,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, k8sVersionString),
+                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpecBuilder;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
@@ -78,6 +79,10 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
     private final String whitelist = ".*";
     private final String image = "my-image:latest";
 
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -127,7 +132,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -232,7 +238,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -352,7 +359,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(eq(clusterCmNamespace), anyString(), any());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -463,7 +471,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -534,7 +543,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -607,7 +617,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockPdbOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture());
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -682,7 +693,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         Async async = context.async(2);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx, true,
+        KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
+                new PlatformFeaturesAvailability(true, k8sVersionString),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -80,6 +80,8 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
     private final String whitelist = ".*";
     private final String image = "my-image:latest";
 
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_9;
+
     @BeforeClass
     public static void before() {
         vertx = Vertx.vertx();
@@ -130,7 +132,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -236,7 +238,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.reconcile(anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(null)));
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -357,7 +359,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -469,7 +471,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -541,7 +543,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -615,7 +617,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,
@@ -691,7 +693,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         KafkaMirrorMakerAssemblyOperator ops = new KafkaMirrorMakerAssemblyOperator(vertx,
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(),
                 mockMirrorOps,
                 mockSecretOps,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -71,6 +72,10 @@ public class KafkaUpdateTest {
             singletonMap("2.0.0", "kafka-connect"),
             singletonMap("2.0.0", "kafka-connect-s2i"),
             singletonMap("2.0.0", "kafka-mirror-maker-s2i")) { };
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     public static EnvVar findEnv(List<EnvVar> env, String envVar) {
         EnvVar value = null;
@@ -148,7 +153,7 @@ public class KafkaUpdateTest {
             return Future.succeededFuture();
         });
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, false, 1L,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, k8sVersionString), 1L,
                 new MockCertManager(),
                 new ResourceOperatorSupplier(null, null, null,
                         kso, null, null, null, null,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -16,6 +16,7 @@ import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
@@ -72,10 +73,6 @@ public class KafkaUpdateTest {
             singletonMap("2.0.0", "kafka-connect"),
             singletonMap("2.0.0", "kafka-connect-s2i"),
             singletonMap("2.0.0", "kafka-mirror-maker-s2i")) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     public static EnvVar findEnv(List<EnvVar> env, String envVar) {
         EnvVar value = null;
@@ -153,7 +150,7 @@ public class KafkaUpdateTest {
             return Future.succeededFuture();
         });
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, k8sVersionString), 1L,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L,
                 new MockCertManager(),
                 new ResourceOperatorSupplier(null, null, null,
                         kso, null, null, null, null,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.ClientsCa;
 import io.strimzi.operator.cluster.model.ClusterCa;
@@ -67,6 +68,10 @@ public class MaintenanceTimeWindowsTest {
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
 
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
+
     private Vertx vertx;
     private Kafka kafka;
     private KubernetesClient mockClient;
@@ -106,11 +111,12 @@ public class MaintenanceTimeWindowsTest {
 
         this.vertx = Vertx.vertx();
 
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, k8sVersionString);
         // creating the Kafka operator
         ResourceOperatorSupplier ros =
-                new ResourceOperatorSupplier(this.vertx, this.mockClient, false, 60_000L);
+                new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);
 
-        KafkaAssemblyOperator kao = new KafkaAssemblyOperator(this.vertx, false, 2_000, null, ros, VERSIONS, null);
+        KafkaAssemblyOperator kao = new KafkaAssemblyOperator(this.vertx, pfa, 2_000, null, ros, VERSIONS, null);
 
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MaintenanceTimeWindowsTest.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.TopicOperator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.ResourceType;
@@ -67,10 +68,6 @@ public class MaintenanceTimeWindowsTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
     private Kafka kafka;
@@ -111,7 +108,7 @@ public class MaintenanceTimeWindowsTest {
 
         this.vertx = Vertx.vertx();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, k8sVersionString);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9);
         // creating the Kafka operator
         ResourceOperatorSupplier ros =
                 new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -22,6 +22,7 @@ import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
@@ -58,10 +59,6 @@ public class PartialRollingUpdateTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
-
-    private final String k8sVersionString = "{\n" +
-            "  \"major\": \"1\",\n" +
-            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
     private Kafka cluster;
@@ -123,7 +120,7 @@ public class PartialRollingUpdateTest {
                 .build();
 
         ResourceOperatorSupplier supplier = supplier(bootstrapClient);
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
 
         LOGGER.info("bootstrap reconciliation");
@@ -153,7 +150,7 @@ public class PartialRollingUpdateTest {
 
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient);
-        return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, new PlatformFeaturesAvailability(true, k8sVersionString), 60_000L);
+        return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 60_000L);
     }
 
     private void startKube() {
@@ -170,7 +167,7 @@ public class PartialRollingUpdateTest {
 
         ResourceOperatorSupplier supplier = supplier(mockClient);
 
-        this.kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
+        this.kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
         LOGGER.info("Started test KafkaAssemblyOperator");
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
@@ -57,6 +58,10 @@ public class PartialRollingUpdateTest {
             "2.0.0 default 2.0 2.0 1234567890abcdef"),
             singletonMap("2.0.0", "strimzi/kafka:latest-kafka-2.0.0"),
             emptyMap(), emptyMap(), emptyMap()) { };
+
+    private final String k8sVersionString = "{\n" +
+            "  \"major\": \"1\",\n" +
+            "  \"minor\": \"9\"}";
 
     private Vertx vertx;
     private Kafka cluster;
@@ -118,7 +123,7 @@ public class PartialRollingUpdateTest {
                 .build();
 
         ResourceOperatorSupplier supplier = supplier(bootstrapClient);
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
 
         LOGGER.info("bootstrap reconciliation");
@@ -148,7 +153,7 @@ public class PartialRollingUpdateTest {
 
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient);
-        return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, true, 60_000L);
+        return new ResourceOperatorSupplier(vertx, bootstrapClient, leaderFinder, new PlatformFeaturesAvailability(true, k8sVersionString), 60_000L);
     }
 
     private void startKube() {
@@ -165,7 +170,7 @@ public class PartialRollingUpdateTest {
 
         ResourceOperatorSupplier supplier = supplier(mockClient);
 
-        this.kco = new KafkaAssemblyOperator(vertx, true, 2_000,
+        this.kco = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, k8sVersionString), 2_000,
                 new MockCertManager(), supplier, VERSIONS, null);
         LOGGER.info("Started test KafkaAssemblyOperator");
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -115,6 +115,7 @@ public class Resources extends AbstractResources {
                     x.delete(resource);
                     client.rbac().kubernetesClusterRoleBindings().delete((KubernetesClusterRoleBinding) resource);
                 });
+                break;
             default :
                 resources.add(() -> {
                     LOGGER.info("Deleting {} {}", resource.getKind(), resource.getMetadata().getName());


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
When the CO starts it determines the version of kubernetes which it is running on. Thanks to that we can enable/disable some features (todo which features with which version + enable/disable them at the right place)

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

