### PR TITLE
ST: Fix new line handling in rack awareness test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -742,7 +742,7 @@ class KafkaST extends MessagingBaseST {
         KUBE_CLIENT.waitForPod(kafkaPodName);
 
         String rackId = KUBE_CLIENT.execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /opt/kafka/init/rack.id").out();
-        assertEquals("zone", rackId);
+        assertEquals("zone", rackId.trim());
 
         String brokerRack = KUBE_CLIENT.execInPodContainer(kafkaPodName, "kafka", "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack").out();
         assertTrue(brokerRack.contains("broker.rack=zone"));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The rack awareness system test seems to be crashing because of new lines when comparing the zone identifier:

```
expected: <zone> but was: <zone
>
```

This PR tries to fix this.

