### PR TITLE
ST: check the handling of the topic without labels

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -616,6 +616,15 @@ class KafkaST extends AbstractST {
         assertThat(listTopicsUsingPodCLI(CLUSTER_NAME, 0), hasItems("my-topic", "topic-from-cli"));
         assertThat(KUBE_CLIENT.list("kafkatopic"), hasItems("my-topic", "topic-from-cli", "my-topic"));
 
+        resources().topic(CLUSTER_NAME, "topic-without-labels")
+                .editMetadata()
+                    .withLabels(null)
+                .endMetadata()
+                .done();
+
+        assertThat(listTopicsUsingPodCLI(CLUSTER_NAME, 0), hasItems("my-topic", "topic-from-cli", "topic-without-labels"));
+        assertThat(KUBE_CLIENT.list("kafkatopic"), hasItems("my-topic", "topic-from-cli", "topic-without-labels"));
+
         //Updating first topic using pod CLI
         updateTopicPartitionsCountUsingPodCLI(CLUSTER_NAME, 0, "my-topic", 2);
         assertThat(describeTopicUsingPodCLI(CLUSTER_NAME, 0, "my-topic"),


### PR DESCRIPTION
### Type of change
- Added steps in existing ST

### Description
This PR has a few additional checks for handling topics without labels and relates to #1360 
Note: We can't deploy standalone topic right now in ST because of complicated authentication between TO and zk pods

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

