### PR TITLE
Add more detailed OpenShift detection

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -37,7 +37,6 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_KAFKA_CONNECT_S2I_IMAGES = "STRIMZI_KAFKA_CONNECT_S2I_IMAGES";
     public static final String STRIMZI_KAFKA_MIRROR_MAKER_IMAGES = "STRIMZI_KAFKA_MIRROR_MAKER_IMAGES";
     public static final String STRIMZI_IMAGE_PULL_POLICY = "STRIMZI_IMAGE_PULL_POLICY";
-    public static final String STRIMZI_ASSUME_OPENSHIFT = "STRIMZI_ASSUME_OPENSHIFT";
 
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
@@ -50,7 +49,6 @@ public class ClusterOperatorConfig {
     private final boolean createClusterRoles;
     private final KafkaVersion.Lookup versions;
     private final ImagePullPolicy imagePullPolicy;
-    private final Boolean assumeOpenShift;
 
     /**
      * Constructor
@@ -61,16 +59,14 @@ public class ClusterOperatorConfig {
      * @param createClusterRoles true to create the cluster roles
      * @param versions The configured Kafka versions
      * @param imagePullPolicy Image pull policy configured by the user
-     * @param assumeOpenShift Assumes whether we are on Kubernetes on OPenShift and skips autodetection
      */
-    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs, boolean createClusterRoles, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy, Boolean assumeOpenShift) {
+    public ClusterOperatorConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs, boolean createClusterRoles, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
         this.createClusterRoles = createClusterRoles;
         this.versions = versions;
         this.imagePullPolicy = imagePullPolicy;
-        this.assumeOpenShift = assumeOpenShift;
     }
 
     /**
@@ -153,13 +149,7 @@ public class ClusterOperatorConfig {
             }
         }
 
-        Boolean assumeOpenShift = DEFAULT_STRIMZI_ASSUME_OPENSHIFT;
-        String assumeOpenShiftEnvVar = map.get(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT);
-        if (assumeOpenShiftEnvVar != null) {
-            assumeOpenShift = Boolean.parseBoolean(assumeOpenShiftEnvVar);
-        }
-
-        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles, lookup, imagePullPolicy, assumeOpenShift);
+        return new ClusterOperatorConfig(namespaces, reconciliationInterval, operationTimeout, createClusterRoles, lookup, imagePullPolicy);
     }
 
 
@@ -202,13 +192,6 @@ public class ClusterOperatorConfig {
         return imagePullPolicy;
     }
 
-    /**
-     * @return  Whether we should assume that we are on OPenShift without the autodetection
-     */
-    public Boolean isAssumeOpenShift() {
-        return assumeOpenShift;
-    }
-
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +
@@ -218,7 +201,6 @@ public class ClusterOperatorConfig {
                 ",createClusterRoles=" + createClusterRoles +
                 ",versions=" + versions +
                 ",imagePullPolicy=" + imagePullPolicy +
-                ",assumeOpenShift=" + assumeOpenShift +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -41,7 +41,6 @@ public class ClusterOperatorConfig {
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
     public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
-    public static final Boolean DEFAULT_STRIMZI_ASSUME_OPENSHIFT = null;
 
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
@@ -23,7 +21,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
@@ -43,9 +40,6 @@ import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -78,16 +72,18 @@ public class Main {
 
         maybeCreateClusterRoles(vertx, config, client).setHandler(crs -> {
             if (crs.succeeded())    {
-                getPlatformFeaturesAvailability(vertx, client, config).setHandler(os -> {
-                    if (os.succeeded()) {
-                        run(vertx, client, os.result(), config).setHandler(ar -> {
+                PlatformFeaturesAvailability.create(vertx, client).setHandler(pfa -> {
+                    if (pfa.succeeded()) {
+                        log.info("Environment facts gathered: {}", pfa.result());
+
+                        run(vertx, client, pfa.result(), config).setHandler(ar -> {
                             if (ar.failed()) {
                                 log.error("Unable to start operator for 1 or more namespace", ar.cause());
                                 System.exit(1);
                             }
                         });
                     } else {
-                        log.error("Failed to distinguish between Kubernetes and OpenShift", os.cause());
+                        log.error("Failed to gather environment facts", pfa.cause());
                         System.exit(1);
                     }
                 });
@@ -121,11 +117,11 @@ public class Main {
                 networkPolicyOperator, podDisruptionBudgetOperator, resourceOperatorSupplier, config.versions(), config.getImagePullPolicy());
 
         KafkaConnectS2IAssemblyOperator kafkaConnectS2IClusterOperations = null;
-        if (pfa.isOpenshift()) {
+        if (pfa.isBuilds() && pfa.isApps() && pfa.isImages()) {
             kafkaConnectS2IClusterOperations = createS2iOperator(vertx, client, pfa, serviceOperations,
                     configMapOperations, secretOperations, certManager, resourceOperatorSupplier, config.versions(), config.getImagePullPolicy());
         } else {
-            maybeLogS2iOnKubeWarning(vertx, client);
+            log.warn("The KafkaConnectS2I custom resource definition can only be used in environment which supports OpenShift build, image and apps APIs. These APIs do not seem to be supported in this environment.");
         }
 
         KafkaMirrorMakerAssemblyOperator kafkaMirrorMakerAssemblyOperator =
@@ -158,19 +154,6 @@ public class Main {
         return CompositeFuture.join(futures);
     }
 
-    private static void maybeLogS2iOnKubeWarning(Vertx vertx, KubernetesClient client) {
-        try {
-            // Check the KafkaConnectS2I isn't installed and whinge if it is
-            CustomResourceDefinition crd = client.customResourceDefinitions().withName(KafkaConnectS2I.CRD_NAME).get();
-            if (crd != null) {
-                log.warn("The KafkaConnectS2I custom resource definition can only be installed on OpenShift, because plain Kubernetes doesn't support S2I. " +
-                        "Execute 'kubectl delete crd " + KafkaConnectS2I.CRD_NAME + "' to remove this warning.");
-            }
-        } catch (KubernetesClientException e) {
-
-        }
-    }
-
     private static KafkaConnectS2IAssemblyOperator createS2iOperator(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, ServiceOperator serviceOperations, ConfigMapOperator configMapOperations, SecretOperator secretOperations, OpenSslCertManager certManager, ResourceOperatorSupplier resourceOperatorSupplier, KafkaVersion.Lookup versions, ImagePullPolicy imagePullPolicy) {
         ImageStreamOperator imagesStreamOperations;
         BuildConfigOperator buildConfigOperations;
@@ -192,59 +175,6 @@ public class Main {
                  configMapOperations, deploymentConfigOperations,
                 serviceOperations, imagesStreamOperations, buildConfigOperations, secretOperations, networkPolicyOperator, podDisruptionBudgetOperator, resourceOperatorSupplier, versions, imagePullPolicy);
         return kafkaConnectS2IClusterOperations;
-    }
-
-    static Future<Boolean> isOpenshift(Vertx vertx, KubernetesClient client, ClusterOperatorConfig config)  {
-        if (client.isAdaptable(OkHttpClient.class)) {
-            OkHttpClient ok = client.adapt(OkHttpClient.class);
-            Future<Boolean> fut = Future.future();
-
-            vertx.executeBlocking(request -> {
-                try {
-                    Boolean isOpenShift;
-                    if (config.isAssumeOpenShift() != null)  {
-                        log.debug("OpenShift has been set to {} through {}.", config.isAssumeOpenShift(), ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT);
-                        isOpenShift = config.isAssumeOpenShift();
-                    } else {
-                        Response resp = ok.newCall(new Request.Builder().get().url(client.getMasterUrl().toString() + "apis/route.openshift.io/v1").build()).execute();
-                        if (resp.code() >= 200 && resp.code() < 300) {
-                            log.debug("{} returned {}. We are on OpenShift.", resp.request().url(), resp.code());
-                            // We should be on OpenShift based on the /apis/route.openshift.io/v1 result. We can now safely try isAdaptable() to be 100% sure.
-                            isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-                        } else {
-                            log.debug("{} returned {}. We are not on OpenShift.", resp.request().url(), resp.code());
-                            isOpenShift = false;
-                        }
-                    }
-
-                    request.complete(isOpenShift);
-                } catch (Exception e) {
-                    log.error("OpenShift detection failed. You can use Cluster Operator's `assumeOpenShift` flag.", e);
-                    request.fail(e);
-                }
-            }, fut.completer());
-            return fut;
-        } else {
-            log.error("Cannot adapt KubernetesClient to OkHttpClient");
-            return Future.failedFuture("Cannot adapt KubernetesClient to OkHttpClient");
-        }
-    }
-
-
-    static Future<PlatformFeaturesAvailability> getPlatformFeaturesAvailability(Vertx vertx, KubernetesClient client, ClusterOperatorConfig config)  {
-        Future<PlatformFeaturesAvailability> fut2 = Future.future();
-        isOpenshift(vertx, client, config).setHandler(is -> {
-            /* test */
-            String major = client.getVersion().getMajor().equals("") ? Integer.toString(KubernetesVersion.MINIMAL_SUPPORTED_MAJOR) : client.getVersion().getMajor();
-            /* test */
-            String minor = client.getVersion().getMinor().equals("") ? Integer.toString(KubernetesVersion.MINIMAL_SUPPORTED_MINOR) : client.getVersion().getMinor();
-
-            PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(is.result(),
-                    new KubernetesVersion(Integer.parseInt(major.split("\\D")[0]),
-                            Integer.parseInt(minor.split("\\D")[0])));
-            fut2.complete(pfa);
-        });
-        return fut2;
     }
 
     private static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -117,11 +117,11 @@ public class Main {
                 networkPolicyOperator, podDisruptionBudgetOperator, resourceOperatorSupplier, config.versions(), config.getImagePullPolicy());
 
         KafkaConnectS2IAssemblyOperator kafkaConnectS2IClusterOperations = null;
-        if (pfa.isBuilds() && pfa.isApps() && pfa.isImages()) {
+        if (pfa.hasBuilds() && pfa.hasApps() && pfa.hasImages()) {
             kafkaConnectS2IClusterOperations = createS2iOperator(vertx, client, pfa, serviceOperations,
                     configMapOperations, secretOperations, certManager, resourceOperatorSupplier, config.versions(), config.getImagePullPolicy());
         } else {
-            log.warn("The KafkaConnectS2I custom resource definition can only be used in environment which supports OpenShift build, image and apps APIs. These APIs do not seem to be supported in this environment.");
+            log.info("The KafkaConnectS2I custom resource definition can only be used in environment which supports OpenShift build, image and apps APIs. These APIs do not seem to be supported in this environment.");
         }
 
         KafkaMirrorMakerAssemblyOperator kafkaMirrorMakerAssemblyOperator =

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -4,23 +4,138 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Gives a info about certain features availability regarding to kubernetes version
  */
 public class PlatformFeaturesAvailability {
+    private static final Logger log = LogManager.getLogger(PlatformFeaturesAvailability.class.getName());
 
-    private boolean isOpenshift;
-    private final KubernetesVersion kubernetesVersion;
+    private boolean routes = false;
+    private boolean builds = false;
+    private boolean images = false;
+    private boolean apps = false;
+    private KubernetesVersion kubernetesVersion;
 
-    public PlatformFeaturesAvailability(boolean isOpenshift, KubernetesVersion kubernetesVersion) {
-        this.isOpenshift = isOpenshift;
+    public static Future<PlatformFeaturesAvailability> create(Vertx vertx, KubernetesClient client) {
+        Future<PlatformFeaturesAvailability> pfaFuture = Future.future();
+        Future<Void> composeFuture = Future.future();
+        OkHttpClient httpClient = getOkHttpClient(client);
+
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability();
+
+        Future<VersionInfo> futureVersion = getVersionInfo(vertx, client);
+
+        futureVersion.compose(versionInfo -> {
+            String major = versionInfo.getMajor().equals("") ? Integer.toString(KubernetesVersion.MINIMAL_SUPPORTED_MAJOR) : versionInfo.getMajor();
+            String minor = versionInfo.getMinor().equals("") ? Integer.toString(KubernetesVersion.MINIMAL_SUPPORTED_MINOR) : versionInfo.getMinor();
+            pfa.setKubernetesVersion(new KubernetesVersion(Integer.parseInt(major.split("\\D")[0]), Integer.parseInt(minor.split("\\D")[0])));
+
+            return checkApiAvailability(vertx, httpClient, client.getMasterUrl().toString(), "route.openshift.io", "v1");
+        }).compose(supported -> {
+            pfa.setRoutes(supported);
+            return checkApiAvailability(vertx, httpClient, client.getMasterUrl().toString(), "build.openshift.io", "v1");
+        }).compose(supported -> {
+            pfa.setBuilds(supported);
+            return checkApiAvailability(vertx, httpClient, client.getMasterUrl().toString(), "apps.openshift.io", "v1");
+        }).compose(supported -> {
+            pfa.setApps(supported);
+            return checkApiAvailability(vertx, httpClient, client.getMasterUrl().toString(), "image.openshift.io", "v1");
+        }).compose(supported -> {
+            pfa.setImages(supported);
+            composeFuture.complete();
+        }, composeFuture);
+
+        composeFuture.setHandler(res -> {
+            if (res.succeeded())  {
+                pfaFuture.complete(pfa);
+            } else {
+                pfaFuture.fail(res.cause());
+            }
+        });
+
+        return pfaFuture;
+    }
+
+    private static OkHttpClient getOkHttpClient(KubernetesClient client)   {
+        if (client.isAdaptable(OkHttpClient.class)) {
+            return client.adapt(OkHttpClient.class);
+        } else {
+            log.error("Cannot adapt KubernetesClient to OkHttpClient");
+            throw new RuntimeException("Cannot adapt KubernetesClient to OkHttpClient");
+        }
+    }
+
+    private static Future<VersionInfo> getVersionInfo(Vertx vertx, KubernetesClient client)   {
+        Future<VersionInfo> fut = Future.future();
+
+        vertx.executeBlocking(request -> {
+            try {
+                request.complete(client.getVersion());
+            } catch (Exception e) {
+                log.error("Detection of Kuberetes version failed.", e);
+                request.fail(e);
+            }
+        }, fut.completer());
+
+        return fut;
+    }
+
+    private static Future<Boolean> checkApiAvailability(Vertx vertx, OkHttpClient httpClient, String masterUrl, String api, String version)   {
+        Future<Boolean> fut = Future.future();
+
+        vertx.executeBlocking(request -> {
+            try {
+                Boolean isSupported;
+
+                Response resp = httpClient.newCall(new Request.Builder().get().url(masterUrl + "apis/" + api + "/" + version).build()).execute();
+                if (resp.code() >= 200 && resp.code() < 300) {
+                    log.debug("{} returned {}. This API is supported.", resp.request().url(), resp.code());
+                    isSupported = true;
+                } else {
+                    log.debug("{} returned {}. This API is not supported.", resp.request().url(), resp.code());
+                    isSupported = false;
+                }
+
+                resp.close();
+                request.complete(isSupported);
+            } catch (Exception e) {
+                log.error("Detection of {}/{} API failed.", api, version, e);
+                request.fail(e);
+            }
+        }, fut.completer());
+
+        return fut;
+    }
+
+    private PlatformFeaturesAvailability() {}
+
+    /**
+     * This constructor is used in tests. It sets all OpenShift APIs to true or false depending on the isOpenShift paremeter
+     *
+     * @param isOpenShift           Set all OpenShift APIs to true
+     * @param kubernetesVersion     Set the Kubernetes version
+     */
+    /* test */public PlatformFeaturesAvailability(boolean isOpenShift, KubernetesVersion kubernetesVersion) {
         this.kubernetesVersion = kubernetesVersion;
+        this.routes = isOpenShift;
+        this.images = isOpenShift;
+        this.builds = isOpenShift;
+        this.apps = isOpenShift;
     }
 
     public boolean isOpenshift() {
-        return this.isOpenshift;
+        return this.isRoutes();
     }
 
     public boolean isNamespaceAndPodSelectorNetworkPolicySupported() {
@@ -29,5 +144,52 @@ public class PlatformFeaturesAvailability {
 
     public KubernetesVersion getKubernetesVersion() {
         return this.kubernetesVersion;
+    }
+
+    private void setKubernetesVersion(KubernetesVersion kubernetesVersion) {
+        this.kubernetesVersion = kubernetesVersion;
+    }
+
+    public boolean isRoutes() {
+        return routes;
+    }
+
+    private void setRoutes(boolean routes) {
+        this.routes = routes;
+    }
+
+    public boolean isBuilds() {
+        return builds;
+    }
+
+    private void setBuilds(boolean builds) {
+        this.builds = builds;
+    }
+
+    public boolean isImages() {
+        return images;
+    }
+
+    private void setImages(boolean images) {
+        this.images = images;
+    }
+
+    public boolean isApps() {
+        return apps;
+    }
+
+    private void setApps(boolean apps) {
+        this.apps = apps;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterOperatorConfig(" +
+                "KubernetesVersion=" + kubernetesVersion +
+                ",OpenShiftRoutes=" + routes +
+                ",OpenShiftBuilds=" + builds +
+                ",OpenShiftImageStreams=" + images +
+                ",OpenShiftDeploymentConfigs=" + apps +
+                ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1182,7 +1182,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaBootstrapRoute() {
             Route route = kafkaCluster.generateExternalBootstrapRoute();
 
-            if (pfa.isRoutes()) {
+            if (pfa.hasRoutes()) {
                 return withVoid(routeOperations.reconcile(namespace, KafkaCluster.serviceName(name), route));
             } else if (route != null) {
                 log.warn("{}: The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation, name);
@@ -1199,7 +1199,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             for (int i = 0; i < replicas; i++) {
                 Route route = kafkaCluster.generateExternalRoute(i);
 
-                if (pfa.isRoutes()) {
+                if (pfa.hasRoutes()) {
                     routeFutures.add(routeOperations.reconcile(namespace, KafkaCluster.externalServiceName(name, i), route));
                 } else if (route != null) {
                     log.warn("{}: The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation, name);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1182,11 +1182,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaBootstrapRoute() {
             Route route = kafkaCluster.generateExternalBootstrapRoute();
 
-            if (routeOperations != null) {
+            if (pfa.isRoutes()) {
                 return withVoid(routeOperations.reconcile(namespace, KafkaCluster.serviceName(name), route));
             } else if (route != null) {
-                log.warn("{}: Exposing Kafka cluster {} using OpenShift Routes is available only on OpenShift", reconciliation, name);
-                return withVoid(Future.failedFuture("Exposing Kafka cluster " + name + " using OpenShift Routes is available only on OpenShift"));
+                log.warn("{}: The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation, name);
+                return withVoid(Future.failedFuture("The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster " + name + " using routes is not possible."));
             }
 
             return withVoid(Future.succeededFuture());
@@ -1199,11 +1199,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             for (int i = 0; i < replicas; i++) {
                 Route route = kafkaCluster.generateExternalRoute(i);
 
-                if (routeOperations != null) {
+                if (pfa.isRoutes()) {
                     routeFutures.add(routeOperations.reconcile(namespace, KafkaCluster.externalServiceName(name, i), route));
                 } else if (route != null) {
-                    log.warn("{}: Exposing Kafka cluster {} using OpenShift Routes is available only on OpenShift", reconciliation, name);
-                    return withVoid(Future.failedFuture("Exposing Kafka cluster " + name + " using OpenShift Routes is available only on OpenShift"));
+                    log.warn("{}: The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation, name);
+                    return withVoid(Future.failedFuture("The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster " + name + " using routes is not possible."));
                 }
             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -105,7 +105,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
             log.error("{} spec cannot be null", kafkaConnectS2I.getMetadata().getName());
             return Future.failedFuture("Spec cannot be null");
         }
-        if (pfa.isImages() && pfa.isApps() && pfa.isBuilds()) {
+        if (pfa.hasImages() && pfa.hasApps() && pfa.hasBuilds()) {
             KafkaConnectS2ICluster connect;
             try {
                 connect = KafkaConnectS2ICluster.fromCrd(kafkaConnectS2I, versions);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -105,7 +105,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
             log.error("{} spec cannot be null", kafkaConnectS2I.getMetadata().getName());
             return Future.failedFuture("Spec cannot be null");
         }
-        if (pfa.isOpenshift()) {
+        if (pfa.isImages() && pfa.isApps() && pfa.isBuilds()) {
             KafkaConnectS2ICluster connect;
             try {
                 connect = KafkaConnectS2ICluster.fromCrd(kafkaConnectS2I, versions);
@@ -131,7 +131,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                     .compose(i -> buildConfigOperations.reconcile(namespace, connect.getName(), connect.generateBuildConfig()))
                     .compose(i -> deploymentConfigOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()).map((Void) null));
         } else {
-            return Future.failedFuture("S2I only available on OpenShift");
+            return Future.failedFuture("The OpenShift build, image or apps APIs are not available in this Kubernetes cluster. Kafka Connect S2I deployment cannot be enabled.");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -53,7 +53,7 @@ public class ResourceOperatorSupplier {
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
-                pfa.isRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
+                pfa.hasRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 new ZookeeperSetOperator(vertx, client, zlf, operationTimeoutMs),
                 new KafkaSetOperator(vertx, client, operationTimeoutMs),
                 new ConfigMapOperator(vertx, client),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -53,7 +53,7 @@ public class ResourceOperatorSupplier {
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
-                pfa.isOpenshift() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
+                pfa.isRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 new ZookeeperSetOperator(vertx, client, zlf, operationTimeoutMs),
                 new KafkaSetOperator(vertx, client, operationTimeoutMs),
                 new ConfigMapOperator(vertx, client),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -19,8 +19,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 public class ClusterOperatorConfigTest {
 
@@ -49,7 +47,7 @@ public class ClusterOperatorConfigTest {
     @Test
     public void testReconciliationInterval() {
 
-        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null, null);
+        ClusterOperatorConfig config = new ClusterOperatorConfig(singleton("namespace"), 60_000, 30_000, false, new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(60_000, config.getReconciliationIntervalMs());
@@ -175,34 +173,5 @@ public class ClusterOperatorConfigTest {
         envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "Sometimes");
 
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
-    }
-
-    @Test
-    public void testForceOpenShift() {
-        ClusterOperatorConfig config;
-        Map<String, String> envVars;
-
-        envVars = new HashMap<>(1);
-        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        config = ClusterOperatorConfig.fromMap(envVars);
-        assertNull(config.isAssumeOpenShift());
-
-        envVars = new HashMap<>(2);
-        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "TRUE");
-        config = ClusterOperatorConfig.fromMap(envVars);
-        assertTrue(config.isAssumeOpenShift());
-
-        envVars = new HashMap<>(2);
-        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "FALSE");
-        config = ClusterOperatorConfig.fromMap(envVars);
-        assertFalse(config.isAssumeOpenShift());
-
-        envVars = new HashMap<>(2);
-        envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterOperatorConfig.STRIMZI_ASSUME_OPENSHIFT, "something");
-        config = ClusterOperatorConfig.fromMap(envVars);
-        assertFalse(config.isAssumeOpenShift());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -5,41 +5,40 @@
 package io.strimzi.operator.cluster;
 
 
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(VertxUnitRunner.class)
 public class PlatformFeaturesAvailabilityTest {
+    protected Vertx vertx;
 
-    @Test
-    public void versionTest() {
+    @Before
+    public void before() {
+        vertx = Vertx.vertx();
+    }
 
-        KubernetesVersion kv1p9 = new KubernetesVersion(1, 5);
-        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_8) < 0);
-        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_9) < 0);
-        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_10) < 0);
-        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_11) < 0);
-
-        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_8) == 0);
-        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_9) < 0);
-        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_10) < 0);
-        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_11) < 0);
-
-
-        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_8) > 0);
-        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_9) > 0);
-        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_10) > 0);
-        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_11) > 0);
-        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_12) == 0);
-
-        KubernetesVersion kv2p9 = new KubernetesVersion(2, 9);
-        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_8) > 0);
-        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_9) > 0);
-        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_10) > 0);
-        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_11) > 0);
+    @After
+    public void after() {
+        vertx.close();
     }
 
     @Test
@@ -51,8 +50,191 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     @Test
-    public void versionsEqualTest() {
-        KubernetesVersion kv1p9 = new KubernetesVersion(1, 9);
-        assertEquals(kv1p9, KubernetesVersion.V1_9);
+    public void testVersionDetectionOpenShift39(TestContext context)  {
+        String version = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"9\",\n" +
+                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
+                "  \"gitCommit\": \"a0ce1bc\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        HttpServer mockHttp = mockApi(version, Collections.EMPTY_LIST);
+
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:8080");
+        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
+
+        Async async = context.async();
+
+        futurePfa.setHandler(res -> {
+            if (res.succeeded())    {
+                context.assertEquals(KubernetesVersion.V1_9, res.result().getKubernetesVersion(), "Versions are not equal");
+                async.complete();
+            } else {
+                context.fail("Failed to create PlatformFeaturesAvailability object");
+                async.complete();
+            }
+        });
+
+        async.awaitSuccess();
+        mockHttp.close();
+    }
+
+    @Test
+    public void testVersionDetectionMinikube114(TestContext context)  {
+        String version = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"14\",\n" +
+                "  \"gitVersion\": \"v1.14.0\",\n" +
+                "  \"gitCommit\": \"641856db18352033a0d96dbc99153fa3b27298e5\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2019-03-25T15:45:25Z\",\n" +
+                "  \"goVersion\": \"go1.12.1\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        HttpServer mockHttp = mockApi(version, Collections.EMPTY_LIST);
+
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:8080");
+        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
+
+        Async async = context.async();
+
+        futurePfa.setHandler(res -> {
+            if (res.succeeded())    {
+                context.assertEquals(KubernetesVersion.V1_14, res.result().getKubernetesVersion(), "Versions are not equal");
+                async.complete();
+            } else {
+                context.fail("Failed to create PlatformFeaturesAvailability object");
+                async.complete();
+            }
+        });
+
+        async.awaitSuccess();
+        mockHttp.close();
+    }
+
+    @Test
+    public void testApiDetectionOce(TestContext context)  {
+        List<String> apis = new ArrayList<>();
+        apis.add("/apis/route.openshift.io/v1");
+        apis.add("/apis/build.openshift.io/v1");
+
+        HttpServer mockHttp = mockApi(apis);
+
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:8080");
+        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
+
+        Async async = context.async();
+
+        futurePfa.setHandler(res -> {
+            if (res.succeeded())    {
+                PlatformFeaturesAvailability pfa = res.result();
+                context.assertTrue(pfa.isRoutes());
+                context.assertTrue(pfa.isBuilds());
+                context.assertFalse(pfa.isImages());
+                context.assertFalse(pfa.isApps());
+                async.complete();
+            } else {
+                context.fail("Failed to create PlatformFeaturesAvailability object");
+                async.complete();
+            }
+        });
+
+        async.awaitSuccess();
+        mockHttp.close();
+    }
+
+    @Test
+    public void testApiDetectionOpenshift(TestContext context)  {
+        List<String> apis = new ArrayList<>();
+        apis.add("/apis/route.openshift.io/v1");
+        apis.add("/apis/build.openshift.io/v1");
+        apis.add("/apis/apps.openshift.io/v1");
+        apis.add("/apis/image.openshift.io/v1");
+
+        HttpServer mockHttp = mockApi(apis);
+
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:8080");
+        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
+
+        Async async = context.async();
+
+        futurePfa.setHandler(res -> {
+            if (res.succeeded())    {
+                PlatformFeaturesAvailability pfa = res.result();
+                context.assertTrue(pfa.isRoutes());
+                context.assertTrue(pfa.isBuilds());
+                context.assertTrue(pfa.isImages());
+                context.assertTrue(pfa.isApps());
+                async.complete();
+            } else {
+                context.fail("Failed to create PlatformFeaturesAvailability object");
+                async.complete();
+            }
+        });
+
+        async.awaitSuccess();
+        mockHttp.close();
+    }
+
+    @Test
+    public void testApiDetectionKubernetes(TestContext context)  {
+        HttpServer mockHttp = mockApi(Collections.EMPTY_LIST);
+
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:8080");
+        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
+
+        Async async = context.async();
+
+        futurePfa.setHandler(res -> {
+            if (res.succeeded())    {
+                PlatformFeaturesAvailability pfa = res.result();
+                context.assertFalse(pfa.isRoutes());
+                context.assertFalse(pfa.isBuilds());
+                context.assertFalse(pfa.isImages());
+                context.assertFalse(pfa.isApps());
+                async.complete();
+            } else {
+                context.fail("Failed to create PlatformFeaturesAvailability object");
+                async.complete();
+            }
+        });
+
+        async.awaitSuccess();
+        mockHttp.close();
+    }
+
+    public HttpServer mockApi(String version, List<String> apis)   {
+        return vertx.createHttpServer().requestHandler(request -> {
+            if (HttpMethod.GET.equals(request.method()) && apis.contains(request.uri()))   {
+                request.response().setStatusCode(200).end();
+            } else if (HttpMethod.GET.equals(request.method()) && "/version".equals(request.uri())) {
+                request.response().setStatusCode(200).end(version);
+            } else {
+                request.response().setStatusCode(404).end();
+            }
+        }).listen(8080);
+    }
+
+    public HttpServer mockApi(List<String> apis)    {
+        String version = "{\n" +
+                "  \"major\": \"1\",\n" +
+                "  \"minor\": \"9\",\n" +
+                "  \"gitVersion\": \"v1.9.1+a0ce1bc657\",\n" +
+                "  \"gitCommit\": \"a0ce1bc\",\n" +
+                "  \"gitTreeState\": \"clean\",\n" +
+                "  \"buildDate\": \"2018-06-24T01:54:00Z\",\n" +
+                "  \"goVersion\": \"go1.9\",\n" +
+                "  \"compiler\": \"gc\",\n" +
+                "  \"platform\": \"linux/amd64\"\n" +
+                "}";
+
+        return mockApi(version, apis);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -135,10 +135,10 @@ public class PlatformFeaturesAvailabilityTest {
         futurePfa.setHandler(res -> {
             if (res.succeeded())    {
                 PlatformFeaturesAvailability pfa = res.result();
-                context.assertTrue(pfa.isRoutes());
-                context.assertTrue(pfa.isBuilds());
-                context.assertFalse(pfa.isImages());
-                context.assertFalse(pfa.isApps());
+                context.assertTrue(pfa.hasRoutes());
+                context.assertTrue(pfa.hasBuilds());
+                context.assertFalse(pfa.hasImages());
+                context.assertFalse(pfa.hasApps());
                 async.complete();
             } else {
                 context.fail("Failed to create PlatformFeaturesAvailability object");
@@ -168,10 +168,10 @@ public class PlatformFeaturesAvailabilityTest {
         futurePfa.setHandler(res -> {
             if (res.succeeded())    {
                 PlatformFeaturesAvailability pfa = res.result();
-                context.assertTrue(pfa.isRoutes());
-                context.assertTrue(pfa.isBuilds());
-                context.assertTrue(pfa.isImages());
-                context.assertTrue(pfa.isApps());
+                context.assertTrue(pfa.hasRoutes());
+                context.assertTrue(pfa.hasBuilds());
+                context.assertTrue(pfa.hasImages());
+                context.assertTrue(pfa.hasApps());
                 async.complete();
             } else {
                 context.fail("Failed to create PlatformFeaturesAvailability object");
@@ -195,10 +195,10 @@ public class PlatformFeaturesAvailabilityTest {
         futurePfa.setHandler(res -> {
             if (res.succeeded())    {
                 PlatformFeaturesAvailability pfa = res.result();
-                context.assertFalse(pfa.isRoutes());
-                context.assertFalse(pfa.isBuilds());
-                context.assertFalse(pfa.isImages());
-                context.assertFalse(pfa.isApps());
+                context.assertFalse(pfa.hasRoutes());
+                context.assertFalse(pfa.hasBuilds());
+                context.assertFalse(pfa.hasImages());
+                context.assertFalse(pfa.hasApps());
                 async.complete();
             } else {
                 context.fail("Failed to create PlatformFeaturesAvailability object");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/KubernetesVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/KubernetesVersionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator;
+
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KubernetesVersionTest {
+    @Test
+    public void versionTest() {
+        KubernetesVersion kv1p9 = new KubernetesVersion(1, 5);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_8) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_9) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_10) < 0);
+        assertTrue(kv1p9.compareTo(KubernetesVersion.V1_11) < 0);
+
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_8) == 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_9) < 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_10) < 0);
+        assertTrue(KubernetesVersion.V1_8.compareTo(KubernetesVersion.V1_11) < 0);
+
+
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_8) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_9) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_10) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_11) > 0);
+        assertTrue(KubernetesVersion.V1_12.compareTo(KubernetesVersion.V1_12) == 0);
+
+        KubernetesVersion kv2p9 = new KubernetesVersion(2, 9);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_8) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_9) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_10) > 0);
+        assertTrue(kv2p9.compareTo(KubernetesVersion.V1_11) > 0);
+    }
+
+    @Test
+    public void versionsEqualTest() {
+        KubernetesVersion kv1p9 = new KubernetesVersion(1, 9);
+        assertEquals(kv1p9, KubernetesVersion.V1_9);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The current code is detecting the presence of Route API and based on that decided that we run on OpenShift or not. However, this might not be enough in some environments such as OCE. This PR adds detection of the different APIs (Routes, Images, Builds, Apps) and based on that enabled different aspects such as `KafkaConnectS2I` or off-cluster access using Routes.

General `isOpenShift` flag is still based on the presence of Routes as a smallest common denominator. It is used for setting the access modes on mounted volumes.

This PR also removes the old `STRIMZI_ASSUME_OPENSHIFT` configuration flag from the Cluster Operator. This should hopefully not be needed anymore.

As part of this I moved the whole detection logic to the `PlatformFeaturesAvailability` as a static methods. That should help to clean up a bit the `Main` class.

The test of this is using mocked HTTP server which provides the paths for testing the detection functionality.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally