### PR TITLE
Fix network policies on OpenShift 3.11

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -130,7 +130,11 @@ public class PlatformFeaturesAvailability {
     }
 
     public boolean isNamespaceAndPodSelectorNetworkPolicySupported() {
-        return this.kubernetesVersion.compareTo(KubernetesVersion.V1_11) >= 0;
+        if (isOpenshift()) {
+            return this.kubernetesVersion.compareTo(KubernetesVersion.V1_12) >= 0;
+        } else {
+            return this.kubernetesVersion.compareTo(KubernetesVersion.V1_11) >= 0;
+        }
     }
 
     public KubernetesVersion getKubernetesVersion() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -324,34 +324,12 @@ public class ZookeeperCluster extends AbstractModel {
         NetworkPolicyPort leaderElectionPort = new NetworkPolicyPort();
         leaderElectionPort.setPort(new IntOrString(LEADER_ELECTION_PORT));
 
-        NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector = new LabelSelector();
-        Map<String, String> expressions = new HashMap<>();
-        expressions.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster));
-        labelSelector.setMatchLabels(expressions);
-        kafkaClusterPeer.setPodSelector(labelSelector);
-
         NetworkPolicyPeer zookeeperClusterPeer = new NetworkPolicyPeer();
         LabelSelector labelSelector2 = new LabelSelector();
         Map<String, String> expressions2 = new HashMap<>();
         expressions2.put(Labels.STRIMZI_NAME_LABEL, zookeeperClusterName(cluster));
         labelSelector2.setMatchLabels(expressions2);
         zookeeperClusterPeer.setPodSelector(labelSelector2);
-
-        NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector3 = new LabelSelector();
-        Map<String, String> expressions3 = new HashMap<>();
-        expressions3.put(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(cluster));
-        labelSelector3.setMatchLabels(expressions3);
-        entityOperatorPeer.setPodSelector(labelSelector3);
-
-        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector4 = new LabelSelector();
-        Map<String, String> expressions4 = new HashMap<>();
-        expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
-        labelSelector4.setMatchLabels(expressions4);
-        clusterOperatorPeer.setPodSelector(labelSelector4);
-        clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
 
         // Zookeeper only ports - 2888 & 3888 which need to be accessed by the Zookeeper cluster members only
         NetworkPolicyIngressRule zookeeperClusteringIngressRule = new NetworkPolicyIngressRuleBuilder()
@@ -368,6 +346,28 @@ public class ZookeeperCluster extends AbstractModel {
                 .build();
 
         if (namespaceAndPodSelectorNetworkPolicySupported) {
+            NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeer();
+            LabelSelector labelSelector = new LabelSelector();
+            Map<String, String> expressions = new HashMap<>();
+            expressions.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster));
+            labelSelector.setMatchLabels(expressions);
+            kafkaClusterPeer.setPodSelector(labelSelector);
+
+            NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeer();
+            LabelSelector labelSelector3 = new LabelSelector();
+            Map<String, String> expressions3 = new HashMap<>();
+            expressions3.put(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(cluster));
+            labelSelector3.setMatchLabels(expressions3);
+            entityOperatorPeer.setPodSelector(labelSelector3);
+
+            NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
+            LabelSelector labelSelector4 = new LabelSelector();
+            Map<String, String> expressions4 = new HashMap<>();
+            expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
+            labelSelector4.setMatchLabels(expressions4);
+            clusterOperatorPeer.setPodSelector(labelSelector4);
+            clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
+
             // This is a hack because we have no guarantee that the CO namespace has some particular labels
             List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(4);
             clientsPortPeers.add(kafkaClusterPeer);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -312,7 +312,7 @@ public class ZookeeperCluster extends AbstractModel {
         return cluster + NETWORK_POLICY_KEY_SUFFIX + NAME_SUFFIX;
     }
 
-    public NetworkPolicy generateNetworkPolicy(boolean coInAllNamespaces) {
+    public NetworkPolicy generateNetworkPolicy(boolean namespaceAndPodSelectorNetworkPolicySupported) {
         List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
 
         NetworkPolicyPort clientsPort = new NetworkPolicyPort();
@@ -367,7 +367,7 @@ public class ZookeeperCluster extends AbstractModel {
                 .withFrom()
                 .build();
 
-        if (coInAllNamespaces) {
+        if (namespaceAndPodSelectorNetworkPolicySupported) {
             // This is a hack because we have no guarantee that the CO namespace has some particular labels
             List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(4);
             clientsPortPeers.add(kafkaClusterPeer);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -46,6 +46,10 @@ public class PlatformFeaturesAvailabilityTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_8);
         assertFalse(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
         pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_11);
+        assertFalse(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
+        pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_11);
+        assertTrue(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
+        pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_12);
         assertTrue(pfa.isNamespaceAndPodSelectorNetworkPolicySupported());
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issue with network policies on OpenShift 3.11 where the network policy plugin doesn't support namespace and pod selectors combined. Therefore on Kubernetes <= 1.10 and OpenShift <= 3.11, the 3.11 port is open to everyone on the network policy level (authentication is of course still there).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally