### PR TITLE
Persistent volume resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Support for Kafka 2.2.0
 * Support off-cluster access using Kubernetes Nginx Ingress
 * Add ability to configure Image Pull Secrets for all pods in Cluster Operator
-* Support for SASL PLAIN mechanism in Kafka Connect and Mirror Maker (for use with non-Strimzi Kafka cluster) 
+* Support for SASL PLAIN mechanism in Kafka Connect and Mirror Maker (for use with non-Strimzi Kafka cluster)
+* Add resizing of persistent volumes
 
 ## 0.11.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -354,7 +354,7 @@ public class KafkaCluster extends AbstractModel {
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {
-                log.warn("Only following changes to Kafka storage are allowed: changing the deleteClaim flag, adding volumes to Jbod storage or removing volumes from Jbod storage.");
+                log.warn("Only following changes to Kafka storage are allowed: changing the deleteClaim flag, adding volumes to Jbod storage or removing volumes from Jbod storage and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 log.warn("Your desired Kafka storage configuration contains changes which are not allowed. As a result, all storage changes will be ignored. Use DEBUG level logging for more information about the detected changes.");
                 result.setStorage(oldStorage);
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -354,7 +354,7 @@ public class KafkaCluster extends AbstractModel {
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {
-                log.warn("Only following changes to Kafka storage are allowed: changing the deleteClaim flag, adding volumes to Jbod storage or removing volumes from Jbod storage and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
+                log.warn("Only the following changes to Kafka storage are allowed: changing the deleteClaim flag, adding volumes to Jbod storage or removing volumes from Jbod storage and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 log.warn("Your desired Kafka storage configuration contains changes which are not allowed. As a result, all storage changes will be ignored. Use DEBUG level logging for more information about the detected changes.");
                 result.setStorage(oldStorage);
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -35,6 +35,7 @@ public class StorageDiff extends AbstractResourceDiff {
         this(current, desired, "");
     }
 
+    //@SuppressFBWarnings("unchecked")
     public StorageDiff(Storage current, Storage desired, String volumeDesc) {
         boolean changesType = false;
         boolean shrinkSize = false;
@@ -77,14 +78,14 @@ public class StorageDiff extends AbstractResourceDiff {
 
                 // It might be possible to increase the volume size, but never to shrink volumes
                 // When size changes, we need to detect whether it is shrinking or increasing
-                if (pathValue.endsWith("/size") && desired.getType().equals(current.getType()))    {
+                if (pathValue.endsWith("/size") && desired.getType().equals(current.getType()) && current instanceof PersistentClaimStorage && desired instanceof PersistentClaimStorage)    {
                     PersistentClaimStorage persistentCurrent = (PersistentClaimStorage) current;
                     PersistentClaimStorage persistentDesired = (PersistentClaimStorage) desired;
 
                     long currentSize = parseMemory(persistentCurrent.getSize());
                     long desiredSize = parseMemory(persistentDesired.getSize());
 
-                    if (currentSize > desiredSize)  {
+                    if (currentSize > desiredSize) {
                         shrinkSize = true;
                     } else {
                         continue;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -212,7 +212,7 @@ public class ZookeeperCluster extends AbstractModel {
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {
-                log.warn("Only following changes to Zookeeper storage are allowed: changing the deleteClaim flag.");
+                log.warn("Only following changes to Zookeeper storage are allowed: changing the deleteClaim flag and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 log.warn("Your desired Zookeeper storage configuration contains changes which are not allowed. As a result, all storage changes will be ignored. Use DEBUG level logging for more information about the detected changes.");
                 zk.setStorage(oldStorage);
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -212,7 +212,7 @@ public class ZookeeperCluster extends AbstractModel {
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {
-                log.warn("Only following changes to Zookeeper storage are allowed: changing the deleteClaim flag and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
+                log.warn("Only the following changes to Zookeeper storage are allowed: changing the deleteClaim flag and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 log.warn("Your desired Zookeeper storage configuration contains changes which are not allowed. As a result, all storage changes will be ignored. Use DEBUG level logging for more information about the detected changes.");
                 zk.setStorage(oldStorage);
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -18,6 +19,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Route;
@@ -64,6 +66,7 @@ import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RouteOperator;
+import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -77,6 +80,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
@@ -120,6 +124,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private final RoleBindingOperator roleBindingOperations;
     private final PodOperator podOperations;
     private final IngressOperator ingressOperations;
+    private final StorageClassOperator storageClassOperator;
 
     /**
      * @param vertx The Vertx instance
@@ -143,6 +148,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         this.roleBindingOperations = supplier.roleBindingOperations;
         this.podOperations = supplier.podOperations;
         this.ingressOperations = supplier.ingressOperations;
+        this.storageClassOperator = supplier.storageClassOperations;
 
     }
 
@@ -274,6 +280,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private ConfigMap topicOperatorMetricsAndLogsConfigMap = null;
         private ConfigMap userOperatorMetricsAndLogsConfigMap;
         private Secret oldCoSecret;
+
+        private Set<String> fsResizingRestartRequest = new HashSet<>();
 
         ReconciliationState(Reconciliation reconciliation, Kafka kafkaAssembly) {
             this.reconciliation = reconciliation;
@@ -1545,26 +1553,114 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return withVoid(podDisruptionBudgetOperator.reconcile(namespace, kafkaCluster.getName(), kafkaCluster.generatePodDisruptionBudget()));
         }
 
-        Future<ReconciliationState> zkPvcs() {
-            List<PersistentVolumeClaim> pvcs = zkCluster.generatePersistentVolumeClaims();
+        int getPodIndexFromPvcName(String pvcName)  {
+            return Integer.parseInt(pvcName.substring(pvcName.lastIndexOf("-") + 1));
+        }
+
+        Future<ReconciliationState> reconcilePvcs(List<PersistentVolumeClaim> pvcs, AbstractModel cluster) {
             List<Future> futures = new ArrayList<>(pvcs.size());
 
             for (PersistentVolumeClaim pvc : pvcs)  {
-                futures.add(pvcOperations.reconcile(namespace, pvc.getMetadata().getName(), pvc));
+                Future<Void> result = Future.future();
+
+                pvcOperations.getAsync(namespace, pvc.getMetadata().getName()).setHandler(res -> {
+                    if (res.succeeded())    {
+                        PersistentVolumeClaim realPvc = res.result();
+
+                        if (realPvc == null || !"Bound".equals(realPvc.getStatus().getPhase())) {
+                            // This branch handles the following conditions:
+                            // * The PVC doesn't exist yet, we should create it
+                            // * The PVC is not Bound and we should reconcile it
+                            pvcOperations.reconcile(namespace, pvc.getMetadata().getName(), pvc).setHandler(pvcRes -> {
+                                if (pvcRes.succeeded()) {
+                                    result.complete();
+                                } else {
+                                    result.fail(pvcRes.cause());
+                                }
+                            });
+                        } else if (realPvc.getStatus().getConditions().stream().filter(cond -> "Resizing".equals(cond.getType()) && "true".equals(cond.getStatus().toLowerCase(Locale.ENGLISH))).findFirst().orElse(null) != null)  {
+                            // The PVC is Bound but it is already resizing => Nothing to do, we should let it resize
+                            log.debug("{}: The PVC {} is resizing, nothing to do", reconciliation, pvc.getMetadata().getName());
+                            result.complete();
+                        } else if (realPvc.getStatus().getConditions().stream().filter(cond -> "FileSystemResizePending".equals(cond.getType()) && "true".equals(cond.getStatus().toLowerCase(Locale.ENGLISH))).findFirst().orElse(null) != null)  {
+                            // The PVC is Bound and resized but waiting for FS resizing => We need to restart the pod which is using it
+                            String podName = cluster.getPodName(getPodIndexFromPvcName(pvc.getMetadata().getName()));
+                            fsResizingRestartRequest.add(podName);
+                            log.info("{}: The PVC {} is waiting for file system resizing and the pod {} needs to be restarted.", reconciliation, pvc.getMetadata().getName(), podName);
+                            result.complete();
+                        } else {
+                            // The PVC is Bound and resizing is not in progress => We should check if the SC supports resizing and check if size changed
+                            Quantity currentSize = realPvc.getStatus().getCapacity().get("storage");
+                            Quantity desiredSize = pvc.getSpec().getResources().getRequests().get("storage");
+
+                            if (!desiredSize.equals(currentSize))   {
+                                // The sizes are different => we should resize (shrinking will be handled in StorageDiff, so we do not need to check that)
+                                String storageClassName = realPvc.getSpec().getStorageClassName();
+
+                                if (storageClassName != null && !storageClassName.isEmpty()) {
+                                    storageClassOperator.getAsync(storageClassName).setHandler(scRes -> {
+                                        if (scRes.succeeded()) {
+                                            StorageClass sc = scRes.result();
+
+                                            if (sc == null) {
+                                                log.warn("{}: Storage Class {} not found. PVC {} cannot be resized. Reconciliation will proceed without reconciling this PVC.", reconciliation, storageClassName, pvc.getMetadata().getName());
+                                                result.complete();
+                                            } else if (sc.getAllowVolumeExpansion() == null || !sc.getAllowVolumeExpansion())    {
+                                                // Resizing not suported in SC => do nothing
+                                                log.warn("{}: Storage Class {} does not support resizing of volumes. PVC {} cannot be resized. Reconciliation will proceed without reconciling this PVC.", reconciliation, storageClassName, pvc.getMetadata().getName());
+                                                result.complete();
+                                            } else  {
+                                                // Resizing supported by SC => We can reconcile the PVC to have it resized
+                                                log.info("{}: Resizing PVC {} from {} to {}.", reconciliation, pvc.getMetadata().getName(), realPvc.getStatus().getCapacity().get("storage").getAmount(), pvc.getSpec().getResources().getRequests().get("storage").getAmount());
+                                                pvcOperations.reconcile(namespace, pvc.getMetadata().getName(), pvc).setHandler(pvcRes -> {
+                                                    if (pvcRes.succeeded()) {
+                                                        result.complete();
+                                                    } else {
+                                                        result.fail(pvcRes.cause());
+                                                    }
+                                                });
+                                            }
+                                        } else {
+                                            log.error("{}: Storage Class {} not found. PVC {} cannot be resized.", reconciliation, storageClassName, pvc.getMetadata().getName(), res.cause());
+                                            result.fail(scRes.cause());
+                                        }
+                                    });
+                                } else {
+                                    log.warn("{}: PVC {} does not use any Storage Class and cannot be resized. Reconciliation will proceed without reconciling this PVC.", reconciliation, pvc.getMetadata().getName());
+                                    result.complete();
+                                }
+                            } else  {
+                                // size didn't changed, just reconcile
+                                pvcOperations.reconcile(namespace, pvc.getMetadata().getName(), pvc).setHandler(pvcRes -> {
+                                    if (pvcRes.succeeded()) {
+                                        result.complete();
+                                    } else {
+                                        result.fail(pvcRes.cause());
+                                    }
+                                });
+                            }
+                        }
+                    } else {
+                        result.fail(res.cause());
+                    }
+                });
+
+                futures.add(result);
             }
 
             return withVoid(CompositeFuture.all(futures));
         }
 
+        Future<ReconciliationState> zkPvcs() {
+            List<PersistentVolumeClaim> pvcs = zkCluster.generatePersistentVolumeClaims();
+
+            return reconcilePvcs(pvcs, zkCluster);
+        }
+
         Future<ReconciliationState> kafkaPvcs() {
             List<PersistentVolumeClaim> pvcs = kafkaCluster.generatePersistentVolumeClaims(kafkaCluster.getStorage());
-            List<Future> futures = new ArrayList<>(pvcs.size());
 
-            for (PersistentVolumeClaim pvc : pvcs)  {
-                futures.add(pvcOperations.reconcile(namespace, pvc.getMetadata().getName(), pvc));
-            }
-
-            return withVoid(CompositeFuture.all(futures));
+            return reconcilePvcs(pvcs, kafkaCluster);
         }
 
         Future<ReconciliationState> kafkaStatefulSet() {
@@ -2124,6 +2220,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             boolean isPodUpToDate = isPodUpToDate(ss, pod);
             boolean isPodCaCertUpToDate = true;
             boolean isCaCertsChanged = false;
+            boolean isFsResizeNeeded = false;
+
             for (Ca ca: cas) {
                 isCaCertsChanged |= ca.certRenewed() || ca.certsRemoved();
                 isPodCaCertUpToDate &= isPodCaCertUpToDate(pod, ca);
@@ -2136,6 +2234,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 isSatisfiedBy = isMaintenanceTimeWindowsSatisfied(dateSupplier);
                 isPodToRestart |= isSatisfiedBy;
             }
+
+            if (fsResizingRestartRequest.contains(pod.getMetadata().getName())) {
+                isFsResizeNeeded = true;
+            }
+            isPodToRestart |= isFsResizeNeeded;
 
             if (log.isDebugEnabled()) {
                 List<String> reasons = new ArrayList<>();
@@ -2155,6 +2258,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 }
                 if (!isPodUpToDate) {
                     reasons.add("Pod has old generation");
+                }
+                if (isFsResizeNeeded)   {
+                    reasons.add("file system needs to be resized");
                 }
                 if (!reasons.isEmpty()) {
                     if (isPodToRestart) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -281,7 +281,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private ConfigMap userOperatorMetricsAndLogsConfigMap;
         private Secret oldCoSecret;
 
-        private Set<String> fsResizingRestartRequest = new HashSet<>();
+        /* test */ Set<String> fsResizingRestartRequest = new HashSet<>();
 
         ReconciliationState(Reconciliation reconciliation, Kafka kafkaAssembly) {
             this.reconciliation = reconciliation;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1567,7 +1567,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     if (res.succeeded())    {
                         PersistentVolumeClaim realPvc = res.result();
 
-                        if (realPvc == null || !"Bound".equals(realPvc.getStatus().getPhase())) {
+                        if (realPvc == null || realPvc.getStatus() == null || !"Bound".equals(realPvc.getStatus().getPhase())) {
                             // This branch handles the following conditions:
                             // * The PVC doesn't exist yet, we should create it
                             // * The PVC is not Bound and we should reconcile it

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -44,6 +44,10 @@ public class KafkaSetOperator extends StatefulSetOperator {
             log.debug("Changed volume claim template => needs rolling update");
             return true;
         }
+        if (diff.changesVolumeSize()) {
+            log.debug("Changed size of the volume claim template => no need for rolling update");
+            return false;
+        }
         return false;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -38,6 +38,7 @@ import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.Vertx;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
@@ -64,6 +65,7 @@ public class ResourceOperatorSupplier {
     public final ImageStreamOperator imagesStreamOperations;
     public final BuildConfigOperator buildConfigOperations;
     public final DeploymentConfigOperator deploymentConfigOperations;
+    public final StorageClassOperator storageClassOperations;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client, new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
@@ -94,7 +96,8 @@ public class ResourceOperatorSupplier {
                 new CrdOperator<>(vertx, client, Kafka.class, KafkaList.class, DoneableKafka.class),
                 new CrdOperator<>(vertx, client, KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class),
                 pfa.hasBuilds() && pfa.hasApps() && pfa.hasImages() ? new CrdOperator<>(vertx, client.adapt(OpenShiftClient.class), KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class) : null,
-                new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class));
+                new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class),
+                new StorageClassOperator(vertx, client));
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
@@ -118,7 +121,8 @@ public class ResourceOperatorSupplier {
                                     CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> kafkaOperator,
                                     CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperator,
                                     CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2IOperator,
-                                    CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker> mirrorMakerOperator) {
+                                    CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker> mirrorMakerOperator,
+                                    StorageClassOperator storageClassOperator) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
@@ -141,5 +145,6 @@ public class ResourceOperatorSupplier {
         this.connectOperator = connectOperator;
         this.connectS2IOperator = connectS2IOperator;
         this.mirrorMakerOperator = mirrorMakerOperator;
+        this.storageClassOperations = storageClassOperator;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -257,7 +257,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             log.debug("Patching {} {}/{}", resourceKind, namespace, name);
         }
 
-        if (diff.changesVolumeClaimTemplates()) {
+        if (diff.changesVolumeClaimTemplates() || diff.changesVolumeSize()) {
             // When volume claim templates change, we need to delete the STS and re-create it
             return internalReplace(namespace, name, current, desired, false);
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -62,6 +62,10 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
             log.debug("Changed volume claim template => needs rolling update");
             return true;
         }
+        if (diff.changesVolumeSize()) {
+            log.debug("Changed size of the volume claim template => no need for rolling update");
+            return false;
+        }
         return false;
     }
 

--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,3 +15,9 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -67,6 +67,7 @@ import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -500,7 +501,8 @@ public class ResourceUtils {
                 mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class),
                 mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
                 mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(CrdOperator.class));
+                mock(CrdOperator.class),
+                mock(StorageClassOperator.class));
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -100,7 +100,7 @@ public class CertificateRenewalTest {
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), certManager,
                 new ResourceOperatorSupplier(null, null, null,
                         null, null, secretOps, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null),
+                        null, null, null, null, null, null, null, null, null, null, null),
                 ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -395,6 +395,17 @@ public class KafkaAssemblyOperatorTest {
                     return null;
                 });
 
+        when(mockPvcOps.getAsync(eq(clusterCmNamespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    if (pvcName.contains(zookeeperCluster.getName())) {
+                        return Future.succeededFuture(zkPvcs.get(pvcName));
+                    } else if (pvcName.contains(kafkaCluster.getName())) {
+                        return Future.succeededFuture(kafkaPvcs.get(pvcName));
+                    }
+                    return Future.succeededFuture(null);
+                });
+
         when(mockPvcOps.listAsync(eq(clusterCmNamespace), ArgumentMatchers.any(Labels.class)))
                 .thenAnswer(invocation -> {
                     return Future.succeededFuture(Collections.EMPTY_LIST);
@@ -746,6 +757,17 @@ public class KafkaAssemblyOperatorTest {
                         return kafkaPvcs.get(pvcName);
                     }
                     return null;
+                });
+
+        when(mockPvcOps.getAsync(eq(clusterNamespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    if (pvcName.contains(originalZookeeperCluster.getName())) {
+                        return Future.succeededFuture(zkPvcs.get(pvcName));
+                    } else if (pvcName.contains(originalKafkaCluster.getName())) {
+                        return Future.succeededFuture(kafkaPvcs.get(pvcName));
+                    }
+                    return Future.succeededFuture(null);
                 });
 
         when(mockPvcOps.listAsync(eq(clusterNamespace), ArgumentMatchers.any(Labels.class)))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -155,7 +155,7 @@ public class KafkaUpdateTest {
                 new MockCertManager(),
                 new ResourceOperatorSupplier(null, null, null,
                         kso, null, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null, null),
+                        null, null, null, null, null, null, null, null, null, null, null, null),
                 ResourceUtils.dummyClusterOperatorConfig(lookup, 1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", ResourceType.KAFKA, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -1,0 +1,656 @@
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimCondition;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimConditionBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimStatus;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimStatusBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.storage.StorageClass;
+import io.fabric8.kubernetes.api.model.storage.StorageClassBuilder;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.certs.CertManager;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.KubernetesVersion;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.ResourceType;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.common.operator.resource.PvcOperator;
+import io.strimzi.operator.common.operator.resource.StorageClassOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.test.TestUtils.map;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+public class VolumeResizingTest {
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_11;
+    private final MockCertManager certManager = new MockCertManager();
+    private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig();
+    private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(
+            new StringReader(
+                    "2.0.0  default  2.0  2.0  1234567890abcdef\n" +
+                            "2.0.1           2.0  2.0  1234567890abcdef\n" +
+                            "2.1.0           2.1  2.1  1234567890abcdef\n"),
+            map("2.0.0", "strimzi/kafka:0.8.0-kafka-2.0.0",
+                    "2.0.1", "strimzi/kafka:0.8.0-kafka-2.0.1",
+                    "2.1.0", "strimzi/kafka:0.8.0-kafka-2.1.0"),
+            singletonMap("2.0.0", "kafka-connect"),
+            singletonMap("2.0.0", "kafka-connect-s2i"),
+            singletonMap("2.0.0", "kafka-mirror-maker-s2i")) { };
+    private final String namespace = "testns";
+    private final String clusterName = "testkafka";
+    protected static Vertx vertx;
+
+    @BeforeClass
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterClass
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testNoExistingVolumes()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewListeners()
+                            .withNewPlain()
+                            .endPlain()
+                        .endListeners()
+                        .withNewPersistentClaimStorage()
+                            .withStorageClass("mysc")
+                            .withSize("20Gi")
+                        .endPersistentClaimStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewPersistentClaimStorage()
+                            .withStorageClass("mysc")
+                            .withSize("20Gi")
+                        .endPersistentClaimStorage()
+                    .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture();
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                                .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+            assertEquals(3, pvcCaptor.getAllValues().size());
+            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+        });
+    }
+
+    @Test
+    public void testNotBoundVolumes()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+            assertEquals(3, pvcCaptor.getAllValues().size());
+            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+        });
+    }
+
+    @Test
+    public void testVolumesBoundExpandableStorageClass()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+
+        for (PersistentVolumeClaim pvc : realPvcs)    {
+            pvc.getSpec().getResources().getRequests().put("storage", new Quantity("10Gi"));
+            pvc.setStatus(new PersistentVolumeClaimStatusBuilder()
+                    .withPhase("Bound")
+                    .withCapacity(pvc.getSpec().getResources().getRequests())
+                    .build());
+        }
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+            assertEquals(3, pvcCaptor.getAllValues().size());
+            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+        });
+    }
+
+    @Test
+    public void testVolumesBoundNonExpandableStorageClass()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+
+        for (PersistentVolumeClaim pvc : realPvcs)    {
+            pvc.getSpec().getResources().getRequests().put("storage", new Quantity("10Gi"));
+            pvc.setStatus(new PersistentVolumeClaimStatusBuilder()
+                    .withPhase("Bound")
+                    .withCapacity(pvc.getSpec().getResources().getRequests())
+                    .build());
+        }
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(false)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+            // Resizing is not supported, we do not reconcile
+            assertEquals(0, pvcCaptor.getAllValues().size());
+        });
+    }
+
+    @Test
+    public void testVolumesResizing()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+
+        for (PersistentVolumeClaim pvc : realPvcs)    {
+            pvc.setStatus(new PersistentVolumeClaimStatusBuilder()
+                    .withPhase("Bound")
+                    .withConditions(new PersistentVolumeClaimConditionBuilder()
+                            .withStatus("True")
+                            .withType("Resizing")
+                            .build())
+                    .withCapacity(singletonMap("storage", new Quantity("10Gi")))
+                    .build());
+        }
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+            // The volumes are resizing => no reconciliation
+            assertEquals(0, pvcCaptor.getAllValues().size());
+        });
+    }
+
+    @Test
+    public void testVolumesWaitingForRestart()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+
+        for (PersistentVolumeClaim pvc : realPvcs)    {
+            pvc.setStatus(new PersistentVolumeClaimStatusBuilder()
+                    .withPhase("Bound")
+                    .withConditions(new PersistentVolumeClaimConditionBuilder()
+                            .withStatus("True")
+                            .withType("FileSystemResizePending")
+                            .build())
+                    .withCapacity(singletonMap("storage", new Quantity("10Gi")))
+                    .build());
+        }
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+
+            // The volumes are waiting for pod restart => no reconciliation
+            assertEquals(0, pvcCaptor.getAllValues().size());
+
+            for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
+                assertTrue(res.result().fsResizingRestartRequest.contains(kafkaCluster.getPodName(i)));
+            }
+
+        });
+    }
+
+    @Test
+    public void testVolumesResized()  {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(clusterName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(3)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(3)
+                .withNewPersistentClaimStorage()
+                .withStorageClass("mysc")
+                .withSize("20Gi")
+                .endPersistentClaimStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the PVC Operator
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+
+        List<PersistentVolumeClaim> realPvcs = kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage());
+
+        for (PersistentVolumeClaim pvc : realPvcs)    {
+            pvc.setStatus(new PersistentVolumeClaimStatusBuilder()
+                    .withPhase("Bound")
+                    .withCapacity(singletonMap("storage", new Quantity("20Gi")))
+                    .build());
+        }
+
+        when(mockPvcOps.getAsync(eq(namespace), ArgumentMatchers.startsWith("data-")))
+                .thenAnswer(invocation -> {
+                    String pvcName = invocation.getArgument(1);
+                    return Future.succeededFuture(realPvcs.stream().filter(pvc -> pvcName.equals(pvc.getMetadata().getName())).findFirst().orElse(null));
+                });
+
+        ArgumentCaptor<PersistentVolumeClaim> pvcCaptor = ArgumentCaptor.forClass(PersistentVolumeClaim.class);
+        when(mockPvcOps.reconcile(anyString(), anyString(), pvcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the StorageClass Operator
+        StorageClassOperator mockSco = supplier.storageClassOperations;
+
+        when(mockSco.getAsync(eq("mysc")))
+                .thenAnswer(invocation -> {
+                    StorageClass sc = new StorageClassBuilder()
+                            .withNewMetadata()
+                            .withName("mysc")
+                            .endMetadata()
+                            .withAllowVolumeExpansion(true)
+                            .build();
+
+                    return Future.succeededFuture(sc);
+                });
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                supplier,
+                config);
+
+        kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
+                kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
+            assertTrue(res.succeeded());
+
+            assertEquals(3, pvcCaptor.getAllValues().size());
+            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+        });
+    }
+
+    // This allows to test the resizing on its own without any other methods being called and mocked
+    class MockKafkaAssemblyOperator extends KafkaAssemblyOperator  {
+        public MockKafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
+            super(vertx, pfa, certManager, supplier, config);
+        }
+
+        public Future<ReconciliationState> resizeVolumes(Reconciliation reconciliation, Kafka kafkaAssembly, List<PersistentVolumeClaim> pvcs, KafkaCluster kafkaCluster) {
+            ReconciliationState rs = createReconciliationState(reconciliation, kafkaAssembly);
+            return rs.reconcilePvcs(pvcs, kafkaCluster);
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -491,7 +491,7 @@ public class VolumeResizingTest {
 
         public Future<ReconciliationState> resizeVolumes(Reconciliation reconciliation, Kafka kafkaAssembly, List<PersistentVolumeClaim> pvcs, KafkaCluster kafkaCluster) {
             ReconciliationState rs = createReconciliationState(reconciliation, kafkaAssembly);
-            return rs.reconcilePvcs(pvcs, kafkaCluster);
+            return rs.maybeResizeReconcilePvcs(pvcs, kafkaCluster);
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -1,9 +1,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimCondition;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimConditionBuilder;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimStatus;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimStatusBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.storage.StorageClass;
@@ -26,7 +24,6 @@ import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,14 +31,11 @@ import org.mockito.ArgumentMatchers;
 
 import java.io.StringReader;
 import java.util.List;
-import java.util.Map;
 
 import static io.strimzi.test.TestUtils.map;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -75,9 +69,8 @@ public class VolumeResizingTest {
         vertx.close();
     }
 
-    @Test
-    public void testNoExistingVolumes()  {
-        Kafka kafka = new KafkaBuilder()
+    public Kafka getKafkaCrd()  {
+        return new KafkaBuilder()
                 .withNewMetadata()
                     .withName(clusterName)
                     .withNamespace(namespace)
@@ -103,7 +96,11 @@ public class VolumeResizingTest {
                     .endZookeeper()
                 .endSpec()
                 .build();
+    }
 
+    @Test
+    public void testNoExistingVolumes()  {
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -149,33 +146,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testNotBoundVolumes()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -222,33 +193,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testVolumesBoundExpandableStorageClass()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -304,33 +249,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testVolumesBoundNonExpandableStorageClass()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -386,33 +305,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testVolumesResizing()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -471,33 +364,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testVolumesWaitingForRestart()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -562,33 +429,7 @@ public class VolumeResizingTest {
 
     @Test
     public void testVolumesResized()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                .withName(clusterName)
-                .withNamespace(namespace)
-                .endMetadata()
-                .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewListeners()
-                .withNewPlain()
-                .endPlain()
-                .endListeners()
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withReplicas(3)
-                .withNewPersistentClaimStorage()
-                .withStorageClass("mysc")
-                .withSize("20Gi")
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec()
-                .build();
-
+        Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
@@ -138,10 +142,10 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
-            assertEquals(3, pvcCaptor.getAllValues().size());
-            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
-        });
+                    assertTrue(res.succeeded());
+                    assertEquals(3, pvcCaptor.getAllValues().size());
+                    assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+                });
     }
 
     @Test
@@ -185,10 +189,10 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
-            assertEquals(3, pvcCaptor.getAllValues().size());
-            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
-        });
+                    assertTrue(res.succeeded());
+                    assertEquals(3, pvcCaptor.getAllValues().size());
+                    assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+                });
     }
 
     @Test
@@ -241,10 +245,10 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
-            assertEquals(3, pvcCaptor.getAllValues().size());
-            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
-        });
+                    assertTrue(res.succeeded());
+                    assertEquals(3, pvcCaptor.getAllValues().size());
+                    assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+                });
     }
 
     @Test
@@ -297,10 +301,10 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
-            // Resizing is not supported, we do not reconcile
-            assertEquals(0, pvcCaptor.getAllValues().size());
-        });
+                    assertTrue(res.succeeded());
+                    // Resizing is not supported, we do not reconcile
+                    assertEquals(0, pvcCaptor.getAllValues().size());
+                });
     }
 
     @Test
@@ -356,10 +360,10 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
-            // The volumes are resizing => no reconciliation
-            assertEquals(0, pvcCaptor.getAllValues().size());
-        });
+                    assertTrue(res.succeeded());
+                    // The volumes are resizing => no reconciliation
+                    assertEquals(0, pvcCaptor.getAllValues().size());
+                });
     }
 
     @Test
@@ -415,16 +419,16 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
+                    assertTrue(res.succeeded());
 
-            // The volumes are waiting for pod restart => no reconciliation
-            assertEquals(0, pvcCaptor.getAllValues().size());
+                    // The volumes are waiting for pod restart => no reconciliation
+                    assertEquals(0, pvcCaptor.getAllValues().size());
 
-            for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
-                assertTrue(res.result().fsResizingRestartRequest.contains(kafkaCluster.getPodName(i)));
-            }
+                    for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
+                        assertTrue(res.result().fsResizingRestartRequest.contains(kafkaCluster.getPodName(i)));
+                    }
 
-        });
+                });
     }
 
     @Test
@@ -476,11 +480,11 @@ public class VolumeResizingTest {
 
         kao.resizeVolumes(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName),
                 kafka, kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), kafkaCluster).setHandler(res -> {
-            assertTrue(res.succeeded());
+                    assertTrue(res.succeeded());
 
-            assertEquals(3, pvcCaptor.getAllValues().size());
-            assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
-        });
+                    assertEquals(3, pvcCaptor.getAllValues().size());
+                    assertEquals(kafkaCluster.generatePersistentVolumeClaims(kafka.getSpec().getKafka().getStorage()), pvcCaptor.getAllValues());
+                });
     }
 
     // This allows to test the resizing on its own without any other methods being called and mocked

--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -17,7 +17,7 @@ function create_truststore {
 # $5: CA public key to be imported
 # $6: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $6 -password pass:$2 -out $1
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $6 -password pass:$2 -out $1
 }
 
 echo "Preparing truststore for replication listener"

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -20,4 +20,10 @@ rules:
     - delete
     - patch
     - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+   - get
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -20,6 +20,8 @@ rules:
     - delete
     - patch
     - update
+# Persistent Volumes can be resized only when it is supported in the storage class.
+# Therefore we need the ability to get the storage class details and we require this access right.
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,3 +15,9 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,8 +15,6 @@ rules:
   - delete
   - patch
   - update
-# Persistent Volumes can be resized only when it is supported in the storage class.
-# Therefore we need the ability to get the storage class details and we require this access right.
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,6 +15,8 @@ rules:
   - delete
   - patch
   - update
+# Persistent Volumes can be resized only when it is supported in the storage class.
+# Therefore we need the ability to get the storage class details and we require this access right.
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for resizing of persistent volumes. The volumes can be resized only in case it is supported in the StorageClass.

When using this / testing this, be careful about the about the limits to number of disk resizings per hour (e.g. one per 6 hours in AWS). These will cause the volumes to be stuck in Resizing state (probably until the quota refreshes).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md