### PR TITLE
ST: fix check of kafka rolling update

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -617,8 +617,19 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
      * @throws Exception
      */
     void waitForClusterAvailability(String namespace) throws Exception {
-        int messageCount = 50;
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
+        waitForClusterAvailability(namespace, topicName);
+    }
+
+
+    /**
+     * Wait for cluster availability, check availability of external routes without TLS
+     * @param namespace cluster namespace
+     * @param topicName topic name
+     * @throws Exception
+     */
+    void waitForClusterAvailability(String namespace, String topicName) throws Exception {
+        int messageCount = 50;
 
         KafkaClient testClient = new KafkaClient();
         try {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -547,10 +547,19 @@ public class Resources extends AbstractResources {
     }
 
     DoneableKafkaTopic topic(String clusterName, String topicName) {
-        return topic(defaultTopic(clusterName, topicName).build());
+        return topic(defaultTopic(clusterName, topicName, 1, 1).build());
     }
 
-    private KafkaTopicBuilder defaultTopic(String clusterName, String topicName) {
+    DoneableKafkaTopic topic(String clusterName, String topicName, int partitions) {
+        return topic(defaultTopic(clusterName, topicName, partitions, 1).build());
+    }
+
+    DoneableKafkaTopic topic(String clusterName, String topicName, int partitions, int replicas) {
+        return topic(defaultTopic(clusterName, topicName, partitions, replicas).build());
+    }
+
+    private KafkaTopicBuilder defaultTopic(String clusterName, String topicName, int partitions, int replicas) {
+        LOGGER.info("Creating topic: {} with {} partitions and {} replicas", topicName, partitions, replicas);
         return new KafkaTopicBuilder()
                 .withMetadata(
                         new ObjectMetaBuilder()
@@ -559,8 +568,9 @@ public class Resources extends AbstractResources {
                                 .addToLabels("strimzi.io/cluster", clusterName)
                 .build())
                 .withNewSpec()
-                    .withPartitions(1)
-                    .withReplicas(1)
+                    .withPartitions(partitions)
+                    .withReplicas(replicas)
+                    .addToConfig("min.insync.replicas", replicas)
                 .endSpec();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -183,6 +183,13 @@ public class KubeClient {
     }
 
     /**
+     * Gets statefulset Uid
+     */
+    public String getSsUid(String name) {
+        return client.apps().statefulSets().inNamespace(getNamespace()).withName(name).get().getMetadata().getUid();
+    }
+
+    /**
      * Deletes pod
      */
     public Boolean deletePod(Pod pod) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Check kafka rolling update via cluster availability (produce/consume msg) instead of check errors in the pods. 

### Checklist

- [x] Make sure all tests pass

