### PR TITLE
[DOC] User feedback: Clarify which file is applied in procedures, plus style edits.

### DIFF
--- a/documentation/book/assembly-kafka-broker-configuration.adoc
+++ b/documentation/book/assembly-kafka-broker-configuration.adoc
@@ -10,10 +10,8 @@
 
 = Kafka broker configuration
 
-{ProductName} allows you to customize the configuration of Apache Kafka brokers.
-You can specify and configure most of the options listed in {ApacheKafkaBrokerConfig}.
-
-The only options which cannot be configured are those related to the following areas:
+{ProductName} allows you to customize the configuration of each Kafka broker in your Kafka cluster.
+You can specify and configure most of the options listed in the "Broker Configs" section of the {ApacheKafkaBrokerConfig}. You cannot configure options that are related to the following areas:
 
 * Security (Encryption, Authentication, and Authorization)
 * Listener configuration

--- a/documentation/book/assembly-kafka-broker-configuration.adoc
+++ b/documentation/book/assembly-kafka-broker-configuration.adoc
@@ -10,7 +10,7 @@
 
 = Kafka broker configuration
 
-{ProductName} allows you to customize the configuration of each Kafka broker in your Kafka cluster.
+{ProductName} allows you to customize the configuration of the Kafka brokers in your Kafka cluster.
 You can specify and configure most of the options listed in the "Broker Configs" section of the {ApacheKafkaBrokerConfig}. You cannot configure options that are related to the following areas:
 
 * Security (Encryption, Authentication, and Authorization)

--- a/documentation/book/proc-configuring-kafka-brokers.adoc
+++ b/documentation/book/proc-configuring-kafka-brokers.adoc
@@ -14,7 +14,9 @@ You can configure an existing Kafka broker, or create a new Kafka broker with a 
 
 .Procedure
 
-. In the `Kafka` resource that specifies the cluster deployment, edit the `config` property. For example:
+. Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
+
+. Edit the `config` property in the `Kafka.spec.kafka` resource. For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -46,4 +48,4 @@ On {OpenShiftName}, use `oc apply`:
 [source,shell,subs=+quotes]
 oc apply -f _kafka.yaml_
 +
-where `_kafka.yaml_` is the filename of the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.
+where `_kafka.yaml_` is the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.

--- a/documentation/book/proc-configuring-kafka-brokers.adoc
+++ b/documentation/book/proc-configuring-kafka-brokers.adoc
@@ -16,7 +16,7 @@ You can configure an existing Kafka broker, or create a new Kafka broker with a 
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. In the `kafka.config` property in the `Kafka` resource, enter one or more Kafka configuration settings. For example:
+. In the `spec.kafka.config` property in the `Kafka` resource, enter one or more Kafka configuration settings. For example:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/book/proc-configuring-kafka-brokers.adoc
+++ b/documentation/book/proc-configuring-kafka-brokers.adoc
@@ -9,14 +9,14 @@ You can configure an existing Kafka broker, or create a new Kafka broker with a 
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster exists.
+* An {ProductPlatformName} cluster is available.
 * The Cluster Operator is running.
 
 .Procedure
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. Edit the `config` property in the `Kafka.spec.kafka` resource. For example:
+. In the `kafka.config` property in the `Kafka` resource, enter one or more Kafka configuration settings. For example:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/book/proc-configuring-kafka-brokers.adoc
+++ b/documentation/book/proc-configuring-kafka-brokers.adoc
@@ -5,15 +5,16 @@
 [id='proc-configuring-kafka-brokers-{context}']
 = Configuring Kafka brokers
 
+You can configure an existing Kafka broker, or create a new Kafka broker with a specified configuration.
+
 .Prerequisites
 
-* An {ProductPlatformName} cluster
-* A running Cluster Operator
+* An {ProductPlatformName} cluster exists.
+* The Cluster Operator is running.
 
 .Procedure
 
-. Edit the `config` property in the `Kafka` resource specifying the cluster deployment.
-For example:
+. In the `Kafka` resource that specifies the cluster deployment, edit the `config` property. For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -32,15 +33,17 @@ spec:
     # ...
 ----
 
-. Create or update the resource.
+. Apply the new configuration to create or update the resource.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName}, use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+kubectl apply -f _kafka.yaml_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName}, use `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _your-file_
+oc apply -f _kafka.yaml_
++
+where `_kafka.yaml_` is the filename of the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.

--- a/documentation/book/proc-configuring-zookeeper-nodes.adoc
+++ b/documentation/book/proc-configuring-zookeeper-nodes.adoc
@@ -7,14 +7,14 @@
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster exists.
+* An {ProductPlatformName} cluster is available.
 * The Cluster Operator is running.
 
 .Procedure
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. Edit the `config` property in the `Kafka.spec.zookeeper` resource. For example:
+. In the `zookeeper.config` property in the `Kafka` resource, enter one or more Zookeeper configuration settings. For example:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/book/proc-configuring-zookeeper-nodes.adoc
+++ b/documentation/book/proc-configuring-zookeeper-nodes.adoc
@@ -14,7 +14,7 @@
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. In the `zookeeper.config` property in the `Kafka` resource, enter one or more Zookeeper configuration settings. For example:
+. In the `spec.zookeeper.config` property in the `Kafka` resource, enter one or more Zookeeper configuration settings. For example:
 +
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/book/proc-configuring-zookeeper-nodes.adoc
+++ b/documentation/book/proc-configuring-zookeeper-nodes.adoc
@@ -7,13 +7,14 @@
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster
-* A running Cluster Operator
+* An {ProductPlatformName} cluster exists.
+* The Cluster Operator is running.
 
 .Procedure
 
-. Edit the `config` property in the `Kafka` resource specifying the cluster deployment.
-For example:
+. Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
+
+. Edit the `config` property in the `Kafka.spec.zookeeper` resource. For example:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -30,15 +31,17 @@ spec:
     # ...
 ----
 
-. Create or update the resource.
+. Apply the new configuration to create or update the resource.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName}, use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+kubectl apply -f _kafka.yaml_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName}, use `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _your-file_
+oc apply -f _kafka.yaml_
++
+where `_kafka.yaml_` is the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.

--- a/documentation/book/proc-configuring-zookeeper-replicas.adoc
+++ b/documentation/book/proc-configuring-zookeeper-replicas.adoc
@@ -3,18 +3,18 @@
 // assembly-zookeeper-replicas.adoc
 
 [id='proc-configuring-zookeeper-replicas-{context}']
-= Changing the number of replicas
+= Changing the number of Zookeeper replicas
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster exists.
+* An {ProductPlatformName} cluster is available.
 * The Cluster Operator is running.
 
 .Procedure
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. Edit the `replicas` property in the `Kafka.spec.zookeeper` resource.
+. In the `zookeeper.replicas` property in the `Kafka` resource, enter the number of replicated Zookeeper servers.
 For example:
 +
 [source,yaml,subs=attributes+]

--- a/documentation/book/proc-configuring-zookeeper-replicas.adoc
+++ b/documentation/book/proc-configuring-zookeeper-replicas.adoc
@@ -14,7 +14,7 @@
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. In the `zookeeper.replicas` property in the `Kafka` resource, enter the number of replicated Zookeeper servers.
+. In the `spec.zookeeper.replicas` property in the `Kafka` resource, enter the number of replicated Zookeeper servers.
 For example:
 +
 [source,yaml,subs=attributes+]

--- a/documentation/book/proc-configuring-zookeeper-replicas.adoc
+++ b/documentation/book/proc-configuring-zookeeper-replicas.adoc
@@ -3,16 +3,18 @@
 // assembly-zookeeper-replicas.adoc
 
 [id='proc-configuring-zookeeper-replicas-{context}']
-= Changing number of replicas
+= Changing the number of replicas
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster
-* A running Cluster Operator
+* An {ProductPlatformName} cluster exists.
+* The Cluster Operator is running.
 
 .Procedure
 
-. Edit the `replicas` property in the `Kafka` resource.
+. Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
+
+. Edit the `replicas` property in the `Kafka.spec.zookeeper` resource.
 For example:
 +
 [source,yaml,subs=attributes+]
@@ -29,16 +31,18 @@ spec:
     replicas: 3
     # ...
 ----
-+
-. Create or update the resource.
+
+. Apply the new configuration to create or update the resource.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName}, use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+kubectl apply -f _kafka.yaml_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName}, use `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _your-file_
+oc apply -f _kafka.yaml_
++
+where `_kafka.yaml_` is the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -7,14 +7,14 @@
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster exists.
+* An {ProductPlatformName} cluster is available.
 * The Cluster Operator is running.
 
 .Procedure
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. In the `listeners` property in the `Kafka.spec.kafka` resource, add the `authentication` field to the listeners for which you want to enable authentication.
+. In the `kafka.listeners` property in the `Kafka` resource, add the `authentication` field to the listeners for which you want to enable authentication.
 For example:
 +
 [source,yaml,subs=attributes+]

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -14,7 +14,7 @@
 
 . Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
 
-. In the `kafka.listeners` property in the `Kafka` resource, add the `authentication` field to the listeners for which you want to enable authentication.
+. In the `spec.kafka.listeners` property in the `Kafka` resource, add the `authentication` field to the listeners for which you want to enable authentication.
 For example:
 +
 [source,yaml,subs=attributes+]

--- a/documentation/book/proc-kafka-authentication.adoc
+++ b/documentation/book/proc-kafka-authentication.adoc
@@ -7,13 +7,14 @@
 
 .Prerequisites
 
-* An {ProductPlatformName} cluster
-* A running Cluster Operator
+* An {ProductPlatformName} cluster exists.
+* The Cluster Operator is running.
 
 .Procedure
 
-. Edit the `listeners` property in the `Kafka.spec.kafka` resource.
-Add the `authentication` field to the listeners where you want to enable authentication.
+. Open the YAML configuration file that contains the `Kafka` resource specifying the cluster deployment.
+
+. In the `listeners` property in the `Kafka.spec.kafka` resource, add the `authentication` field to the listeners for which you want to enable authentication.
 For example:
 +
 [source,yaml,subs=attributes+]
@@ -32,18 +33,20 @@ spec:
     # ...
 ----
 
-. Create or update the resource.
+. Apply the new configuration to create or update the resource.
 +
 ifdef::Kubernetes[]
-On {KubernetesName} this can be done using `kubectl apply`:
+On {KubernetesName}, use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _your-file_
+kubectl apply -f _kafka.yaml_
 +
 endif::Kubernetes[]
-On {OpenShiftName} this can be done using `oc apply`:
+On {OpenShiftName}, use `oc apply`:
 +
 [source,shell,subs=+quotes]
-oc apply -f _your-file_
+oc apply -f _kafka.yaml_
++
+where `_kafka.yaml_` is the YAML configuration file for the resource that you want to configure; for example, `kafka-persistent.yaml`.
 
 .Additional resources
 * For more information about the supported authentication mechanisms, see xref:ref-kafka-authentication-{context}[authentication reference].

--- a/documentation/book/ref-kafka-broker-configuration.adoc
+++ b/documentation/book/ref-kafka-broker-configuration.adoc
@@ -5,17 +5,16 @@
 [id='ref-kafka-broker-configuration-{context}']
 = Kafka broker configuration
 
-Kafka broker can be configured using the `config` property in `Kafka.spec.kafka`.
+A Kafka broker can be configured using the `config` property in `Kafka.spec.kafka`.
 
-This property should contain the Kafka broker configuration options as keys.
-The values could be in one of the following JSON types:
+This property should contain the Kafka broker configuration options as keys with values in one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-Users can specify and configure the options listed in {ApacheKafkaBrokerConfig} with the exception of those options which are managed directly by {ProductName}.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+You can specify and configure all of the options in the "Broker Configs" section of the {ApacheKafkaBrokerConfig} apart from those managed directly by {ProductName}.
+Specifically, you are prevented from modifying all configuration options with keys equal to or starting with one of the following strings:
 
 * `listeners`
 * `advertised.`
@@ -35,14 +34,14 @@ Specifically, all configuration options with keys equal to or starting with one 
 * `authorizer.`
 * `super.user`
 
-When one of the forbidden options is present in the `config` property, it will be ignored and a warning message will be printed to the Cluster Operator log file.
-All other options will be passed to Kafka.
+If the `config` property specifies a restricted option, it is ignored and a warning message is printed to the Cluster Operator log file.
+All other supported options are passed to Kafka.
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the provided `config` object.
-When invalid configuration is provided, the Kafka cluster might not start or might become unstable.
-In such cases, the configuration in the `Kafka.spec.kafka.config` object should be fixed and the cluster operator will roll out the new configuration to all Kafka brokers.
+If invalid configuration is provided, the Kafka cluster might not start or might become unstable.
+In such cases, you must fix the configuration in the `Kafka.spec.kafka.config` object and the Cluster Operator will roll out the new configuration to all Kafka brokers.
 
-.An example showing Kafka broker configuration
+.An example Kafka broker configuration
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -65,7 +65,7 @@
 :K8sPodDisruptionBudgets: link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/[Disruptions^]
 :K8sImagePullPolicies: link:https://kubernetes.io/docs/concepts/containers/images/#updating-images[Disruptions^]
 
-:ApacheKafkaBrokerConfig: link:http://kafka.apache.org/20/documentation.html#brokerconfigs[Apache Kafka documentation^]
+:ApacheKafkaBrokerConfig: link:http://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation^]
 :ApacheKafkaConnectConfig: link:http://kafka.apache.org/20/documentation.html#connectconfigs[Apache Kafka documentation^]
 :ApacheZookeeperConfig: link:http://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html[Zookeeper documentation^]
 :ApacheKafkaConsumerConfig: link:http://kafka.apache.org/20/documentation.html#newconsumerconfigs[Apache Kafka documentation^]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This pull request modifies three procedures to clarify which YAML file is applied. 

- Kafka broker configuration
- Configuring authentication in Kafka brokers
- Changing the number of replicas
- Configuring Zookeeper

For each procedure, I modified the code samples to refer to `_kafka.yaml_` instead of `_my-file_`.  This is based on feedback from users.

I also took the opportunity to make some style edits across the procedures involved, and to the Kafka broker configuration assembly.

I changed the `:ApacheKafkaBrokerConfig:` attribute to refer to the latest Kafka documentation. I think we should make the same change to the other Kafka documentation link attributes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x]  Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

