### PR TITLE
Diff resource requirements better

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+class Quantities {
+    private Quantities() {
+
+    }
+
+    /**
+     * Parse a K8S-style representation of a quantity of memory, such as {@code 512Mi},
+     * into the equivalent number of bytes represented as a long.
+     * @param memory The String representation of the quantity of memory.
+     * @return The equivalent number of bytes.
+     */
+    public static long parseMemory(String memory) {
+        boolean seenDot = false;
+        boolean seenE = false;
+        long factor = 1L;
+        int end = memory.length();
+        for (int i = 0; i < memory.length(); i++) {
+            char ch = memory.charAt(i);
+            if (ch == 'e') {
+                seenE = true;
+            } else if (ch == '.') {
+                seenDot = true;
+            } else if (ch < '0' || '9' < ch) {
+                end = i;
+                factor = memoryFactor(memory.substring(i));
+                break;
+            }
+        }
+        long result;
+        String numberPart = memory.substring(0, end);
+        if (seenDot || seenE) {
+            result = (long) (Double.parseDouble(numberPart) * factor);
+        } else {
+            result = Long.parseLong(numberPart) * factor;
+        }
+        return result;
+    }
+
+    private static long memoryFactor(String suffix) {
+        long factor;
+        switch (suffix) {
+            case "E":
+                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L;
+                break;
+            case "T":
+                factor = 1_000L * 1_000L * 1_000L * 1_000;
+                break;
+            case "G":
+                factor = 1_000L * 1_000L * 1_000L;
+                break;
+            case "M":
+                factor = 1_000L * 1_000L;
+                break;
+            case "K":
+                factor = 1_000L;
+                break;
+            case "Ei":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Ti":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Gi":
+                factor = 1_024L * 1_024L * 1_024L;
+                break;
+            case "Mi":
+                factor = 1_024L * 1_024L;
+                break;
+            case "Ki":
+                factor = 1_024L;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid memory suffix: " + suffix);
+        }
+        return factor;
+    }
+
+    public static String formatMemory(long bytes) {
+        return Long.toString(bytes);
+    }
+
+    public static String normalizeMemory(String memory) {
+        return formatMemory(parseMemory(memory));
+    }
+
+
+    /**
+     * Parse a K8S-style representation of a quantity of cpu, such as {@code 1000m},
+     * into the equivalent number of "millicpus" represented as an int.
+     * @param cpu The String representation of the quantity of cpu.
+     * @return The equivalent number of "millicpus".
+     */
+    public static int parseCpuAsMilliCpus(String cpu) {
+        int suffixIndex = cpu.length();
+        int factor = 1000;
+        for (int i = 0; i < cpu.length(); i++) {
+            char ch = cpu.charAt(i);
+            if (ch < '0' || '9' < ch) {
+                suffixIndex = i;
+                if ("m".equals(cpu.substring(i))) {
+                    factor = 1;
+                    break;
+                } else if (cpu.substring(i).startsWith(".")) {
+                    return (int) (Double.parseDouble(cpu) * 1000L);
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+        }
+        return factor * Integer.parseInt(cpu.substring(0, suffixIndex));
+    }
+
+    public static String formatMilliCpu(int milliCpu) {
+        if (milliCpu % 1000 == 0) {
+            return Long.toString(milliCpu / 1000L);
+        } else {
+            return Long.toString(milliCpu) + "m";
+        }
+    }
+
+    public static String normalizeCpu(String milliCpu) {
+        return formatMilliCpu(parseCpuAsMilliCpus(milliCpu));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -4,16 +4,18 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
-import static java.lang.Integer.parseInt;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.zjsonpatch.JsonDiff;
-import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
+import static java.lang.Integer.parseInt;
 
 public class StatefulSetDiff {
 
@@ -22,7 +24,6 @@ public class StatefulSetDiff {
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
         "^(/spec/revisionHistoryLimit"
         + "|/spec/template/metadata/annotations/strimzi.io~1generation"
-        + "|/spec/template/spec/initContainers/[0-9]+/resources"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePath"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePolicy"
         + "|/spec/template/spec/initContainers/[0-9]+/env/[0-9]+/valueFrom/fieldRef/apiVersion"
@@ -33,7 +34,6 @@ public class StatefulSetDiff {
         + "|/spec/template/spec/containers/[0-9]+/readinessProbe/failureThreshold"
         + "|/spec/template/spec/containers/[0-9]+/readinessProbe/periodSeconds"
         + "|/spec/template/spec/containers/[0-9]+/readinessProbe/successThreshold"
-        + "|/spec/template/spec/containers/[0-9]+/resources"
         + "|/spec/template/spec/containers/[0-9]+/terminationMessagePath"
         + "|/spec/template/spec/containers/[0-9]+/terminationMessagePolicy"
         + "|/spec/template/spec/dnsPolicy"
@@ -49,6 +49,8 @@ public class StatefulSetDiff {
         + "|/spec/template/spec/serviceAccount"
         + "|/status)$");
 
+    private static final Pattern RESOURCE_PATH = Pattern.compile("^/spec/template/spec/(?:initContainers|containers)/[0-9]+/resources/(?:limits|requests)/(memory|cpu)$");
+
     private static boolean equalsOrPrefix(String path, String pathValue) {
         return pathValue.equals(path)
                 || pathValue.startsWith(path + "/");
@@ -61,7 +63,9 @@ public class StatefulSetDiff {
     private final boolean changesSpecReplicas;
 
     public StatefulSetDiff(StatefulSet current, StatefulSet desired) {
-        JsonNode diff = JsonDiff.asJson(patchMapper().valueToTree(current), patchMapper().valueToTree(desired));
+        JsonNode source = patchMapper().valueToTree(current);
+        JsonNode target = patchMapper().valueToTree(desired);
+        JsonNode diff = JsonDiff.asJson(source, target);
         int num = 0;
         boolean changesVolumeClaimTemplate = false;
         boolean changesSpecTemplate = false;
@@ -73,6 +77,15 @@ public class StatefulSetDiff {
                 ObjectMeta md = current.getMetadata();
                 log.debug("StatefulSet {}/{} ignoring diff {}", md.getNamespace(), md.getName(), d);
                 continue;
+            }
+            Matcher resourceMatchers = RESOURCE_PATH.matcher(pathValue);
+            if (resourceMatchers.matches()) {
+                if ("replace".equals(d.path("op").asText())) {
+                    boolean same = compareResources(source, target, pathValue, resourceMatchers);
+                    if (same) {
+                        continue;
+                    }
+                }
             }
             if (log.isDebugEnabled()) {
                 ObjectMeta md = current.getMetadata();
@@ -94,6 +107,39 @@ public class StatefulSetDiff {
         this.changesSpecReplicas = changesSpecReplicas;
         this.changesSpecTemplate = changesSpecTemplate;
         this.changesVolumeClaimTemplate = changesVolumeClaimTemplate;
+    }
+
+    boolean compareResources(JsonNode source, JsonNode target, String pathValue, Matcher resourceMatchers) {
+        JsonNode s = source;
+        JsonNode t = target;
+        for (String component : pathValue.substring(1).split("/")) {
+            if (s.isArray()) {
+                s = s.path(Integer.parseInt(component));
+            } else {
+                s = s.path(component);
+            }
+            if (t.isArray()) {
+                t = t.path(Integer.parseInt(component));
+            } else {
+                t = t.path(component);
+            }
+        }
+        String group = resourceMatchers.group(1);
+        if (!s.isMissingNode()
+            && !t.isMissingNode()) {
+            if ("cpu".equals(group)) {
+                // Ignore single millicpu differences as they could be due to rounding error
+                if (Math.abs(Quantities.parseCpuAsMilliCpus(s.asText()) - Quantities.parseCpuAsMilliCpus(t.asText())) < 1) {
+                    return true;
+                }
+            } else {
+                // Ignore single byte differences as they could be due to rounding error
+                if (Math.abs(Quantities.parseMemory(s.asText()) - Quantities.parseMemory(t.asText())) < 1) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private JsonNode getFromPath(StatefulSet current, String pathValue) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import org.junit.Test;
+
+import static io.strimzi.operator.cluster.operator.resource.Quantities.formatMemory;
+import static io.strimzi.operator.cluster.operator.resource.Quantities.formatMilliCpu;
+import static io.strimzi.operator.cluster.operator.resource.Quantities.normalizeCpu;
+import static io.strimzi.operator.cluster.operator.resource.Quantities.normalizeMemory;
+import static io.strimzi.operator.cluster.operator.resource.Quantities.parseCpuAsMilliCpus;
+import static io.strimzi.operator.cluster.operator.resource.Quantities.parseMemory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class QuantitiesTest {
+
+    @Test
+    public void testParseMemory() {
+        assertEquals(1234, parseMemory("1234"));
+        assertEquals(0, parseMemory("0"));
+        assertEquals(1000, parseMemory("1K"));
+        assertEquals(1024, parseMemory("1Ki"));
+        assertEquals(512 * 1024, parseMemory("512Ki"));
+        assertEquals(1_000_000, parseMemory("1e6"));
+
+        assertEquals(0, parseMemory("0"));
+        assertEquals(0, parseMemory("0K"));
+        assertEquals(0, parseMemory("0e6"));
+        assertEquals(524288000L, parseMemory("500Mi"));
+        assertEquals(1181116006L, parseMemory("1.1Gi"));
+        assertEquals(1100000000L, parseMemory("1.1G"));
+        assertEquals(1100000L, parseMemory("1.1e3K"));
+
+        try {
+            parseMemory("-1K");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parseMemory("K");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parseMemory("1Kb");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parseMemory("foo");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parseMemory("1.1x");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parseMemory("1.1e-1");
+            fail();
+        } catch (IllegalArgumentException e) {
+
+        }
+    }
+
+    @Test
+    public void testFormatMemory() {
+        assertEquals("0", formatMemory(0));
+        assertEquals("1", formatMemory(1));
+        assertEquals("1023", formatMemory(1023));
+        assertEquals("1024", formatMemory(1024));
+        assertEquals("1000", formatMemory(1000));
+        assertEquals("2048", formatMemory(2048));
+        assertEquals("2000", formatMemory(2000));
+        assertEquals("2097152", formatMemory(2048 * 1024));
+        assertEquals("4096000", formatMemory(2048 * 2000));
+        assertEquals("4000000", formatMemory(2000 * 2000));
+        assertEquals("1000000000000000", formatMemory(1_000_000_000_000_000L));
+        assertEquals("1000000000000000000", formatMemory(1_000_000_000_000_000_000L));
+        assertEquals("1125899906842624", formatMemory(parseMemory("1Ei")));
+        assertEquals("1152921504606846976", formatMemory(parseMemory("1024Ei")));
+        assertEquals("524288000", formatMemory(524288000L));
+    }
+
+    @Test
+    public void testNormalizeMemory() {
+        assertEquals("1000", normalizeMemory("1K"));
+        assertEquals("1024", normalizeMemory("1Ki"));
+        assertEquals("1000000", normalizeMemory("1M"));
+        assertEquals("1048576", normalizeMemory("1Mi"));
+        assertEquals("12345", normalizeMemory("12345"));
+        assertEquals("524288000", normalizeMemory("500Mi"));
+        assertEquals("1181116006", normalizeMemory("1.1Gi"));
+        assertEquals("1288490189", normalizeMemory("1.2Gi"));
+    }
+
+    @Test
+    public void testParse() {
+        assertEquals(1000, parseCpuAsMilliCpus("1"));
+        assertEquals(1, parseCpuAsMilliCpus("1m"));
+        assertEquals(500, parseCpuAsMilliCpus("0.5"));
+        assertEquals(0, parseCpuAsMilliCpus("0"));
+        assertEquals(0, parseCpuAsMilliCpus("0m"));
+        assertEquals(0, parseCpuAsMilliCpus("0.0"));
+        assertEquals(0, parseCpuAsMilliCpus("0.000001"));
+
+        try {
+            parseCpuAsMilliCpus("0.0m");
+            fail();
+        } catch (NumberFormatException e) { }
+
+        try {
+            parseCpuAsMilliCpus("0.1m");
+            fail();
+        } catch (NumberFormatException e) { }
+    }
+
+    @Test
+    public void testFormat() {
+        assertEquals("1", formatMilliCpu(1000));
+        assertEquals("500m", formatMilliCpu(500));
+        assertEquals("1m", formatMilliCpu(1));
+    }
+
+    @Test
+    public void testRt() {
+        assertEquals("1", formatMilliCpu(parseCpuAsMilliCpus("1")));
+        assertEquals("500m", formatMilliCpu(parseCpuAsMilliCpus("500m")));
+        assertEquals("1m", formatMilliCpu(parseCpuAsMilliCpus("1m")));
+    }
+
+    @Test
+    public void testNormalizeCpu() {
+        assertEquals("1", normalizeCpu("1"));
+        assertEquals("1", normalizeCpu("1000m"));
+        assertEquals("500m", normalizeCpu("500m"));
+        assertEquals("500m", normalizeCpu("0.5"));
+        assertEquals("100m", normalizeCpu("0.1"));
+        assertEquals("10m", normalizeCpu("0.01"));
+        assertEquals("1m", normalizeCpu("0.001"));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -5,12 +5,20 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StatefulSetDiffTest {
     @Test
@@ -46,5 +54,72 @@ public class StatefulSetDiffTest {
             .endSpec()
             .build();
         assertFalse(new StatefulSetDiff(ss1, ss2).changesSpecTemplate());
+    }
+
+    public StatefulSetDiff testCpuResources(ResourceRequirements requirements1, ResourceRequirements requirements2) {
+        StatefulSet ss1 = new StatefulSetBuilder()
+                .withNewMetadata()
+                    .withNamespace("test")
+                    .withName("foo")
+                .endMetadata()
+                .withNewSpec().
+                    withNewTemplate()
+                        .withNewSpec()
+                            .addNewContainer()
+                                .withResources(requirements1)
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+            .build();
+        StatefulSet ss2 = new StatefulSetBuilder()
+                .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewTemplate()
+                        .withNewSpec()
+                            .addNewContainer()
+                                .withResources(requirements2)
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        return new StatefulSetDiff(ss1, ss2);
+    }
+
+    @Test
+    public void testCpuResources() {
+        assertTrue(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("cpu", new Quantity("1000m")))
+                        .addToRequests(singletonMap("memory", new Quantity("1.1Gi")))
+                        .addToLimits(singletonMap("cpu", new Quantity("1000m")))
+                        .addToLimits(singletonMap("memory", new Quantity("500Mi")))
+                        .build(),
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("cpu", new Quantity("1")))
+                        .addToRequests(singletonMap("memory", new Quantity("1181116006")))
+                        .addToLimits(singletonMap("cpu", new Quantity("1")))
+                        .addToLimits(singletonMap("memory", new Quantity("524288000")))
+                        .build()).isEmpty());
+
+        assertFalse(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("cpu", new Quantity("1001m")))
+                        .build(),
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("cpu", new Quantity("1")))
+                        .build()).isEmpty());
+
+        assertFalse(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("memory", new Quantity("1.1Gi")))
+                        .build(),
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("memory", new Quantity("1181116007")))
+                        .build()).isEmpty());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -13,9 +13,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.Map;
-
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix problem where CO incorrectly determines that a STS has been changed even though it has not, because the memory/cpu request/limit has been rewritten by kube. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

