### PR TITLE
Issue #1616: EntityTopicOperator and EntityUserOperator should not us…

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -27,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"watchedNamespace", "image",
         "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
+        "livenessProbe", "readinessProbe",
         "resources", "topicMetadataMaxAttempts", "logging", "jvmOptions"})
 @EqualsAndHashCode
 public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Serializable {
@@ -47,6 +48,8 @@ public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Seria
     protected int reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
     protected int zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
     protected int topicMetadataMaxAttempts = DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
+    private Probe livenessProbe;
+    private Probe readinessProbe;
     protected ResourceRequirements resources;
     protected Logging logging;
     private EntityOperatorJvmOptions jvmOptions;
@@ -109,6 +112,27 @@ public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Seria
     public void setResources(ResourceRequirements resources) {
         this.resources = resources;
     }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
+    }
+
 
     @Description("Logging configuration")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -27,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"watchedNamespace", "image",
         "reconciliationIntervalSeconds", "zookeeperSessionTimeoutSeconds",
+        "livenessProbe", "readinessProbe",
         "resources", "logging", "jvmOptions"})
 @EqualsAndHashCode
 public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serializable {
@@ -43,6 +44,8 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
     private String image;
     private long reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
     private long zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
+    private Probe livenessProbe;
+    private Probe readinessProbe;
     private ResourceRequirements resources;
     private Logging logging;
     private EntityOperatorJvmOptions jvmOptions;
@@ -94,6 +97,26 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
     @Description("Resource constraints (limits and requests).")
     public void setResources(ResourceRequirements resources) {
         this.resources = resources;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
     }
 
     @Description("Logging configuration")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -68,11 +68,7 @@ public class EntityTopicOperator extends AbstractModel {
         super(namespace, cluster, labels);
         this.name = topicOperatorName(cluster);
         this.readinessPath = "/";
-        this.readinessTimeout = EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
-        this.readinessInitialDelay = EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
         this.livenessPath = "/";
-        this.livenessTimeout = EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
-        this.livenessInitialDelay = EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
 
         // create a default configuration
         this.kafkaBootstrapServers = defaultBootstrapServers(cluster);
@@ -210,6 +206,20 @@ public class EntityTopicOperator extends AbstractModel {
                 result.setLogging(topicOperatorSpec.getLogging());
                 result.setGcLoggingEnabled(topicOperatorSpec.getJvmOptions() == null ? true : topicOperatorSpec.getJvmOptions().isGcLoggingEnabled());
                 result.setResources(topicOperatorSpec.getResources());
+                if (topicOperatorSpec.getReadinessProbe() != null) {
+                    result.setReadinessInitialDelay(topicOperatorSpec.getReadinessProbe().getInitialDelaySeconds());
+                    result.setReadinessTimeout(topicOperatorSpec.getReadinessProbe().getTimeoutSeconds());
+                } else {
+                    result.setReadinessInitialDelay(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY);
+                    result.setReadinessTimeout(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT);
+                }
+                if (topicOperatorSpec.getLivenessProbe() != null) {
+                    result.setLivenessInitialDelay(topicOperatorSpec.getLivenessProbe().getInitialDelaySeconds());
+                    result.setLivenessTimeout(topicOperatorSpec.getLivenessProbe().getTimeoutSeconds());
+                } else {
+                    result.setLivenessInitialDelay(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY);
+                    result.setLivenessTimeout(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT);
+                }
             }
         }
         return result;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -68,11 +68,7 @@ public class EntityUserOperator extends AbstractModel {
         super(namespace, cluster, labels);
         this.name = userOperatorName(cluster);
         this.readinessPath = "/";
-        this.readinessTimeout = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
-        this.readinessInitialDelay = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
         this.livenessPath = "/";
-        this.livenessTimeout = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT;
-        this.livenessInitialDelay = EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY;
 
         // create a default configuration
         this.zookeeperConnect = defaultZookeeperConnect(cluster);
@@ -197,6 +193,22 @@ public class EntityUserOperator extends AbstractModel {
                 result.setLogging(userOperatorSpec.getLogging());
                 result.setGcLoggingEnabled(userOperatorSpec.getJvmOptions() == null ? true : userOperatorSpec.getJvmOptions().isGcLoggingEnabled());
                 result.setResources(userOperatorSpec.getResources());
+                if (userOperatorSpec.getReadinessProbe() != null) {
+                    result.setReadinessInitialDelay(userOperatorSpec.getReadinessProbe().getInitialDelaySeconds());
+                    result.setReadinessTimeout(userOperatorSpec.getReadinessProbe().getTimeoutSeconds());
+                } else {
+                    result.setReadinessInitialDelay(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY);
+                    result.setReadinessTimeout(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT);
+                }
+                if (userOperatorSpec.getLivenessProbe() != null) {
+                    result.setLivenessInitialDelay(userOperatorSpec.getLivenessProbe().getInitialDelaySeconds());
+                    result.setLivenessTimeout(userOperatorSpec.getLivenessProbe().getTimeoutSeconds());
+                } else {
+                    result.setLivenessInitialDelay(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY);
+                    result.setLivenessTimeout(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT);
+                }
+
+
                 if (kafkaAssembly.getSpec().getClientsCa() != null) {
                     result.setClientsCaValidityDays(kafkaAssembly.getSpec().getClientsCa().getValidityDays());
                     result.setClientsCaRenewalDays(kafkaAssembly.getSpec().getClientsCa().getRenewalDays());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.EntityTopicOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.operator.cluster.ResourceUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,6 +40,17 @@ public class EntityTopicOperatorTest {
     {
         topicOperatorLogging.setLoggers(Collections.singletonMap("topic-operator.root.logger", "OFF"));
     }
+    private final Probe livenessProbe = new Probe();
+    {
+        livenessProbe.setInitialDelaySeconds(15);
+        livenessProbe.setTimeoutSeconds(20);
+    }
+
+    private final Probe readinessProbe = new Probe();
+    {
+        readinessProbe.setInitialDelaySeconds(15);
+        livenessProbe.setInitialDelaySeconds(20);
+    }
 
     private final String toWatchedNamespace = "my-topic-namespace";
     private final String toImage = "my-topic-operator-image";
@@ -52,6 +64,8 @@ public class EntityTopicOperatorTest {
             .withReconciliationIntervalSeconds(toReconciliationInterval)
             .withZookeeperSessionTimeoutSeconds(toZookeeperSessionTimeout)
             .withTopicMetadataMaxAttempts(toTopicMetadataMaxAttempts)
+            .withLivenessProbe(livenessProbe)
+            .withReadinessProbe(readinessProbe)
             .withLogging(topicOperatorLogging)
             .build();
 
@@ -92,10 +106,10 @@ public class EntityTopicOperatorTest {
         assertEquals(namespace, entityTopicOperator.namespace);
         assertEquals(cluster, entityTopicOperator.cluster);
         assertEquals(toImage, entityTopicOperator.image);
-        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.readinessInitialDelay);
-        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.readinessTimeout);
-        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.livenessInitialDelay);
-        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.livenessTimeout);
+        assertEquals(readinessProbe.getInitialDelaySeconds(), entityTopicOperator.readinessInitialDelay);
+        assertEquals(readinessProbe.getTimeoutSeconds(), entityTopicOperator.readinessTimeout);
+        assertEquals(livenessProbe.getInitialDelaySeconds(), entityTopicOperator.livenessInitialDelay);
+        assertEquals(livenessProbe.getTimeoutSeconds(), entityTopicOperator.livenessTimeout);
         assertEquals(toWatchedNamespace, entityTopicOperator.getWatchedNamespace());
         assertEquals(toReconciliationInterval * 1000, entityTopicOperator.getReconciliationIntervalMs());
         assertEquals(toZookeeperSessionTimeout * 1000, entityTopicOperator.getZookeeperSessionTimeoutMs());
@@ -130,6 +144,10 @@ public class EntityTopicOperatorTest {
         assertEquals(EntityTopicOperator.defaultZookeeperConnect(cluster), entityTopicOperator.getZookeeperConnect());
         assertEquals(EntityTopicOperator.defaultBootstrapServers(cluster), entityTopicOperator.getKafkaBootstrapServers());
         assertEquals(ModelUtils.defaultResourceLabels(cluster), entityTopicOperator.getResourceLabels());
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.readinessInitialDelay);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.readinessTimeout);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY, entityTopicOperator.livenessInitialDelay);
+        assertEquals(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT, entityTopicOperator.livenessTimeout);
         assertNull(entityTopicOperator.getLogging());
     }
 
@@ -163,10 +181,10 @@ public class EntityTopicOperatorTest {
         assertEquals(EntityTopicOperator.TOPIC_OPERATOR_CONTAINER_NAME, container.getName());
         assertEquals(entityTopicOperator.getImage(), container.getImage());
         assertEquals(getExpectedEnvVars(), container.getEnv());
-        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY), container.getLivenessProbe().getInitialDelaySeconds());
-        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT), container.getLivenessProbe().getTimeoutSeconds());
-        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY), container.getReadinessProbe().getInitialDelaySeconds());
-        assertEquals(new Integer(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT), container.getReadinessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(livenessProbe.getInitialDelaySeconds()), container.getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(livenessProbe.getTimeoutSeconds()), container.getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(readinessProbe.getInitialDelaySeconds()), container.getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(readinessProbe.getTimeoutSeconds()), container.getReadinessProbe().getTimeoutSeconds());
         assertEquals(1, container.getPorts().size());
         assertEquals(new Integer(EntityTopicOperator.HEALTHCHECK_PORT), container.getPorts().get(0).getContainerPort());
         assertEquals(EntityTopicOperator.HEALTHCHECK_PORT_NAME, container.getPorts().get(0).getName());

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -559,7 +559,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 [id='type-Probe-{context}']
 ### `Probe` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -862,6 +862,10 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |jvmOptions                      1.2+<.<|JVM Options for pods.
 |xref:type-EntityOperatorJvmOptions-{context}[`EntityOperatorJvmOptions`]
+|livenessProbe                   1.2+<.<|Pod liveness checking.
+|xref:type-Probe-{context}[`Probe`]
+|readinessProbe                  1.2+<.<|Pod readiness checking.
+|xref:type-Probe-{context}[`Probe`]
 |====
 
 [id='type-EntityOperatorJvmOptions-{context}']
@@ -921,6 +925,10 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |integer
 |zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the Zookeeper session.
 |integer
+|livenessProbe                   1.2+<.<|Pod liveness checking.
+|xref:type-Probe-{context}[`Probe`]
+|readinessProbe                  1.2+<.<|Pod readiness checking.
+|xref:type-Probe-{context}[`Probe`]
 |resources                       1.2+<.<|Resource constraints (limits and requests).
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
 |topicMetadataMaxAttempts        1.2+<.<|The number of attempts at getting topic metadata.
@@ -948,6 +956,10 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |integer
 |zookeeperSessionTimeoutSeconds  1.2+<.<|Timeout for the Zookeeper session.
 |integer
+|livenessProbe                   1.2+<.<|Pod liveness checking.
+|xref:type-Probe-{context}[`Probe`]
+|readinessProbe                  1.2+<.<|Pod readiness checking.
+|xref:type-Probe-{context}[`Probe`]
 |resources                       1.2+<.<|Resource constraints (limits and requests).
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
 |logging                         1.2+<.<|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2049,6 +2049,24 @@ spec:
                   properties:
                     gcLoggingEnabled:
                       type: boolean
+                livenessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                readinessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
             entityOperator:
               type: object
               properties:
@@ -2065,6 +2083,24 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:
@@ -2107,6 +2143,24 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
                     resources:
                       type: object
                       properties:


### PR DESCRIPTION
Issue #1616: EntityTopicOperator and EntityUserOperator should not use hard coded values for health checks

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

See Issue #1616

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

