### PR TITLE
Docs api version

### DIFF
--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -25,7 +25,7 @@ Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML fil
 
 The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed. To change the cluster name before you deploy the cluster, edit the `Kafka.metadata.name` property of the resource in the relevant YAML file.
 
-[source,yaml,subs="+quotes,+attributes"]
+[source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -25,7 +25,7 @@ Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML fil
 
 The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed. To change the cluster name before you deploy the cluster, edit the `Kafka.metadata.name` property of the resource in the relevant YAML file.
 
-[source,yaml,subs=+quotes,attributes]
+[source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/assembly-kafka-cluster.adoc
+++ b/documentation/book/assembly-kafka-cluster.adoc
@@ -25,9 +25,9 @@ Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML fil
 
 The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed. To change the cluster name before you deploy the cluster, edit the `Kafka.metadata.name` property of the resource in the relevant YAML file.
 
-[source,yaml,subs=+quotes]
+[source,yaml,subs=+quotes,attributes]
 ----
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -37,7 +37,7 @@ USER {DockerImageUser}
 +
 [source,yaml,subs=attributes+]
 ----
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster

--- a/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
@@ -18,7 +18,7 @@ If you want to use the Topic Operator with a Kafka cluster that is not managed b
 
 . Ensure that the `Kafka.spec.entityOperator` object exists in the `Kafka` resource. This configures the Entity Operator.
 +
-[source,yaml,subs="+quotes,+attributes"]
+[source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
@@ -18,7 +18,7 @@ If you want to use the Topic Operator with a Kafka cluster that is not managed b
 
 . Ensure that the `Kafka.spec.entityOperator` object exists in the `Kafka` resource. This configures the Entity Operator.
 +
-[source,yaml,subs=+quotes,attributes]
+[source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-using-the-cluster-operator.adoc
@@ -18,9 +18,9 @@ If you want to use the Topic Operator with a Kafka cluster that is not managed b
 
 . Ensure that the `Kafka.spec.entityOperator` object exists in the `Kafka` resource. This configures the Entity Operator.
 +
-[source,yaml,subs=+quotes]
+[source,yaml,subs=+quotes,attributes]
 ----
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster

--- a/documentation/book/proc-installing-your-own-ca-certificates.adoc
+++ b/documentation/book/proc-installing-your-own-ca-certificates.adoc
@@ -95,10 +95,10 @@ oc label secret _<ca-key-secret>_ strimzi.io/kind=Kafka strimzi.io/cluster=_<my-
 . Create the `Kafka` resource for your cluster, configuring either the `Kafka.spec.clusterCa` or the `Kafka.spec.clientsCa` object to _not_ use generated CAs:
 +
 .Example fragment `Kafka` resource configuring the cluster CA to use certificates you supply for yourself
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 kind: Kafka
-version: v1alpha1
+version: {KafkaApiVersion}
 spec:
   # ...
   clusterCa:

--- a/documentation/book/proc-kafka-external-logging.adoc
+++ b/documentation/book/proc-kafka-external-logging.adoc
@@ -8,7 +8,7 @@
 
 . Edit the YAML file to specify the name of the `ConfigMap` which should be used for the required components. For example:
 +
-[source,yaml,subs="+quotes,+attributes"]
+[source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/proc-kafka-external-logging.adoc
+++ b/documentation/book/proc-kafka-external-logging.adoc
@@ -8,7 +8,7 @@
 
 . Edit the YAML file to specify the name of the `ConfigMap` which should be used for the required components. For example:
 +
-[source,yaml,subs=+quotes]
+[source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/proc-kafka-inline-logging.adoc
+++ b/documentation/book/proc-kafka-inline-logging.adoc
@@ -8,7 +8,7 @@
 
 . Edit the YAML file to specify the loggers and their level for the required components. For example:
 +
-[source,yaml,subs=+quotes]
+[source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/proc-kafka-inline-logging.adoc
+++ b/documentation/book/proc-kafka-inline-logging.adoc
@@ -8,7 +8,7 @@
 
 . Edit the YAML file to specify the loggers and their level for the required components. For example:
 +
-[source,yaml,subs="+quotes,+attributes"]
+[source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka

--- a/documentation/book/snip-reassign-partitions.adoc
+++ b/documentation/book/snip-reassign-partitions.adoc
@@ -147,7 +147,7 @@ kubectl exec my-cluster-kafka-0 -c kafka -it -- \
 ----
 endif::Kubernetes[]
 +
-For example, on {OpenShift},
+For example, on {OpenShiftName},
 +
 [source,shell,subs=+quotes]
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This fixes almost all the v1alpha1 `apiVersions` used in the documentation, except for the following:

```
$ grep -lr 'v1alpha1' documentation/book/
documentation/book/proc-downgrading-brokers-older-kafka.adoc:apiVersion: v1alpha1
documentation/book/proc-upgrading-brokers-newer-kafka.adoc:apiVersion: v1alpha1
```

I've not done those because we've yet to write a procedure for how to change resources from `v1alpha1` to `v1beta1`. Whether the above procedures need changing depends on whether the user has upgraded the apiversions before or after the broker upgrade.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

