### PR TITLE
Disable the GC logging when disabled in CR

### DIFF
--- a/docker-images/kafka/scripts/set_kafka_gc_options.sh
+++ b/docker-images/kafka/scripts/set_kafka_gc_options.sh
@@ -13,4 +13,7 @@ function get_gc_opts {
 
 if [ "${STRIMZI_KAFKA_GC_LOG_ENABLED}" == "true" ]; then
     export KAFKA_GC_LOG_OPTS=$(get_gc_opts)
+else
+    export KAFKA_GC_LOG_OPTS=" "
+    export GC_LOG_ENABLED="false"
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the user disables the GC logging in the custom resource, it should be disabled in Kafka. That currently doesn't work, because all the scripts do is that they don't use our configuration and instead let Kafka inject its own default configuration. The is causing problems because it tries to write the GC log into a directory where it has no access:

```
[0.000s][error][logging] Error opening log file '/opt/kafka/kafkaServer-gc.log': Permission denied
```

On Java 8 this seems to be just ignored. But on Java 11 this seems to cause a crash. This PR fixes our own scripts to make sure they disable the Kafka's default GC logging configuration when GC logging is disabled.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally