### PR TITLE
Add missing UnknownPropertyPreserving

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
@@ -6,12 +6,17 @@ package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Configures overrides for LoadBalancer listeners
@@ -24,11 +29,12 @@ import java.util.List;
     builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @EqualsAndHashCode
-public class LoadBalancerListenerOverride implements Serializable {
+public class LoadBalancerListenerOverride implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private LoadBalancerListenerBootstrapOverride bootstrap;
     private List<LoadBalancerListenerBrokerOverride> brokers;
+    private Map<String, Object> additionalProperties;
 
     @Description("External bootstrap service configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -48,5 +54,18 @@ public class LoadBalancerListenerOverride implements Serializable {
 
     public void setBrokers(List<LoadBalancerListenerBrokerOverride> brokers) {
         this.brokers = brokers;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
@@ -6,12 +6,17 @@ package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Configures overrides for Route listeners
@@ -24,11 +29,12 @@ import java.util.List;
     builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @EqualsAndHashCode
-public class RouteListenerOverride implements Serializable {
+public class RouteListenerOverride implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private RouteListenerBootstrapOverride bootstrap;
     private List<RouteListenerBrokerOverride> brokers;
+    private Map<String, Object> additionalProperties;
 
     @Description("External bootstrap service configuration")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -48,5 +54,18 @@ public class RouteListenerOverride implements Serializable {
 
     public void setBrokers(List<RouteListenerBrokerOverride> brokers) {
         this.brokers = brokers;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seem to be some classes in the `api` module which still don't implement the `UnknownPropertyPreserving` interface. This PR adds them.