### PR TITLE
Fix bugs in StrafulSetOperator tests for deleteAsync()

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -338,7 +338,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
                         log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);
                         future.complete();
                     } else  {
-                        log.error("{} {} in namespace {} has been not been deleted", resourceKind, name, namespace);
+                        log.debug("{} {} in namespace {} has been not been deleted", resourceKind, name, namespace);
                         future.fail(resourceKind + " " + name + " in namespace " + namespace + " has been not been deleted");
                     }
                 } catch (Exception e) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -407,12 +406,15 @@ public class StatefulSetOperatorTest
             }
         };
 
-        op.deleteAsync("myns", "mysts", true).setHandler(res -> {
+        Async async = context.async();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, true).setHandler(res -> {
             if (res.succeeded())    {
                 assertTrue(cascadingCaptor.getValue());
             } else {
                 fail();
             }
+
+            async.complete();
         });
     }
 
@@ -444,12 +446,15 @@ public class StatefulSetOperatorTest
             }
         };
 
-        op.deleteAsync("myns", "mysts", false).setHandler(res -> {
+        Async async = context.async();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
                 assertFalse(cascadingCaptor.getValue());
             } else {
                 fail();
             }
+
+            async.complete();
         });
     }
 
@@ -480,10 +485,13 @@ public class StatefulSetOperatorTest
             }
         };
 
-        op.deleteAsync("myns", "mysts", false).setHandler(res -> {
+        Async async = context.async();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
                 fail();
             }
+
+            async.complete();
         });
     }
 
@@ -514,12 +522,16 @@ public class StatefulSetOperatorTest
             }
         };
 
-        op.deleteAsync("myns", "mysts", false).setHandler(res -> {
+        Async async = context.async();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
                 fail();
             } else {
-                assertEquals("Something failed", res.cause().getMessage());
+                assertTrue("org.mockito.exceptions.base.MockitoException".equals(res.cause().getClass().getName()));
+                assertTrue("Something failed".equals(res.cause().getMessage()));
             }
+
+            async.complete();
         });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -39,8 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -372,7 +372,7 @@ public class StatefulSetOperatorTest
         Async async = context.async();
         op.reconcile(sts1.getMetadata().getNamespace(), sts1.getMetadata().getName(), sts2).setHandler(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
-            assertTrue(ar.succeeded());
+            context.assertTrue(ar.succeeded());
             verify(mockERPD).delete();
             async.complete();
         });
@@ -409,9 +409,9 @@ public class StatefulSetOperatorTest
         Async async = context.async();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, true).setHandler(res -> {
             if (res.succeeded())    {
-                assertTrue(cascadingCaptor.getValue());
+                context.assertTrue(cascadingCaptor.getValue());
             } else {
-                fail();
+                context.fail();
             }
 
             async.complete();
@@ -449,9 +449,9 @@ public class StatefulSetOperatorTest
         Async async = context.async();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
-                assertFalse(cascadingCaptor.getValue());
+                context.assertFalse(cascadingCaptor.getValue());
             } else {
-                fail();
+                context.fail();
             }
 
             async.complete();
@@ -488,7 +488,7 @@ public class StatefulSetOperatorTest
         Async async = context.async();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
-                fail();
+                context.fail();
             }
 
             async.complete();
@@ -525,10 +525,10 @@ public class StatefulSetOperatorTest
         Async async = context.async();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
             if (res.succeeded())    {
-                fail();
+                context.fail();
             } else {
-                assertTrue("org.mockito.exceptions.base.MockitoException".equals(res.cause().getClass().getName()));
-                assertTrue("Something failed".equals(res.cause().getMessage()));
+                context.assertTrue("org.mockito.exceptions.base.MockitoException".equals(res.cause().getClass().getName()));
+                context.assertTrue("Something failed".equals(res.cause().getMessage()));
             }
 
             async.complete();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The tests for the `deleteAsync()` method in `StatefulSetOperator` seem to be crap :-(. This PR tries to fix them by using the right name and namespace and by synchronising them.