### PR TITLE
Fix YAML change detection in Travis builds

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -23,6 +23,9 @@ make docu_check
 if [ "${MAIN_BUILD}" = "TRUE" ] ; then
   make findbugs
 fi
+
+make crd_install
+make helm_install
 make docker_build
 
 if [ ! -e  documentation/book/appendix_crds.adoc ] ; then

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
-$(DOCKER_TARGETS): crd_install helm_install $(SUBDIRS)
+$(DOCKER_TARGETS): $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 
 next_version:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -772,8 +772,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             version:
               type: string
           required:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -759,8 +759,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -97,6 +97,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -118,8 +119,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - groupId
               - bootstrapServers
@@ -159,6 +158,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -180,8 +180,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - bootstrapServers
             resources:

--- a/install/Makefile
+++ b/install/Makefile
@@ -20,17 +20,17 @@ crd_install:
 	$(CP) ./cluster-operator/043-Crd-kafkatopic.yaml ../helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
 	$(CP) ./cluster-operator/044-Crd-kafkauser.yaml ../helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
 	$(CP) ./cluster-operator/045-Crd-kafkamirrormaker.yaml ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
-	pushd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.app "{{ template \"strimzi.name\" . }}" \; && popd
-	pushd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.chart "{{ template \"strimzi.chart\" . }}" \; && popd
+	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.app "{{ template \"strimzi.name\" . }}" \; && cd $$oldpath
+	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.chart "{{ template \"strimzi.chart\" . }}" \; && cd $$oldpath
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml metadata.labels.component "kafkas.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml metadata.labels.component "kafkaconnects.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml metadata.labels.component "kafkaconnects2is.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml metadata.labels.component "kafkatopics.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml metadata.labels.component "kafkausers.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml metadata.labels.component "kafkamirrormakers.kafka.strimzi.io-crd"
-	pushd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.release "{{ .Release.Name }}" \; && popd
-	pushd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.heritage "{{ .Release.Service }}" \; && popd
-	pushd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec $(SED) -i -e '1s/^/{{- if .Values.createGlobalResources -}}\n/' -e '$$s/$$/\n{{- end -}}/' {} \; && popd
+	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.release "{{ .Release.Name }}" \; && cd $$oldpath
+	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.heritage "{{ .Release.Service }}" \; && cd $$oldpath
+	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec $(SED) -i -e '1s/^/{{- if .Values.createGlobalResources -}}\n/' -e '$$s/$$/\n{{- end -}}/' {} \; && cd $$oldpath
 
 release:
 	mkdir -p $(RELEASE_PATH)

--- a/olm/kafkaconnects.crd.yaml
+++ b/olm/kafkaconnects.crd.yaml
@@ -767,8 +767,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             version:
               type: string
           required:

--- a/olm/kafkaconnects2is.crd.yaml
+++ b/olm/kafkaconnects2is.crd.yaml
@@ -754,8 +754,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/olm/kafkamirrormakers.crd.yaml
+++ b/olm/kafkamirrormakers.crd.yaml
@@ -92,6 +92,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -113,8 +114,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - groupId
               - bootstrapServers
@@ -154,6 +153,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -175,8 +175,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - bootstrapServers
             resources:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Travis build should check that any changes to the CRDs or to YAML deployment files are done to all their copies ... in `install` folder, in `helm-charts` and in `olm`. This currently doesn't work, because Travis currently doesn't build the make steps which regenerate these files. This PR resolves this by explicitly running the corresponding make steps.