### PR TITLE
ST: move most of the constasts used in system test to separeted interface

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -88,7 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
-public abstract class AbstractST extends BaseITST implements TestSeparator {
+public abstract class AbstractST extends BaseITST implements TestSeparator, Constants {
 
     static {
         Crds.registerCustomKinds();
@@ -103,25 +103,16 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
     protected static final String KAFKA_CONNECT_IMAGE_MAP = "STRIMZI_KAFKA_CONNECT_IMAGES";
     protected static final String TO_IMAGE = "STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE";
     protected static final String UO_IMAGE = "STRIMZI_DEFAULT_USER_OPERATOR_IMAGE";
-    protected static final String TEST_TOPIC_NAME = "test-topic";
     protected static final String KAFKA_INIT_IMAGE = "STRIMZI_DEFAULT_KAFKA_INIT_IMAGE";
     protected static final String TLS_SIDECAR_ZOOKEEPER_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE";
     protected static final String TLS_SIDECAR_KAFKA_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE";
     protected static final String TLS_SIDECAR_EO_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
+    protected static final String TEST_TOPIC_NAME = "test-topic";
     private static final String CLUSTER_OPERATOR_PREFIX = "strimzi";
-    private static final long GET_BROKER_API_TIMEOUT = 60_000L;
-    private static final long GET_BROKER_API_INTERVAL = 5_000L;
-    static final long TIMEOUT_FOR_GET_SECRETS = 60_000;
-    static final long GLOBAL_TIMEOUT = 300000;
-    static final long GLOBAL_POLL_INTERVAL = 1000;
-    static final long TEARDOWN_GLOBAL_WAIT = 10000;
-    public static final Pattern BRACE_PATTERN = Pattern.compile("^\\{.*\\}$", Pattern.MULTILINE);
-    public static final String KAFKA_CLIENTS = "kafka-clients";
 
     public static final String TOPIC_CM = "../examples/topic/kafka-topic.yaml";
     public static final String HELM_CHART = "../helm-charts/strimzi-kafka-operator/";
     public static final String HELM_RELEASE_NAME = "strimzi-systemtests";
-    public static final String IMAGE_PULL_POLICY = "Always";
     public static final String REQUESTS_MEMORY = "512Mi";
     public static final String REQUESTS_CPU = "200m";
     public static final String LIMITS_MEMORY = "512Mi";

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import java.time.Duration;
+
+/**
+ * Interface for keep global constants used across system tests.
+ */
+public interface Constants {
+    long TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS = Duration.ofMinutes(7).toMillis();
+    long TIMEOUT_FOR_RESOURCE_CREATION = Duration.ofMinutes(5).toMillis();
+    long TIMEOUT_FOR_RESOURCE_READINESS = Duration.ofMinutes(7).toMillis();
+    long TIMEOUT_FOR_MIRROR_JOIN_TO_GROUP = Duration.ofMinutes(2).toMillis();
+    long TIMEOUT_FOR_TOPIC_CREATION = Duration.ofMinutes(1).toMillis();
+    long POLL_INTERVAL_FOR_RESOURCE_CREATION = Duration.ofSeconds(3).toMillis();
+    long POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(1).toMillis();
+    long WAIT_FOR_ROLLING_UPDATE_INTERVAL = Duration.ofSeconds(5).toMillis();
+    long WAIT_FOR_ROLLING_UPDATE_TIMEOUT = Duration.ofMinutes(5).toMillis();
+
+    long TIMEOUT_FOR_SEND_RECEIVE_MSG = Duration.ofSeconds(30).toMillis();
+    long TIMEOUT_AVAILABILITY_TEST = Duration.ofMinutes(1).toMillis();
+    long TIMEOUT_SEND_MESSAGES = Duration.ofMinutes(1).toMillis();
+    long TIMEOUT_RECV_MESSAGES = Duration.ofMinutes(1).toMillis();
+
+    long TIMEOUT_FOR_CLUSTER_STABLE = Duration.ofMinutes(20).toMillis();
+    long TIMEOUT_FOR_ZK_CLUSTER_STABILIZATION = Duration.ofMinutes(7).toMillis();
+
+    long GET_BROKER_API_TIMEOUT = Duration.ofMinutes(1).toMillis();
+    long GET_BROKER_API_INTERVAL = Duration.ofSeconds(5).toMillis();
+    long TIMEOUT_FOR_GET_SECRETS = Duration.ofMinutes(1).toMillis();
+    long TIMEOUT_TEARDOWN = Duration.ofSeconds(10).toMillis();
+    long GLOBAL_TIMEOUT = Duration.ofMinutes(5).toMillis();
+    long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
+
+    long CO_OPERATION_TIMEOUT = Duration.ofMinutes(1).toMillis();
+    long CO_OPERATION_TIMEOUT_WAIT = CO_OPERATION_TIMEOUT + Duration.ofSeconds(20).toMillis();
+    long CO_OPERATION_TIMEOUT_POLL = Duration.ofSeconds(2).toMillis();
+
+    String KAFKA_CLIENTS = "kafka-clients";
+    String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
+    String IMAGE_PULL_POLICY = "Always";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -42,6 +42,10 @@ public class Environment {
      * URL of the kubernetes cluster. It's used for specify URL endpoint of testing clients.
      */
     public static final String KUBERNETES_API_URL_ENV = "KUBERNETES_API_URL";
+    /**
+     * CO reconciliation interval.
+     */
+    public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
 
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
     public static final String STRIMZI_TAG_DEFAULT = "latest";
@@ -50,6 +54,7 @@ public class Environment {
     public static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     public static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";
     public static final String KUBERNETES_API_URL_DEFAULT = "https://127.0.0.1:8443";
+    public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_DEFAULT = "30000";
     public static final int INGRESS_DEFAULT_PORT = 4242;
 
     private final String strimziOrg = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
@@ -59,6 +64,7 @@ public class Environment {
     private final String strimziLogLevel = System.getenv().getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
     private final String kubernetesDomain = System.getenv().getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
     private final String kubernetesApiUrl = System.getenv().getOrDefault(KUBERNETES_API_URL_ENV, KUBERNETES_API_URL_DEFAULT);
+    private final String strimziFullReconciliationIntervalMs = System.getenv().getOrDefault(STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_DEFAULT);
 
     private Environment() {
         String debugFormat = "{}:{}";
@@ -105,5 +111,9 @@ public class Environment {
 
     public String getKubernetesApiUrl() {
         return kubernetesApiUrl;
+    }
+
+    public String getStrimziFullReconciliationInterval() {
+        return strimziFullReconciliationIntervalMs;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
@@ -64,7 +64,7 @@ public class MessagingBaseST extends AbstractST {
      * @param timeout timeout
      * @param clusterName cluster name
      */
-    void availabilityTest(int messageCount, int timeout, String clusterName) throws Exception {
+    void availabilityTest(int messageCount, long timeout, String clusterName) throws Exception {
         availabilityTest(messageCount, timeout, clusterName, false, "my-topic", null);
     }
 
@@ -77,7 +77,7 @@ public class MessagingBaseST extends AbstractST {
      * @param topicName topic name
      * @param user user for tls if it's used for messages
      */
-    void availabilityTest(int messageCount, int timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
+    void availabilityTest(int messageCount, long timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
         sendMessages(messageCount, timeout, clusterName, tlsListener, topicName, user);
         receiveMessages(messageCount, timeout, clusterName, tlsListener, topicName, user);
         assertSentAndReceivedMessages(sent, received);
@@ -93,7 +93,7 @@ public class MessagingBaseST extends AbstractST {
      * @param user user for tls if it's used for messages
      * @return count of send and acknowledged messages
      */
-    int sendMessages(int messageCount, int timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
+    int sendMessages(int messageCount, long timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
         String bootstrapServer = tlsListener ? clusterName + "-kafka-bootstrap:9093" : clusterName + "-kafka-bootstrap:9092";
         ClientArgumentMap producerArguments = new ClientArgumentMap();
         producerArguments.put(ClientArgument.BROKER_LIST, bootstrapServer);
@@ -135,7 +135,7 @@ public class MessagingBaseST extends AbstractST {
      * @param user user for tls if it's used for messages
      * @return count of received messages
      */
-    int receiveMessages(int messageCount, int timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
+    int receiveMessages(int messageCount, long timeout, String clusterName, boolean tlsListener, String topicName, KafkaUser user) throws Exception {
         String bootstrapServer = tlsListener ? clusterName + "-kafka-bootstrap:9093" : clusterName + "-kafka-bootstrap:9092";
         ClientArgumentMap consumerArguments = new ClientArgumentMap();
         consumerArguments.put(ClientArgument.BROKER_LIST, bootstrapServer);
@@ -179,8 +179,8 @@ public class MessagingBaseST extends AbstractST {
      * @param description description for wait method
      * @param timeout timeout
      */
-    private void waitTillProcessFinish(String processUuid, String description, int timeout) {
-        TestUtils.waitFor("Wait till " + description + " finished", 2000, timeout, () -> {
+    private void waitTillProcessFinish(String processUuid, String description, long timeout) {
+        TestUtils.waitFor("Wait till " + description + " finished", GLOBAL_POLL_INTERVAL, timeout, () -> {
             JsonObject out;
             try {
                 out = cliApiClient.getClientInfo(processUuid);

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -66,7 +66,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -79,29 +78,19 @@ import static io.strimzi.test.TestUtils.changeOrgAndTag;
 import static io.strimzi.test.TestUtils.toYamlString;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
-public class Resources extends AbstractResources {
+public class Resources extends AbstractResources implements Constants {
 
     private static final Environment ENVIRONMENT = Environment.getInstance();
 
     private static final Logger LOGGER = LogManager.getLogger(Resources.class);
-    private static final long POLL_INTERVAL_FOR_RESOURCE_CREATION = Duration.ofSeconds(3).toMillis();
-    public static final long POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(1).toMillis();
-    /* Timeout for deployment config is bigger than the timeout for default resource readiness because of creating a new image
-    during the deployment process.*/
-    private static final long TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS = Duration.ofMinutes(7).toMillis();
-    private static final long TIMEOUT_FOR_RESOURCE_CREATION = Duration.ofMinutes(5).toMillis();
-    public static final long TIMEOUT_FOR_RESOURCE_READINESS = Duration.ofMinutes(7).toMillis();
     private static final String KAFKA_VERSION = ENVIRONMENT.getStKafkaVersionEnv();
 
     public static final String STRIMZI_PATH_TO_CO_CONFIG = "../install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml";
-    public static final String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
-    public static final String STRIMZI_DEFAULT_LOG_LEVEL = "DEBUG";
-    public static final String KAFKA_CLIENTS = "kafka-clients";
 
-    public static final String DEPLOYMENT = "Deployment";
-    public static final String SERVICE = "Service";
-    public static final String INGRESS = "Ingress";
-    public static final String CLUSTER_ROLE_BINDING = "ClusterRoleBinding";
+    private static final String DEPLOYMENT = "Deployment";
+    private static final String SERVICE = "Service";
+    private static final String INGRESS = "Ingress";
+    private static final String CLUSTER_ROLE_BINDING = "ClusterRoleBinding";
 
     Resources(NamespacedKubernetesClient client) {
         super(client);
@@ -660,7 +649,7 @@ public class Resources extends AbstractResources {
                     envVar.setValueFrom(null);
                     break;
                 case "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS":
-                    envVar.setValue("30000");
+                    envVar.setValue(ENVIRONMENT.getStrimziFullReconciliationInterval());
                     break;
                 case "STRIMZI_OPERATION_TIMEOUT_MS":
                     envVar.setValue(operationTimeout);
@@ -929,7 +918,7 @@ public class Resources extends AbstractResources {
                     .withInitialDelaySeconds(10)
                     .withPeriodSeconds(5)
                 .endLivenessProbe()
-                .withImagePullPolicy("IfNotPresent");
+                .withImagePullPolicy(IMAGE_PULL_POLICY);
 
         if (kafkaUsers == null) {
             String producerConfiguration = "acks=all\n";

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -52,7 +52,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
         LOGGER.info("Creating topic {} in namespace {}", topic, topicNamespace);
         KUBE_CLIENT.namespace(topicNamespace);
         KUBE_CLIENT.create(new File(TOPIC_EXAMPLES_DIR));
-        TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", 5000, 120000, () -> {
+        TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_TOPIC_CREATION, () -> {
             KUBE_CLIENT.namespace(clusterNamespace);
             List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
             return topics2.contains(topic);
@@ -76,7 +76,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
     @AfterEach
     void deleteSecondNamespaceResources() throws Exception {
         secondNamespaceResources.deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, SECOND_NAMESPACE);
+        waitForDeletion(TIMEOUT_TEARDOWN, SECOND_NAMESPACE);
         KUBE_CLIENT.namespace(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -94,7 +94,7 @@ class ConnectST extends AbstractST {
 
         sendMessages(kafkaConnectPodName, KAFKA_CLUSTER_NAME, TEST_TOPIC_NAME, 2);
 
-        TestUtils.waitFor("messages in file sink", 1_000, 30_000,
+        TestUtils.waitFor("messages in file sink", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_SEND_RECEIVE_MSG,
             () -> KUBE_CLIENT.execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out().equals("0\n1\n"));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -45,7 +45,7 @@ class HelmChartST extends AbstractST {
     @AfterEach
     void deleteTestResources() throws Exception {
         deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
+        waitForDeletion(TIMEOUT_TEARDOWN, NAMESPACE);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -37,10 +37,6 @@ class RollingUpdateST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RecoveryST.class);
 
     static final String NAMESPACE = "rolling-update-cluster-test";
-    static final String CLUSTER_NAME = "my-cluster";
-    private static final int CO_OPERATION_TIMEOUT = 60000;
-    private static final int CO_OPERATION_TIMEOUT_WAIT = CO_OPERATION_TIMEOUT + 20000;
-    private static final int CO_OPERATION_TIMEOUT_POLL = 2000;
     private static final String RECONCILIATION_PATTERN = "'Triggering periodic reconciliation for namespace " + NAMESPACE + "'";
 
     @Test
@@ -178,7 +174,7 @@ class RollingUpdateST extends AbstractST {
     @AfterEach
     void deleteTestResources() throws Exception {
         deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
+        waitForDeletion(TIMEOUT_TEARDOWN, NAMESPACE);
     }
 
     @BeforeAll
@@ -189,7 +185,7 @@ class RollingUpdateST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources.clusterOperator(NAMESPACE, Integer.toString(CO_OPERATION_TIMEOUT)).done();
+        testClassResources.clusterOperator(NAMESPACE, Long.toString(CO_OPERATION_TIMEOUT)).done();
     }
 
     @AfterAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -59,10 +59,6 @@ class SecurityST extends AbstractST {
     public static final String STRIMZI_IO_FORCE_RENEW = "strimzi.io/force-renew";
     public static final String STRIMZI_IO_FORCE_REPLACE = "strimzi.io/force-replace";
 
-    private static final long TIMEOUT_FOR_GET_SECRETS = 60_000;
-    private static final long TIMEOUT_FOR_SEND_RECEIVE_MSG = 30_000;
-    private static final long TIMEOUT_FOR_CLUSTER_STABLE = 1_200_000;
-
     @Test
     @Tag(REGRESSION)
     void testCertificates() {
@@ -176,7 +172,7 @@ class SecurityST extends AbstractST {
         createClusterWithExternalRoute();
         String userName = "alice";
         resources().tlsUser(CLUSTER_NAME, userName).done();
-        waitFor("", 1_000, TIMEOUT_FOR_GET_SECRETS, () -> CLIENT.secrets().inNamespace(NAMESPACE).withName("alice").get() != null,
+        waitFor("", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_GET_SECRETS, () -> CLIENT.secrets().inNamespace(NAMESPACE).withName("alice").get() != null,
             () -> LOGGER.error("Couldn't find user secret {}", CLIENT.secrets().inNamespace(NAMESPACE).list().getItems()));
 
         waitForClusterAvailability(userName);
@@ -227,7 +223,7 @@ class SecurityST extends AbstractST {
         // Finally check a new client (signed by new client key) can consume
         String bobUserName = "bob";
         resources().tlsUser(CLUSTER_NAME, bobUserName).done();
-        waitFor("", 1_000, 60_000, () -> {
+        waitFor("", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_GET_SECRETS, () -> {
             return CLIENT.secrets().inNamespace(NAMESPACE).withName(bobUserName).get() != null;
         },
             () -> {
@@ -244,7 +240,7 @@ class SecurityST extends AbstractST {
         createClusterWithExternalRoute();
         String aliceUserName = "alice";
         resources().tlsUser(CLUSTER_NAME, aliceUserName).done();
-        waitFor("Alic's secret to exist", 1_000, 60_000,
+        waitFor("Alic's secret to exist", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_GET_SECRETS,
             () -> CLIENT.secrets().inNamespace(NAMESPACE).withName(aliceUserName).get() != null,
             () -> LOGGER.error("Couldn't find user secret {}", CLIENT.secrets().inNamespace(NAMESPACE).list().getItems()));
 
@@ -303,7 +299,7 @@ class SecurityST extends AbstractST {
         // Finally check a new client (signed by new client key) can consume
         String bobUserName = "bob";
         resources().tlsUser(CLUSTER_NAME, bobUserName).done();
-        waitFor("Bob's secret to exist", 1_000, 60_000,
+        waitFor("Bob's secret to exist", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_GET_SECRETS,
             () -> CLIENT.secrets().inNamespace(NAMESPACE).withName(bobUserName).get() != null,
             () -> LOGGER.error("Couldn't find user secret {}", CLIENT.secrets().inNamespace(NAMESPACE).list().getItems()));
 
@@ -412,7 +408,7 @@ class SecurityST extends AbstractST {
         zkPods[0] = StUtils.ssSnapshot(CLIENT, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME));
         kafkaPods[0] = StUtils.ssSnapshot(CLIENT, NAMESPACE, kafkaStatefulSetName(CLUSTER_NAME));
         eoPods[0] = StUtils.depSnapshot(CLIENT, NAMESPACE, entityOperatorDeploymentName(CLUSTER_NAME));
-        TestUtils.waitFor("Cluster stable and ready", 1_000, TIMEOUT_FOR_CLUSTER_STABLE, () -> {
+        TestUtils.waitFor("Cluster stable and ready", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_CLUSTER_STABLE, () -> {
             Map<String, String> zkSnapshot = StUtils.ssSnapshot(CLIENT, NAMESPACE, zookeeperStatefulSetName(CLUSTER_NAME));
             Map<String, String> kafkaSnaptop = StUtils.ssSnapshot(CLIENT, NAMESPACE, kafkaStatefulSetName(CLUSTER_NAME));
             Map<String, String> eoSnapshot = StUtils.depSnapshot(CLIENT, NAMESPACE, entityOperatorDeploymentName(CLUSTER_NAME));
@@ -443,7 +439,7 @@ class SecurityST extends AbstractST {
     }
 
     private void waitForCertToChange(String originalCert, String secretName) {
-        waitFor("Cert to be replaced", 1_000, TIMEOUT_FOR_CLUSTER_STABLE, () -> {
+        waitFor("Cert to be replaced", GLOBAL_POLL_INTERVAL, TIMEOUT_FOR_CLUSTER_STABLE, () -> {
             Secret secret = CLIENT.secrets().inNamespace(NAMESPACE).withName(secretName).get();
             if (secret != null && secret.getData() != null && secret.getData().containsKey("ca.crt")) {
                 String currentCert = new String(Base64.getDecoder().decode(secret.getData().get("ca.crt")), StandardCharsets.US_ASCII);
@@ -481,7 +477,7 @@ class SecurityST extends AbstractST {
     @AfterEach
     void deleteTestResources() throws Exception {
         deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
+        waitForDeletion(TIMEOUT_TEARDOWN, NAMESPACE);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -96,7 +96,7 @@ class UserST extends AbstractST {
     @AfterEach
     void deleteTestResources() throws Exception {
         deleteResources();
-        waitForDeletion(TEARDOWN_GLOBAL_WAIT, NAMESPACE);
+        waitForDeletion(TIMEOUT_TEARDOWN, NAMESPACE);
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We had a lot of constants on multiple places. This PR introduce one interface, which contains most of he constants used inside system tests

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass


