### PR TITLE
ST: delete pods after test execution by force

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -540,6 +540,10 @@ public abstract class AbstractST extends BaseITST implements TestSeparator, Cons
 
         LOGGER.info("Wait for {} ms after cleanup to make sure everything is deleted", time);
         Thread.sleep(time);
+
+        // Collect pods again after proper removal
+        pods = CLIENT.pods().inNamespace(namespace).list().getItems().stream().filter(
+                p -> !p.getMetadata().getName().startsWith(CLUSTER_OPERATOR_PREFIX)).collect(Collectors.toList());
         long podCount = pods.size();
 
         StringBuilder nonTerminated = new StringBuilder();

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -543,7 +543,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator, Cons
 
         // Collect pods again after proper removal
         pods = CLIENT.pods().inNamespace(namespace).list().getItems().stream().filter(
-                p -> !p.getMetadata().getName().startsWith(CLUSTER_OPERATOR_PREFIX)).collect(Collectors.toList());
+            p -> !p.getMetadata().getName().startsWith(CLUSTER_OPERATOR_PREFIX)).collect(Collectors.toList());
         long podCount = pods.size();
 
         StringBuilder nonTerminated = new StringBuilder();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -30,7 +30,6 @@ import io.strimzi.test.timemeasuring.Operation;
 import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -1062,12 +1061,6 @@ class KafkaST extends MessagingBaseST {
         createTestMethodResources();
         testMethodResources.createServiceResource(Resources.KAFKA_CLIENTS, Environment.INGRESS_DEFAULT_PORT, NAMESPACE).done();
         testMethodResources.createIngress(Resources.KAFKA_CLIENTS, Environment.INGRESS_DEFAULT_PORT, CONFIG.getMasterUrl(), NAMESPACE).done();
-    }
-
-    @AfterEach
-    void deleteTestResources() throws Exception {
-        deleteTestMethodResources();
-        waitForDeletion(TIMEOUT_TEARDOWN, NAMESPACE);
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

From time to time, kubernetes keep some pods alive, even if deployment for these pods is deleted. I added force deletion of the pods before check if there are some unexpected pods after test execution.

### Checklist

- [x] Make sure all tests pass

