### PR TITLE
Fix the typo in the procedure about accssing Kafka using node ports

### DIFF
--- a/documentation/book/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/book/proc-accessing-kafka-using-nodeports.adoc
@@ -3,7 +3,7 @@
 // assembly-configuring-kafka-listeners.adoc
 
 [id='proc-accessing-kafka-using-nodeports-{context}']
-= Accessing Kafka using node ports routes
+= Accessing Kafka using node ports
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Fix typo in the name of the procedure about accessing Kafka using node ports. Node ports are not routes.