### PR TITLE
Set storage size to 100Gi for Kafka metrics example

### DIFF
--- a/metrics/examples/kafka/kafka-metrics.yaml
+++ b/metrics/examples/kafka/kafka-metrics.yaml
@@ -22,7 +22,7 @@ spec:
       log.message.format.version: "2.1"
     storage:
       type: persistent-claim
-      size: 1Gi
+      size: 100Gi
       deleteClaim: false
     metrics:
       # Inspired by config from Kafka 2.0.0 example rules:
@@ -131,7 +131,7 @@ spec:
       timeoutSeconds: 5
     storage:
       type: persistent-claim
-      size: 1Gi
+      size: 100Gi
       deleteClaim: false
     metrics:
       # Inspired by Zookeeper rules


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This trivial PR just increase the storage size to 100Gi for the Kafka metrics example like for the others without metrics. Having 1Gi doesn't make sense even because just starting a consumer so with the 50 consumer_offset partitions creation and having the almost 20 MB per partition index, fill the space.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

