### PR TITLE
Fix the recipe for adding plugins to our Kafka image

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -89,7 +89,7 @@
 :DockerTopicOperator: strimzi/operator:{DockerTag}
 :DockerUserOperator: strimzi/operator:{DockerTag}
 :DockerEntityOperatorStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerImageUser: kafka:kafka
+:DockerImageUser: 1001
 
 // API Versions
 :KafkaApiVersion: kafka.strimzi.io/v1beta1


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The documentation around building custom image with Connect plugins is still using `USER kafka:kafka`. But we do not use that anymore. So it should rather be `USER 1001`.

See #1587 for more details.