### PR TITLE
ST: kafka rolling update fix

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -18,7 +18,7 @@ public interface Constants {
     long POLL_INTERVAL_FOR_RESOURCE_CREATION = Duration.ofSeconds(3).toMillis();
     long POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(1).toMillis();
     long WAIT_FOR_ROLLING_UPDATE_INTERVAL = Duration.ofSeconds(5).toMillis();
-    long WAIT_FOR_ROLLING_UPDATE_TIMEOUT = Duration.ofMinutes(5).toMillis();
+    long WAIT_FOR_ROLLING_UPDATE_TIMEOUT = Duration.ofMinutes(7).toMillis();
 
     long TIMEOUT_FOR_SEND_RECEIVE_MSG = Duration.ofSeconds(30).toMillis();
     long TIMEOUT_AVAILABILITY_TEST = Duration.ofMinutes(1).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -11,7 +11,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.strimzi.systemtest.Resources;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-public class StUtils {
+public class StUtils implements Constants {
 
     private static final Logger LOGGER = LogManager.getLogger(StUtils.class);
 
@@ -123,10 +123,13 @@ public class StUtils {
         }
     }
 
-
     public static Map<String, String> waitTillSsHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
+        return waitTillSsHasRolled(client, namespace, name, snapshot, WAIT_FOR_ROLLING_UPDATE_TIMEOUT);
+    }
+
+    public static Map<String, String> waitTillSsHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot, long timeout) {
         TestUtils.waitFor("SS roll of " + name,
-            1_000, 450_000, () -> {
+                WAIT_FOR_ROLLING_UPDATE_INTERVAL, timeout, () -> {
                 try {
                     return ssHasRolled(client, namespace, name, snapshot);
                 } catch (Exception e) {
@@ -140,9 +143,9 @@ public class StUtils {
 
     public static Map<String, String> waitTillDepHasRolled(KubernetesClient client, String namespace, String name, Map<String, String> snapshot) {
         long timeLeft = TestUtils.waitFor("Deployment roll of " + name,
-            1_000, 300_000, () -> depHasRolled(client, namespace, name, snapshot));
+                WAIT_FOR_ROLLING_UPDATE_INTERVAL, WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depHasRolled(client, namespace, name, snapshot));
         StUtils.waitForDeploymentReady(client, namespace, name);
-        StUtils.waitForPodsReady(client, namespace, client.extensions().deployments().inNamespace(namespace).withName(name).get().getSpec().getSelector(), true);
+        StUtils.waitForPodsReady(client, namespace, client.apps().deployments().inNamespace(namespace).withName(name).get().getSpec().getSelector(), true);
         return depSnapshot(client, namespace, name);
     }
 
@@ -175,7 +178,7 @@ public class StUtils {
      */
     public static void waitForAllStatefulSetPodsReady(KubernetesClient client, String namespace, String name) {
         LOGGER.info("Waiting for StatefulSet {} to be ready", name);
-        TestUtils.waitFor("statefulset " + name, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("statefulset " + name, POLL_INTERVAL_FOR_RESOURCE_READINESS, TIMEOUT_FOR_RESOURCE_READINESS,
             () -> client.apps().statefulSets().inNamespace(namespace).withName(name).isReady());
         LOGGER.info("StatefulSet {} is ready", name);
         LOGGER.info("Waiting for Pods of StatefulSet {} to be ready", name);
@@ -183,7 +186,7 @@ public class StUtils {
     }
 
     public static void waitForPodsReady(KubernetesClient client, String namespace, LabelSelector selector, boolean containers) {
-        TestUtils.waitFor("All pods matching " + selector + "to be ready", Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS, () -> {
+        TestUtils.waitFor("All pods matching " + selector + "to be ready", POLL_INTERVAL_FOR_RESOURCE_READINESS, TIMEOUT_FOR_RESOURCE_READINESS, () -> {
             List<Pod> pods = client.pods().inNamespace(namespace).withLabelSelector(selector).list().getItems();
             if (pods.isEmpty()) {
                 LOGGER.debug("Not ready (no pods matching {})", selector);
@@ -215,7 +218,7 @@ public class StUtils {
      */
     public static void waitForDeploymentReady(KubernetesClient client, String namespace, String name) {
         LOGGER.info("Waiting for Deployment {}", name);
-        TestUtils.waitFor("deployment " + name, Resources.POLL_INTERVAL_FOR_RESOURCE_READINESS, Resources.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("deployment " + name, POLL_INTERVAL_FOR_RESOURCE_READINESS, TIMEOUT_FOR_RESOURCE_READINESS,
             () -> client.apps().deployments().inNamespace(namespace).withName(name).isReady());
         LOGGER.info("Deployment {} is ready", name);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -123,6 +123,7 @@ class KafkaST extends MessagingBaseST {
                             .withTls(false)
                         .endKafkaListenerExternalLoadBalancer()
                     .endListeners()
+                    .withConfig(singletonMap("default.replication.factor", 3))
                 .endKafka()
             .endSpec().done();
 
@@ -139,8 +140,11 @@ class KafkaST extends MessagingBaseST {
         final String newPodName = kafkaPodName(CLUSTER_NAME,  newPodId);
         final String firstPodName = kafkaPodName(CLUSTER_NAME,  0);
         LOGGER.info("Scaling up to {}", scaleTo);
+        // Create snapshot of current cluster
+        String kafkaSsName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StUtils.ssSnapshot(CLIENT, NAMESPACE, kafkaSsName);
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(initialReplicas + 1));
-        KUBE_CLIENT.waitForStatefulSet(kafkaClusterName(CLUSTER_NAME), initialReplicas + 1);
+        kafkaPods = StUtils.waitTillSsHasRolled(CLIENT, NAMESPACE, kafkaSsName, kafkaPods, 600000);
 
         // Test that the new broker has joined the kafka cluster by checking it knows about all the other broker's API versions
         // (execute bash because we want the env vars expanded in the pod)
@@ -160,11 +164,11 @@ class KafkaST extends MessagingBaseST {
 
         // scale down
         LOGGER.info("Scaling down");
+        // Get kafka new pod uid before deletion
+        uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newPodName).get().getMetadata().getUid();
         operationID = startTimeMeasuring(Operation.SCALE_DOWN);
-        replaceKafkaResource(CLUSTER_NAME, k -> {
-            k.getSpec().getKafka().setReplicas(initialReplicas);
-        });
-        KUBE_CLIENT.waitForStatefulSet(kafkaClusterName(CLUSTER_NAME), initialReplicas);
+        replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getKafka().setReplicas(initialReplicas));
+        StUtils.waitTillSsHasRolled(CLIENT, NAMESPACE, kafkaSsName, kafkaPods, 600000);
 
         final int finalReplicas = CLIENT.apps().statefulSets().inNamespace(KUBE_CLIENT.namespace()).withName(kafkaClusterName(CLUSTER_NAME)).get().getStatus().getReplicas();
         assertEquals(initialReplicas, finalReplicas);
@@ -174,7 +178,6 @@ class KafkaST extends MessagingBaseST {
                 "Expect the added broker, " + newBrokerId + ",  to no longer be present in output of kafka-broker-api-versions.sh");
 
         //Test that the new broker has event 'Killing'
-        uid = CLIENT.pods().inNamespace(NAMESPACE).withName(newPodName).get().getMetadata().getUid();
         assertThat(getEvents(uid), hasAllOfReasons(Killing));
         //Test that stateful set has event 'SuccessfulDelete'
         uid = CLIENT.apps().statefulSets().inNamespace(NAMESPACE).withName(kafkaClusterName(CLUSTER_NAME)).get().getMetadata().getUid();
@@ -182,6 +185,7 @@ class KafkaST extends MessagingBaseST {
         //Test that CO doesn't have any exceptions in log
         TimeMeasuringSystem.stopOperation(operationID);
         assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, operationID));
+        waitForClusterAvailability(NAMESPACE);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Check for kafka rolling update was used wrongly - all pods has to be rolled and then new pod is created, but check waits only for whole stateful set readiness. Timeout for this check wasn't enough for our test environment.  Right now, test execution will wait till all pods are rolled and then for new pod readiness.

### Checklist

- [x] Make sure all tests pass


