### PR TITLE
Do not touch the sercrets with CA which were created by the users

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -55,6 +55,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -331,6 +332,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 .build();
 
                         CertificateAuthority clusterCaConfig = kafkaAssembly.getSpec().getClusterCa();
+
+                        // When we are not supposed to generate the CA but it does not exist, we should just throw an error
+                        if (clusterCaConfig != null && !clusterCaConfig.isGenerateCertificateAuthority() && (clusterCaCertSecret == null || clusterCaKeySecret == null))   {
+                            future.fail(new InvalidConfigurationException("Cluster CA should not be generated, but the secrets were not found!"));
+                            return;
+                        }
+
                         this.clusterCa = new ClusterCa(certManager, name, clusterCaCertSecret, clusterCaKeySecret,
                                 ModelUtils.getCertificateValidity(clusterCaConfig),
                                 ModelUtils.getRenewalDays(clusterCaConfig),
@@ -343,6 +351,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         this.clusterCa.initCaSecrets(clusterSecrets);
 
                         CertificateAuthority clientsCaConfig = kafkaAssembly.getSpec().getClientsCa();
+
+                        // When we are not supposed to generate the CA but it does not exist, we should just throw an error
+                        if (clientsCaConfig != null && !clientsCaConfig.isGenerateCertificateAuthority() && (clientsCaCertSecret == null || clientsCaKeySecret == null))   {
+                            future.fail(new InvalidConfigurationException("Clients CA should not be generated, but the secrets were not found!"));
+                            return;
+                        }
+
                         this.clientsCa = new ClientsCa(certManager,
                                 clientsCaCertName, clientsCaCertSecret,
                                 clientsCaKeyName, clientsCaKeySecret,
@@ -353,13 +368,27 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         clientsCa.createRenewOrReplace(reconciliation.namespace(), reconciliation.name(),
                                 caLabels.toMap(), ownerRef);
 
-                        secretOperations.reconcile(reconciliation.namespace(), clusterCaCertName, this.clusterCa.caCertSecret())
-                                .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clusterCaKeyName, this.clusterCa.caKeySecret()))
-                                .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clientsCaCertName, this.clientsCa.caCertSecret()))
-                                .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clientsCaKeyName, this.clientsCa.caKeySecret()))
-                                .compose(ignored -> {
-                                    future.complete(this);
-                                }, future);
+                        List<Future> secretReconciliations = new ArrayList<>(2);
+
+                        if (clusterCaConfig == null || clusterCaConfig.isGenerateCertificateAuthority())   {
+                            Future clusterSecretReconciliation = secretOperations.reconcile(reconciliation.namespace(), clusterCaCertName, this.clusterCa.caCertSecret())
+                                    .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clusterCaKeyName, this.clusterCa.caKeySecret()));
+                            secretReconciliations.add(clusterSecretReconciliation);
+                        }
+
+                        if (clientsCaConfig == null || clientsCaConfig.isGenerateCertificateAuthority())   {
+                            Future clientsSecretReconciliation = secretOperations.reconcile(reconciliation.namespace(), clientsCaCertName, this.clientsCa.caCertSecret())
+                                .compose(ignored -> secretOperations.reconcile(reconciliation.namespace(), clientsCaKeyName, this.clientsCa.caKeySecret()));
+                            secretReconciliations.add(clientsSecretReconciliation);
+                        }
+
+                        CompositeFuture.join(secretReconciliations).setHandler(res -> {
+                            if (res.succeeded())    {
+                                future.complete(this);
+                            } else {
+                                future.fail(res.cause());
+                            }
+                        });
                     } catch (Throwable e) {
                         future.fail(e);
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -20,6 +20,7 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.ResourceType;
@@ -33,6 +34,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
@@ -198,20 +200,15 @@ public class CertificateRenewalTest {
         assertEquals(singleton(CA_KEY), c.getAllValues().get(3).getData().keySet());
     }
 
-    @Test
-    public void certsNotGeneratedInitiallyManual(TestContext context) throws IOException {
+    @Test(expected = InvalidConfigurationException.class)
+    public void failsWhenCustomCertsAreMissing(TestContext context) throws IOException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
                 .withRenewalDays(10)
                 .withGenerateCertificateAuthority(false)
                 .build();
         secrets.clear();
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
-        assertEquals(c.getAllValues().toString(), 4, c.getAllValues().size());
-        assertTrue(c.getAllValues().get(0).getData().isEmpty());
-        assertTrue(c.getAllValues().get(1).getData().isEmpty());
-        assertTrue(c.getAllValues().get(2).getData().isEmpty());
-        assertTrue(c.getAllValues().get(3).getData().isEmpty());
+        reconcileCa(context, certificateAuthority, certificateAuthority);
     }
 
     @Test
@@ -256,11 +253,6 @@ public class CertificateRenewalTest {
 
         assertEquals(set(CA_KEY), c.getAllValues().get(3).getData().keySet());
         assertEquals(initialClientsCaKeySecret.getData().get(CA_KEY), c.getAllValues().get(3).getData().get(CA_KEY));
-    }
-
-    @Test
-    public void noCertsGetGeneratedOutsideRenewalPeriodManual(TestContext context) throws IOException {
-        noCertsGetGeneratedOutsideRenewalPeriod(context, false);
     }
 
     @Test
@@ -385,41 +377,6 @@ public class CertificateRenewalTest {
     }
 
     @Test
-    public void newCertsNotGeneratedWhenInRenewalPeriodManual(TestContext context) throws IOException {
-        CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(2)
-                .withRenewalDays(3)
-                .withGenerateCertificateAuthority(false)
-                .build();
-        Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
-        Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
-        assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
-        assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
-        assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
-        assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
-
-        Secret initialClientsCaCertSecret = initialClientsCaCertSecret(certificateAuthority);
-        Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
-        assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
-        assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
-        assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
-        assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
-
-        secrets.add(initialClusterCaCertSecret);
-        secrets.add(initialClusterCaKeySecret);
-        secrets.add(initialClientsCaCertSecret);
-        secrets.add(initialClientsCaKeySecret);
-
-        ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
-        assertEquals(4, c.getAllValues().size());
-
-        assertEquals(initialClusterCaCertSecret.getData(), c.getAllValues().get(0).getData());
-        assertEquals(initialClusterCaKeySecret.getData(), c.getAllValues().get(1).getData());
-        assertEquals(initialClientsCaCertSecret.getData(), c.getAllValues().get(2).getData());
-        assertEquals(initialClientsCaKeySecret.getData(), c.getAllValues().get(3).getData());
-    }
-
-    @Test
     public void expiredCertsGetRemovedAuto(TestContext context) throws IOException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -469,17 +426,16 @@ public class CertificateRenewalTest {
     }
 
     @Test
-    public void expiredCertsNotRemovedManual(TestContext context) throws IOException {
+    public void customCertsNotReconciled(TestContext context) throws IOException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
-                .withValidityDays(100)
-                .withRenewalDays(10)
+                .withValidityDays(2)
+                .withRenewalDays(3)
                 .withGenerateCertificateAuthority(false)
                 .build();
         Secret initialClusterCaCertSecret = initialClusterCaCertSecret(certificateAuthority);
         Secret initialClusterCaKeySecret = initialClusterCaKeySecret(certificateAuthority);
         assertEquals(singleton(CA_CRT), initialClusterCaCertSecret.getData().keySet());
         assertNotNull(initialClusterCaCertSecret.getData().get(CA_CRT));
-        initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
         assertEquals(singleton(CA_KEY), initialClusterCaKeySecret.getData().keySet());
         assertNotNull(initialClusterCaKeySecret.getData().get(CA_KEY));
 
@@ -487,7 +443,6 @@ public class CertificateRenewalTest {
         Secret initialClientsCaKeySecret = initialClientsCaKeySecret(certificateAuthority);
         assertEquals(singleton(CA_CRT), initialClientsCaCertSecret.getData().keySet());
         assertNotNull(initialClientsCaCertSecret.getData().get(CA_CRT));
-        initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", "whatever");
         assertEquals(singleton(CA_KEY), initialClientsCaKeySecret.getData().keySet());
         assertNotNull(initialClientsCaKeySecret.getData().get(CA_KEY));
 
@@ -497,9 +452,6 @@ public class CertificateRenewalTest {
         secrets.add(initialClientsCaKeySecret);
 
         ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
-        assertEquals(4, c.getAllValues().size());
-
-        assertEquals(initialClusterCaCertSecret.getData(), c.getAllValues().get(0).getData());
-        assertEquals(initialClientsCaCertSecret.getData(), c.getAllValues().get(2).getData());
+        assertEquals(0, c.getAllValues().size());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -34,7 +34,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
@@ -62,7 +61,6 @@ import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

When the user disables the CO to generate the CAs, the CO behaves a bit strangely:
* If the secrets with CAs were not provided by the user, it will create the secrets, but empty and will later throw NPEs because of it being empty
* It will take over the secrets and reconcile them periodically, although technically it should not change them.
* It will set the `ownerReference` over them and delete them when the CR is deleted.

The first issue is just wrong - if the secrets don't exist, we should just throw and clear exception and error message and end the reconciliation instead of creating empty issues and failing anyway. The other two points are IMHO also wrong. We should not touch and not take ownership of resources created intentionally by someone else.

This PR makes sure that if the secrets are missing in the first place, we just throw an exception and call it a day. It also does the secret reconciliation only when the secrets are actually ours.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally