### PR TITLE
ST: collect and check events only for specific resource defined by uid

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -296,10 +296,9 @@ public abstract class AbstractST extends BaseITST implements TestSeparator, Cons
         return "$.spec.containers[*].env[?(@.name=='" + envVar + "')].value";
     }
 
-    List<Event> getEvents(String resourceType, String resourceName) {
+    List<Event> getEvents(String resourceUid) {
         return CLIENT.events().inNamespace(KUBE_CLIENT.namespace()).list().getItems().stream()
-                .filter(event -> event.getInvolvedObject().getKind().equals(resourceType))
-                .filter(event -> event.getInvolvedObject().getName().equals(resourceName))
+                .filter(event -> event.getInvolvedObject().getUid().equals(resourceUid))
                 .collect(Collectors.toList());
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -149,7 +149,7 @@ class ConnectST extends AbstractST {
         assertEquals(scaleTo, connectPods.size());
         for (String pod : connectPods) {
             KUBE_CLIENT.waitForPod(pod);
-            String uid = CLIENT.pods().withName(pod).get().getMetadata().getUid();
+            String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(pod).get().getMetadata().getUid();
             List<Event> events = getEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
@@ -163,7 +163,7 @@ class ConnectST extends AbstractST {
         connectPods = KUBE_CLIENT.listResourcesByLabel("pod", "strimzi.io/kind=KafkaConnect");
         assertEquals(initialReplicas, connectPods.size());
         for (String pod : connectPods) {
-            String uid = CLIENT.pods().withName(pod).get().getMetadata().getUid();
+            String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(pod).get().getMetadata().getUid();
             List<Event> events = getEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -149,7 +149,8 @@ class ConnectST extends AbstractST {
         assertEquals(scaleTo, connectPods.size());
         for (String pod : connectPods) {
             KUBE_CLIENT.waitForPod(pod);
-            List<Event> events = getEvents("Pod", pod);
+            String uid = CLIENT.pods().withName(pod).get().getMetadata().getUid();
+            List<Event> events = getEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
         }
@@ -162,7 +163,8 @@ class ConnectST extends AbstractST {
         connectPods = KUBE_CLIENT.listResourcesByLabel("pod", "strimzi.io/kind=KafkaConnect");
         assertEquals(initialReplicas, connectPods.size());
         for (String pod : connectPods) {
-            List<Event> events = getEvents("Pod", pod);
+            String uid = CLIENT.pods().withName(pod).get().getMetadata().getUid();
+            List<Event> events = getEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -247,6 +247,8 @@ class KafkaST extends MessagingBaseST {
 
         // scale down
         LOGGER.info("Scaling down");
+        // Get zk-3 uid before deletion
+        String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newZkPodNames.get(3)).get().getMetadata().getUid();
         operationID = startTimeMeasuring(Operation.SCALE_DOWN);
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getZookeeper().setReplicas(initialZkReplicas));
 
@@ -258,7 +260,6 @@ class KafkaST extends MessagingBaseST {
         waitForZkMntr(ZK_SERVER_STATE, 0, 1, 2);
 
         //Test that the second pod has event 'Killing'
-        String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newZkPodNames.get(3)).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
         uid = CLIENT.apps().statefulSets().inNamespace(NAMESPACE).withName(zookeeperClusterName(CLUSTER_NAME)).get().getMetadata().getUid();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -186,7 +186,7 @@ class KafkaST extends MessagingBaseST {
         uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newPodName).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
-        uid = CLIENT.apps().statefulSets().withName(kafkaClusterName(CLUSTER_NAME)).get().getMetadata().getUid();
+        uid = CLIENT.apps().statefulSets().inNamespace(NAMESPACE).withName(kafkaClusterName(CLUSTER_NAME)).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(SuccessfulDelete));
         //Test that CO doesn't have any exceptions in log
         TimeMeasuringSystem.stopOperation(operationID);
@@ -258,10 +258,10 @@ class KafkaST extends MessagingBaseST {
         waitForZkMntr(ZK_SERVER_STATE, 0, 1, 2);
 
         //Test that the second pod has event 'Killing'
-        String uid = CLIENT.pods().withName(newZkPodNames.get(3)).get().getMetadata().getUid();
+        String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newZkPodNames.get(3)).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
-        uid = CLIENT.apps().statefulSets().withName(zookeeperClusterName(CLUSTER_NAME)).get().getMetadata().getUid();
+        uid = CLIENT.apps().statefulSets().inNamespace(NAMESPACE).withName(zookeeperClusterName(CLUSTER_NAME)).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(SuccessfulDelete));
         // Stop measuring
         TimeMeasuringSystem.stopOperation(operationID);
@@ -1173,7 +1173,7 @@ class KafkaST extends MessagingBaseST {
         for (String name : newZkPodNames) {
             //Test that second pod does not have errors or failures in events
             LOGGER.info("Checking logs fro pod {}", name);
-            String uid = CLIENT.pods().withName(name).get().getMetadata().getUid();
+            String uid = CLIENT.pods().inNamespace(NAMESPACE).withName(name).get().getMetadata().getUid();
             List<Event> eventsForSecondPod = getEvents(uid);
             assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Events was collected based on resource name and type. What if there were same resource with same type in previous tests? This PR change events collection for resources - events are collected by resource uuid now. This should guarantee, that event check will work with events for resources used in the specific tests.

### Checklist

- [x] Make sure all tests pass

