### PR TITLE
deflake-template-test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -115,15 +115,15 @@ class KafkaST extends AbstractST {
         oc.deleteByName("Kafka", clusterName);
 
         // Delete all pods created by this test
-        CLIENT.pods().list().getItems().stream()
+        CLIENT.pods().inNamespace(NAMESPACE).list().getItems().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(clusterName))
-                .forEach(p -> CLIENT.pods().delete(p));
+                .forEach(p -> CLIENT.pods().inNamespace(NAMESPACE).delete(p));
 
         oc.waitForResourceDeletion("statefulset", kafkaClusterName(clusterName));
         oc.waitForResourceDeletion("statefulset", zookeeperClusterName(clusterName));
         oc.waitForResourceDeletion("deployment", entityOperatorDeploymentName(clusterName));
 
-        CLIENT.pods().list().getItems().stream()
+        CLIENT.pods().inNamespace(NAMESPACE).list().getItems().stream()
                 .filter(p -> p.getMetadata().getName().startsWith(clusterName))
                 .forEach(p -> waitForPodDeletion(NAMESPACE, p.getMetadata().getName()));
         deleteCustomResources("../examples/templates/cluster-operator");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

We weren't always using the right namespace in the test. It was flaky locally but seems to be reliable now locally.

This is really a band-aid; there's a bigger problem in the tests because we have both `KubernetesClient` and `KubeClient` and we're not doing a good job of managing the namespace they both use in a coordinated way. The main problem is `io.strimzi.test.BaseITST#CLIENT` is not using the test's namespace. Most of the time that's fine because we use it with `.inNamespace()` queries, but we should probably make `CLIENT` private and thus require use sites to use `io.strimzi.systemtest.AbstractST#namespacedClient()` instead.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

