### PR TITLE
Make it possible to use different alphabet for the first password character

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -58,6 +58,8 @@ public class KafkaUserOperator {
     private final ScramShaCredentialsOperator scramShaCredentialOperator;
     private PasswordGenerator passwordGenerator = new PasswordGenerator(12,
             "abcdefghijklmnopqrstuvwxyz" +
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "abcdefghijklmnopqrstuvwxyz" +
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
                     "0123456789");
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/PasswordGenerator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/PasswordGenerator.java
@@ -6,22 +6,44 @@ package io.strimzi.operator.user.operator;
 
 import java.security.SecureRandom;
 
+/**
+ * Class for generating passwords for SASL users
+ */
 public class PasswordGenerator {
-
     private final SecureRandom rng = new SecureRandom();
     private final int length;
+    private final String firstCharacterAlphabet;
     private final String alphabet;
 
-    public PasswordGenerator(int length, String alphabet) {
+    /**
+     * Constructor to initialize the PasswordGenerator with alphabets and password length.
+     * It distinguishes between the alphabet for the first character of the password and the rest.
+     * This is needed because of how Java JAAS parses the configuration string.
+     *
+     * @param length    The length of the generated passwords
+     * @param firstCharacterAlphabet    A String with characters which will be used to generate the first character of the password
+     * @param alphabet  A String with characters which will be used to generate the character of the password starting with the second character
+     */
+    public PasswordGenerator(int length, String firstCharacterAlphabet, String alphabet) {
         this.length = length;
+        this.firstCharacterAlphabet = firstCharacterAlphabet;
         this.alphabet = alphabet;
     }
 
+    /**
+     * Generates the password
+     *
+     * @return String with new password
+     */
     public String generate() {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < length; i++) {
+
+        sb.append(firstCharacterAlphabet.charAt(rng.nextInt(firstCharacterAlphabet.length())));
+
+        for (int i = 1; i < length; i++) {
             sb.append(alphabet.charAt(rng.nextInt(alphabet.length())));
         }
+
         return sb.toString();
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -31,7 +31,7 @@ public class KafkaUserModelTest {
     private final Secret clientsCaCert = ResourceUtils.createClientsCaCertSecret();
     private final Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
     private final CertManager mockCertManager = new MockCertManager();
-    private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a");
+    private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
 
     public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
         assertEquals(1, resource.getMetadata().getOwnerReferences().size());

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/PasswordGeneratorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/PasswordGeneratorTest.java
@@ -13,13 +13,21 @@ public class PasswordGeneratorTest {
 
     @Test
     public void length() {
-        PasswordGenerator generator = new PasswordGenerator(10, "a");
+        PasswordGenerator generator = new PasswordGenerator(10, "a", "a");
         assertEquals("aaaaaaaaaa", generator.generate());
     }
 
     @Test
     public void alphabet() {
-        PasswordGenerator generator = new PasswordGenerator(10, "ab");
+        PasswordGenerator generator = new PasswordGenerator(10, "ab", "ab");
         assertTrue(generator.generate().matches("[ab]{10}"));
+    }
+
+    @Test
+    public void firstLetterAlphabet() {
+        PasswordGenerator generator = new PasswordGenerator(10, "a", "b");
+        String password = generator.generate();
+        assertEquals("a", password.substring(0, 1));
+        assertEquals("bbbbbbbbb", password.substring(1, 10));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Passwords starting with number can cause problems with certain JASS configurations. For example following configuration:

```ini
security.protocol=SASL_PLAINTEXT
sasl.mechanism=SCRAM-SHA-512
sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=my-user2 password=0password;
```

would fail with following exception in the consoler consumer:

```
$ bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --consumer.config /tmp/properties --group my-group --topic kafka-test-apps
OpenJDK 64-Bit Server VM warning: If the number of processors is expected to increase from one, then you should configure the number of parallel GC threads appropriately using -XX:ParallelGCThreads=N
[2019-05-15 20:05:14,021] ERROR Unknown error when running consumer:  (kafka.tools.ConsoleConsumer$)
org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:805)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:652)
	at kafka.tools.ConsoleConsumer$.run(ConsoleConsumer.scala:67)
	at kafka.tools.ConsoleConsumer$.main(ConsoleConsumer.scala:54)
	at kafka.tools.ConsoleConsumer.main(ConsoleConsumer.scala)
Caused by: java.lang.IllegalArgumentException: Value not specified for key 'password' in JAAS config
	at org.apache.kafka.common.security.JaasConfig.parseAppConfigurationEntry(JaasConfig.java:116)
	at org.apache.kafka.common.security.JaasConfig.<init>(JaasConfig.java:63)
	at org.apache.kafka.common.security.JaasContext.load(JaasContext.java:90)
	at org.apache.kafka.common.security.JaasContext.loadClientContext(JaasContext.java:84)
	at org.apache.kafka.common.network.ChannelBuilders.create(ChannelBuilders.java:119)
	at org.apache.kafka.common.network.ChannelBuilders.clientChannelBuilder(ChannelBuilders.java:65)
	at org.apache.kafka.clients.ClientUtils.createChannelBuilder(ClientUtils.java:108)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:718)
	... 4 more
```

It can be worked around by using apostrophes in the configuration:

```ini
security.protocol=SASL_PLAINTEXT
sasl.mechanism=SCRAM-SHA-512
sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=my-user2 password='0password';
```

But that is not completely intuitive given the exceptions which are a bit unclear. So it might make sense to modify the password generator to avid this kind of issues and improve the usability.