### PR TITLE
Upgrade Jackson version due to CVE-2019-12086 in jackson-databind<2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
-        <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
         <kafka.version>2.2.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>


### PR DESCRIPTION
### Type of change

- Security vuln fix

### Description

Strimzi is not vulnerable, but it's nice to get rid of the warning on github.

https://nvd.nist.gov/vuln/detail/CVE-2019-12086

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

