### PR TITLE
[DOC] Make product version references generic

### DIFF
--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -6,7 +6,7 @@
 = {ProductName} resource upgrades
 For this release of {ProductName}, resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
 
-The `{KafkaApiVersionPrev}` API version is deprecated in release {ProductVersion}.
+The `{KafkaApiVersionPrev}` API version is deprecated in this release.
 
 IMPORTANT: The upgrade of resources _must_ be performed after xref:assembly-upgrade-{context}[], so the Cluster Operator can understand the resources.
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -81,10 +81,10 @@
 :DockerZookeeper: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerZookeeperStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImage: strimzi/kafka
-:DockerKafka: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
+:DockerKafka: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
 :DockerKafkaStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerKafkaConnect: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerKafkaConnectS2I: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
+:DockerKafkaConnect: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
+:DockerKafkaConnectS2I: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
 :DockerClusterOperator: strimzi/operator:{DockerTag}
 :DockerKafkaInit: strimzi/operator:{DockerTag}
 :DockerTopicOperator: strimzi/operator:{DockerTag}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -76,15 +76,15 @@
 
 // Container image names and repositories
 :DockerOrg: docker.io/strimzi
-:DockerTag: {ProductVersion}
+:DockerTag: x.y.z
 :DockerRepository: https://hub.docker.com/u/strimzi[Docker Hub^]
 :DockerZookeeper: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerZookeeperStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImage: strimzi/kafka
-:DockerKafka: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
+:DockerKafka: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerKafkaConnect: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
-:DockerKafkaConnectS2I: strimzi/kafka:x.y.z-kafka-{DefaultKafkaVersion}
+:DockerKafkaConnect: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
+:DockerKafkaConnectS2I: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerClusterOperator: strimzi/operator:{DockerTag}
 :DockerKafkaInit: strimzi/operator:{DockerTag}
 :DockerTopicOperator: strimzi/operator:{DockerTag}


### PR DESCRIPTION
### Type of change
- Documentation

### Description

References to a specific product version have been made generic using 'x.y.z'. 
Change to attribute is reflected in 66 places

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

