### PR TITLE
Fix multiplatform support in test-client docker build

### DIFF
--- a/docker-images/test-client/Makefile
+++ b/docker-images/test-client/Makefile
@@ -1,5 +1,7 @@
 PROJECT_NAME=test-client
 
+include ../../Makefile.os
+
 clean:
 	rm -rf lib
 	rm -rf tmp
@@ -7,7 +9,7 @@ clean:
 
 .test-client.tmp: ../../test-client/target/test-client*.jar
 	test -d tmp || mkdir tmp
-	cp -f ../../test-client/target/test-client*.jar -d tmp
+	$(CP) -f ../../test-client/target/test-client*.jar -d tmp
 	touch .test-client.tmp
 
 docker_build: .test-client.tmp


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `test-client` Docker image build currently breaks the build on MacOS because it uses `cp` command instead of the multi-platform command. This PR should fix it.