### PR TITLE
Topic Operator log verbosity

### DIFF
--- a/.travis/push-to-nexus.sh
+++ b/.travis/push-to-nexus.sh
@@ -3,7 +3,7 @@
 openssl aes-256-cbc -K $encrypted_cdaf52794220_key -iv $encrypted_cdaf52794220_iv -in .travis/signing.gpg.enc -out signing.gpg -d
 gpg --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B -q -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh clean package gpg:sign deploy
+GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh clean package gpg:sign deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/topic-operator/src/test/resources/log4j2-test.properties
+++ b/topic-operator/src/test/resources/log4j2-test.properties
@@ -11,4 +11,4 @@ rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
 logger.strimzi.name = io.strimzi
-logger.strimzi.level = debug
+logger.strimzi.level = info


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Reduce logging verbosity of TO test, and reinstate slightly more verbose logging for mvn publishing to nexus.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

