### PR TITLE
Add support for SASL PLAIN to Kafka Mirror Maker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support for Kafka 2.2.0
 * Support off-cluster access using Kubernetes Nginx Ingress
 * Add ability to configure Image Pull Secrets for all pods in Cluster Operator
+* Support for SASL PLAIN mechanism in Kafka Connect and Mirror Maker (for use with non-Strimzi Kafka cluster) 
 
 ## 0.11.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectAuthentication.java
@@ -33,7 +33,7 @@ public abstract class KafkaConnectAuthentication implements UnknownPropertyPrese
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the only supported types are `tls`, `scram-sha-512` and `plain`. " +
+            "Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`plain` type uses SASL PLAIN Authentication. " +
             "`tls` type uses TLS Client Authentication. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
@@ -5,7 +5,6 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -34,7 +33,6 @@ public class KafkaConnectTls implements UnknownPropertyPreserving, Serializable 
     private Map<String, Object> additionalProperties;
 
     @Description("Trusted certificates for TLS connection")
-    @JsonProperty(required = true)
     public List<CertSecretSource> getTrustedCertificates() {
         return trustedCertificates;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthentication.java
@@ -23,6 +23,7 @@ import java.util.Map;
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaMirrorMakerAuthenticationTls.TYPE_TLS, value = KafkaMirrorMakerAuthenticationTls.class),
         @JsonSubTypes.Type(name = KafkaMirrorMakerAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaMirrorMakerAuthenticationScramSha512.class),
+        @JsonSubTypes.Type(name = KafkaMirrorMakerAuthenticationPlain.TYPE_PLAIN, value = KafkaMirrorMakerAuthenticationPlain.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
@@ -32,8 +33,9 @@ public abstract class KafkaMirrorMakerAuthentication implements UnknownPropertyP
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the only supported types are `tls` and `scram-sha-512`. " +
+            "Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
+            "`plain` type uses SASL PLAIN Authentication. " +
             "The `tls` type uses TLS Client Authentication. " +
             "The `tls` type is supported only over TLS connections.")
     public abstract String getType();

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerAuthenticationPlain.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Configures the Kafka Mirror Maker authentication
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+public class KafkaMirrorMakerAuthenticationPlain extends KafkaMirrorMakerAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_PLAIN = "plain";
+
+    private String username;
+    private PasswordSecretSource passwordSecret;
+
+    @Description("Must be `" + TYPE_PLAIN + "`")
+    @Override
+    public String getType() {
+        return TYPE_PLAIN;
+    }
+
+    @Description("Reference to the `Secret` which holds the password.")
+    public PasswordSecretSource getPasswordSecret() {
+        return passwordSecret;
+    }
+
+    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
+        this.passwordSecret = passwordSecret;
+    }
+
+    @Description("Username used for the authentication.")
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
@@ -5,7 +5,6 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -34,7 +33,6 @@ public class KafkaMirrorMakerTls implements UnknownPropertyPreserving, Serializa
     private Map<String, Object> additionalProperties;
 
     @Description("Trusted certificates for TLS connection")
-    @JsonProperty(required = true)
     public List<CertSecretSource> getTrustedCertificates() {
         return trustedCertificates;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationPlain;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationTls;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerClientSpec;
@@ -55,9 +56,11 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     // Kafka Mirror Maker configuration keys (EnvVariables)
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_METRICS_ENABLED = "KAFKA_MIRRORMAKER_METRICS_ENABLED";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_CONSUMER = "KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_CONSUMER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_CONSUMER = "KAFKA_MIRRORMAKER_TLS_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER = "KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_CERT_CONSUMER = "KAFKA_MIRRORMAKER_TLS_AUTH_CERT_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_KEY_CONSUMER = "KAFKA_MIRRORMAKER_TLS_AUTH_KEY_CONSUMER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER = "KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER = "KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER = "KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_GROUPID_CONSUMER = "KAFKA_MIRRORMAKER_GROUPID_CONSUMER";
@@ -65,9 +68,11 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER = "KAFKA_MIRRORMAKER_CONFIGURATION_PRODUCER";
 
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_PRODUCER = "KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_PRODUCER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_PRODUCER = "KAFKA_MIRRORMAKER_TLS_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER = "KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_CERT_PRODUCER = "KAFKA_MIRRORMAKER_TLS_AUTH_CERT_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_KEY_PRODUCER = "KAFKA_MIRRORMAKER_TLS_AUTH_KEY_PRODUCER";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER = "KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER = "KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER = "KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER";
 
@@ -78,10 +83,12 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
     protected KafkaMirrorMakerClientSpec producer;
     protected CertAndKeySecretSource producerTlsAuthCertAndKey;
+    private String producerSaslMechanism;
     private String producerUsername;
     private PasswordSecretSource producerPasswordSecret;
     protected KafkaMirrorMakerConsumerSpec consumer;
     protected CertAndKeySecretSource consumerTlsAuthCertAndKey;
+    private String consumerSaslMechanism;
     private String consumerUsername;
     private PasswordSecretSource consumerPasswordSecret;
 
@@ -145,9 +152,20 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 KafkaMirrorMakerAuthenticationScramSha512 auth = (KafkaMirrorMakerAuthenticationScramSha512) client.getAuthentication();
                 if (auth.getUsername() != null && auth.getPasswordSecret() != null) {
                     if (client instanceof KafkaMirrorMakerConsumerSpec)
-                        kafkaMirrorMakerCluster.setConsumerUsernameAndPassword(auth.getUsername(), auth.getPasswordSecret());
+                        kafkaMirrorMakerCluster.setConsumerUsernameAndPassword(auth.getType(), auth.getUsername(), auth.getPasswordSecret());
                     else if (client instanceof KafkaMirrorMakerProducerSpec)
-                        kafkaMirrorMakerCluster.setProducerUsernameAndPassword(auth.getUsername(), auth.getPasswordSecret());
+                        kafkaMirrorMakerCluster.setProducerUsernameAndPassword(auth.getType(), auth.getUsername(), auth.getPasswordSecret());
+                } else {
+                    log.warn("SCRAM-SHA-512 authentication selected, but no username and password configured.");
+                    throw new InvalidResourceException("SCRAM-SHA-512 authentication selected, but no username and password configured.");
+                }
+            } else if (client.getAuthentication() instanceof KafkaMirrorMakerAuthenticationPlain) {
+                KafkaMirrorMakerAuthenticationPlain auth = (KafkaMirrorMakerAuthenticationPlain) client.getAuthentication();
+                if (auth.getUsername() != null && auth.getPasswordSecret() != null) {
+                    if (client instanceof KafkaMirrorMakerConsumerSpec)
+                        kafkaMirrorMakerCluster.setConsumerUsernameAndPassword(auth.getType(), auth.getUsername(), auth.getPasswordSecret());
+                    else if (client instanceof KafkaMirrorMakerProducerSpec)
+                        kafkaMirrorMakerCluster.setProducerUsernameAndPassword(auth.getType(), auth.getUsername(), auth.getPasswordSecret());
                 } else {
                     log.warn("SCRAM-SHA-512 authentication selected, but no username and password configured.");
                     throw new InvalidResourceException("SCRAM-SHA-512 authentication selected, but no username and password configured.");
@@ -363,48 +381,60 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         jvmPerformanceOptions(varList);
 
         /** consumer */
-        if (consumer.getTls() != null && consumer.getTls().getTrustedCertificates() != null && consumer.getTls().getTrustedCertificates().size() > 0) {
-            StringBuilder sb = new StringBuilder();
-            boolean separator = false;
-            for (CertSecretSource certSecretSource: consumer.getTls().getTrustedCertificates()) {
-                if (separator) {
-                    sb.append(";");
+        if (consumer.getTls() != null) {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_CONSUMER, "true"));
+
+            if (consumer.getTls().getTrustedCertificates() != null && consumer.getTls().getTrustedCertificates().size() > 0) {
+                StringBuilder sb = new StringBuilder();
+                boolean separator = false;
+                for (CertSecretSource certSecretSource : consumer.getTls().getTrustedCertificates()) {
+                    if (separator) {
+                        sb.append(";");
+                    }
+                    sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
+                    separator = true;
                 }
-                sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
-                separator = true;
+                varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER, sb.toString()));
             }
-            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER, sb.toString()));
         }
+
         if (consumerTlsAuthCertAndKey != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_CERT_CONSUMER,
                     String.format("%s/%s", consumerTlsAuthCertAndKey.getSecretName(), consumerTlsAuthCertAndKey.getCertificate())));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_KEY_CONSUMER,
                     String.format("%s/%s", consumerTlsAuthCertAndKey.getSecretName(), consumerTlsAuthCertAndKey.getKey())));
         } else if (consumerPasswordSecret != null)  {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER, consumerSaslMechanism));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER, consumerUsername));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER,
                     String.format("%s/%s", consumerPasswordSecret.getSecretName(), consumerPasswordSecret.getPassword())));
         }
 
         /** producer */
-        if (producer.getTls() != null && producer.getTls().getTrustedCertificates() != null && producer.getTls().getTrustedCertificates().size() > 0) {
-            StringBuilder sb = new StringBuilder();
-            boolean separator = false;
-            for (CertSecretSource certSecretSource: producer.getTls().getTrustedCertificates()) {
-                if (separator) {
-                    sb.append(";");
+        if (producer.getTls() != null) {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_PRODUCER, "true"));
+
+            if (producer.getTls().getTrustedCertificates() != null && producer.getTls().getTrustedCertificates().size() > 0) {
+                StringBuilder sb = new StringBuilder();
+                boolean separator = false;
+                for (CertSecretSource certSecretSource : producer.getTls().getTrustedCertificates()) {
+                    if (separator) {
+                        sb.append(";");
+                    }
+                    sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
+                    separator = true;
                 }
-                sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
-                separator = true;
+                varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER, sb.toString()));
             }
-            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER, sb.toString()));
         }
+
         if (producerTlsAuthCertAndKey != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_CERT_PRODUCER,
                     String.format("%s/%s", producerTlsAuthCertAndKey.getSecretName(), producerTlsAuthCertAndKey.getCertificate())));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_AUTH_KEY_PRODUCER,
                     String.format("%s/%s", producerTlsAuthCertAndKey.getSecretName(), producerTlsAuthCertAndKey.getKey())));
         } else if (producerPasswordSecret != null)  {
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER, producerSaslMechanism));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER, producerUsername));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER,
                     String.format("%s/%s", producerPasswordSecret.getSecretName(), producerPasswordSecret.getPassword())));
@@ -447,12 +477,14 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         this.producerTlsAuthCertAndKey = producerTlsAuthCertAndKey;
     }
 
-    private void setConsumerUsernameAndPassword(String username, PasswordSecretSource passwordSecret) {
+    private void setConsumerUsernameAndPassword(String saslMechanism, String username, PasswordSecretSource passwordSecret) {
+        this.consumerSaslMechanism = saslMechanism;
         this.consumerUsername = username;
         this.consumerPasswordSecret = passwordSecret;
     }
 
-    private void setProducerUsernameAndPassword(String username, PasswordSecretSource passwordSecret) {
+    private void setProducerUsernameAndPassword(String saslMechanism, String username, PasswordSecretSource passwordSecret) {
+        this.producerSaslMechanism = saslMechanism;
         this.producerUsername = username;
         this.producerPasswordSecret = passwordSecret;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -167,8 +167,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                     else if (client instanceof KafkaMirrorMakerProducerSpec)
                         kafkaMirrorMakerCluster.setProducerUsernameAndPassword(auth.getType(), auth.getUsername(), auth.getPasswordSecret());
                 } else {
-                    log.warn("SCRAM-SHA-512 authentication selected, but no username and password configured.");
-                    throw new InvalidResourceException("SCRAM-SHA-512 authentication selected, but no username and password configured.");
+                    log.warn("PLAIN authentication selected, but no username and password configured.");
+                    throw new InvalidResourceException("PLAIN authentication selected, but no username and password configured.");
                 }
             }
         }

--- a/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
@@ -2,15 +2,18 @@
 
 SECURITY_PROTOCOL=PLAINTEXT
 
-if [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER" ]; then
+if [ "$KAFKA_MIRRORMAKER_TLS_CONSUMER" = "true" ]; then
     SECURITY_PROTOCOL="SSL"
-    TLS_CONFIGURATION=$(cat <<EOF
+
+    if [ -n "$KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER" ]; then
+        TLS_CONFIGURATION=$(cat <<EOF
 # TLS / SSL
 ssl.truststore.location=/tmp/kafka/consumer.truststore.p12
 ssl.truststore.password=${CERTS_STORE_PASSWORD}
 ssl.truststore.type=PKCS12
 EOF
 )
+    fi
 
     if [ -n "$KAFKA_MIRRORMAKER_TLS_AUTH_CERT_CONSUMER" ] && [ -n "$KAFKA_MIRRORMAKER_TLS_AUTH_KEY_CONSUMER" ]; then
         TLS_AUTH_CONFIGURATION=$(cat <<EOF
@@ -30,11 +33,18 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER" ] && [ -n "$KAFKA_MIRRORMAKE
     fi
 
     PASSWORD=$(cat /opt/kafka/consumer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER)
-    SASL_MECHANISM="SCRAM-SHA-512"
+
+    if [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "xplain" ]; then
+        SASL_MECHANISM="PLAIN"
+        JAAS_SECURITY_MODULE="plain.PlainLoginModule"
+    elif [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "xscram-sha-512" ]; then
+        SASL_MECHANISM="SCRAM-SHA-512"
+        JAAS_SECURITY_MODULE="scram.ScramLoginModule"
+    fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 sasl.mechanism=${SASL_MECHANISM}
-sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}" password="${PASSWORD}";
+sasl.jaas.config=org.apache.kafka.common.security.${JAAS_SECURITY_MODULE} required username="${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}" password="${PASSWORD}";
 EOF
 )
 fi

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1114,7 +1114,7 @@ It must have the value `scram-sha-512` for the type `KafkaConnectAuthenticationS
 [id='type-PasswordSecretSource-{context}']
 ### `PasswordSecretSource` schema reference
 
-Used in: xref:type-KafkaConnectAuthenticationPlain-{context}[`KafkaConnectAuthenticationPlain`], xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
+Used in: xref:type-KafkaConnectAuthenticationPlain-{context}[`KafkaConnectAuthenticationPlain`], xref:type-KafkaConnectAuthenticationScramSha512-{context}[`KafkaConnectAuthenticationScramSha512`], xref:type-KafkaMirrorMakerAuthenticationPlain-{context}[`KafkaMirrorMakerAuthenticationPlain`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
 
 
 [options="header"]
@@ -1566,8 +1566,8 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |string
 |bootstrapServers  1.2+<.<|A list of host:port pairs to use for establishing the initial connection to the Kafka cluster.
 |string
-|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
-|xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
+|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain].
+|xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`], xref:type-KafkaMirrorMakerAuthenticationPlain-{context}[`KafkaMirrorMakerAuthenticationPlain`]
 |config            1.2+<.<|The mirror maker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security.
 |map
 |tls               1.2+<.<|TLS configuration for connecting to the cluster.
@@ -1580,7 +1580,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 Used in: xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaMirrorMakerAuthenticationTls` from xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaMirrorMakerAuthenticationTls` from xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`], xref:type-KafkaMirrorMakerAuthenticationPlain-{context}[`KafkaMirrorMakerAuthenticationPlain`].
 It must have the value `tls` for the type `KafkaMirrorMakerAuthenticationTls`.
 [options="header"]
 |====
@@ -1597,7 +1597,7 @@ It must have the value `tls` for the type `KafkaMirrorMakerAuthenticationTls`.
 Used in: xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaMirrorMakerAuthenticationScramSha512` from xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaMirrorMakerAuthenticationScramSha512` from xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationPlain-{context}[`KafkaMirrorMakerAuthenticationPlain`].
 It must have the value `scram-sha-512` for the type `KafkaMirrorMakerAuthenticationScramSha512`.
 [options="header"]
 |====
@@ -1605,6 +1605,25 @@ It must have the value `scram-sha-512` for the type `KafkaMirrorMakerAuthenticat
 |passwordSecret  1.2+<.<|Reference to the `Secret` which holds the password.
 |xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
 |type            1.2+<.<|Must be `scram-sha-512`.
+|string
+|username        1.2+<.<|Username used for the authentication.
+|string
+|====
+
+[id='type-KafkaMirrorMakerAuthenticationPlain-{context}']
+### `KafkaMirrorMakerAuthenticationPlain` schema reference
+
+Used in: xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaMirrorMakerAuthenticationPlain` from xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`].
+It must have the value `plain` for the type `KafkaMirrorMakerAuthenticationPlain`.
+[options="header"]
+|====
+|Field                  |Description
+|passwordSecret  1.2+<.<|Reference to the `Secret` which holds the password.
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|type            1.2+<.<|Must be `plain`.
 |string
 |username        1.2+<.<|Username used for the authentication.
 |string
@@ -1634,8 +1653,8 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |Field                    |Description
 |bootstrapServers  1.2+<.<|A list of host:port pairs to use for establishing the initial connection to the Kafka cluster.
 |string
-|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
-|xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`]
+|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain].
+|xref:type-KafkaMirrorMakerAuthenticationTls-{context}[`KafkaMirrorMakerAuthenticationTls`], xref:type-KafkaMirrorMakerAuthenticationScramSha512-{context}[`KafkaMirrorMakerAuthenticationScramSha512`], xref:type-KafkaMirrorMakerAuthenticationPlain-{context}[`KafkaMirrorMakerAuthenticationPlain`]
 |config            1.2+<.<|The mirror maker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
 |map
 |tls               1.2+<.<|TLS configuration for connecting to the cluster.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -544,8 +544,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             version:
               type: string
           required:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -531,8 +531,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -92,6 +92,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -113,8 +114,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - groupId
               - bootstrapServers
@@ -154,6 +153,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -175,8 +175,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - bootstrapServers
             resources:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

PR #1584 added support for SASL PLAIN to Kafka Connect. This is useful when using it in combination with Kafka Clusters not managed by Strimzi (Since Strimzi doesn't support SASL PLAIN).

This PR brings the Mirror Maker deployment on par with it and also adds support for SASL PLAIN. Additionally, it also adds support for deploying Mirror Maker with TLS but without specifying any TLS certificates. This is useful when your brokers use certificates signed by a real trusted CA and do not need a specific truststore but can just use the system truststore.

Documentation will be done in a separate PR.

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Update CHANGELOG.md

