### PR TITLE
Add support for off-cluster access using Kubernetes Nginx Ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Reduce the number of images needed to run Strimzi to just two: `kafka` and `operator`.
 * Add support for unprivileged users to install the operator with Helm
 * Support for Kafka 2.2.0
+* Support off-cluster access using Kubernetes Nginx Ingress
 
 ## 0.11.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -30,6 +31,7 @@ public class IngressListenerBootstrapConfiguration extends ExternalListenerBoots
 
     @Description("Host for the bootstrap route. " +
             "This field will be used in the Ingress resource.")
+    @JsonProperty(required = true)
     public String getHost() {
         return host;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.listener;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures Ingress for Bootstrap service
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(
+    editableEnabled = false,
+    generateBuilderPackage = false,
+    builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@EqualsAndHashCode(callSuper = true)
+public class IngressListenerBootstrapConfiguration extends ExternalListenerBootstrapOverride {
+    private static final long serialVersionUID = 1L;
+
+    private String host;
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
+
+    @Description("Host for the bootstrap route. " +
+            "This field will be used in the Ingress resource.")
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @Description("Annotations which will be added to the Ingress resource. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.listener;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures boker ingress
+ */
+@JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(
+    editableEnabled = false,
+    generateBuilderPackage = false,
+    builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@EqualsAndHashCode(callSuper = true)
+public class IngressListenerBrokerConfiguration extends ExternalListenerBrokerOverride {
+    private static final long serialVersionUID = 1L;
+
+    private String host;
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
+
+    @Description("Host for the broker ingress. " +
+            "This field will be used in the Ingress resource.")
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @Description("Annotations which will be added to the Ingress resources for individual brokers. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -32,6 +33,7 @@ public class IngressListenerBrokerConfiguration extends ExternalListenerBrokerOv
 
     @Description("Host for the broker ingress. " +
             "This field will be used in the Ingress resource.")
+    @JsonProperty(required = true)
     public String getHost() {
         return host;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Configures boker ingress
+ * Configures broker ingress
  */
 @JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host"})
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.listener;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Configures Ingress listeners
+ */
+@JsonPropertyOrder({"bootstrap", "brokers"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(
+    editableEnabled = false,
+    generateBuilderPackage = false,
+    builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@EqualsAndHashCode
+public class IngressListenerConfiguration implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private IngressListenerBootstrapConfiguration bootstrap;
+    private List<IngressListenerBrokerConfiguration> brokers;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("External bootstrap ingress configuration")
+    public IngressListenerBootstrapConfiguration getBootstrap() {
+        return bootstrap;
+    }
+
+    public void setBootstrap(IngressListenerBootstrapConfiguration bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    @Description("External broker ingress configuration")
+    public List<IngressListenerBrokerConfiguration> getBrokers() {
+        return brokers;
+    }
+
+    public void setBrokers(List<IngressListenerBrokerConfiguration> brokers) {
+        this.brokers = brokers;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
@@ -29,6 +29,7 @@ import java.util.Map;
         @JsonSubTypes.Type(name = KafkaListenerExternalRoute.TYPE_ROUTE, value = KafkaListenerExternalRoute.class),
         @JsonSubTypes.Type(name = KafkaListenerExternalLoadBalancer.TYPE_LOADBALANCER, value = KafkaListenerExternalLoadBalancer.class),
         @JsonSubTypes.Type(name = KafkaListenerExternalNodePort.TYPE_NODEPORT, value = KafkaListenerExternalNodePort.class),
+        @JsonSubTypes.Type(name = KafkaListenerExternalIngress.TYPE_INGRESS, value = KafkaListenerExternalIngress.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
@@ -16,7 +16,7 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 /**
- * Configures the external listener which exposes Kafka outside of OpenShift using Routes
+ * Configures the external listener which exposes Kafka outside of Kubernetes using Ingress
  */
 @Buildable(
         editableEnabled = false,
@@ -26,19 +26,19 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "authentication", "overrides"})
 @EqualsAndHashCode
-public class KafkaListenerExternalRoute extends KafkaListenerExternal {
+public class KafkaListenerExternalIngress extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;
 
-    public static final String TYPE_ROUTE = "route";
+    public static final String TYPE_INGRESS = "ingress";
 
     private KafkaListenerAuthentication auth;
     private List<NetworkPolicyPeer> networkPolicyPeers;
-    private RouteListenerOverride overrides;
+    private IngressListenerConfiguration configuration;
 
-    @Description("Must be `" + TYPE_ROUTE + "`")
+    @Description("Must be `" + TYPE_INGRESS + "`")
     @Override
     public String getType() {
-        return TYPE_ROUTE;
+        return TYPE_INGRESS;
     }
 
     @Override
@@ -71,12 +71,11 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
     }
 
     @Description("Overrides for external bootstrap and broker services and externally advertised addresses")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public RouteListenerOverride getOverrides() {
-        return overrides;
+    public IngressListenerConfiguration getConfiguration() {
+        return configuration;
     }
 
-    public void setOverrides(RouteListenerOverride overrides) {
-        this.overrides = overrides;
+    public void setConfiguration(IngressListenerConfiguration configuration) {
+        this.configuration = configuration;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
@@ -25,7 +25,7 @@ import java.util.List;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type", "authentication"})
+@JsonPropertyOrder({"type", "authentication", "overrides"})
 @EqualsAndHashCode
 public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
@@ -25,7 +25,7 @@ import java.util.List;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type", "authentication"})
+@JsonPropertyOrder({"type", "authentication", "overrides"})
 @EqualsAndHashCode
 public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -38,6 +38,8 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private ResourceTemplate perPodService;
     private ResourceTemplate externalBootstrapRoute;
     private ResourceTemplate perPodRoute;
+    private ResourceTemplate externalBootstrapIngress;
+    private ResourceTemplate perPodIngress;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -101,6 +103,36 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
         this.perPodService = perPodService;
     }
 
+    @Description("Template for Kafka external bootstrap `Ingress`.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getExternalBootstrapIngress() {
+        return externalBootstrapIngress;
+    }
+
+    public void setExternalBootstrapIngress(ResourceTemplate externalBootstrapIngress) {
+        this.externalBootstrapIngress = externalBootstrapIngress;
+    }
+
+    @Description("Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPerPodIngress() {
+        return perPodIngress;
+    }
+
+    public void setPerPodIngress(ResourceTemplate perPodIngress) {
+        this.perPodIngress = perPodIngress;
+    }
+
+    @Description("Template for Kafka `PodDisruptionBudget`.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public PodDisruptionBudgetTemplate getPodDisruptionBudget() {
+        return podDisruptionBudget;
+    }
+
+    public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
+        this.podDisruptionBudget = podDisruptionBudget;
+    }
+
     @Description("Template for Kafka external bootstrap `Route`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ResourceTemplate getExternalBootstrapRoute() {
@@ -119,16 +151,6 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setPerPodRoute(ResourceTemplate perPodRoute) {
         this.perPodRoute = perPodRoute;
-    }
-
-    @Description("Template for Kafka `PodDisruptionBudget`.")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public PodDisruptionBudgetTemplate getPodDisruptionBudget() {
-        return podDisruptionBudget;
-    }
-
-    public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
-        this.podDisruptionBudget = podDisruptionBudget;
     }
 
     @Override

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka.out.yaml
@@ -42,16 +42,6 @@ spec:
         type: "route"
         authentication:
           type: "tls"
-        networkPolicyPeers:
-        - namespaceSelector:
-            matchLabels:
-              kafka-enabled: "true"
-          podSelector:
-            matchLabels:
-              app: "kafka-consumer"
-        - podSelector:
-            matchLabels:
-              app: "kafka-producer"
         overrides:
           bootstrap:
             address: "my-bootstrap-host"
@@ -69,6 +59,16 @@ spec:
             advertisedHost: "my-broker-2"
             advertisedPort: 10002
             host: "my-broker-2"
+        networkPolicyPeers:
+        - namespaceSelector:
+            matchLabels:
+              kafka-enabled: "true"
+          podSelector:
+            matchLabels:
+              app: "kafka-consumer"
+        - podSelector:
+            matchLabels:
+              app: "kafka-producer"
     authorization:
       type: "simple"
       superUsers:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1120,21 +1120,23 @@ public abstract class AbstractModel {
         return KafkaResources.clusterCaKeySecretName(cluster);
     }
 
-    protected static Map<String, String> mergeAnnotations(Map<String, String> internal, Map<String, String> template) {
+    protected static Map<String, String> mergeAnnotations(Map<String, String> internal, Map<String, String>... templates) {
         Map<String, String> merged = new HashMap<>();
 
         if (internal != null) {
             merged.putAll(internal);
         }
 
-        if (template != null) {
-            for (String key : template.keySet()) {
-                if (key.contains("strimzi.io")) {
-                    throw new IllegalArgumentException("User annotations includes a Strimzi annotation: " + key);
+        for (Map<String, String> template : templates) {
+            if (template != null) {
+                for (String key : template.keySet()) {
+                    if (key.contains("strimzi.io")) {
+                        throw new IllegalArgumentException("User annotations includes a Strimzi annotation: " + key);
+                    }
                 }
-            }
 
-            merged.putAll(template);
+                merged.putAll(template);
+            }
         }
 
         return merged;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1127,15 +1127,17 @@ public abstract class AbstractModel {
             merged.putAll(internal);
         }
 
-        for (Map<String, String> template : templates) {
-            if (template != null) {
-                for (String key : template.keySet()) {
-                    if (key.contains("strimzi.io")) {
-                        throw new IllegalArgumentException("User annotations includes a Strimzi annotation: " + key);
+        if (templates != null) {
+            for (Map<String, String> template : templates) {
+                if (template != null) {
+                    for (String key : template.keySet()) {
+                        if (key.contains("strimzi.io")) {
+                            throw new InvalidResourceException("User annotations includes a Strimzi annotation: " + key);
+                        }
                     }
-                }
 
-                merged.putAll(template);
+                    merged.putAll(template);
+                }
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -23,6 +23,14 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPath;
+import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPathBuilder;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressRule;
+import io.fabric8.kubernetes.api.model.extensions.IngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressTLS;
+import io.fabric8.kubernetes.api.model.extensions.IngressTLSBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
@@ -48,6 +56,9 @@ import io.strimzi.api.kafka.model.KafkaAuthorizationSimple;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.listener.ExternalListenerBootstrapOverride;
 import io.strimzi.api.kafka.model.listener.ExternalListenerBrokerOverride;
+import io.strimzi.api.kafka.model.listener.IngressListenerBrokerConfiguration;
+import io.strimzi.api.kafka.model.listener.IngressListenerConfiguration;
+import io.strimzi.api.kafka.model.listener.KafkaListenerExternalIngress;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerOverride;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.NodePortListenerOverride;
@@ -165,6 +176,10 @@ public class KafkaCluster extends AbstractModel {
     protected Map<String, String> templateExternalBootstrapRouteAnnotations;
     protected Map<String, String> templatePerPodRouteLabels;
     protected Map<String, String> templatePerPodRouteAnnotations;
+    protected Map<String, String> templateExternalBootstrapIngressLabels;
+    protected Map<String, String> templateExternalBootstrapIngressAnnotations;
+    protected Map<String, String> templatePerPodIngressLabels;
+    protected Map<String, String> templatePerPodIngressAnnotations;
 
     // Configuration defaults
     private static final int DEFAULT_REPLICAS = 3;
@@ -280,6 +295,7 @@ public class KafkaCluster extends AbstractModel {
         return fromCrd(kafkaAssembly, versions, null);
     }
 
+    @SuppressWarnings("checkstyle:MethodLength")
     public static KafkaCluster fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions, Storage oldStorage) {
         KafkaCluster result = new KafkaCluster(kafkaAssembly.getMetadata().getNamespace(),
                 kafkaAssembly.getMetadata().getName(),
@@ -419,6 +435,16 @@ public class KafkaCluster extends AbstractModel {
             if (template.getPerPodRoute() != null && template.getPerPodRoute().getMetadata() != null)  {
                 result.templatePerPodRouteLabels = template.getPerPodRoute().getMetadata().getLabels();
                 result.templatePerPodRouteAnnotations = template.getPerPodRoute().getMetadata().getAnnotations();
+            }
+
+            if (template.getExternalBootstrapIngress() != null && template.getExternalBootstrapIngress().getMetadata() != null)  {
+                result.templateExternalBootstrapIngressLabels = template.getExternalBootstrapIngress().getMetadata().getLabels();
+                result.templateExternalBootstrapIngressAnnotations = template.getExternalBootstrapIngress().getMetadata().getAnnotations();
+            }
+
+            if (template.getPerPodIngress() != null && template.getPerPodIngress().getMetadata() != null)  {
+                result.templatePerPodIngressLabels = template.getPerPodIngress().getMetadata().getLabels();
+                result.templatePerPodIngressAnnotations = template.getPerPodIngress().getMetadata().getAnnotations();
             }
 
             ModelUtils.parsePodDisruptionBudgetTemplate(result, template.getPodDisruptionBudget());
@@ -667,6 +693,143 @@ public class KafkaCluster extends AbstractModel {
             }
 
             return route;
+        }
+
+        return null;
+    }
+
+    /**
+     * Generates ingress for pod. This ingress is used for exposing it externally using Nginx Ingress.
+     *
+     * @param pod   Number of the pod for which this ingress should be generated
+     * @return The generated Ingress
+     */
+    public Ingress generateExternalIngress(int pod) {
+        if (isExposedWithIngress()) {
+            Map<String, String> internalAnnotations = new HashMap<>(4);
+            internalAnnotations.put("kubernetes.io/ingress.class", "nginx");
+            internalAnnotations.put("ingress.kubernetes.io/ssl-passthrough", "true");
+            internalAnnotations.put("nginx.ingress.kubernetes.io/ssl-passthrough", "true");
+            internalAnnotations.put("nginx.ingress.kubernetes.io/backend-protocol", "HTTPS");
+
+            KafkaListenerExternalIngress listener = (KafkaListenerExternalIngress) listeners.getExternal();
+            Map<String, String> dnsAnnotations = null;
+            String host = null;
+
+            if (listener.getConfiguration() != null && listener.getConfiguration().getBrokers() != null) {
+                host = listener.getConfiguration().getBrokers().stream()
+                        .filter(broker -> broker != null && broker.getBroker() == pod
+                                && broker.getHost() != null)
+                        .map(IngressListenerBrokerConfiguration::getHost)
+                        .findAny()
+                        .orElseThrow(() -> new InvalidResourceException("Hostname for broker with id " + pod + " is required for exposing Kafka cluster using Ingress"));
+
+                dnsAnnotations = listener.getConfiguration().getBrokers().stream()
+                        .filter(broker -> broker != null && broker.getBroker() == pod
+                                && broker.getHost() != null)
+                        .map(IngressListenerBrokerConfiguration::getDnsAnnotations)
+                        .findAny()
+                        .orElse(null);
+            }
+
+            String perPodServiceName = externalServiceName(cluster, pod);
+
+            HTTPIngressPath path = new HTTPIngressPathBuilder()
+                    .withPath("/")
+                    .withNewBackend()
+                        .withNewServicePort(EXTERNAL_PORT)
+                        .withServiceName(perPodServiceName)
+                    .endBackend()
+                    .build();
+
+            IngressRule rule = new IngressRuleBuilder()
+                    .withHost(host)
+                    .withNewHttp()
+                        .withPaths(path)
+                    .endHttp()
+                    .build();
+
+            IngressTLS tls = new IngressTLSBuilder()
+                    .withHosts(host)
+                    .build();
+
+            Ingress ingress = new IngressBuilder()
+                    .withNewMetadata()
+                        .withName(perPodServiceName)
+                        .withLabels(getLabelsWithName(perPodServiceName, templatePerPodIngressLabels))
+                        .withAnnotations(mergeAnnotations(internalAnnotations, templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
+                    .endMetadata()
+                    .withNewSpec()
+                        .withRules(rule)
+                        .withTls(tls)
+                    .endSpec()
+                    .build();
+
+            return ingress;
+        }
+
+        return null;
+    }
+
+    /**
+     * Generates a bootstrap ingress which can be used to bootstrap clients outside of Kubernetes.
+     * @return The generated Routes
+     */
+    public Ingress generateExternalBootstrapIngress() {
+        if (isExposedWithIngress()) {
+            Map<String, String> internalAnnotations = new HashMap<>(4);
+            internalAnnotations.put("kubernetes.io/ingress.class", "nginx");
+            internalAnnotations.put("ingress.kubernetes.io/ssl-passthrough", "true");
+            internalAnnotations.put("nginx.ingress.kubernetes.io/ssl-passthrough", "true");
+            internalAnnotations.put("nginx.ingress.kubernetes.io/backend-protocol", "HTTPS");
+
+            KafkaListenerExternalIngress listener = (KafkaListenerExternalIngress) listeners.getExternal();
+            Map<String, String> dnsAnnotations;
+            String host;
+
+            if (listener.getConfiguration() != null && listener.getConfiguration().getBootstrap() != null && listener.getConfiguration().getBootstrap().getHost() != null) {
+                host = listener.getConfiguration().getBootstrap().getHost();
+                dnsAnnotations = listener.getConfiguration().getBootstrap().getDnsAnnotations();
+            } else {
+                throw new InvalidResourceException("Boostrap hostname is required for exposing Kafka cluster using Ingress");
+            }
+
+            HTTPIngressPath path = new HTTPIngressPathBuilder()
+                    .withPath("/")
+                    .withNewBackend()
+                        .withNewServicePort(EXTERNAL_PORT)
+                        .withServiceName(externalBootstrapServiceName(cluster))
+                    .endBackend()
+                    .build();
+
+            IngressRule rule = new IngressRuleBuilder()
+                    .withHost(host)
+                    .withNewHttp()
+                        .withPaths(path)
+                    .endHttp()
+                    .build();
+
+            IngressTLS tls = new IngressTLSBuilder()
+                    .withHosts(host)
+                    .build();
+
+            Ingress ingress = new IngressBuilder()
+                    .withNewMetadata()
+                        .withName(serviceName)
+                        .withLabels(getLabelsWithName(serviceName, templateExternalBootstrapIngressLabels))
+                        .withAnnotations(mergeAnnotations(internalAnnotations, templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
+                    .endMetadata()
+                    .withNewSpec()
+                        .withRules(rule)
+                        .withTls(tls)
+                    .endSpec()
+                    .build();
+
+            return ingress;
         }
 
         return null;
@@ -1279,6 +1442,15 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
+     * Returns true when the Kafka cluster is exposed to the outside of Kubernetes using Ingress
+     *
+     * @return
+     */
+    public boolean isExposedWithIngress()  {
+        return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalIngress;
+    }
+
+    /**
      * Returns the list broker overrides for external listeners
      *
      * @return
@@ -1303,6 +1475,12 @@ public class KafkaCluster extends AbstractModel {
 
             if (overrides != null && overrides.getBrokers() != null) {
                 brokerOverride.addAll(overrides.getBrokers());
+            }
+        } else if (isExposedWithIngress()) {
+            IngressListenerConfiguration configuration = ((KafkaListenerExternalIngress) listeners.getExternal()).getConfiguration();
+
+            if (configuration != null && configuration.getBrokers() != null) {
+                brokerOverride.addAll(configuration.getBrokers());
             }
         }
 
@@ -1334,6 +1512,12 @@ public class KafkaCluster extends AbstractModel {
 
             if (overrides != null) {
                 bootstrapOverride = overrides.getBootstrap();
+            }
+        } else if (isExposedWithIngress()) {
+            IngressListenerConfiguration configuration = ((KafkaListenerExternalIngress) listeners.getExternal()).getConfiguration();
+
+            if (configuration != null) {
+                bootstrapOverride = configuration.getBootstrap();
             }
         }
 
@@ -1414,6 +1598,8 @@ public class KafkaCluster extends AbstractModel {
      */
     public boolean isExposedWithTls() {
         if (isExposed() && listeners.getExternal() instanceof KafkaListenerExternalRoute) {
+            return true;
+        } else if (isExposed() && listeners.getExternal() instanceof KafkaListenerExternalIngress) {
             return true;
         } else if (isExposed()) {
             if (listeners.getExternal() instanceof KafkaListenerExternalLoadBalancer) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1214,7 +1214,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 }
 
                 this.kafkaExternalBootstrapDnsName.add(ingress.getSpec().getRules().get(0).getHost());
-                //this.kafkaExternalBootstrapDnsName.add(ingress.getSpec().getTls().get(0).getHosts().get(0));
 
                 return withVoid(ingressOperations.reconcile(namespace, KafkaCluster.serviceName(name), ingress));
             } else {
@@ -1238,7 +1237,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     }
 
                     String host = ingress.getSpec().getRules().get(0).getHost();
-                    //String host = ingress.getSpec().getTls().get(0).getHosts().get(0);
                     dnsNames.add(host);
 
                     this.kafkaExternalDnsNames.put(i, dnsNames);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -59,6 +60,7 @@ import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOper
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
@@ -125,6 +127,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private final RoleBindingOperator roleBindingOperator;
     private final ClusterRoleBindingOperator clusterRoleBindingOperator;
     private final PodOperator podOperations;
+    private final IngressOperator ingressOperations;
 
     private final KafkaVersion.Lookup versions;
 
@@ -153,6 +156,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         this.roleBindingOperator = supplier.roleBindingOperator;
         this.clusterRoleBindingOperator = supplier.clusterRoleBindingOperator;
         this.podOperations = supplier.podOperations;
+        this.ingressOperations = supplier.ingressOperations;
         this.versions = versions;
     }
 
@@ -201,6 +205,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.kafkaReplicaServices())
                 .compose(state -> state.kafkaBootstrapRoute())
                 .compose(state -> state.kafkaReplicaRoutes())
+                .compose(state -> state.kafkaBootstrapIngress())
+                .compose(state -> state.kafkaReplicaIngress())
                 .compose(state -> state.kafkaExternalBootstrapServiceReady())
                 .compose(state -> state.kafkaReplicaServicesReady())
                 .compose(state -> state.kafkaBootstrapRouteReady())
@@ -1196,6 +1202,55 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             }
 
             return withVoid(CompositeFuture.join(routeFutures));
+        }
+
+        Future<ReconciliationState> kafkaBootstrapIngress() {
+            if (kafkaCluster.isExposedWithIngress()) {
+                Ingress ingress = kafkaCluster.generateExternalBootstrapIngress();
+
+                if (kafkaCluster.getExternalListenerBootstrapOverride() != null && kafkaCluster.getExternalListenerBootstrapOverride().getAddress() != null) {
+                    log.debug("{}: Adding address {} from overrides to certificate DNS names", reconciliation, kafkaCluster.getExternalListenerBootstrapOverride().getAddress());
+                    this.kafkaExternalBootstrapDnsName.add(kafkaCluster.getExternalListenerBootstrapOverride().getAddress());
+                }
+
+                this.kafkaExternalBootstrapDnsName.add(ingress.getSpec().getRules().get(0).getHost());
+                //this.kafkaExternalBootstrapDnsName.add(ingress.getSpec().getTls().get(0).getHosts().get(0));
+
+                return withVoid(ingressOperations.reconcile(namespace, KafkaCluster.serviceName(name), ingress));
+            } else {
+                return withVoid(Future.succeededFuture());
+            }
+        }
+
+        Future<ReconciliationState> kafkaReplicaIngress() {
+            if (kafkaCluster.isExposedWithIngress()) {
+                int replicas = kafkaCluster.getReplicas();
+                List<Future> routeFutures = new ArrayList<>(replicas);
+
+                for (int i = 0; i < replicas; i++) {
+                    Ingress ingress = kafkaCluster.generateExternalIngress(i);
+
+                    Set<String> dnsNames = new HashSet<>();
+
+                    String dnsOverride = kafkaCluster.getExternalServiceAdvertisedHostOverride(i);
+                    if (dnsOverride != null)    {
+                        dnsNames.add(dnsOverride);
+                    }
+
+                    String host = ingress.getSpec().getRules().get(0).getHost();
+                    //String host = ingress.getSpec().getTls().get(0).getHosts().get(0);
+                    dnsNames.add(host);
+
+                    this.kafkaExternalDnsNames.put(i, dnsNames);
+                    this.kafkaExternalAddresses.add(kafkaCluster.getExternalAdvertisedUrl(i, host, "443"));
+
+                    routeFutures.add(ingressOperations.reconcile(namespace, KafkaCluster.externalServiceName(name, i), ingress));
+                }
+
+                return withVoid(CompositeFuture.join(routeFutures));
+            } else {
+                return withVoid(Future.succeededFuture());
+            }
         }
 
         Future<ReconciliationState> kafkaExternalBootstrapServiceReady() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -14,6 +14,7 @@ import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
@@ -43,6 +44,7 @@ public class ResourceOperatorSupplier {
     public final NetworkPolicyOperator networkPolicyOperator;
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
     public final PodOperator podOperations;
+    public final IngressOperator ingressOperations;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client, new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
@@ -66,6 +68,7 @@ public class ResourceOperatorSupplier {
                 new NetworkPolicyOperator(vertx, client),
                 new PodDisruptionBudgetOperator(vertx, client),
                 new PodOperator(vertx, client),
+                new IngressOperator(vertx, client),
                 new CrdOperator<>(vertx, client, Kafka.class, KafkaList.class, DoneableKafka.class));
     }
 
@@ -83,6 +86,7 @@ public class ResourceOperatorSupplier {
                                     NetworkPolicyOperator networkPolicyOperator,
                                     PodDisruptionBudgetOperator podDisruptionBudgetOperator,
                                     PodOperator podOperations,
+                                    IngressOperator ingressOperations,
                                     CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> kafkaOperator) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
@@ -99,5 +103,6 @@ public class ResourceOperatorSupplier {
         this.podDisruptionBudgetOperator = podDisruptionBudgetOperator;
         this.kafkaOperator = kafkaOperator;
         this.podOperations = podOperations;
+        this.ingressOperations = ingressOperations;
     }
 }

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -252,3 +252,15 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -53,6 +53,7 @@ import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
@@ -491,7 +492,7 @@ public class ResourceUtils {
                 mock(KafkaSetOperator.class), mock(ConfigMapOperator.class), mock(SecretOperator.class),
                 mock(PvcOperator.class), mock(DeploymentOperator.class),
                 mock(ServiceAccountOperator.class), mock(RoleBindingOperator.class), mock(ClusterRoleBindingOperator.class),
-                mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class), mock(CrdOperator.class));
+                mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class), mock(IngressOperator.class), mock(CrdOperator.class));
         when(supplier.serviceAccountOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperator.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
@@ -42,6 +43,8 @@ import io.strimzi.api.kafka.model.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
+import io.strimzi.api.kafka.model.listener.IngressListenerBrokerConfiguration;
+import io.strimzi.api.kafka.model.listener.IngressListenerBrokerConfigurationBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBootstrapOverride;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBrokerOverride;
@@ -75,6 +78,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings({
         "checkstyle:ClassDataAbstractionCoupling",
@@ -1679,5 +1683,157 @@ public class KafkaClusterTest {
                 .build();
         kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, jbod);
         assertEquals(jbod, kc.getStorage());
+    }
+
+    @Test
+    public void testExternalIngress() {
+        IngressListenerBrokerConfiguration broker0 = new IngressListenerBrokerConfigurationBuilder()
+                .withHost("my-broker-kafka-0.com")
+                .withBroker(0)
+                .build();
+
+        IngressListenerBrokerConfiguration broker1 = new IngressListenerBrokerConfigurationBuilder()
+                .withHost("my-broker-kafka-1.com")
+                .withBroker(1)
+                .build();
+
+        IngressListenerBrokerConfiguration broker2 = new IngressListenerBrokerConfigurationBuilder()
+                .withHost("my-broker-kafka-2.com")
+                .withBroker(2)
+                .build();
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalIngress()
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                                .withNewConfiguration()
+                                    .withNewBootstrap()
+                                        .withHost("my-kafka-bootstrap.com")
+                                        .withDnsAnnotations(Collections.singletonMap("dns-annotation", "my-kafka-bootstrap.com"))
+                                    .endBootstrap()
+                                    .withBrokers(broker0, broker1, broker2)
+                                .endConfiguration()
+                            .endKafkaListenerExternalIngress()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        assertTrue(kc.isExposedWithIngress());
+
+        Set<String> addresses = new HashSet<>();
+        addresses.add("my-broker-kafka-0.com");
+        addresses.add("my-broker-kafka-1.com");
+        addresses.add("my-broker-kafka-2.com");
+        kc.setExternalAddresses(addresses);
+
+        // Check StatefulSet changes
+        StatefulSet ss = kc.generateStatefulSet(true, null);
+
+        List<EnvVar> envs = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ENABLED, "ingress")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_TLS, "true")));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_ADDRESSES, String.join(" ", addresses))));
+        assertTrue(envs.contains(kc.buildEnvVar(KafkaCluster.ENV_VAR_KAFKA_EXTERNAL_AUTHENTICATION, KafkaListenerAuthenticationTls.TYPE_TLS)));
+
+        List<ContainerPort> ports = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
+        assertTrue(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")));
+
+        // Check external bootstrap service
+        Service ext = kc.generateExternalBootstrapService();
+        assertEquals(KafkaCluster.externalBootstrapServiceName(cluster), ext.getMetadata().getName());
+        assertEquals("ClusterIP", ext.getSpec().getType());
+        assertEquals(kc.getSelectorLabels(), ext.getSpec().getSelector());
+        assertEquals(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP")), ext.getSpec().getPorts());
+        checkOwnerReference(kc.createOwnerReference(), ext);
+
+        // Check per pod services
+        for (int i = 0; i < replicas; i++)  {
+            Service srv = kc.generateExternalService(i);
+            assertEquals(KafkaCluster.externalServiceName(cluster, i), srv.getMetadata().getName());
+            assertEquals("ClusterIP", srv.getSpec().getType());
+            assertEquals(KafkaCluster.kafkaPodName(cluster, i), srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL));
+            assertEquals(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP")), srv.getSpec().getPorts());
+            checkOwnerReference(kc.createOwnerReference(), srv);
+        }
+
+        // Check bootstrap ingress
+        Ingress bing = kc.generateExternalBootstrapIngress();
+        assertEquals(KafkaCluster.serviceName(cluster), bing.getMetadata().getName());
+        assertEquals(1, bing.getSpec().getTls().size());
+        assertEquals(1, bing.getSpec().getTls().get(0).getHosts().size());
+        assertEquals("my-kafka-bootstrap.com", bing.getSpec().getTls().get(0).getHosts().get(0));
+        assertEquals(1, bing.getSpec().getRules().size());
+        assertEquals("my-kafka-bootstrap.com", bing.getSpec().getRules().get(0).getHost());
+        assertEquals(1, bing.getSpec().getRules().get(0).getHttp().getPaths().size());
+        assertEquals("/", bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(KafkaCluster.externalBootstrapServiceName(cluster), bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName());
+        assertEquals(new IntOrString(KafkaCluster.EXTERNAL_PORT), bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort());
+        checkOwnerReference(kc.createOwnerReference(), bing);
+
+        // Check per pod router
+        for (int i = 0; i < replicas; i++)  {
+            Ingress ing = kc.generateExternalIngress(i);
+            assertEquals(KafkaCluster.externalServiceName(cluster, i), ing.getMetadata().getName());
+            assertEquals(1, ing.getSpec().getTls().size());
+            assertEquals(1, ing.getSpec().getTls().get(0).getHosts().size());
+            assertTrue(addresses.contains(ing.getSpec().getTls().get(0).getHosts().get(0)));
+            assertEquals(1, ing.getSpec().getRules().size());
+            assertTrue(addresses.contains(ing.getSpec().getRules().get(0).getHost()));
+            assertEquals(1, ing.getSpec().getRules().get(0).getHttp().getPaths().size());
+            assertEquals("/", ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+            assertEquals(KafkaCluster.externalServiceName(cluster, i), ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName());
+            assertEquals(new IntOrString(KafkaCluster.EXTERNAL_PORT), ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort());
+            checkOwnerReference(kc.createOwnerReference(), ing);
+        }
+    }
+
+    @Test
+    public void testExternalIngressMissingConfiguration() {
+        IngressListenerBrokerConfiguration broker0 = new IngressListenerBrokerConfigurationBuilder()
+                .withBroker(0)
+                .build();
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalIngress()
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                                .withNewConfiguration()
+                                    .withBrokers(broker0)
+                                .endConfiguration()
+                            .endKafkaListenerExternalIngress()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        try {
+            kc.generateExternalBootstrapIngress();
+            fail("Expected exception was not thrown");
+        } catch (InvalidResourceException e)    {
+            // pass
+        }
+
+        // Check per pod router
+        for (int i = 0; i < replicas; i++)  {
+            try {
+                kc.generateExternalIngress(i);
+                fail("Expected exception was not thrown");
+            } catch (InvalidResourceException e)    {
+                // pass
+            }
+        }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -21,7 +21,6 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
-import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -100,9 +99,7 @@ public class CertificateRenewalTest {
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L, certManager,
-                new ResourceOperatorSupplier(null, null, null,
-                        null, null, secretOps, null, null,
-                        null, null, null, null, null, null, null),
+                ResourceUtils.supplierWithMocks(true),
                 new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -99,7 +100,9 @@ public class CertificateRenewalTest {
         when(secretOps.reconcile(eq(NAMESPACE), eq(KafkaCluster.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L, certManager,
-                ResourceUtils.supplierWithMocks(true),
+                new ResourceOperatorSupplier(null, null, null,
+                        null, null, secretOps, null, null,
+                        null, null, null, null, null, null, null, null),
                 new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap()), null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
-import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -13,12 +13,12 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
-import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -152,9 +152,7 @@ public class KafkaUpdateTest {
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L,
                 new MockCertManager(),
-                new ResourceOperatorSupplier(null, null, null,
-                        kso, null, null, null, null,
-                        null, null, null, null, null, null, null),
+                ResourceUtils.supplierWithMocks(false),
                 lookup, null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.ResourceType;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -152,7 +153,9 @@ public class KafkaUpdateTest {
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), 1L,
                 new MockCertManager(),
-                ResourceUtils.supplierWithMocks(false),
+                new ResourceOperatorSupplier(null, null, null,
+                        kso, null, null, null, null,
+                        null, null, null, null, null, null, null, null),
                 lookup, null);
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -81,6 +81,8 @@ if [ "$KAFKA_EXTERNAL_ENABLED" ]; then
 
   if [ "$KAFKA_EXTERNAL_ENABLED" = "route" ]; then
     ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},EXTERNAL://$(get_address_for_broker $KAFKA_BROKER_ID)"
+  elif [ "$KAFKA_EXTERNAL_ENABLED" = "ingress" ]; then
+    ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},EXTERNAL://$(get_address_for_broker $KAFKA_BROKER_ID)"
   elif [ "$KAFKA_EXTERNAL_ENABLED" = "loadbalancer" ]; then
     ADVERTISED_LISTENERS="${ADVERTISED_LISTENERS},EXTERNAL://$(get_address_for_broker $KAFKA_BROKER_ID)"
   elif [ "$KAFKA_EXTERNAL_ENABLED" = "nodeport" ]; then

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -162,8 +162,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`]
 |tls       1.2+<.<|Configures TLS listener on port 9093.
 |xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
-|external  1.2+<.<|Configures external listener on port 9094. The type depends on the value of the `external.type` property within the given object, which must be one of [route, loadbalancer, nodeport].
-|xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`]
+|external  1.2+<.<|Configures external listener on port 9094. The type depends on the value of the `external.type` property within the given object, which must be one of [route, loadbalancer, nodeport, ingress].
+|xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`]
 |====
 
 [id='type-KafkaListenerPlain-{context}']
@@ -186,7 +186,7 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 [id='type-KafkaListenerAuthenticationTls-{context}']
 ### `KafkaListenerAuthenticationTls` schema reference
 
-Used in: xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+Used in: xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationTls` from xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`].
@@ -201,7 +201,7 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 [id='type-KafkaListenerAuthenticationScramSha512-{context}']
 ### `KafkaListenerAuthenticationScramSha512` schema reference
 
-Used in: xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
+Used in: xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerPlain-{context}[`KafkaListenerPlain`], xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerAuthenticationScramSha512` from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`].
@@ -236,7 +236,7 @@ Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalRoute` from xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalRoute` from xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`].
 It must have the value `route` for the type `KafkaListenerExternalRoute`.
 [options="header"]
 |====
@@ -245,12 +245,12 @@ It must have the value `route` for the type `KafkaListenerExternalRoute`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
+|xref:type-RouteListenerOverride-{context}[`RouteListenerOverride`]
 |networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
-|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
-|xref:type-RouteListenerOverride-{context}[`RouteListenerOverride`]
 |====
 
 [id='type-RouteListenerOverride-{context}']
@@ -308,7 +308,7 @@ Used in: xref:type-RouteListenerOverride-{context}[`RouteListenerOverride`]
 Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalLoadBalancer` from xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalLoadBalancer` from xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`].
 It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBalancer`.
 [options="header"]
 |====
@@ -317,12 +317,12 @@ It must have the value `loadbalancer` for the type `KafkaListenerExternalLoadBal
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
+|xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerOverride`]
 |networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
-|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
-|xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerOverride`]
 |tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====
@@ -378,7 +378,7 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalNodePort` from xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalNodePort` from xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`].
 It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 [options="header"]
 |====
@@ -387,12 +387,12 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 |string
 |authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
+|xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`]
 |networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
 
 
 |https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
-|overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
-|xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`]
 |tls                 1.2+<.<|Enables TLS encryption on the listener. By default set to `true` for enabled TLS encryption.
 |boolean
 |====
@@ -444,6 +444,82 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 |integer
 |nodePort        1.2+<.<|Node port for the broker service.
 |integer
+|====
+
+[id='type-KafkaListenerExternalIngress-{context}']
+### `KafkaListenerExternalIngress` schema reference
+
+Used in: xref:type-KafkaListeners-{context}[`KafkaListeners`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaListenerExternalIngress` from xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`], xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`].
+It must have the value `ingress` for the type `KafkaListenerExternalIngress`.
+[options="header"]
+|====
+|Field                      |Description
+|type                1.2+<.<|Must be `ingress`.
+|string
+|authentication      1.2+<.<|Authentication configuration for Kafka brokers. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
+|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`]
+|configuration       1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
+|xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`]
+|networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list.See external documentation of https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[networking/v1 networkpolicypeer].
+
+
+|https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#networkpolicypeer-v1-networking[NetworkPolicyPeer] array
+|====
+
+[id='type-IngressListenerConfiguration-{context}']
+### `IngressListenerConfiguration` schema reference
+
+Used in: xref:type-KafkaListenerExternalIngress-{context}[`KafkaListenerExternalIngress`]
+
+
+[options="header"]
+|====
+|Field             |Description
+|bootstrap  1.2+<.<|External bootstrap ingress configuration.
+|xref:type-IngressListenerBootstrapConfiguration-{context}[`IngressListenerBootstrapConfiguration`]
+|brokers    1.2+<.<|External broker ingress configuration.
+|xref:type-IngressListenerBrokerConfiguration-{context}[`IngressListenerBrokerConfiguration`] array
+|====
+
+[id='type-IngressListenerBootstrapConfiguration-{context}']
+### `IngressListenerBootstrapConfiguration` schema reference
+
+Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`]
+
+
+[options="header"]
+|====
+|Field                  |Description
+|address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
+|string
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Ingress resource. You can use this field to instrument DNS providers such as External DNS.
+|map
+|host            1.2+<.<|Host for the bootstrap route. This field will be used in the Ingress resource.
+|string
+|====
+
+[id='type-IngressListenerBrokerConfiguration-{context}']
+### `IngressListenerBrokerConfiguration` schema reference
+
+Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`]
+
+
+[options="header"]
+|====
+|Field                  |Description
+|broker          1.2+<.<|Id of the kafka broker (broker identifier).
+|integer
+|advertisedHost  1.2+<.<|The host name which will be used in the brokers' `advertised.brokers`.
+|string
+|advertisedPort  1.2+<.<|The port number which will be used in the brokers' `advertised.brokers`.
+|integer
+|host            1.2+<.<|Host for the broker ingress. This field will be used in the Ingress resource.
+|string
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Ingress resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|map
 |====
 
 [id='type-KafkaAuthorizationSimple-{context}']
@@ -597,9 +673,13 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |brokersService            1.2+<.<|Template for Kafka broker `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|externalBootstrapIngress  1.2+<.<|Template for Kafka external bootstrap `Ingress`.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |externalBootstrapRoute    1.2+<.<|Template for Kafka external bootstrap `Route`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |externalBootstrapService  1.2+<.<|Template for Kafka external bootstrap `Service`.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|perPodIngress             1.2+<.<|Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |perPodRoute               1.2+<.<|Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -258,4 +258,16 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -239,6 +239,37 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        configuration:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                dnsAnnotations:
+                                  type: object
+                                host:
+                                  type: string
+                              required:
+                              - host
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                  advertisedHost:
+                                    type: string
+                                  advertisedPort:
+                                    type: integer
+                                  host:
+                                    type: string
+                                  dnsAnnotations:
+                                    type: object
+                                required:
+                                - host
                         networkPolicyPeers:
                           type: array
                           items:
@@ -320,6 +351,7 @@ spec:
                           - route
                           - loadbalancer
                           - nodeport
+                          - ingress
                       required:
                       - type
                 authorization:
@@ -753,6 +785,16 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    externalBootstrapIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -764,6 +806,16 @@ spec:
                             annotations:
                               type: object
                     externalBootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    perPodIngress:
                       type: object
                       properties:
                         metadata:

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -252,3 +252,15 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -234,6 +234,33 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        configuration:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                dnsAnnotations:
+                                  type: object
+                                host:
+                                  type: string
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                  advertisedHost:
+                                    type: string
+                                  advertisedPort:
+                                    type: integer
+                                  host:
+                                    type: string
+                                  dnsAnnotations:
+                                    type: object
                         networkPolicyPeers:
                           type: array
                           items:
@@ -315,6 +342,7 @@ spec:
                           - route
                           - loadbalancer
                           - nodeport
+                          - ingress
                       required:
                       - type
                 authorization:
@@ -748,6 +776,16 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    externalBootstrapIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -759,6 +797,16 @@ spec:
                             annotations:
                               type: object
                     externalBootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    perPodIngress:
                       type: object
                       properties:
                         metadata:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -246,6 +246,8 @@ spec:
                                   type: object
                                 host:
                                   type: string
+                              required:
+                              - host
                             brokers:
                               type: array
                               items:
@@ -261,6 +263,8 @@ spec:
                                     type: string
                                   dnsAnnotations:
                                     type: object
+                                required:
+                                - host
                         networkPolicyPeers:
                           type: array
                           items:

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -64,7 +64,7 @@ public class InitWriter {
         String externalAddress = findAddress(addresses);
 
         if (externalAddress == null) {
-            log.error("External address nto found");
+            log.error("External address not found");
             return false;
         } else  {
             log.info("External address found {}", externalAddress);

--- a/olm/kafkas.crd.yaml
+++ b/olm/kafkas.crd.yaml
@@ -234,6 +234,37 @@ spec:
                               - scram-sha-512
                           required:
                           - type
+                        configuration:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                dnsAnnotations:
+                                  type: object
+                                host:
+                                  type: string
+                              required:
+                              - host
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                  advertisedHost:
+                                    type: string
+                                  advertisedPort:
+                                    type: integer
+                                  host:
+                                    type: string
+                                  dnsAnnotations:
+                                    type: object
+                                required:
+                                - host
                         networkPolicyPeers:
                           type: array
                           items:
@@ -315,6 +346,7 @@ spec:
                           - route
                           - loadbalancer
                           - nodeport
+                          - ingress
                       required:
                       - type
                 authorization:
@@ -748,6 +780,16 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    externalBootstrapIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -759,6 +801,16 @@ spec:
                             annotations:
                               type: object
                     externalBootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    perPodIngress:
                       type: object
                       properties:
                         metadata:

--- a/olm/strimzi-cluster-operator.clusterserviceversion.yaml
+++ b/olm/strimzi-cluster-operator.clusterserviceversion.yaml
@@ -414,6 +414,18 @@ spec:
           - delete
           - patch
           - update
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
       deployments:
       - name: strimzi-cluster-operator
         spec:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for exposing Kafka for off-cluster access using Kubernetes Nginx Ingress and its TLS passthrough feature. It is intentionally not using its TCP routing features which seem to be a bit cumbersome. 

Here is an example configuration of the Ingress access:

```yaml
    listeners:
      external:
        type: ingress
        authentication:
          type: tls
        configuration:
          bootstrap:
            dnsAnnotations:
              external-dns.alpha.kubernetes.io/hostname: bootstrap.j9z.cz.
              external-dns.alpha.kubernetes.io/ttl: "60"
            host: bootstrap.j9z.cz
          brokers:
          - broker: 0
            dnsAnnotations:
              external-dns.alpha.kubernetes.io/hostname: broker-0.j9z.cz.
              external-dns.alpha.kubernetes.io/ttl: "60"
            host: broker-0.j9z.cz
          - broker: 1
            dnsAnnotations:
              external-dns.alpha.kubernetes.io/hostname: broker-1.j9z.cz.
              external-dns.alpha.kubernetes.io/ttl: "60"
            host: broker-1.j9z.cz
          - broker: 2
            dnsAnnotations:
              external-dns.alpha.kubernetes.io/hostname: broker-2.j9z.cz.
              external-dns.alpha.kubernetes.io/ttl: "60"
            host: broker-2.j9z.cz
```

It requires a mandatory configuration of the host names, because unlike Routes, the Ingress will not generate its own host names when they are not specified. optionally, it also allows attach specific annotations to each Ingress objects which can be used to manage some DNS tooling such as External DNS.

There are several Ingress implementations available for Kubernetes. This was tested only with the Nginx Ingress controller. Although it might work with others as well.

Documentation will be delivered in separate PR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

