### PR TITLE
Add GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,7 @@
 # Strimzi Governance
 
 This document defines project governance for the Strimzi project.
+The maintainers are identified in the [`MAINTAINERS`](MAINTAINERS) file. 
 
 ## Voting
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,36 @@
+# Strimzi Governance
+
+This document defines project governance for the Strimzi project.
+
+## Voting
+
+The Strimzi project employs voting to ensure no single member can dominate the project. Any maintainer may cast a vote.
+
+For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR.
+Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+
+## Changes in Maintainership
+
+New maintainers are proposed by an existing maintainer and are elected by a ⅔ majority vote.
+
+Maintainers can be removed by a ⅔ majority vote.
+
+## Approving PRs
+
+PRs may be merged after receiving at least two positive votes. If the PR author is a maintainer, this counts as a vote.
+
+## Github Project Administration
+
+Maintainers will be added to the collaborators list of the Strimzi repository with "Write" access.
+
+After 6 months a maintainer will be given "Admin" access to the Strimzi repository.
+
+## Changes in Governance
+
+All changes in Governance require a ⅔ majority vote.
+
+## Other Changes
+
+Unless specified above, all other changes to the project require a ⅔ majority vote.
+Additionally, any maintainer may request that any change require a ⅔ majority vote.
+

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,3 @@
 Jakub Scholz, Red Hat <github@scholzj.com> (@scholzj)
-Paolo Patierno, Red Hat <ppatierno@live.com> (@ppartierno)
+Paolo Patierno, Red Hat <ppatierno@live.com> (@ppatierno)
 Tom Bentley, Red Hat <tbentley@redhat.com> (@tombentley)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,3 @@
+Jakub Scholz, Red Hat <github@scholzj.com> (@scholzj)
+Paolo Patierno, Red Hat <ppatierno@live.com> (@ppartierno)
+Tom Bentley, Red Hat <tbentley@redhat.com> (@tombentley)


### PR DESCRIPTION
### Description

This PR adds a new `GOVERNANCE.md` file which describes how the project would be governed once the PR was merged. This is a slightly adapted version of https://github.com/cortexproject/cortex/blob/master/GOVERNANCE.md. The rules are lightweight by intent.

If merged, the project would abide by those rules. Under the rules anyone with commit access to the project (a maintainer) gets a vote. The intent behind this is to start on a pathway towards making Strimzi more vendor neutral. This is not something which will happen overnight, and obviously the project will need to identify suitable non-Red Hatters to become maintainers. That does not prevent us discussing and merging this PR now. At some point during this transition we will need to shrink the current maintainership. Note that if we waited till after this PR was merged, the shrinking would need to be via maintainer voting.

Although not required in order to merge this PR, we _may_ want to discuss who of the current maintainership should continue to be maintainers in the future, but that should not be focus of the discussion at this point.
