### PR TITLE
Topic Operator startup

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/InFlight.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/InFlight.java
@@ -115,7 +115,7 @@ class InFlight<T> {
             } else {
                 LOGGER.debug("Queueing {} for deferred execution after {}", action, current);
                 current.setHandler(ar -> {
-                    LOGGER.debug("Queueing {} after deferred execution", action);
+                    LOGGER.debug("Executing {} after now {} has finished", action, current);
                     vertx.runOnContext(ar2 ->
                             action.handle(fut.fut));
                 });

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -83,13 +83,13 @@ public class Session extends AbstractVerticle {
                     if (!topicOperator.isWorkInflight()) {
                         LOGGER.error("Inflight work has finished");
                         f.complete();
-                    }
-                    if (System.currentTimeMillis() > deadline) {
+                    } else if (System.currentTimeMillis() > deadline) {
                         LOGGER.error("Timeout waiting for inflight work to finish");
                         f.complete();
+                    } else {
+                        LOGGER.debug("Waiting for inflight work to finish");
+                        vertx.setTimer(1_000, this);
                     }
-                    LOGGER.debug("Waiting for inflight work to finish");
-                    vertx.setTimer(1_000, this);
                 }
             };
             longHandler.handle(null);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -34,7 +34,7 @@ public class Session extends AbstractVerticle {
     private final KubernetesClient kubeClient;
 
     /*test*/ OperatorAssignedKafkaImpl kafka;
-    /*test*/ AdminClient adminClient;
+    private AdminClient adminClient;
     /*test*/ K8sImpl k8s;
     /*test*/ TopicOperator topicOperator;
     private Watch topicWatch;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -413,7 +413,6 @@ public class TopicOperator {
                     // delete privateState
                     LOGGER.debug("KafkaTopic deleted in k8s and topic deleted in kafka => delete from topicStore");
                     enqueue(new DeleteFromTopicStore(privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
-                    reconciliationResultHandler.handle(Future.succeededFuture());
                 } else {
                     // it was deleted in k8s so delete in kafka and privateState
                     LOGGER.debug("KafkaTopic deleted in k8s => delete topic from kafka and from topicStore");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1001,6 +1001,7 @@ public class TopicOperator {
 
         LOGGER.debug("Reconciling kafka topics {}", topicsFromKafka);
 
+        final ReconcileState result = new ReconcileState(succeeded, undetermined, failed);
         if (topicsFromKafka.size() > 0) {
             CountDownLatch countDownLatch = new CountDownLatch(topicsFromKafka.size());
             for (TopicName topicName : topicsFromKafka) {
@@ -1016,16 +1017,15 @@ public class TopicOperator {
                     }
                     countDownLatch.countDown();
                     if (countDownLatch.getCount() == 0) {
-                        topicFutures.complete(new ReconcileState(succeeded, undetermined, failed));
+                        topicFutures.complete(result);
                     }
                 });
             }
         } else {
-            topicFutures.complete(new ReconcileState(succeeded, undetermined, failed));
+            topicFutures.complete(result);
         }
 
         return topicFutures;
-    }
 
     /**
      * Reconcile the given topic which has the given {@code privateTopic} in the topic store.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.disjoint;
@@ -537,25 +536,39 @@ public class TopicOperator {
                     // depending on what the diffs are.
                     LOGGER.debug("Updating KafkaTopic, kafka topic and topicStore");
                     // TODO replace this with compose
-                    enqueue(new UpdateResource(result, ar -> {
-                        Handler<Void> topicStoreHandler =
-                            ignored -> enqueue(new UpdateInTopicStore(
-                                result, involvedObject, reconciliationResultHandler));
-                        Handler<Void> partitionsHandler;
-                        if (partitionsDelta > 0) {
-                            partitionsHandler = ar4 -> enqueue(new IncreaseKafkaPartitions(result, involvedObject, ar2 -> topicStoreHandler.handle(null)));
-                        } else {
-                            partitionsHandler = topicStoreHandler;
-                        }
-                        if (merged.changesConfig()) {
-                            enqueue(new UpdateKafkaConfig(result, involvedObject, ar2 -> partitionsHandler.handle(null)));
-                        } else {
-                            enqueue(partitionsHandler);
-                        }
-                    }));
+                    TopicDiff diff = TopicDiff.diff(k8sTopic, result);
+                    if (diff.isEmpty()) {
+                        LOGGER.debug("No need to update KafkaTopic with {}", diff);
+                        enqueue(updateTopicStoreAndKafka(involvedObject, reconciliationResultHandler, merged, result, partitionsDelta));
+                    } else {
+                        LOGGER.debug("Updating KafkaTopic with {}", diff);
+                        UpdateResource event = new UpdateResource(result, ar -> {
+                            enqueue(updateTopicStoreAndKafka(involvedObject, reconciliationResultHandler, merged, result, partitionsDelta));
+                        });
+                        enqueue(event);
+                    }
                 }
             }
         }
+    }
+
+    private Handler<Void> updateTopicStoreAndKafka(HasMetadata involvedObject, Handler<AsyncResult<Void>> reconciliationResultHandler, TopicDiff merged, Topic topic, int partitionsDelta) {
+        Handler<Void> topicStoreHandler =
+            ignored -> enqueue(new UpdateInTopicStore(topic, involvedObject, reconciliationResultHandler));
+        Handler<Void> partitionsHandler;
+        if (partitionsDelta > 0) {
+            partitionsHandler = ar4 -> enqueue(new IncreaseKafkaPartitions(topic, involvedObject, ar2 -> topicStoreHandler.handle(null)));
+        } else {
+            partitionsHandler = topicStoreHandler;
+        }
+
+        Handler<Void> result;
+        if (merged.changesConfig()) {
+            result = new UpdateKafkaConfig(topic, involvedObject, ar2 -> partitionsHandler.handle(null));
+        } else {
+            result = partitionsHandler;
+        }
+        return result;
     }
 
     void enqueue(Handler<Void> event) {
@@ -911,10 +924,10 @@ public class TopicOperator {
     static class ReconcileState {
         private final Set<TopicName> succeeded;
         private final Set<TopicName> undetermined;
-        private final List<Future> failed;
+        private final Map<TopicName, Throwable> failed;
         private List<KafkaTopic> ktList;
 
-        public ReconcileState(Set<TopicName> succeeded, Set<TopicName> undetermined, List<Future> failed) {
+        public ReconcileState(Set<TopicName> succeeded, Set<TopicName> undetermined, Map<TopicName, Throwable> failed) {
             this.succeeded = succeeded;
             this.undetermined = undetermined;
             this.failed = failed;
@@ -950,7 +963,7 @@ public class TopicOperator {
             for (KafkaTopic kt : reconcileState.ktList) {
                 Topic topic = TopicSerialization.fromTopicResource(kt);
                 TopicName topicName = topic.getTopicName();
-                if (reconcileState.failed.contains(topicName)) {
+                if (reconcileState.failed.containsKey(topicName)) {
                     // we already failed to reconcile this topic in reconcileFromKafka(), /
                     // don't bother trying again
                     LOGGER.trace("Already failed to reconcile {}", topicName);
@@ -967,6 +980,7 @@ public class TopicOperator {
                     }));
                 } else {
                     // Topic exists in kube, but not in Kafka
+                    LOGGER.debug("Topic {} exists in Kafka, but not Kubernetes", topicName, logTopic(kt));
                     futs.add(reconcileWithKubeTopic(reconciliationType, kt, topic).compose(r -> {
                         // if success then add to success
                         reconcileState.succeeded.add(topicName);
@@ -975,16 +989,15 @@ public class TopicOperator {
                 }
             }
             return CompositeFuture.join(futs).compose(joined -> {
-                for (Future ts : reconcileState.failed) {
-                    futs.add(ts);
+                List<Future> futs2 = new ArrayList<>();
+                for (Throwable exception : reconcileState.failed.values()) {
+                    futs2.add(Future.failedFuture(exception));
                 }
-                // anything left in undetermined doesn't exist in topic store not kube -> delete it in kafka
+                // anything left in undetermined doesn't exist in topic store nor kube
                 for (TopicName tn : reconcileState.undetermined) {
-                    Future f = Future.future();
-                    kafka.deleteTopic(tn, f.completer());
-                    futs.add(f);
+                    futs2.add(getKafkaAndReconcile(tn, null, null));
                 }
-                return CompositeFuture.join(futs);
+                return CompositeFuture.join(futs2);
             });
         });
     }
@@ -994,95 +1007,104 @@ public class TopicOperator {
      * Reconcile all the topics in {@code foundFromKafka}, returning a ReconciliationState.
      */
     private Future<ReconcileState> reconcileFromKafka(String reconciliationType, List<TopicName> topicsFromKafka) {
-        Future<ReconcileState> topicFutures = Future.future();
         Set<TopicName> succeeded = new HashSet<>();
         Set<TopicName> undetermined = new HashSet<>();
-        List<Future> failed = new ArrayList<>();
+        Map<TopicName, Throwable> failed = new HashMap<>();
 
         LOGGER.debug("Reconciling kafka topics {}", topicsFromKafka);
 
-        final ReconcileState result = new ReconcileState(succeeded, undetermined, failed);
+        final ReconcileState state = new ReconcileState(succeeded, undetermined, failed);
         if (topicsFromKafka.size() > 0) {
-            CountDownLatch countDownLatch = new CountDownLatch(topicsFromKafka.size());
+            List<Future<Void>> futures = new ArrayList<>();
             for (TopicName topicName : topicsFromKafka) {
-                topicStore.read(topicName, tsr -> {
-                    if (tsr.failed()) {
-                        failed.add(Future.failedFuture(
-                            new OperatorException("Error getting KafkaTopic " + topicName + " during " + reconciliationType + " reconciliation", tsr.cause())));
-                    } else if (tsr.result() == null) {
+                Future<Topic> f = Future.future();
+                topicStore.read(topicName, f.completer());
+                futures.add(f.recover(error -> {
+                    failed.put(topicName,
+                            new OperatorException("Error getting KafkaTopic " + topicName + " during "
+                                    + reconciliationType + " reconciliation", error));
+                    return Future.succeededFuture();
+                }).compose(topic -> {
+                    if (topic == null) {
                         undetermined.add(topicName);
+                        return Future.succeededFuture();
                     } else {
-                        reconcileWithPrivateTopic(reconciliationType, topicName, tsr.result());
-                        succeeded.add(topicName);
+                        LOGGER.debug("Have private topic for topic {} in Kafka", topicName);
+                        return reconcileWithPrivateTopic(reconciliationType, topicName, topic).otherwise(error -> {
+                            failed.put(topicName, error);
+                            return null;
+                        }).map(ignored -> {
+                            succeeded.add(topicName);
+                            return null;
+                        });
                     }
-                    countDownLatch.countDown();
-                    if (countDownLatch.getCount() == 0) {
-                        topicFutures.complete(result);
-                    }
-                });
+                }));
             }
+            return CompositeFuture.join((List) futures).map(state);
         } else {
-            topicFutures.complete(result);
+            return Future.succeededFuture(state);
         }
 
-        return topicFutures;
+
+    }
 
     /**
      * Reconcile the given topic which has the given {@code privateTopic} in the topic store.
      */
-    private Future<Boolean> reconcileWithPrivateTopic(String reconciliationType, TopicName topicName, Topic privateTopic) {
-        Future<Boolean> topicFuture = Future.future();
-
-        ResourceName kubeName = privateTopic.getResourceName();
-        k8s.getFromName(kubeName, topicResult -> {
-            if (topicResult.succeeded()) {
-                KafkaTopic kafkaTopicResource = topicResult.result();
-                Future<Void> result = Future.future();
-                Handler<Future<Void>> action = new Reconciliation("reconcile") {
-                    @Override
-                    public void handle(Future<Void> fut) {
-                        try {
-                            Topic k8sTopic = kafkaTopicResource != null ? TopicSerialization.fromTopicResource(kafkaTopicResource) : null;
-                            kafka.topicMetadata(topicName, metadataResult -> {
-                                if (metadataResult.succeeded()) {
-                                    TopicMetadata kafkaTopicMeta = metadataResult.result();
-                                    Topic topicFromKafka = TopicSerialization.fromTopicMetadata(kafkaTopicMeta);
-                                    reconcile(kafkaTopicResource, k8sTopic, topicFromKafka, privateTopic, reconcileResult -> {
-                                        if (reconcileResult.succeeded()) {
-                                            LOGGER.info("Success reconciling KafkaTopic {}", logTopic(kafkaTopicResource));
-                                            fut.complete();
-                                        } else {
-                                            LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), reconcileResult.cause());
-                                            fut.fail(reconcileResult.cause());
-                                        }
-                                    });
-                                } else {
-                                    LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), metadataResult.cause());
-                                    fut.fail(metadataResult.cause());
-                                }
-                            });
-                        } catch (InvalidTopicException e) {
-                            LOGGER.error("Error reconciling KafkaTopic {}: Invalid resource: ", logTopic(kafkaTopicResource), e.getMessage());
-                            fut.fail(e);
-                        } catch (OperatorException e) {
-                            LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), e);
-                            fut.fail(e);
-                        }
-                    }
-                };
-                inFlight.enqueue(topicName, action, result);
-                result.setHandler(ar -> {
-                    if (ar.succeeded()) {
-                        topicFuture.complete(Boolean.TRUE);
-                    } else {
-                        topicFuture.fail(ar.cause());
-                    }
-                });
-            } else {
+    private Future<Void> reconcileWithPrivateTopic(String reconciliationType, TopicName topicName, Topic privateTopic) {
+        Future<KafkaTopic> kubeFuture = Future.future();
+        k8s.getFromName(privateTopic.getResourceName(), kubeFuture.completer());
+        return kubeFuture
+            .compose(kafkaTopicResource -> getKafkaAndReconcile(topicName, privateTopic, kafkaTopicResource))
+            .recover(error -> {
                 LOGGER.error("Error {} getting KafkaTopic {} for topic {}",
                         reconciliationType,
-                        topicName.asKubeName(), topicName, topicResult.cause());
-                topicFuture.fail(new OperatorException("Error getting KafkaTopic " + topicName.asKubeName() + " during " + reconciliationType + " reconciliation", topicResult.cause()));
+                        topicName.asKubeName(), topicName, error);
+                return Future.failedFuture(new OperatorException("Error getting KafkaTopic " + topicName.asKubeName() + " during " + reconciliationType + " reconciliation", error));
+            });
+    }
+
+    private Future<Void> getKafkaAndReconcile(TopicName topicName, Topic privateTopic, KafkaTopic kafkaTopicResource) {
+        Future<Void> topicFuture = Future.future();
+        Future<Void> result = Future.future();
+        Handler<Future<Void>> action = new Reconciliation("reconcile") {
+            @Override
+            public void handle(Future<Void> fut) {
+                try {
+                    Topic k8sTopic = kafkaTopicResource != null ? TopicSerialization.fromTopicResource(kafkaTopicResource) : null;
+                    kafka.topicMetadata(topicName, metadataResult -> {
+                        if (metadataResult.succeeded()) {
+                            TopicMetadata kafkaTopicMeta = metadataResult.result();
+                            Topic topicFromKafka = TopicSerialization.fromTopicMetadata(kafkaTopicMeta);
+                            reconcile(kafkaTopicResource, k8sTopic, topicFromKafka, privateTopic, reconcileResult -> {
+                                if (reconcileResult.succeeded()) {
+                                    LOGGER.info("Success reconciling KafkaTopic {}", logTopic(kafkaTopicResource));
+                                    fut.complete();
+                                } else {
+                                    LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), reconcileResult.cause());
+                                    fut.fail(reconcileResult.cause());
+                                }
+                            });
+                        } else {
+                            LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), metadataResult.cause());
+                            fut.fail(metadataResult.cause());
+                        }
+                    });
+                } catch (InvalidTopicException e) {
+                    LOGGER.error("Error reconciling KafkaTopic {}: Invalid resource: ", logTopic(kafkaTopicResource), e.getMessage());
+                    fut.fail(e);
+                } catch (OperatorException e) {
+                    LOGGER.error("Error reconciling KafkaTopic {}", logTopic(kafkaTopicResource), e);
+                    fut.fail(e);
+                }
+            }
+        };
+        inFlight.enqueue(topicName, action, result);
+        result.setHandler(ar -> {
+            if (ar.succeeded()) {
+                topicFuture.complete();
+            } else {
+                topicFuture.fail(ar.cause());
             }
         });
         return topicFuture;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -29,6 +29,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreatePartitionsResult;
@@ -38,6 +39,7 @@ import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
+import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,9 +57,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -92,7 +96,7 @@ public class TopicOperatorIT extends BaseITST {
             }
         }
     };
-    private final long timeout = 120_000L;
+    private final long timeout = 30_000L;
     private volatile TopicConfigsWatcher topicsConfigWatcher;
     private volatile ZkTopicWatcher topicWatcher;
 
@@ -145,9 +149,27 @@ public class TopicOperatorIT extends BaseITST {
             }
         } while (true);
 
+        Properties p = new Properties();
+        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.brokerList());
+        adminClient = AdminClient.create(p);
+
         kubeClient = CLIENT.inNamespace(NAMESPACE);
         Crds.registerCustomKinds();
         LOGGER.info("Using namespace {}", NAMESPACE);
+        startTopicOperator(context);
+
+        // We can't delete events, so record the events which exist at the start of the test
+        // and then waitForEvents() can ignore those
+        preExistingEvents = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().
+                getItems().stream().
+                map(evt -> evt.getMetadata().getUid()).
+                collect(Collectors.toSet());
+
+        LOGGER.info("Finished setting up test");
+    }
+
+    void startTopicOperator(TestContext context) {
+        LOGGER.info("Starting Topic Operator");
         Map<String, String> m = new HashMap();
         m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
         m.put(Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
@@ -160,7 +182,6 @@ public class TopicOperatorIT extends BaseITST {
         vertx.deployVerticle(session, ar -> {
             if (ar.succeeded()) {
                 deploymentId = ar.result();
-                adminClient = session.adminClient;
                 topicsConfigWatcher = session.topicConfigsWatcher;
                 topicWatcher = session.topicWatcher;
                 topicsWatcher = session.topicsWatcher;
@@ -171,19 +192,10 @@ public class TopicOperatorIT extends BaseITST {
             }
         });
         async.await();
-
         waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
         waitFor(context, () -> this.topicsConfigWatcher.started(), timeout, "Topic configs watcher not started");
         waitFor(context, () -> this.topicWatcher.started(), timeout, "Topic watcher not started");
-
-        // We can't delete events, so record the events which exist at the start of the test
-        // and then waitForEvents() can ignore those
-        preExistingEvents = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().
-                getItems().stream().
-                map(evt -> evt.getMetadata().getUid()).
-                collect(Collectors.toSet());
-
-        LOGGER.info("Finished setting up test");
+        LOGGER.info("Started Topic Operator");
     }
 
     private static int zkPort(KafkaCluster cluster) {
@@ -203,14 +215,30 @@ public class TopicOperatorIT extends BaseITST {
         LOGGER.info("Tearing down test");
 
         if (kubeClient != null) {
+            List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
             operation().inNamespace(NAMESPACE).delete();
+            // Wait for the operator to delete all the existing topics in Kafka
+            for (KafkaTopic item : items) {
+                waitForTopicInKafka(context, new TopicName(item).toString(), false);
+            }
         }
 
+        stopTopicOperator(context);
+
+        adminClient.close();
+        if (kafkaCluster != null) {
+            kafkaCluster.shutdown();
+        }
+        Runtime.getRuntime().removeShutdownHook(kafkaHook);
+        LOGGER.info("Finished tearing down test");
+    }
+
+    void stopTopicOperator(TestContext context) {
+        LOGGER.info("Stopping Topic Operator");
         Async async = context.async();
         if (deploymentId != null) {
             vertx.undeploy(deploymentId, ar -> {
                 deploymentId = null;
-                adminClient = null;
                 topicsConfigWatcher = null;
                 topicWatcher = null;
                 topicsWatcher = null;
@@ -222,11 +250,7 @@ public class TopicOperatorIT extends BaseITST {
             });
         }
         async.await();
-        if (kafkaCluster != null) {
-            kafkaCluster.shutdown();
-        }
-        Runtime.getRuntime().removeShutdownHook(kafkaHook);
-        LOGGER.info("Finished tearing down test");
+        LOGGER.info("Stopped Topic Operator");
     }
 
 
@@ -236,20 +260,7 @@ public class TopicOperatorIT extends BaseITST {
         operation().inNamespace(NAMESPACE).create(topicResource);
 
         // Wait for the topic to be created
-        waitFor(context, () -> {
-            try {
-                adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
-                return true;
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                    return false;
-                } else {
-                    throw new RuntimeException(e);
-                }
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }, timeout, "Expected topic to be created by now");
+        waitForTopicInKafka(context, topicName);
         return topicResource;
     }
 
@@ -267,33 +278,53 @@ public class TopicOperatorIT extends BaseITST {
         crt.all().get();
 
         // Wait for the resource to be created
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {} waiting for creation", resourceName);
-            return topic != null;
-        }, timeout, "Expected the topic to have been created by now");
+        waitForTopicInKube(context, resourceName);
 
         LOGGER.info("topic {} has been created", resourceName);
         return resourceName;
     }
 
-    private void alterTopicConfig(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+    private void waitForTopicInKube(TestContext context, String resourceName) {
+        waitForTopicInKube(context, resourceName, true);
+    }
+
+    private void waitForTopicInKube(TestContext context, String resourceName, boolean exist) {
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
+            return topic != null == exist;
+        }, timeout, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
+    }
+
+    private void alterTopicConfigInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        String key = "compression.type";
+        final String changedValue = alterTopicConfigInKafka(topicName, key,
+            value -> "snappy".equals(value) ? "lz4" : "snappy");
+        awaitTopicConfigInKube(context, resourceName, key, changedValue);
+    }
+
+    private void awaitTopicConfigInKube(TestContext context, String resourceName, String key, String expectedValue) {
+
+        // Wait for the resource to be modified
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {}, waiting for config change", resourceName);
+            String gotValue = TopicSerialization.fromTopicResource(topic).getConfig().get(key);
+            LOGGER.info("Expecting value {}, got value {}", expectedValue, gotValue);
+            return expectedValue.equals(gotValue);
+        }, timeout, "Expected the config of topic " + resourceName + " to have " + key + "=" + expectedValue + " in Kube by now");
+    }
+
+    private String alterTopicConfigInKafka(String topicName, String key, Function<String, String> mutator) throws InterruptedException, ExecutionException {
         // Get the topic config
         ConfigResource configResource = topicConfigResource(topicName);
         org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
-
-        String key = "compression.type";
 
         Map<String, ConfigEntry> m = new HashMap<>();
         for (ConfigEntry entry: config.entries()) {
             m.put(entry.name(), entry);
         }
-        final String changedValue;
-        if ("snappy".equals(m.get(key).value())) {
-            changedValue = "lz4";
-        } else {
-            changedValue = "snappy";
-        }
+        final String changedValue = mutator.apply(m.get(key).value());
         m.put(key, new ConfigEntry(key, changedValue));
         LOGGER.info("Changing topic config {} to {}", key, changedValue);
 
@@ -301,15 +332,7 @@ public class TopicOperatorIT extends BaseITST {
         AlterConfigsResult cgf = adminClient.alterConfigs(singletonMap(configResource,
                 new org.apache.kafka.clients.admin.Config(m.values())));
         cgf.all().get();
-
-        // Wait for the resource to be modified
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {}, waiting for config change", resourceName);
-            String gotValue = TopicSerialization.fromTopicResource(topic).getConfig().get(key);
-            LOGGER.info("Got value {}", gotValue);
-            return changedValue.equals(gotValue);
-        }, timeout, "Expected the topic to have been deleted by now");
+        return changedValue;
     }
 
     private void alterTopicNumPartitions(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
@@ -327,9 +350,9 @@ public class TopicOperatorIT extends BaseITST {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {}, waiting for partitions change", resourceName);
             int gotValue = TopicSerialization.fromTopicResource(topic).getNumPartitions();
-            LOGGER.info("Got value {}", gotValue);
+            LOGGER.info("Expected value {}, got value {}", changedValue, gotValue);
             return changedValue == gotValue;
-        }, timeout, "Expected the topic to have been deleted by now");
+        }, timeout, "Expected the topic " + topicName + "to have " + changedValue + " partitions by now");
     }
 
     private org.apache.kafka.clients.admin.Config getTopicConfig(ConfigResource configResource) {
@@ -348,27 +371,31 @@ public class TopicOperatorIT extends BaseITST {
 
     private void createAndAlterTopicConfig(TestContext context, String topicName) throws InterruptedException, ExecutionException {
         String resourceName = createTopic(context, topicName);
-        alterTopicConfig(context, topicName, resourceName);
+        alterTopicConfigInKafkaAndAwaitReconciliation(context, topicName, resourceName);
     }
 
-    private void deleteTopic(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
-        LOGGER.info("Deleting topic {} (KafkaTopic {})", topicName, resourceName);
-        // Now we can delete the topic
-        DeleteTopicsResult dlt = adminClient.deleteTopics(singletonList(topicName));
-        dlt.all().get();
-        LOGGER.info("Deleted topic {}", topicName);
+    private void deleteTopicInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        deleteTopicInKafka(topicName, resourceName);
 
         // Wait for the resource to be deleted
         waitFor(context, () -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {}, got {}, waiting for deletion", resourceName, topic);
             return topic == null;
-        }, timeout, "Expected the topic to have been deleted by now");
+        }, timeout, "Expected the topic " + topicName + " to have been deleted by now");
+    }
+
+    private void deleteTopicInKafka(String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        LOGGER.info("Deleting topic {} (KafkaTopic {})", topicName, resourceName);
+        // Now we can delete the topic
+        DeleteTopicsResult dlt = adminClient.deleteTopics(singletonList(topicName));
+        dlt.all().get();
+        LOGGER.info("Deleted topic {}", topicName);
     }
 
     private void createAndDeleteTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
         String resourceName = createTopic(context, topicName);
-        deleteTopic(context, topicName, resourceName);
+        deleteTopicInKafkaAndAwaitReconciliation(context, topicName, resourceName);
     }
 
     private void createAndAlterNumPartitions(TestContext context, String topicName) throws InterruptedException, ExecutionException {
@@ -384,8 +411,13 @@ public class TopicOperatorIT extends BaseITST {
             } else {
                 context.fail(ar.cause());
             }
+        }).setHandler(ar -> {
+            if (ar.failed()) {
+                context.fail(ar.cause());
+            }
+            async.complete();
         });
-        async.await();
+        async.awaitSuccess();
     }
 
     private void waitForEvent(TestContext context, KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) {
@@ -496,9 +528,12 @@ public class TopicOperatorIT extends BaseITST {
         // create the Topic Resource
         String topicName = "test-kafkatopic-deleted";
         KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        deleteInKubeAndAwaitReconciliation(context, topicName, topicResource);
 
-        // can now delete the topicResource
-        operation().inNamespace(NAMESPACE).withName(topicResource.getMetadata().getName()).delete();
+    }
+
+    void deleteInKubeAndAwaitReconciliation(TestContext context, String topicName, KafkaTopic topicResource) {
+        deleteInKube(topicResource.getMetadata().getName());
 
         // Wait for the topic to be deleted
         waitFor(context, () -> {
@@ -506,7 +541,8 @@ public class TopicOperatorIT extends BaseITST {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
                 return false;
             } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException
+                        || e.getCause() instanceof InvalidTopicException) {
                     return true;
                 } else {
                     throw new RuntimeException(e);
@@ -515,7 +551,11 @@ public class TopicOperatorIT extends BaseITST {
                 throw new RuntimeException(e);
             }
         }, timeout, "Expected topic to be deleted by now");
+    }
 
+    private void deleteInKube(String resourceName) {
+        // can now delete the topicResource
+        operation().inNamespace(NAMESPACE).withName(resourceName).delete();
     }
 
 
@@ -524,20 +564,31 @@ public class TopicOperatorIT extends BaseITST {
         // create the topic
         String topicName = "test-kafkatopic-modified-retention-changed";
         KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        String expectedValue = alterTopicConfigInKube(topicResource.getMetadata().getName(),
+                "retention.ms", currentValue -> Integer.toString(Integer.parseInt(currentValue) + 1));
+        awaitTopicConfigInKafka(context, topicName, "retention.ms", expectedValue);
+    }
 
-        // now change the topic resource
-        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(topicResource.getMetadata().getName()).get())
-            .editOrNewSpec().addToConfig("retention.ms", 12341234).endSpec().build();
-        operation().inNamespace(NAMESPACE).withName(topicResource.getMetadata().getName()).replace(changedTopic);
-
+    void awaitTopicConfigInKafka(TestContext context, String topicName, String key, String expectedValue) {
         // Wait for that to be reflected in the kafka topic
         waitFor(context, () -> {
             ConfigResource configResource = topicConfigResource(topicName);
             org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
             String retention = config.get("retention.ms").value();
             LOGGER.debug("retention of {}, waiting for 12341234", retention);
-            return "12341234".equals(retention);
-        },  timeout, "Expected the topic to be updated");
+            return expectedValue.equals(retention);
+        },  timeout, "Expected the topic " + topicName + " to have retention.ms=" + expectedValue + " in Kafka");
+    }
+
+    String alterTopicConfigInKube(String resourceName, String key, Function<String, String> mutator) {
+        // now change the topic resource
+        Object retention = operation().inNamespace(NAMESPACE).withName(resourceName).get().getSpec().getConfig().getOrDefault(key, "12341233");
+        String currentValue = retention instanceof Integer ? retention.toString() : (String) retention;
+        String newValue = mutator.apply(currentValue);
+        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(resourceName).get())
+            .editOrNewSpec().addToConfig(key, newValue).endSpec().build();
+        operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
+        return newValue;
     }
 
     @Test
@@ -625,20 +676,29 @@ public class TopicOperatorIT extends BaseITST {
         session.topicOperator.reconcileAllTopics("periodic");
 
         // Wait for the topic to be created
+        waitForTopicInKafka(context, topicName);
+    }
+
+    void waitForTopicInKafka(TestContext context, String topicName) {
+        waitForTopicInKafka(context, topicName, true);
+    }
+
+    void waitForTopicInKafka(TestContext context, String topicName, boolean exist) {
         waitFor(context, () -> {
             try {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
-                return true;
+                return exist;
             } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                    return false;
+                if (e.getCause() instanceof UnknownTopicOrPartitionException
+                        || e.getCause() instanceof InvalidTopicException) {
+                    return !exist;
                 } else {
                     throw new RuntimeException(e);
                 }
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-        }, timeout, "Expected topic to be created by now");
+        }, timeout, "Expected topic '" + topicName + "' to " + (exist ? "exist" : "not exist") + " in Kafka by now");
     }
 
     // TODO: What happens if we create and then change labels to the resource predicate isn't matched any more
@@ -708,4 +768,105 @@ public class TopicOperatorIT extends BaseITST {
         assertEquals("lee", operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("stan"));
         assertEquals("root", operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("iam"));
     }
+
+    /**
+     * Validates that when TO starts it reconciles properly based on what's been previously observed
+     * 1. Create topic A in Kube and reconcile
+     * 2. Stop TO
+     * 3. Create topic X in Kafka, topic Y in Kube
+     * 4. Start TO
+     * 5. Verify topics A, X and Y exist on both sides
+     */
+    @Test
+    public void testReconciliationOnStartup(TestContext testContext) throws ExecutionException, InterruptedException {
+        // 1. Create topic A in Kube and reconcile
+        String topicNameZ = "topic-z";
+        {
+            Topic topicZ = new Topic.Builder(topicNameZ, 1, (short) 1, emptyMap()).build();
+            KafkaTopic topicResourceZ = TopicSerialization.toTopicResource(topicZ, labels);
+            String resourceNameZ = topicResourceZ.getMetadata().getName();
+            operation().inNamespace(NAMESPACE).create(topicResourceZ);
+            waitForTopicInKafka(testContext, topicNameZ);
+        }
+
+        String topicNameA = "topic-a";
+        {
+            Topic topicA = new Topic.Builder(topicNameA, 1, (short) 1, emptyMap()).build();
+            KafkaTopic topicResourceA = TopicSerialization.toTopicResource(topicA, labels);
+            String resourceNameA = topicResourceA.getMetadata().getName();
+            operation().inNamespace(NAMESPACE).create(topicResourceA);
+            waitForTopicInKafka(testContext, topicNameA);
+        }
+        String topicNameB = "topic-b";
+        String resourceNameB;
+        {
+            Topic topicB = new Topic.Builder(topicNameB, 1, (short) 1, emptyMap()).build();
+            KafkaTopic topicResourceB = TopicSerialization.toTopicResource(topicB, labels);
+            resourceNameB = topicResourceB.getMetadata().getName();
+            operation().inNamespace(NAMESPACE).create(topicResourceB);
+            waitForTopicInKafka(testContext, topicNameB);
+        }
+        String topicNameC = "topic-c";
+        {
+            Topic topicC = new Topic.Builder(topicNameC, 1, (short) 1, emptyMap()).build();
+            KafkaTopic topicResourceC = TopicSerialization.toTopicResource(topicC, labels);
+            String resourceNameC = topicResourceC.getMetadata().getName();
+            operation().inNamespace(NAMESPACE).create(topicResourceC);
+            waitForTopicInKafka(testContext, topicNameC);
+        }
+
+        // 2. Stop TO
+        stopTopicOperator(testContext);
+
+        // 3. Modify topic A in kubernetes and topic Z in Kafka
+        String alteredConfigA = alterTopicConfigInKafka(topicNameA,
+                "retention.ms", currentValue -> Integer.toString(Integer.parseInt(currentValue) + 1));
+        String alteredConfigZ = alterTopicConfigInKube(topicNameZ,
+                "retention.ms", currentValue -> Integer.toString(Integer.parseInt(currentValue) + 1));
+
+        // 3. Delete topic B in Kafka, delete topic C in Kubernetes
+        deleteTopicInKafka(topicNameB, resourceNameB);
+        deleteInKube(topicNameC);
+
+        // 3. Create topic X in Kafka, topic Y in Kubernetes
+        String topicNameX = "topic-x";
+        {
+            String resourceName = new TopicName(topicNameX).asKubeName().toString();
+            CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicNameX, 1, (short) 1)));
+            crt.all().get();
+        }
+
+        String topicNameY = "topic-y";
+        {
+            Topic topicY = new Topic.Builder(topicNameY, 1, (short) 1, emptyMap()).build();
+            KafkaTopic topicResourceY = TopicSerialization.toTopicResource(topicY, labels);
+            String resourceNameY = topicResourceY.getMetadata().getName();
+            operation().inNamespace(NAMESPACE).create(topicResourceY);
+        }
+
+        // 4. Start TO
+        startTopicOperator(testContext);
+
+        // 5. Verify topics A, X and Y exist on both sides
+        waitForTopicInKafka(testContext, topicNameA);
+        waitForTopicInKafka(testContext, topicNameX);
+        waitForTopicInKafka(testContext, topicNameY);
+        waitForTopicInKube(testContext, topicNameA);
+        waitForTopicInKube(testContext, topicNameX);
+        waitForTopicInKube(testContext, topicNameY);
+
+        // 5. Verify topics B and C deleted on both sides
+        waitForTopicInKube(testContext, topicNameB, false);
+        waitForTopicInKube(testContext, topicNameC, false);
+        waitForTopicInKafka(testContext, topicNameB, false);
+        waitForTopicInKafka(testContext, topicNameC, false);
+
+        // 5. Verify topics A and Z were changed.
+        awaitTopicConfigInKube(testContext, topicNameA, "retention.ms", alteredConfigA);
+        awaitTopicConfigInKube(testContext, topicNameZ, "retention.ms", alteredConfigZ);
+        awaitTopicConfigInKafka(testContext, topicNameA, "retention.ms", alteredConfigA);
+        awaitTopicConfigInKafka(testContext, topicNameZ, "retention.ms", alteredConfigZ);
+
+    }
+
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -721,6 +721,10 @@ public class TopicOperatorTest {
                 .create(privateTopic, ar -> { });
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
+        mockK8s.setCreateResponse(resourceName, null);
+        mockK8s.createResource(resource, ar -> {
+            assertSucceeded(context, ar);
+        });
         mockK8s.setModifyResponse(resourceName, null);
 
         Async async = context.async(3);
@@ -734,6 +738,7 @@ public class TopicOperatorTest {
             });
             mockK8s.getFromName(resourceName, ar2 -> {
                 assertSucceeded(context, ar2);
+                context.assertNotNull(ar2.result());
                 context.assertEquals("baz", TopicSerialization.fromTopicResource(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();
             });


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a number of Topic Operator bugs and problems in the tests:

1. The startup behaviour of the TO wasn't properly tested. A test is added to the `TopicOperatorIntegrationTest`.
2. This test found a situation where the TO would continuously reconcile topic(s), this bug is fixed.
3. Another TO in the reconciliation was fixed by @eye0fra.
4. A bug in Session shutdown. This was unlikely to be problematic in practice since the TO typically just gets killed, but was a problem for test reliability.
4. Various races in the TOIT are fixed (e.g. the test now uses its own `AdminClient` instance rather than using the one from `Session`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

