### PR TITLE
Add DNS annotations to load balancer services

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -5,8 +5,12 @@
 package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configures external bootstrap service for LoadBalancer listeners
@@ -20,4 +24,17 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBootstrapOverride {
     private static final long serialVersionUID = 1L;
+
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
+
+    @Description("Annotations which will be added to the Service resource. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -6,8 +6,12 @@ package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configures external broker service and advertised addresses for LoadBalancer listeners
@@ -22,4 +26,17 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOverride {
     private static final long serialVersionUID = 1L;
+
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
+
+    @Description("Annotations which will be added to the Service resources for individual brokers. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -568,7 +568,7 @@ public class KafkaCluster extends AbstractModel {
             ports = Collections.singletonList(createServicePort(EXTERNAL_PORT_NAME, EXTERNAL_PORT, EXTERNAL_PORT,
                 nodePort, "TCP"));
 
-            Map<String, String> dnsAnnotations = Collections.EMPTY_MAP;
+            Map<String, String> dnsAnnotations = Collections.emptyMap();
             if (isExposedWithLoadBalancer())    {
                 KafkaListenerExternalLoadBalancer externalLb = (KafkaListenerExternalLoadBalancer) listeners.getExternal();
 
@@ -609,7 +609,7 @@ public class KafkaCluster extends AbstractModel {
             }
             ports.add(createServicePort(EXTERNAL_PORT_NAME, EXTERNAL_PORT, EXTERNAL_PORT, nodePort, "TCP"));
 
-            Map<String, String> dnsAnnotations = Collections.EMPTY_MAP;
+            Map<String, String> dnsAnnotations = Collections.emptyMap();
             if (isExposedWithLoadBalancer())    {
                 KafkaListenerExternalLoadBalancer externalLb = (KafkaListenerExternalLoadBalancer) listeners.getExternal();
 
@@ -618,7 +618,7 @@ public class KafkaCluster extends AbstractModel {
                             .filter(broker -> broker != null && broker.getBroker() == pod)
                             .map(LoadBalancerListenerBrokerOverride::getDnsAnnotations)
                             .findAny()
-                            .orElse(Collections.EMPTY_MAP);
+                            .orElse(Collections.emptyMap());
                 }
             }
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -350,9 +350,11 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 
 [options="header"]
 |====
-|Field           |Description
-|address  1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
+|Field                  |Description
+|address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
 |string
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resource. You can use this field to instrument DNS providers such as External DNS.
+|map
 |====
 
 [id='type-LoadBalancerListenerBrokerOverride-{context}']
@@ -370,6 +372,8 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |string
 |advertisedPort  1.2+<.<|The port number which will be used in the brokers' `advertised.brokers`.
 |integer
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|map
 |====
 
 [id='type-KafkaListenerExternalNodePort-{context}']


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As part of the work on Ingress support, we added a new override field called `dnsAnnotations` which allows users to instrument DNS tools such as External DNS. This might be useful also for the `loadbalancer` type listener, because the loadbalancer services can be also handled by External DNS. This PR adds this override option also to them.

_(On the other hand the `route` and `nodeport` listeners have no use for this)_

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally