### PR TITLE
Add docs for SASL PLAIn support in Mirror Maker

### DIFF
--- a/documentation/book/con-kafka-connect-authentication.adoc
+++ b/documentation/book/con-kafka-connect-authentication.adoc
@@ -49,7 +49,7 @@ This authentication mechanism requires a username and password.
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of the `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
 
-WARNING: Do not specify the actual password in the `password` field.
+IMPORTANT: Do not specify the actual password in the `password` field.
 
 .An example SASL based SCRAM-SHA-512 client authentication configuration
 [source,yaml,subs=attributes+]
@@ -74,10 +74,13 @@ spec:
 To configure Kafka Connect to use SASL based PLAIN authentication, set the `type` property to `plain`.
 This authentication mechanism requires a username and password.
 
+WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
+It should not be used without TLS encryption.
+
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of such a `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
 
-WARNING: Do not specify the actual password in the `password` field.
+IMPORTANT: Do not specify the actual password in the `password` field.
 
 .An example showing SASL based PLAIN client authentication configuration
 [source,yaml,subs=attributes+]

--- a/documentation/book/con-kafka-connect-authentication.adoc
+++ b/documentation/book/con-kafka-connect-authentication.adoc
@@ -10,8 +10,8 @@ The `authentication` property specifies the type of the authentication mechanism
 The currently supported authentication types are:
 
 * TLS client authentication
-* SASL based authentication using the SCRAM-SHA-512 mechanism
-* SASL based authentication using the PLAIN mechanism
+* SASL-based authentication using the SCRAM-SHA-512 mechanism
+* SASL-based authentication using the PLAIN mechanism
 
 == TLS Client Authentication
 
@@ -43,7 +43,7 @@ spec:
 
 == SASL based SCRAM-SHA-512 authentication
 
-To configure Kafka Connect to use SASL based SCRAM-SHA-512 authentication, set the `type` property to `scram-sha-512`.
+To configure Kafka Connect to use SASL-based SCRAM-SHA-512 authentication, set the `type` property to `scram-sha-512`.
 This authentication mechanism requires a username and password.
 
 * Specify the username in the `username` property.
@@ -71,11 +71,11 @@ spec:
 
 == SASL based PLAIN authentication
 
-To configure Kafka Connect to use SASL based PLAIN authentication, set the `type` property to `plain`.
+To configure Kafka Connect to use SASL-based PLAIN authentication, set the `type` property to `plain`.
 This authentication mechanism requires a username and password.
 
-WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
-It should be used only with TLS encryption.
+WARNING: The SASL PLAIN mechanism involves transferring the username and password across the network in cleartext.
+Only use SASL PLAIN authentication if TLS encryption is enabled.
 
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of such a `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.

--- a/documentation/book/con-kafka-connect-authentication.adoc
+++ b/documentation/book/con-kafka-connect-authentication.adoc
@@ -74,7 +74,7 @@ spec:
 To configure Kafka Connect to use SASL-based PLAIN authentication, set the `type` property to `plain`.
 This authentication mechanism requires a username and password.
 
-WARNING: The SASL PLAIN mechanism involves transferring the username and password across the network in cleartext.
+WARNING: The SASL PLAIN mechanism will transfer the username and password across the network in cleartext.
 Only use SASL PLAIN authentication if TLS encryption is enabled.
 
 * Specify the username in the `username` property.

--- a/documentation/book/con-kafka-connect-authentication.adoc
+++ b/documentation/book/con-kafka-connect-authentication.adoc
@@ -75,7 +75,7 @@ To configure Kafka Connect to use SASL based PLAIN authentication, set the `type
 This authentication mechanism requires a username and password.
 
 WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
-It should not be used without TLS encryption.
+It should be used only with TLS encryption.
 
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of such a `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.

--- a/documentation/book/con-kafka-mirror-maker-authentication.adoc
+++ b/documentation/book/con-kafka-mirror-maker-authentication.adoc
@@ -93,11 +93,11 @@ spec:
 == PLAIN authentication
 
 To configure Kafka Mirror Maker to use PLAIN authentication, set the `type` property to `plain`.
-The broker listener to which clients are connecting must also be configured to use PLAIN SASL authentication.
+The broker listener to which clients are connecting must also be configured to use SASL PLAIN authentication.
 This authentication mechanism requires a username and password.
 
 WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
-It should not be used without TLS encryption.
+It should be used only with TLS encryption.
 
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password.

--- a/documentation/book/con-kafka-mirror-maker-authentication.adoc
+++ b/documentation/book/con-kafka-mirror-maker-authentication.adoc
@@ -11,7 +11,9 @@ The currently supported authentication types are:
 
 * TLS client authentication
 * SASL based authentication using the SCRAM-SHA-512 mechanism
+* SASL based authentication using the PLAIN mechanism
 
+You can use different authentication mechanisms for the Kafka Mirror Maker producer and consumer.
 
 == TLS Client Authentication
 
@@ -59,7 +61,7 @@ This authentication mechanism requires a username and password.
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password. The `secretName` property contains the name of the `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
 
-WARNING: Do not specify the actual password in the `password` field.
+IMPORTANT: Do not specify the actual password in the `password` field.
 
 .An example SCRAM-SHA-512 client authentication configuration
 [source,yaml,subs=attributes+]
@@ -81,6 +83,48 @@ spec:
   producer:
     authentication:
       type: scram-sha-512
+      username: my-producer-user
+      passwordSecret:
+        secretName: my-producer-user
+        password: my-producer-password-key
+  # ...
+----
+
+== PLAIN authentication
+
+To configure Kafka Mirror Maker to use PLAIN authentication, set the `type` property to `plain`.
+The broker listener to which clients are connecting must also be configured to use PLAIN SASL authentication.
+This authentication mechanism requires a username and password.
+
+WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
+It should not be used without TLS encryption.
+
+* Specify the username in the `username` property.
+* In the `passwordSecret` property, specify a link to a `Secret` containing the password.
+The `secretName` property contains the name of the `Secret` and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
+
+IMPORTANT: Do not specify the actual password in the `password` field.
+
+.An example PLAIN client authentication configuration
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: KafkaMirrorMaker
+metadata:
+  name: my-mirror-maker
+spec:
+  # ...
+  consumer:
+    authentication:
+      type: plain
+      username: my-source-user
+      passwordSecret:
+        secretName: my-source-user
+        password: my-source-password-key
+  # ...
+  producer:
+    authentication:
+      type: plain
       username: my-producer-user
       passwordSecret:
         secretName: my-producer-user

--- a/documentation/book/con-kafka-mirror-maker-authentication.adoc
+++ b/documentation/book/con-kafka-mirror-maker-authentication.adoc
@@ -10,8 +10,8 @@ The `authentication` property specifies the type of the authentication method wh
 The currently supported authentication types are:
 
 * TLS client authentication
-* SASL based authentication using the SCRAM-SHA-512 mechanism
-* SASL based authentication using the PLAIN mechanism
+* SASL-based authentication using the SCRAM-SHA-512 mechanism
+* SASL-based authentication using the PLAIN mechanism
 
 You can use different authentication mechanisms for the Kafka Mirror Maker producer and consumer.
 
@@ -55,7 +55,7 @@ spec:
 == SCRAM-SHA-512 authentication
 
 To configure Kafka Mirror Maker to use SCRAM-SHA-512 authentication, set the `type` property to `scram-sha-512`.
-The broker listener to which clients are connecting must also be configured to use SCRAM-SHA-512 SASL authentication.
+The broker listener to which clients will connect must also be configured to use SCRAM-SHA-512 SASL authentication.
 This authentication mechanism requires a username and password.
 
 * Specify the username in the `username` property.
@@ -93,11 +93,11 @@ spec:
 == PLAIN authentication
 
 To configure Kafka Mirror Maker to use PLAIN authentication, set the `type` property to `plain`.
-The broker listener to which clients are connecting must also be configured to use SASL PLAIN authentication.
+The broker listener to which clients will connect must also be configured to use SASL PLAIN authentication.
 This authentication mechanism requires a username and password.
 
-WARNING: SASL PLAIN mechanism transfers the username and password in cleartext over the network.
-It should be used only with TLS encryption.
+WARNING: The SASL PLAIN mechanism involves transferring the username and password across the network in cleartext.
+Only use SASL PLAIN authentication if TLS encryption is enabled.
 
 * Specify the username in the `username` property.
 * In the `passwordSecret` property, specify a link to a `Secret` containing the password.

--- a/documentation/book/con-kafka-mirror-maker-authentication.adoc
+++ b/documentation/book/con-kafka-mirror-maker-authentication.adoc
@@ -96,7 +96,7 @@ To configure Kafka Mirror Maker to use PLAIN authentication, set the `type` prop
 The broker listener to which clients will connect must also be configured to use SASL PLAIN authentication.
 This authentication mechanism requires a username and password.
 
-WARNING: The SASL PLAIN mechanism involves transferring the username and password across the network in cleartext.
+WARNING: The SASL PLAIN mechanism will transfer the username and password across the network in cleartext.
 Only use SASL PLAIN authentication if TLS encryption is enabled.
 
 * Specify the username in the `username` property.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the documentation to the SASL PLAIN support in Kafka Mirror Maker deployment.

### Checklist

- [x] Update documentation