### PR TITLE
ST: Specify namespace for each resource deletion

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -341,7 +341,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
     protected void assertResources(String namespace, String podName, String containerName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {
         Pod po = CLIENT.pods().inNamespace(namespace).withName(podName).get();
         assertNotNull(po, "Not found an expected pod  " + podName + " in namespace " + namespace + " but found " +
-                CLIENT.pods().list().getItems().stream().map(p -> p.getMetadata().getName()).collect(Collectors.toList()));
+                CLIENT.pods().inNamespace(namespace).list().getItems().stream().map(p -> p.getMetadata().getName()).collect(Collectors.toList()));
 
         Optional optional = po.getSpec().getContainers().stream().filter(c -> c.getName().equals(containerName)).findFirst();
         assertTrue(optional.isPresent(), "Not found an expected container " + containerName);
@@ -1049,10 +1049,10 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
             LOGGER.info("Collecting logs for pods in namespace {}", namespace);
 
             try {
-                client.pods().list().getItems().forEach(pod -> {
+                client.pods().inNamespace(namespace).list().getItems().forEach(pod -> {
                     String podName = pod.getMetadata().getName();
                     pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
-                        String log = client.pods().withName(podName).inContainer(containerStatus.getName()).getLog();
+                        String log = client.pods().inNamespace(namespace).withName(podName).inContainer(containerStatus.getName()).getLog();
                         // Write logs from containers to files
                         writeFile(logDir + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
                     });

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -84,28 +84,28 @@ public class Resources extends AbstractResources {
             case Kafka.RESOURCE_KIND:
                 resources.add(() -> {
                     LOGGER.info("Deleting {} {}", resource.getKind(), resource.getMetadata().getName());
-                    x.delete(resource);
+                    x.inNamespace(resource.getMetadata().getNamespace()).delete(resource);
                     waitForDeletion((Kafka) resource);
                 });
                 break;
             case KafkaConnect.RESOURCE_KIND:
                 resources.add(() -> {
                     LOGGER.info("Deleting {} {}", resource.getKind(), resource.getMetadata().getName());
-                    x.delete(resource);
+                    x.inNamespace(resource.getMetadata().getNamespace()).delete(resource);
                     waitForDeletion((KafkaConnect) resource);
                 });
                 break;
             case KafkaConnectS2I.RESOURCE_KIND:
                 resources.add(() -> {
                     LOGGER.info("Deleting {} {}", resource.getKind(), resource.getMetadata().getName());
-                    x.delete(resource);
+                    x.inNamespace(resource.getMetadata().getNamespace()).delete(resource);
                     waitForDeletion((KafkaConnectS2I) resource);
                 });
                 break;
             case KafkaMirrorMaker.RESOURCE_KIND:
                 resources.add(() -> {
                     LOGGER.info("Deleting {} {}", resource.getKind(), resource.getMetadata().getName());
-                    x.delete(resource);
+                    x.inNamespace(resource.getMetadata().getNamespace()).delete(resource);
                     waitForDeletion((KafkaMirrorMaker) resource);
                 });
                 break;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -66,7 +66,7 @@ class RollingUpdateST extends AbstractST {
                 .done();
 
         TestUtils.waitFor("Wait till rolling update of pods start", CO_OPERATION_TIMEOUT_POLL, CO_OPERATION_TIMEOUT,
-            () -> !CLIENT.pods().withName(firstZkPodName).isReady());
+            () -> !CLIENT.pods().inNamespace(NAMESPACE).withName(firstZkPodName).isReady());
 
         TestUtils.waitFor("Wait till rolling update timeout", CO_OPERATION_TIMEOUT_POLL, CO_OPERATION_TIMEOUT_WAIT,
             () -> !KUBE_CLIENT.searchInLog("deploy", "strimzi-cluster-operator", TimeMeasuringSystem.getCurrentDuration(testClass, testName, operationID), logZkPattern).isEmpty());
@@ -118,7 +118,7 @@ class RollingUpdateST extends AbstractST {
                 .done();
 
         TestUtils.waitFor("Wait till rolling update of pods start", CO_OPERATION_TIMEOUT_POLL, CO_OPERATION_TIMEOUT,
-            () -> !CLIENT.pods().withName(firstKafkaPodName).isReady());
+            () -> !CLIENT.pods().inNamespace(NAMESPACE).withName(firstKafkaPodName).isReady());
 
         TestUtils.waitFor("Wait till rolling update timeouted", CO_OPERATION_TIMEOUT_POLL, CO_OPERATION_TIMEOUT_WAIT,
             () -> !KUBE_CLIENT.searchInLog("deploy", "strimzi-cluster-operator", TimeMeasuringSystem.getCurrentDuration(testClass, testName, operationID), logKafkaPattern).isEmpty());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Deletion of cluster resources (kafka, connect, mirror maker...) is done via `MixedOperation`, which is deletable. Delete call was used without namespace specification which can lead to try to delete resource in different namespace that it's deployed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Make sure all tests pass

