### PR TITLE
Try to delete liveness and readiness files if they already exist

### DIFF
--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -22,6 +22,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
+rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
 export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/kafka-agent-${STRIMZI_VERSION}.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
 # enabling Prometheus JMX exporter as Java agent

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -145,6 +145,7 @@ public class KafkaAgent {
 
     private void touch(File file) throws IOException {
         new FileOutputStream(file).close();
+        file.deleteOnExit();
     }
 
     /**
@@ -158,11 +159,11 @@ public class KafkaAgent {
         } else {
             File brokerReadyFile = new File(agentArgs.substring(0, index));
             File sessionConnectedFile = new File(agentArgs.substring(index + 1));
-            if (brokerReadyFile.exists()) {
-                LOGGER.error("Broker readiness file already exists: {}", brokerReadyFile);
+            if (brokerReadyFile.exists() && !brokerReadyFile.delete()) {
+                LOGGER.error("Broker readiness file already exists and could not be deleted: {}", brokerReadyFile);
                 System.exit(1);
-            } else if (sessionConnectedFile.exists()) {
-                LOGGER.error("Session connected file already exists: {}", sessionConnectedFile);
+            } else if (sessionConnectedFile.exists() && !sessionConnectedFile.delete()) {
+                LOGGER.error("Session connected file already exists and could not be deleted: {}", sessionConnectedFile);
                 System.exit(1);
             } else {
                 new KafkaAgent(brokerReadyFile, sessionConnectedFile).run();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR is a minor fix to the new liveness and readiness checks. Now the agent only exits if the files cannot be deleted. It also marks the files for deletion on normal JVM exit. We also delete the files in the startup script.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

