### PR TITLE
add support for watching any namespace to the Helm chart

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -26,9 +26,13 @@ spec:
           env:
             - name: STRIMZI_NAMESPACE
               {{- if .Values.watchNamespaces -}}
+              {{- if has "*" .Values.watchNamespaces }}
+              value: "*"
+              {{- else }}
               {{- $ns := .Values.watchNamespaces -}}
               {{- $ns := append $ns .Release.Namespace }}
               value: "{{ join "," $ns }}"
+              {{- end }}
               {{- else }}
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
Fixes #1661
Allow deployments of the operator done using the Helm chart to watch any namespace.
Check whether the value of `watchNamespaces` contains the item `"*"`, and if so set the `STRIMZI_NAMESPACE` env variable to `"*"`.