### PR TITLE
Fix problem with 0 validity in UO when custom CA is used

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -210,8 +210,13 @@ public class EntityUserOperator extends AbstractModel {
 
 
                 if (kafkaAssembly.getSpec().getClientsCa() != null) {
-                    result.setClientsCaValidityDays(kafkaAssembly.getSpec().getClientsCa().getValidityDays());
-                    result.setClientsCaRenewalDays(kafkaAssembly.getSpec().getClientsCa().getRenewalDays());
+                    if (kafkaAssembly.getSpec().getClientsCa().getValidityDays() > 0) {
+                        result.setClientsCaValidityDays(kafkaAssembly.getSpec().getClientsCa().getValidityDays());
+                    }
+
+                    if (kafkaAssembly.getSpec().getClientsCa().getRenewalDays() > 0) {
+                        result.setClientsCaRenewalDays(kafkaAssembly.getSpec().getClientsCa().getRenewalDays());
+                    }
                 }
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -63,7 +63,14 @@ public class ModelUtils {
     }
 
     public static int getRenewalDays(CertificateAuthority certificateAuthority) {
-        return certificateAuthority != null ? certificateAuthority.getRenewalDays() : CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS;
+        int renewalDays = CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS;
+
+        if (certificateAuthority != null
+                && certificateAuthority.getRenewalDays() > 0) {
+            renewalDays = certificateAuthority.getRenewalDays();
+        }
+
+        return renewalDays;
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the CR contains only partial configuration of the `clusterCa` or `clientsCa`, for example:

```yaml
   clusterCa:
     generateCertificateAuthority: false
   clientsCa:
     generateCertificateAuthority: false
```

Then the validity or the renewalDays might be set to 0. That can cause problems for example in the User Operator which isn't able to sign any user certificates with the 0 days validity (OpenSSL throws an error).

This PR adds checks whether the validity or renewal days are 0, and uses the default values instead in such case.

This was discovered during investigation of #1549.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging