### PR TITLE
ST: Make JBOD ST more stable

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -57,6 +57,7 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
@@ -225,11 +226,11 @@ public class Resources extends AbstractResources {
         return kafka(defaultKafka(name, kafkaReplicas, zookeeperReplicas).build());
     }
 
-    DoneableKafka kafkaJBOD(String name, int kafkaReplicas, List<SingleVolumeStorage> volumes) {
+    DoneableKafka kafkaJBOD(String name, int kafkaReplicas, JbodStorage jbodStorage) {
         return kafka(defaultKafka(name, kafkaReplicas).
                 editSpec()
                     .editKafka()
-                        .withNewJbodStorage().withVolumes(volumes).endJbodStorage()
+                        .withStorage(jbodStorage)
                     .endKafka()
                     .editZookeeper().
                         withReplicas(1)

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -58,7 +58,6 @@ import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
-import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClient;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -306,6 +306,13 @@ public class StUtils {
         );
     }
 
+    public static void waitForKafkaClusterPodsDeletion(String clusterName) {
+        LOGGER.info("Waiting when all pods in Kafka cluster {} will be deleted", clusterName);
+        kubeClient().listPods().stream()
+                .filter(p -> p.getMetadata().getName().startsWith(clusterName))
+                .forEach(p -> StUtils.waitForPodDeletion(p.getMetadata().getName()));
+    }
+
     public static String getPodNameByPrefix(String prefix) {
         return kubeClient().listPods().stream().filter(pod -> pod.getMetadata().getName().startsWith(prefix))
                 .findFirst().get().getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1044,8 +1044,7 @@ class KafkaST extends MessagingBaseST {
 
         JbodStorage jbodStorage = new JbodStorageBuilder().withVolumes(
             new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(0).withSize(diskSizeGi + "Gi").build(),
-            new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build())
-        .build();
+            new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
         testMethodResources().kafkaJBOD(CLUSTER_NAME, kafkaReplicas, jbodStorage).done();
         // kafka cluster already deployed
@@ -1063,8 +1062,7 @@ class KafkaST extends MessagingBaseST {
 
         JbodStorage jbodStorage = new JbodStorageBuilder().withVolumes(
             new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(0).withSize(diskSizeGi + "Gi").build(),
-            new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(1).withSize(diskSizeGi + "Gi").build())
-        .build();
+            new PersistentClaimStorageBuilder().withDeleteClaim(true).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
         testMethodResources().kafkaJBOD(CLUSTER_NAME, kafkaReplicas, jbodStorage).done();
         // kafka cluster already deployed
@@ -1085,8 +1083,7 @@ class KafkaST extends MessagingBaseST {
 
         JbodStorage jbodStorage = new JbodStorageBuilder().withVolumes(
             new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(0).withSize(diskSizeGi + "Gi").build(),
-            new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build())
-        .build();
+            new PersistentClaimStorageBuilder().withDeleteClaim(false).withId(1).withSize(diskSizeGi + "Gi").build()).build();
 
         testMethodResources().kafkaJBOD(CLUSTER_NAME, kafkaReplicas, jbodStorage).done();
         // kafka cluster already deployed


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
These changes were made due to the instability of the JBOD ST on the Jenkins side. 
In this PR we will add: 
1. Additional `wait` for JBOD ST to wait when Kafka cluster pods will be deleted
2. JUnit asserts were updated to use matchers to have all information about the list with PVCs which we want to check. Right now it's not possible to understand what's wrong with ST because of simple verification `True not False`
3. Using builders instead of `new ArrayList<>();`


### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
