### PR TITLE
Correct name of ZK config parameter tickTime

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
@@ -163,6 +163,13 @@ public class OrderedProperties {
         return obj instanceof OrderedProperties && pairs.equals(((OrderedProperties) obj).pairs);
     }
 
+    @Override
+    public String toString() {
+        return "OrderedProperties{" +
+                "pairs=" + pairs +
+                '}';
+    }
+
     /**
      * Read values into a Map&lt;String, String&gt; from a Properties compatible format.
      * An instance of this class is not thread-safe; the result of invoking any of the

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -26,7 +26,7 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
                 ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(" *, *"));
 
         DEFAULTS = new HashMap<>();
-        DEFAULTS.put("timeTick", "2000");
+        DEFAULTS.put("tickTime", "2000");
         DEFAULTS.put("initLimit", "5");
         DEFAULTS.put("syncLimit", "2");
         DEFAULTS.put("autopurge.purgeInterval", "1");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -191,7 +191,7 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
         OrderedProperties expectedConfig = new OrderedProperties()
                 .addPair("autopurge.purgeInterval", "1")
-                .addPair("timeTick", "2000")
+                .addPair("tickTime", "2000")
                 .addPair("syncLimit", "2")
                 .addPair("initLimit", "5")
                 .addPair("foo", "bar");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -190,8 +190,8 @@ public class ZookeeperClusterTest {
         assertEquals(new Integer(healthTimeout), containers.get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), containers.get(0).getReadinessProbe().getInitialDelaySeconds());
         OrderedProperties expectedConfig = new OrderedProperties()
-                .addPair("timeTick", "2000")
                 .addPair("autopurge.purgeInterval", "1")
+                .addPair("timeTick", "2000")
                 .addPair("syncLimit", "2")
                 .addPair("initLimit", "5")
                 .addPair("foo", "bar");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We were erroneously using a non-existent timeTick config parameter for ZK. [It's really called `tickTime`](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_configuration). This means that we will have been picking up the default tickTime of 3000ms. Thus, as well as changing the config parameter this PR is also in effect changing the default value being used from 3000 to 2000 ms.

Adding `OrderedProperties.toString()` to makes test failures due to equality assertions on `OrderedProperties` much more understandable, but is not a necessary part of this PR.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

