### PR TITLE
Add LastTimestamp for Event

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -19,6 +19,8 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,6 +76,8 @@ public class TopicOperator {
         @Override
         public void handle(Void v) {
             EventBuilder evtb = new EventBuilder().withApiVersion("v1");
+            final String eventTime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss'Z'"));
+            
             if (involvedObject != null) {
                 evtb.withNewInvolvedObject()
                         .withKind(involvedObject.getKind())
@@ -86,6 +90,7 @@ public class TopicOperator {
             evtb.withType(eventType.name)
                     .withMessage(message)
                     .withNewMetadata().withLabels(labels.labels()).withGenerateName("topic-operator").withNamespace(namespace).endMetadata()
+                    .withLastTimestamp(eventTime)
                     .withNewSource()
                     .withComponent(TopicOperator.class.getName())
                     .endSource();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -436,6 +436,7 @@ public class TopicOperatorIT extends BaseITST {
                 assertEquals(expectedMessage, event.getMessage());
                 assertEquals(expectedType.name, event.getType());
                 assertNotNull(event.getInvolvedObject());
+                assertNotNull(event.getLastTimestamp());
                 assertEquals("KafkaTopic", event.getInvolvedObject().getKind());
                 assertEquals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName());
                 return true;


### PR DESCRIPTION
The LastTimestamp is used by the Monitoring page to order the events.

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

The timestamp is necessary to display correctly the event on the Monitoring Page.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

