### PR TITLE
Update sundrio version for java 11 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <sundrio.version>0.15.1</sundrio.version>
+        <sundrio.version>0.16.5</sundrio.version>
 
         <fabric8.kubernetes-client.version>4.1.1</fabric8.kubernetes-client.version>
         <fabric8.openshift-client.version>4.1.1</fabric8.openshift-client.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
On QE testing env build with java 11 doesn't work. Update sundrio version to 0.16.5 solved this problem.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Make sure all tests pass


