### PR TITLE
ST: remove min isr from topic for MM tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -555,7 +555,10 @@ public class Resources extends AbstractResources {
     }
 
     DoneableKafkaTopic topic(String clusterName, String topicName, int partitions, int replicas) {
-        return topic(defaultTopic(clusterName, topicName, partitions, replicas).build());
+        return topic(defaultTopic(clusterName, topicName, partitions, replicas)
+            .editSpec()
+            .addToConfig("min.insync.replicas", replicas)
+            .endSpec().build());
     }
 
     private KafkaTopicBuilder defaultTopic(String clusterName, String topicName, int partitions, int replicas) {
@@ -570,7 +573,6 @@ public class Resources extends AbstractResources {
                 .withNewSpec()
                     .withPartitions(partitions)
                     .withReplicas(replicas)
-                    .addToConfig("min.insync.replicas", replicas)
                 .endSpec();
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With `min.insync.replicas` set to 1 in topic, MM tests just failed, because messages weren't available on source cluster, but only on target cluster. After manual review, everything works fine. This change just remove setting from topic and set min isr only i tests where it's needed.

### Checklist

- [x] Make sure all tests pass

