### PR TITLE
ST: More checks for CPU and memory resources

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -83,12 +83,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
             <version>${junit.platform.version}</version>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -83,6 +83,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
             <version>${junit.platform.version}</version>

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -108,7 +108,7 @@ public class StUtils {
         return true;
     }
 
-    private static boolean depHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
+    public static boolean depHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
         LOGGER.debug("Existing snapshot: {}", new TreeMap(snapshot));
         Map<String, String> map = podSnapshot(client, namespace, client.extensions().deployments().inNamespace(namespace).withName(name).get().getSpec().getSelector());
         LOGGER.debug("Current  snapshot: {}", new TreeMap(map));

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -61,7 +61,7 @@ public class StUtils {
         return podSnapshot(client, namespace, selector);
     }
 
-    private static boolean ssHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
+    public static boolean ssHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
         boolean log = true;
         if (log) {
             LOGGER.debug("Existing snapshot: {}", new TreeMap(snapshot));

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -126,7 +126,7 @@ class ConnectST extends AbstractST {
             .endSpec().done();
 
         String podName = KUBE_CLIENT.list("Pod").stream().filter(n -> n.startsWith(kafkaConnectName(KAFKA_CLUSTER_NAME))).findFirst().get();
-        assertResources(NAMESPACE, podName,
+        assertResources(NAMESPACE, podName, "connect-tests-connect",
                 "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName,
                 "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -601,13 +601,13 @@ class KafkaST extends AbstractST {
                 "512M", "300m", "256M", "300m");
 
         TestUtils.waitFor("Wait till reconciliation timeout", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
-            () -> !KUBE_CLIENT.searchInLog("deploy", "strimzi-cluster-operator", TimeMeasuringSystem.getCurrentDuration(testClass, testName, operationID), "Assembly reconciled").isEmpty());
+            () -> !KUBE_CLIENT.searchInLog("deploy", "strimzi-cluster-operator", TimeMeasuringSystem.getCurrentDuration(testClass, testName, operationID), "\"Assembly reconciled\"").isEmpty());
 
         // Checking no rolling update after last CO reconciliation
         LOGGER.info("Checking no rolling update for Kafka cluster");
         assertFalse(StUtils.ssHasRolled(CLIENT, NAMESPACE, zkSsName, zkPods));
         assertFalse(StUtils.ssHasRolled(CLIENT, NAMESPACE, kafkaSsName, kafkaPods));
-        assertFalse(StUtils.ssHasRolled(CLIENT, NAMESPACE, eoDepName, eoPods));
+        assertFalse(StUtils.depHasRolled(CLIENT, NAMESPACE, eoDepName, eoPods));
         TimeMeasuringSystem.stopOperation(operationID);
     }
 


### PR DESCRIPTION
### Type of change
- New checks in ST

### Description
New checks were added for CPU and memory resources units. They were added in the scope of regression testing for fixed issue #1435

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

