### PR TITLE
Fix build order in Makefile - mockkube depends on api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)
 endif
 
-SUBDIRS=kafka-agent mockkube crd-annotations test crd-generator api certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples metrics test-client
+SUBDIRS=kafka-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples metrics test-client
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `mockkube` module seems to be dependent on the `api` module, but in the Make build it is build before it which can cause issues. This PR changes the order of the things in the Makefile to allow clean build just from make.