### PR TITLE
Two handlers is excessive

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -406,12 +406,6 @@ public class TopicOperatorIT extends BaseITST {
     private void waitFor(TestContext context, BooleanSupplier ready, long timeout, String message) {
         Async async = context.async();
         Util.waitFor(vertx, message, 3_000, timeout, ready).setHandler(ar -> {
-            if (ar.succeeded()) {
-                async.complete();
-            } else {
-                context.fail(ar.cause());
-            }
-        }).setHandler(ar -> {
             if (ar.failed()) {
                 context.fail(ar.cause());
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The TopicOperatorIT can completing an `Async` twice; the reason is we've got two near-identical handlers set on a future. This PR removes one of them.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

