### PR TITLE
We should always do rolling update when pod metadata change (labels / annos)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -52,7 +52,7 @@ public class KafkaSetOperator extends StatefulSetOperator {
             log.debug("Changed labels => needs rolling update");
             return true;
         }
-        if (diff.changesSpecTemplateSpec()) {
+        if (diff.changesSpecTemplate()) {
             log.debug("Changed template spec => needs rolling update");
             return true;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -21,7 +21,7 @@ public class StatefulSetDiff {
 
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
         "^(/spec/revisionHistoryLimit"
-        + "|/spec/template/metadata/annotations"  // Actually it's only the statefulset-generation annotation we care about
+        + "|/spec/template/metadata/annotations/strimzi.io~1generation"
         + "|/spec/template/spec/initContainers/[0-9]+/resources"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePath"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePolicy"
@@ -56,7 +56,7 @@ public class StatefulSetDiff {
 
     private final boolean changesVolumeClaimTemplate;
     private final boolean isEmpty;
-    private final boolean changesSpecTemplateSpec;
+    private final boolean changesSpecTemplate;
     private final boolean changesLabels;
     private final boolean changesSpecReplicas;
 
@@ -64,7 +64,7 @@ public class StatefulSetDiff {
         JsonNode diff = JsonDiff.asJson(patchMapper().valueToTree(current), patchMapper().valueToTree(desired));
         int num = 0;
         boolean changesVolumeClaimTemplate = false;
-        boolean changesSpecTemplateSpec = false;
+        boolean changesSpecTemplate = false;
         boolean changesLabels = false;
         boolean changesSpecReplicas = false;
         for (JsonNode d : diff) {
@@ -85,14 +85,14 @@ public class StatefulSetDiff {
             changesVolumeClaimTemplate |= equalsOrPrefix("/spec/volumeClaimTemplates", pathValue);
             // Change changes to /spec/template/spec, except to imagePullPolicy, which gets changed
             // by k8s
-            changesSpecTemplateSpec |= equalsOrPrefix("/spec/template/spec", pathValue);
+            changesSpecTemplate |= equalsOrPrefix("/spec/template", pathValue);
             changesLabels |= equalsOrPrefix("/metadata/labels", pathValue);
             changesSpecReplicas |= equalsOrPrefix("/spec/replicas", pathValue);
         }
         this.isEmpty = num == 0;
         this.changesLabels = changesLabels;
         this.changesSpecReplicas = changesSpecReplicas;
-        this.changesSpecTemplateSpec = changesSpecTemplateSpec;
+        this.changesSpecTemplate = changesSpecTemplate;
         this.changesVolumeClaimTemplate = changesVolumeClaimTemplate;
     }
 
@@ -127,8 +127,8 @@ public class StatefulSetDiff {
     }
 
     /** Returns true if there's a difference in {@code /spec/template/spec} */
-    public boolean changesSpecTemplateSpec() {
-        return changesSpecTemplateSpec;
+    public boolean changesSpecTemplate() {
+        return changesSpecTemplate;
     }
 
     /** Returns true if there's a difference in {@code /metadata/labels} */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -59,7 +59,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
             log.debug("Changed labels => needs rolling update");
             return true;
         }
-        if (diff.changesSpecTemplateSpec()) {
+        if (diff.changesSpecTemplate()) {
             log.debug("Changed template spec => needs rolling update");
             return true;
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -45,6 +45,6 @@ public class StatefulSetDiffTest {
                 .endTemplate()
             .endSpec()
             .build();
-        assertFalse(new StatefulSetDiff(ss1, ss2).changesSpecTemplateSpec());
+        assertFalse(new StatefulSetDiff(ss1, ss2).changesSpecTemplate());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, when pod metadata (labels / annotations) are changed in STS definition we just ignore it and never trigger a rolling update. That might cause the metadata change to be ignored. We should do a rolling update after every metadata change (apart from the Strimzi generation annotation which should be ignored). This should close #1472 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
