### PR TITLE
Do not hardcode Zookeeper connection timeout in Docker images

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -176,7 +176,6 @@ inter.broker.listener.name=REPLICATION
 
 # Zookeeper
 zookeeper.connect=localhost:2181
-zookeeper.connection.timeout.ms=6000
 
 # Logs
 log.dirs=${KAFKA_LOG_DIRS_WITH_PATH}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`zookeeper.connection.timeout.ms` is user configurable property which the users can configure through `Kafka.spec.kafka.config`. However, it is also hardcoded in our script generating the Kafka configuration which is baked into our images. While it seems that Kafka will always take the last value and thus the user configuration works, it can be confusing to see something like:

```ini
zookeeper.connection.timeout.ms=6000
...
zookeeper.connection.timeout.ms=15000
```

The `6000` is anyway the default value. So we should remove this from the script which generates the configuration to avoid any confusion.