### PR TITLE
Use JBOD storage instead of regular persistent storage in all persistent Kafka examples

### DIFF
--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -15,9 +15,12 @@ spec:
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.2"
     storage:
-      type: persistent-claim
-      size: 100Gi
-      deleteClaim: false
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
   zookeeper:
     replicas: 1
     storage:

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -15,9 +15,12 @@ spec:
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.2"
     storage:
-      type: persistent-claim
-      size: 100Gi
-      deleteClaim: false
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
   zookeeper:
     replicas: 3
     storage:

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -88,9 +88,12 @@ objects:
         initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
         timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
       storage:
-        type: "persistent-claim"
-        size: "${KAFKA_VOLUME_CAPACITY}"
-        deleteClaim: false
+        type: jbod
+        volumes:
+        - id: 0
+          type: "persistent-claim"
+          size: "${KAFKA_VOLUME_CAPACITY}"
+          deleteClaim: false
       config:
         default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}

--- a/metrics/examples/kafka/kafka-metrics.yaml
+++ b/metrics/examples/kafka/kafka-metrics.yaml
@@ -21,9 +21,12 @@ spec:
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.2"
     storage:
-      type: persistent-claim
-      size: 100Gi
-      deleteClaim: false
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
     metrics:
       # Inspired by config from Kafka 2.0.0 example rules:
       # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-2_0_0.yml


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As the JBOD storage in Minimal configuration is as good as regular persistent-claim storage but has more flexibility, this PR replaces the usage of persistent-claim storage in our Kafka examples with single volume JBOD storage. If needed in the future, users can add more volumes etc.