### PR TITLE
ST: use test watcher for collect logs from pods

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -31,6 +31,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.systemtest.utils.TestWatcher;
 import io.strimzi.systemtest.clients.lib.KafkaClient;
 import io.strimzi.systemtest.interfaces.TestSeparator;
 import io.strimzi.test.timemeasuring.Operation;
@@ -51,13 +52,12 @@ import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -76,7 +76,6 @@ import static io.strimzi.test.TestUtils.entry;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.toYamlString;
 import static io.strimzi.test.TestUtils.waitFor;
-import static io.strimzi.test.TestUtils.writeFile;
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static java.util.Arrays.asList;
 
@@ -88,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
+@ExtendWith(TestWatcher.class)
 public abstract class AbstractST extends BaseITST implements TestSeparator, Constants {
 
     static {
@@ -455,7 +455,6 @@ public abstract class AbstractST extends BaseITST implements TestSeparator, Cons
     }
 
     protected void deleteResources() throws Exception {
-        collectLogs();
         resources.deleteResources();
         resources = null;
     }
@@ -506,74 +505,6 @@ public abstract class AbstractST extends BaseITST implements TestSeparator, Cons
 
     String clusterCaCertSecretName(String cluster) {
         return cluster + "-cluster-ca-cert";
-    }
-
-    void collectLogs() {
-        // Get current date to create a unique folder
-        String currentDate = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime());
-        String logDir = !testName.isEmpty() ?
-                TEST_LOG_DIR + testClass + "." + testName + "_" + currentDate
-                : TEST_LOG_DIR + currentDate;
-
-        LogCollector logCollector = new LogCollector(CLIENT.inNamespace(KUBE_CLIENT.namespace()), new File(logDir));
-        logCollector.collectEvents();
-        logCollector.collectConfigMaps();
-        logCollector.collectLogsFromPods();
-    }
-
-    private class LogCollector {
-        NamespacedKubernetesClient client;
-        String namespace;
-        File logDir;
-        File configMapDir;
-        File eventsDir;
-
-        private LogCollector(NamespacedKubernetesClient client, File logDir) {
-            this.client = client;
-            this.namespace = client.getNamespace();
-            this.logDir = logDir;
-            this.eventsDir = new File(logDir + "/events");
-            this.configMapDir = new File(logDir + "/configMaps");
-            logDir.mkdirs();
-
-            if (!eventsDir.exists()) {
-                eventsDir.mkdirs();
-            }
-            if (!configMapDir.exists()) {
-                configMapDir.mkdirs();
-            }
-        }
-
-        private void collectLogsFromPods() {
-            LOGGER.info("Collecting logs for pods in namespace {}", namespace);
-
-            try {
-                client.pods().inNamespace(namespace).list().getItems().forEach(pod -> {
-                    String podName = pod.getMetadata().getName();
-                    pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
-                        String log = client.pods().inNamespace(namespace).withName(podName).inContainer(containerStatus.getName()).getLog();
-                        // Write logs from containers to files
-                        writeFile(logDir + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
-                    });
-                });
-            } catch (Exception allExceptions) {
-                LOGGER.warn("Searching for logs in all pods failed! Some of the logs will not be stored.");
-            }
-        }
-
-        private void collectEvents() {
-            LOGGER.info("Collecting events in namespace {}", namespace);
-            String events = KUBE_CLIENT.getEvents();
-            // Write events to file
-            writeFile(eventsDir + "/" + "events-in-namespace" + KUBE_CLIENT.namespace() + ".log", events);
-        }
-
-        private void collectConfigMaps() {
-            LOGGER.info("Collecting configmaps in namespace {}", namespace);
-            client.configMaps().inNamespace(namespace).list().getItems().forEach(configMap -> {
-                writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString());
-            });
-        }
     }
 
     void waitTillSecretExists(String secretName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -31,7 +31,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.systemtest.utils.TestWatcher;
+import io.strimzi.systemtest.utils.TestExecutionWatcher;
 import io.strimzi.systemtest.clients.lib.KafkaClient;
 import io.strimzi.systemtest.interfaces.TestSeparator;
 import io.strimzi.test.timemeasuring.Operation;
@@ -87,7 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
-@ExtendWith(TestWatcher.class)
+@ExtendWith(TestExecutionWatcher.class)
 public abstract class AbstractST extends BaseITST implements TestSeparator, Constants {
 
     static {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
@@ -49,6 +49,9 @@ public class LogCollector {
                     String log = client.pods().inNamespace(namespace).withName(podName).inContainer(containerStatus.getName()).getLog();
                     // Write logs from containers to files
                     writeFile(logDir + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+                    // Describe all pods
+                    String describe = KUBE_CLIENT.describe("pod", podName);
+                    writeFile(logDir + "/" + "describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);
                 });
             });
         } catch (Exception allExceptions) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils;
+
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.strimzi.systemtest.AbstractST;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+
+import static io.strimzi.test.BaseITST.KUBE_CLIENT;
+import static io.strimzi.test.TestUtils.writeFile;
+
+public class LogCollector {
+    private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
+
+    NamespacedKubernetesClient client;
+    String namespace;
+    File logDir;
+    File configMapDir;
+    File eventsDir;
+
+    public LogCollector(NamespacedKubernetesClient client, File logDir) {
+        this.client = client;
+        this.namespace = client.getNamespace();
+        this.logDir = logDir;
+        this.eventsDir = new File(logDir + "/events");
+        this.configMapDir = new File(logDir + "/configMaps");
+        logDir.mkdirs();
+
+        if (!eventsDir.exists()) {
+            eventsDir.mkdirs();
+        }
+        if (!configMapDir.exists()) {
+            configMapDir.mkdirs();
+        }
+    }
+
+    public void collectLogsFromPods() {
+        LOGGER.info("Collecting logs for pods in namespace {}", namespace);
+
+        try {
+            client.pods().inNamespace(namespace).list().getItems().forEach(pod -> {
+                String podName = pod.getMetadata().getName();
+                pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
+                    String log = client.pods().inNamespace(namespace).withName(podName).inContainer(containerStatus.getName()).getLog();
+                    // Write logs from containers to files
+                    writeFile(logDir + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+                });
+            });
+        } catch (Exception allExceptions) {
+            LOGGER.warn("Searching for logs in all pods failed! Some of the logs will not be stored.");
+        }
+    }
+
+    public void collectEvents() {
+        LOGGER.info("Collecting events in namespace {}", namespace);
+        String events = KUBE_CLIENT.getEvents();
+        // Write events to file
+        writeFile(eventsDir + "/" + "events-in-namespace" + KUBE_CLIENT.namespace() + ".log", events);
+    }
+
+    public void collectConfigMaps() {
+        LOGGER.info("Collecting configmaps in namespace {}", namespace);
+        client.configMaps().inNamespace(namespace).list().getItems().forEach(configMap -> {
+            writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString());
+        });
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
@@ -18,8 +18,8 @@ import static io.strimzi.systemtest.AbstractST.TEST_LOG_DIR;
 import static io.strimzi.test.BaseITST.CLIENT;
 import static io.strimzi.test.BaseITST.KUBE_CLIENT;
 
-public class TestWatcher implements AfterTestExecutionCallback {
-    private static final Logger LOGGER = LogManager.getLogger(TestWatcher.class);
+public class TestExecutionWatcher implements AfterTestExecutionCallback {
+    private static final Logger LOGGER = LogManager.getLogger(TestExecutionWatcher.class);
 
     @Override
     public void afterTestExecution(ExtensionContext extensionContext) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestWatcher.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import static io.strimzi.systemtest.AbstractST.TEST_LOG_DIR;
+import static io.strimzi.test.BaseITST.CLIENT;
+import static io.strimzi.test.BaseITST.KUBE_CLIENT;
+
+public class TestWatcher implements AfterTestExecutionCallback {
+    private static final Logger LOGGER = LogManager.getLogger(TestWatcher.class);
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        Method testMethod = extensionContext.getRequiredTestMethod();
+        Class testClass = extensionContext.getRequiredTestClass();
+        collectLogs(testMethod.getName(), testClass.getName());
+    }
+
+    void collectLogs(String testMethod, String testClass) {
+        // Get current date to create a unique folder
+        String currentDate = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime());
+        String logDir = !testMethod.isEmpty() ?
+                TEST_LOG_DIR + testClass + "." + testMethod + "_" + currentDate
+                : TEST_LOG_DIR + currentDate;
+
+        LogCollector logCollector = new LogCollector(CLIENT.inNamespace(KUBE_CLIENT.namespace()), new File(logDir));
+        logCollector.collectEvents();
+        logCollector.collectConfigMaps();
+        logCollector.collectLogsFromPods();
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PS improves log collection. It collect logs right after test execution (before all `@Before*` annotations). It also collect describe for each pod.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass

