### PR TITLE
Bump Zookeeper version to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <kafka.version>2.2.0</kafka.version>
         <zkclient.version>0.11</zkclient.version>
         <scala-library.version>2.12.8</scala-library.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
         <mockito.version>2.23.4</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-annotations</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Zookeeper 3.4.13 and older seems to have some CVE around ACLs and leaking Digest credentials. It should no affect Strimzi since our ZK is locked down. But we should update to 3.4.14 which contains the fix.