### PR TITLE
Additionally use annotation for unready endpoints

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -69,6 +69,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -715,13 +716,14 @@ public abstract class AbstractModel {
         return service;
     }
 
-    protected Service createHeadlessService(List<ServicePort> ports, boolean publishNotReadyAddresses) {
+    protected Service createHeadlessService(List<ServicePort> ports) {
+        Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(headlessServiceName)
                     .withLabels(getLabelsWithName(headlessServiceName, templateHeadlessServiceLabels))
                     .withNamespace(namespace)
-                    .withAnnotations(mergeAnnotations(null, templateHeadlessServiceAnnotations))
+                    .withAnnotations(mergeAnnotations(annotations, templateHeadlessServiceAnnotations))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withNewSpec()
@@ -729,7 +731,7 @@ public abstract class AbstractModel {
                     .withClusterIP("None")
                     .withSelector(getSelectorLabels())
                     .withPorts(ports)
-                    .withPublishNotReadyAddresses(publishNotReadyAddresses)
+                    .withPublishNotReadyAddresses(true)
                 .endSpec()
                 .build();
         log.trace("Created headless service {}", service);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -651,7 +651,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Service
      */
     public Service generateHeadlessService() {
-        return createHeadlessService(getHeadlessServicePorts(), true);
+        return createHeadlessService(getHeadlessServicePorts());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -341,7 +341,7 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     public Service generateHeadlessService() {
-        return createHeadlessService(getServicePortList(), true);
+        return createHeadlessService(getServicePortList());
     }
 
     public StatefulSet generateStatefulSet(boolean isOpenShift, ImagePullPolicy imagePullPolicy) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

On older versions of kube (e.g. v1.9) it seems that the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation is needed even though `publishNotReadyAddresses` was supposed to be supported.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

