### PR TITLE
The health check configurations for UO and TO deployed through CO should be referenced in docs

### DIFF
--- a/documentation/book/ref-healthchecks.adoc
+++ b/documentation/book/ref-healthchecks.adoc
@@ -12,6 +12,8 @@ Liveness and readiness probes can be configured using the `livenessProbe` and `r
 * `Kafka.spec.zookeeper`
 * `Kafka.spec.zookeeper.tlsSidecar`
 * `Kafka.spec.entityOperator.tlsSidecar`
+* `Kafka.spec.entityOperator.topicOperator`
+* `Kafka.spec.entityOperator.userOperator`
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The PR #1619 added the configuration for health checks to the `Kafka.spec.entityOperator.topicOperator` and `Kafka.spec.entityOperator.userOperator` sections of the API. Thi should be also reflected in the documentation.