### PR TITLE
Use OwnerReference in secrets related to KAfkaUser resources

### DIFF
--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.user.model;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserAuthorizationSimple;
@@ -31,6 +33,11 @@ public class KafkaUserModelTest {
     private final CertManager mockCertManager = new MockCertManager();
     private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a");
 
+    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
+        assertEquals(1, resource.getMetadata().getOwnerReferences().size());
+        assertEquals(ownerRef, resource.getMetadata().getOwnerReferences().get(0));
+    }
+
     @Test
     public void testFromCrd()   {
         KafkaUserModel model = KafkaUserModel.fromCrd(mockCertManager, passwordGenerator, tlsUser, clientsCaCert, clientsCaKey, null);
@@ -55,6 +62,9 @@ public class KafkaUserModelTest {
         assertEquals(ResourceUtils.NAME, generated.getMetadata().getName());
         assertEquals(ResourceUtils.NAMESPACE, generated.getMetadata().getNamespace());
         assertEquals(Labels.userLabels(ResourceUtils.LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap(), generated.getMetadata().getLabels());
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -65,6 +75,9 @@ public class KafkaUserModelTest {
         assertEquals("clients-ca-crt", new String(model.decodeFromSecret(generated, "ca.crt")));
         assertEquals("crt file", new String(model.decodeFromSecret(generated, "user.crt")));
         assertEquals("key file", new String(model.decodeFromSecret(generated, "user.key")));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -81,6 +94,9 @@ public class KafkaUserModelTest {
         assertEquals("different-clients-ca-crt", new String(model.decodeFromSecret(generated, "ca.crt")));
         assertEquals("crt file", new String(model.decodeFromSecret(generated, "user.crt")));
         assertEquals("key file", new String(model.decodeFromSecret(generated, "user.key")));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -92,6 +108,9 @@ public class KafkaUserModelTest {
         assertEquals("clients-ca-crt", new String(model.decodeFromSecret(generated, "ca.crt")));
         assertEquals("expected-crt", new String(model.decodeFromSecret(generated, "user.crt")));
         assertEquals("expected-key", new String(model.decodeFromSecret(generated, "user.key")));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -103,6 +122,9 @@ public class KafkaUserModelTest {
         assertEquals("clients-ca-crt", new String(model.decodeFromSecret(generated, "ca.crt")));
         assertEquals("crt file", new String(model.decodeFromSecret(generated, "user.crt")));
         assertEquals("key file", new String(model.decodeFromSecret(generated, "user.key")));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -116,6 +138,9 @@ public class KafkaUserModelTest {
 
         assertEquals(singleton(KafkaUserModel.KEY_PASSWORD), generated.getData().keySet());
         assertEquals("aaaaaaaaaa", new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -131,6 +156,9 @@ public class KafkaUserModelTest {
 
         assertEquals(singleton(KafkaUserModel.KEY_PASSWORD), generated.getData().keySet());
         assertEquals(existing, generated.getData().get(KafkaUserModel.KEY_PASSWORD));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test
@@ -145,6 +173,9 @@ public class KafkaUserModelTest {
 
         assertEquals(singleton("password"), generated.getData().keySet());
         assertEquals("aaaaaaaaaa", new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))));
+
+        // Check owner reference
+        checkOwnerReference(model.createOwnerReference(), generated);
     }
 
     @Test

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -558,11 +558,9 @@ public class KafkaUserOperatorTest {
         existingScramShaUserSecret.getMetadata().setName("existing-scram-sha-user");
         KafkaUser existingScramShaUser = ResourceUtils.createKafkaUserTls();
         existingScramShaUser.getMetadata().setName("existing-scram-sha-user");
-        Secret deletedUserCert = ResourceUtils.createUserSecretTls();
-        deletedUserCert.getMetadata().setName("deleted-user");
 
         when(mockCrdOps.list(eq(ResourceUtils.NAMESPACE), eq(Labels.userLabels(ResourceUtils.LABELS)))).thenReturn(Arrays.asList(newTlsUser, newScramShaUser, existingTlsUser, existingScramShaUser));
-        when(mockSecretOps.list(eq(ResourceUtils.NAMESPACE), eq(Labels.userLabels(ResourceUtils.LABELS).withKind(KafkaUser.RESOURCE_KIND)))).thenReturn(Arrays.asList(existingTlsUserSecret, existingScramShaUserSecret, deletedUserCert));
+        when(mockSecretOps.list(eq(ResourceUtils.NAMESPACE), eq(Labels.userLabels(ResourceUtils.LABELS).withKind(KafkaUser.RESOURCE_KIND)))).thenReturn(Arrays.asList(existingTlsUserSecret, existingScramShaUserSecret));
         when(aclOps.getUsersWithAcls()).thenReturn(new HashSet<String>(Arrays.asList("existing-tls-user", "second-deleted-user")));
         when(scramOps.list()).thenReturn(asList("existing-tls-user", "deleted-scram-sha-user"));
 
@@ -570,18 +568,16 @@ public class KafkaUserOperatorTest {
         when(mockCrdOps.get(eq(newScramShaUser.getMetadata().getNamespace()), eq(newScramShaUser.getMetadata().getName()))).thenReturn(newScramShaUser);
         when(mockCrdOps.get(eq(existingTlsUser.getMetadata().getNamespace()), eq(existingTlsUser.getMetadata().getName()))).thenReturn(existingTlsUser);
         when(mockCrdOps.get(eq(existingTlsUser.getMetadata().getNamespace()), eq(existingScramShaUser.getMetadata().getName()))).thenReturn(existingScramShaUser);
-        when(mockCrdOps.get(eq(deletedUserCert.getMetadata().getNamespace()), eq(deletedUserCert.getMetadata().getName()))).thenReturn(null);
         when(mockSecretOps.get(eq(clientsCa.getMetadata().getNamespace()), eq(clientsCa.getMetadata().getName()))).thenReturn(clientsCa);
         when(mockSecretOps.get(eq(newTlsUser.getMetadata().getNamespace()), eq(newTlsUser.getMetadata().getName()))).thenReturn(null);
         when(mockSecretOps.get(eq(newScramShaUser.getMetadata().getNamespace()), eq(newScramShaUser.getMetadata().getName()))).thenReturn(null);
         when(mockSecretOps.get(eq(existingTlsUser.getMetadata().getNamespace()), eq(existingTlsUser.getMetadata().getName()))).thenReturn(existingTlsUserSecret);
         when(mockSecretOps.get(eq(existingScramShaUser.getMetadata().getNamespace()), eq(existingScramShaUser.getMetadata().getName()))).thenReturn(existingScramShaUserSecret);
-        when(mockSecretOps.get(eq(deletedUserCert.getMetadata().getNamespace()), eq(deletedUserCert.getMetadata().getName()))).thenReturn(deletedUserCert);
 
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
         Set<String> deleted = new CopyOnWriteArraySet<>();
 
-        Async async = context.async(7);
+        Async async = context.async(6);
         KafkaUserOperator op = new KafkaUserOperator(vertx,
                 mockCertManager,
                 mockCrdOps,
@@ -609,7 +605,7 @@ public class KafkaUserOperatorTest {
 
         context.assertEquals(new HashSet(asList("new-tls-user", "existing-tls-user",
                 "new-scram-sha-user", "existing-scram-sha-user")), createdOrUpdated);
-        context.assertEquals(new HashSet(asList("deleted-user", "second-deleted-user", "deleted-scram-sha-user")), deleted);
+        context.assertEquals(new HashSet(asList("second-deleted-user", "deleted-scram-sha-user")), deleted);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

The secrets managed by the User Operator should use Owner Reference so that they can be garbage collected. Without that, the User Operator has to delete them manually which means that if the Kafka resource is deleted before the KafkaUser resources there is nobody left to delete the Secrets.

After we use the garbage collection we also do not need to track the secrets in the KafkaUserOperator anymore and can just leave it to Kubernetes garbage collection.

This will also add the resource tracking for OLM.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally