### PR TITLE
Fix network policies on OpenShift 3.11 in 0.11.x release branch

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -270,7 +270,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         rules.add(zookeeperClusteringIngressRule);
 
-        // Clients port - needs ot be access from outside the Zookeeper cluster as well
+        // Clients port - needs to be accessed from outside the Zookeeper cluster as well
         NetworkPolicyIngressRule clientsIngressRule = new NetworkPolicyIngressRuleBuilder()
                 .withPorts(clientsPort)
                 .withFrom()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -255,34 +255,12 @@ public class ZookeeperCluster extends AbstractModel {
         NetworkPolicyPort leaderElectionPort = new NetworkPolicyPort();
         leaderElectionPort.setPort(new IntOrString(LEADER_ELECTION_PORT));
 
-        NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector = new LabelSelector();
-        Map<String, String> expressions = new HashMap<>();
-        expressions.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster));
-        labelSelector.setMatchLabels(expressions);
-        kafkaClusterPeer.setPodSelector(labelSelector);
-
         NetworkPolicyPeer zookeeperClusterPeer = new NetworkPolicyPeer();
         LabelSelector labelSelector2 = new LabelSelector();
         Map<String, String> expressions2 = new HashMap<>();
         expressions2.put(Labels.STRIMZI_NAME_LABEL, zookeeperClusterName(cluster));
         labelSelector2.setMatchLabels(expressions2);
         zookeeperClusterPeer.setPodSelector(labelSelector2);
-
-        NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector3 = new LabelSelector();
-        Map<String, String> expressions3 = new HashMap<>();
-        expressions3.put(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(cluster));
-        labelSelector3.setMatchLabels(expressions3);
-        entityOperatorPeer.setPodSelector(labelSelector3);
-
-        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector4 = new LabelSelector();
-        Map<String, String> expressions4 = new HashMap<>();
-        expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
-        labelSelector4.setMatchLabels(expressions4);
-        clusterOperatorPeer.setPodSelector(labelSelector4);
-        clusterOperatorPeer.setNamespaceSelector(new LabelSelector());
 
         // Zookeeper only ports - 2888 & 3888 which need to be accessed by the Zookeeper cluster members only
         NetworkPolicyIngressRule zookeeperClusteringIngressRule = new NetworkPolicyIngressRuleBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteIngress;
@@ -970,18 +969,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkNetPolicy() {
-            Future future = networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(true)).recover(
-                cause -> {
-                    if (cause instanceof KubernetesClientException && cause.getMessage() != null && cause.getMessage().contains("Forbidden: may not specify more than 1 from type"))  {
-                        log.debug("Network policy creation failed - retrying without namespace");
-                        return networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy(false));
-                    } else {
-                        return Future.failedFuture(cause);
-                    }
-                }
-            );
-
-            return withVoid(future);
+            return withVoid(networkPolicyOperator.reconcile(namespace, ZookeeperCluster.policyName(name), zkCluster.generateNetworkPolicy()));
         }
 
         Future<ReconciliationState> zkPodDisruptionBudget() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -516,66 +516,36 @@ public class ZookeeperClusterTest {
         kafkaAssembly.getSpec().getKafka().setRack(new RackBuilder().withTopologyKey("topology-key").build());
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        // Check Network Policies
-        NetworkPolicy np = zc.generateNetworkPolicy(true);
+        NetworkPolicy np = zc.generateNetworkPolicy();
 
         LabelSelector podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
         assertEquals(podSelector, np.getSpec().getPodSelector());
 
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress();
-        assertEquals(2, rules.size());
+        assertEquals(3, rules.size());
 
-        NetworkPolicyIngressRule metricsRule = rules.get(1);
+        // Ports 2888 and 3888
+        NetworkPolicyIngressRule zooRule = rules.get(0);
+        assertEquals(2, zooRule.getPorts().size());
+        assertEquals(new IntOrString(2888), zooRule.getPorts().get(0).getPort());
+        assertEquals(new IntOrString(3888), zooRule.getPorts().get(1).getPort());
+
+        assertEquals(1, zooRule.getFrom().size());
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(0));
+
+        // Port 2181
+        NetworkPolicyIngressRule clientsRule = rules.get(1);
+        assertEquals(1, clientsRule.getPorts().size());
+        assertEquals(new IntOrString(2181), clientsRule.getPorts().get(0).getPort());
+        assertEquals(0, clientsRule.getFrom().size());
+
+        // Port 9404
+        NetworkPolicyIngressRule metricsRule = rules.get(2);
         assertEquals(1, metricsRule.getPorts().size());
         assertEquals(new IntOrString(9404), metricsRule.getPorts().get(0).getPort());
         assertEquals(0, metricsRule.getFrom().size());
-
-        NetworkPolicyIngressRule zooRule = rules.get(0);
-        assertEquals(3, zooRule.getPorts().size());
-        assertEquals(new IntOrString(2181), zooRule.getPorts().get(0).getPort());
-        assertEquals(new IntOrString(2888), zooRule.getPorts().get(1).getPort());
-        assertEquals(new IntOrString(3888), zooRule.getPorts().get(2).getPort());
-
-        assertEquals(4, zooRule.getFrom().size());
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(0));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(1));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(2));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(new LabelSelector()).build(), zooRule.getFrom().get(3));
-
-        // Check NetworkPolicy for older OCP versions
-        np = zc.generateNetworkPolicy(false);
-        rules = np.getSpec().getIngress();
-        zooRule = rules.get(0);
-
-        assertEquals(4, zooRule.getFrom().size());
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(0));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(1));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, EntityOperator.entityOperatorName(zc.getCluster())));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(2));
-
-        podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
-        assertEquals(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build(), zooRule.getFrom().get(3));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -803,7 +803,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock NetworkPolicy get
         when(mockPolicyOps.get(clusterNamespace, KafkaCluster.policyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy());
-        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(true));
+        when(mockPolicyOps.get(clusterNamespace, ZookeeperCluster.policyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy());
 
         // Mock PodDisruptionBudget get
         when(mockPdbOps.get(clusterNamespace, KafkaCluster.kafkaClusterName(clusterName))).thenReturn(originalKafkaCluster.generatePodDisruptionBudget());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issue with network policies on OpenShift 3.11 where the network policy plugin doesn't support namespace and pod selectors combined. Therefore on Kubernetes <= 1.10 and OpenShift <= 3.11, the 3.11 port is open to everyone on the network policy level (authentication is of course still there).

This PR contains the back port of #1605 for the 0.11.x branch where the Kubernetes Version handling is not yet available.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally