### PR TITLE
[DOC] Standalone procedures references wrong operators

### DIFF
--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -7,7 +7,7 @@
 = Deploying the standalone Topic Operator
 
 Deploying the Topic Operator as a standalone component is more complicated than installing it using the Cluster Operator, but it is more flexible.
-For instance it can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+For instance, it can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
 
 .Prerequisites
 

--- a/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-topic-operator-standalone.adoc
@@ -6,8 +6,8 @@
 [id='deploying-the-topic-operator-standalone-{context}']
 = Deploying the standalone Topic Operator
 
-Deploying the Topic Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
-For instance is can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+Deploying the Topic Operator as a standalone component is more complicated than installing it using the Cluster Operator, but it is more flexible.
+For instance it can operate _with_ any Kafka cluster, not necessarily one deployed by the Cluster Operator.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ For instance is can operate _with_ any Kafka cluster, not necessarily one deploy
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaTopic` resources.
 
-. Deploy the Cluster Operator.
+. Deploy the Topic Operator.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:

--- a/documentation/book/proc-deploying-the-user-operator-standalone.adoc
+++ b/documentation/book/proc-deploying-the-user-operator-standalone.adoc
@@ -5,8 +5,8 @@
 [id='proc-deploying-the-user-operator-standalone-{context}']
 = Deploying the standalone User Operator
 
-Deploying the User Operator as a standalone component is more complicated than installing it using the Cluster Operator, but is more flexible.
-For instance it can operate _with_ any Kafka cluster, not only the one deployed by the Cluster Operator.
+Deploying the User Operator as a standalone component is more complicated than installing it using the Cluster Operator, but it is more flexible.
+For instance, it can operate _with_ any Kafka cluster, not only the one deployed by the Cluster Operator.
 
 .Prerequisites
 
@@ -23,7 +23,7 @@ The `Secret` should contain the private key of the Certificate Authority under t
 .. The `STRIMZI_ZOOKEEPER_CONNECT` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to a list of the Zookeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same Zookeeper cluster that your Kafka cluster is using.
 .. The `STRIMZI_NAMESPACE` environment variable in `Deployment.spec.template.spec.containers[0].env` should be set to the {ProductPlatformName} namespace in which you want the operator to watch for  `KafkaUser` resources.
 
-. Deploy the Cluster Operator.
+. Deploy the User Operator.
 +
 ifdef::Kubernetes[]
 On {KubernetesName} this can be done using `kubectl apply`:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Typo fixes for:

- Deploying the standalone Topic Operator
- Deploying the standalone User Operator

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

