### PR TITLE
ST: change pull policy for kafka client

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -918,7 +918,7 @@ public class Resources extends AbstractResources implements Constants {
                     .withInitialDelaySeconds(10)
                     .withPeriodSeconds(5)
                 .endLivenessProbe()
-                .withImagePullPolicy(IMAGE_PULL_POLICY);
+                .withImagePullPolicy("IfNotPresent");
 
         if (kafkaUsers == null) {
             String producerConfiguration = "acks=all\n";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Pull policy for kafka test client was set to `Always` instead of `IfNotPresent` (PR build usage)

### Checklist

- [ ] Make sure all tests pass

