### PR TITLE
Fix continual reconciliation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -24,9 +24,11 @@ public class StatefulSetDiff {
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
         "^(/spec/revisionHistoryLimit"
         + "|/spec/template/metadata/annotations/strimzi.io~1generation"
+        + "|/spec/template/spec/initContainers/[0-9]+/resources"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePath"
         + "|/spec/template/spec/initContainers/[0-9]+/terminationMessagePolicy"
         + "|/spec/template/spec/initContainers/[0-9]+/env/[0-9]+/valueFrom/fieldRef/apiVersion"
+        + "|/spec/template/spec/containers/[0-9]+/resources"
         + "|/spec/template/spec/containers/[0-9]+/env/[0-9]+/valueFrom/fieldRef/apiVersion"
         + "|/spec/template/spec/containers/[0-9]+/livenessProbe/failureThreshold"
         + "|/spec/template/spec/containers/[0-9]+/livenessProbe/periodSeconds"

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -118,5 +118,23 @@ public class StatefulSetDiffTest {
                 new ResourceRequirementsBuilder()
                         .addToRequests(singletonMap("memory", new Quantity("1181116007")))
                         .build()).isEmpty());
+
+        assertFalse(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .build(),
+                new ResourceRequirementsBuilder()
+                        .addToRequests(singletonMap("memory", new Quantity("1181116007")))
+                        .build()).isEmpty());
+
+        assertTrue(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .build(),
+                new ResourceRequirementsBuilder()
+                        .build()).isEmpty());
+
+        assertTrue(testCpuResources(
+                new ResourceRequirementsBuilder()
+                        .build(),
+                null).isEmpty());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes a bug causing continual reconciliation by not treating a null and empty resources as being the same.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

