### PR TITLE
Update dependencies to Kafka 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
-        <kafka.version>2.1.1</kafka.version>
+        <kafka.version>2.2.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
-        <scala-library.version>2.12.7</scala-library.version>
+        <scala-library.version>2.12.0</scala-library.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <mockito.version>2.23.4</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
         <kafka.version>2.2.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
-        <scala-library.version>2.12.0</scala-library.version>
+        <scala-library.version>2.12.8</scala-library.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <mockito.version>2.23.4</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
@@ -42,6 +42,8 @@ import org.apache.kafka.clients.admin.DescribeReplicaLogDirsOptions;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ElectPreferredLeadersOptions;
+import org.apache.kafka.clients.admin.ElectPreferredLeadersResult;
 import org.apache.kafka.clients.admin.ExpireDelegationTokenOptions;
 import org.apache.kafka.clients.admin.ExpireDelegationTokenResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
@@ -67,6 +69,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.lang.reflect.Constructor;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +81,12 @@ class MockAdminClient extends AdminClient {
 
     @Override
     public void close(long l, TimeUnit timeUnit) {
+        return;
+    }
 
+    @Override
+    public void close(Duration duration) {
+        return;
     }
 
     @Override
@@ -205,6 +213,11 @@ class MockAdminClient extends AdminClient {
 
     @Override
     public DeleteConsumerGroupsResult deleteConsumerGroups(Collection<String> collection, DeleteConsumerGroupsOptions deleteConsumerGroupsOptions) {
+        return null;
+    }
+
+    @Override
+    public ElectPreferredLeadersResult electPreferredLeaders(Collection<TopicPartition> collection, ElectPreferredLeadersOptions electPreferredLeadersOptions) {
         return null;
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

After adding support for Kafka 2.2 as a version we run, this PR updates the dependencies / Kafka clients used in our applications to 2.2.0 as well. It also updates some related dependencies such as Scala.