### PR TITLE
ST: allow underscore in image tag

### DIFF
--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -74,7 +74,7 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_MIRROR_MAKER = "../install/cluster-operator/045-Crd-kafkamirrormaker.yaml";
 
-    private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile(":([^:]*?)-kafka-(?<version>[0-9.])");
+    private static final Pattern KAFKA_COMPONENT_PATTERN = Pattern.compile(":([^:]*?)(?<kafka>[-|_]kafka[-|_])(?<version>[0-9.])");
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
 
     private TestUtils() {
@@ -156,7 +156,7 @@ public final class TestUtils {
         Matcher m = KAFKA_COMPONENT_PATTERN.matcher(image);
         StringBuffer sb = new StringBuffer();
         if (m.find()) {
-            m.appendReplacement(sb, ":" + newTag + "-kafka-" + m.group("version"));
+            m.appendReplacement(sb, ":" + newTag + m.group("kafka") + m.group("version"));
             m.appendTail(sb);
             image = sb.toString();
         } else {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

We have hardcoded string in image tag used for ST. This allow us to change only tag and version and keep middle-string in the whole image tag as it was loaded from examples.

### Checklist

- [x] Make sure all tests pass
