### PR TITLE
Add link to the report.sh script to our bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,11 +26,12 @@ A clear and concise description of what you expected to happen.
  - Kubernetes cluster: [e.g. Kubernetes 1.14, OpenShift 3.9]
  - Infrastructure: [e.g. Amazon EKS, Minikube]
 
-**Custom Resource YAMLs**
-Attach or copy paste the custom resources you used.
+**YAML files and logs**
 
-**Logs**
-Attach or copy and paste the relevant logs.
+Attach or copy paste the custom resources you used to deploy the Kafka cluster and the relevant YAMLs created by the Cluster Operator.
+Attach or copy and paste also the relevant logs.
+
+*To easily collect all YAMLs and logs, you can use our [report script](https://github.com/strimzi/strimzi-kafka-operator/blob/master/tools/report.sh) whcih will automatically collect all files and prepare a ZIP archive which can be easily attached to this issue.*
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ A clear and concise description of what you expected to happen.
 Attach or copy paste the custom resources you used to deploy the Kafka cluster and the relevant YAMLs created by the Cluster Operator.
 Attach or copy and paste also the relevant logs.
 
-*To easily collect all YAMLs and logs, you can use our [report script](https://github.com/strimzi/strimzi-kafka-operator/blob/master/tools/report.sh) whcih will automatically collect all files and prepare a ZIP archive which can be easily attached to this issue.*
+*To easily collect all YAMLs and logs, you can use our [report script](https://github.com/strimzi/strimzi-kafka-operator/blob/master/tools/report.sh) which will automatically collect all files and prepare a ZIP archive which can be easily attached to this issue.*
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The PR #1633 created the `report.sh` script for collecting the YAMLs and logs into a ZIP archive. This PR links it into the GitHub issue template for _bug_ issues, so that users can use it.