### PR TITLE
Move forward with the Status sub-resource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -72,7 +73,7 @@ import static java.util.Collections.unmodifiableList;
         }
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
 public class Kafka extends CustomResource implements UnknownPropertyPreserving {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
@@ -2,9 +2,10 @@
  * Copyright 2019, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.api.kafka.model;
+package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+/**
+ * Represents a status of the Kafka resource
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "conditions", "listeners" })
+@EqualsAndHashCode
+public class KafkaStatus extends Status {
+    private List<ListenerStatus> listeners;
+
+    @Description("Addresses of the internal and external listeners")
+    public List<ListenerStatus> getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(List<ListenerStatus> listeners) {
+        this.listeners = listeners;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
@@ -2,50 +2,53 @@
  * Copyright 2019, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.api.kafka.model;
+package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
+/**
+ * Represents a single address of particular listener
+ */
 @Buildable(
         editableEnabled = false,
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "address", "host", "port" })
 @EqualsAndHashCode
-public class KafkaStatus implements UnknownPropertyPreserving, Serializable {
-
-    private boolean ready;
-    private ListenersStatus listeners;
-    private List<Condition> conditions;
+public class ListenerAddress implements UnknownPropertyPreserving, Serializable {
+    private String host;
+    private Integer port;
     private Map<String, Object> additionalProperties;
 
-    @Description("Kafka Bootstrap addresses for internal and external listeners")
-    public ListenersStatus getListeners() {
-        return listeners;
+    @Description("The DNS name or IP address of Kafka bootstrap service")
+    public String getHost() {
+        return host;
     }
 
-    public void setListeners(ListenersStatus listeners) {
-        this.listeners = listeners;
+    public void setHost(String host) {
+        this.host = host;
     }
 
-    @Description("List of status conditions")
-    public List<Condition> getConditions() {
-        return conditions;
+    @Description("The port of the Kafka bootstrap service")
+    public Integer getPort() {
+        return port;
     }
 
-    public void setConditions(List<Condition> conditions) {
-        this.conditions = conditions;
+    public void setPort(Integer port) {
+        this.port = port;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -2,62 +2,55 @@
  * Copyright 2019, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.api.kafka.model;
+package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
+/**
+ * Represents a single listener
+ */
 @Buildable(
         editableEnabled = false,
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "plain", "tls", "external"})
+@JsonPropertyOrder({ "authentication" })
 @EqualsAndHashCode
-public class ListenersStatus implements UnknownPropertyPreserving, Serializable {
-    private ListenerStatus plain;
-    private ListenerStatus tls;
-    private ListenerStatus external;
+public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
+    private String type;
+    private List<ListenerAddress> addresses;
     private Map<String, Object> additionalProperties;
 
-    public ListenersStatus() {
+    @Description("The type of the listener. " +
+            "Can be one of the following three types: `plain`, `tls`, and `external`.")
+    public String getType() {
+        return type;
     }
 
-    @Description("The Kafka boostrap address for unencrypted listeners")
-    public ListenerStatus getPlain() {
-        return plain;
+    public void setType(String type) {
+        this.type = type;
     }
 
-    public void setPlain(ListenerStatus plain) {
-        this.plain = plain;
+    @Description("A list of the addresses for this listener.")
+    public List<ListenerAddress> getAddresses() {
+        return addresses;
     }
 
-    @Description("The Kafka bootstrap address for tls encrypted listeners")
-    public ListenerStatus getTls() {
-        return tls;
-    }
-
-    public void setTls(ListenerStatus tls) {
-        this.tls = tls;
-    }
-
-    @Description("The Kafka bootstrap address for external listeners")
-    public ListenerStatus getExternal() {
-        return external;
-    }
-
-    public void setExternal(ListenerStatus external) {
-        this.external = external;
+    public void setAddresses(List<ListenerAddress> addresses) {
+        this.addresses = addresses;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -2,58 +2,42 @@
  * Copyright 2019, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.api.kafka.model;
+package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
+/**
+ * Represents a generic status which can be used across different resources
+ */
 @Buildable(
         editableEnabled = false,
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "authentication" })
 @EqualsAndHashCode
-public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
-    private String host;
-    private Integer port;
+public class Status implements UnknownPropertyPreserving, Serializable {
+    private List<Condition> conditions;
     private Map<String, Object> additionalProperties;
 
-    public ListenerStatus() {
+    @Description("List of status conditions")
+    public List<Condition> getConditions() {
+        return conditions;
     }
 
-    public ListenerStatus(String host, Integer port, Map<String, Object> additionalProperties) {
-        this.host = host;
-        this.port = port;
-        this.additionalProperties = additionalProperties;
-    }
-
-    @Description("The DNS name or IP address of Kafka bootstrap service")
-    public String getHost() {
-        return host;
-    }
-
-    public void setHost(String host) {
-        this.host = host;
-    }
-
-    @Description("The port of the Kafka bootstrap service")
-    public Integer getPort() {
-        return port;
-    }
-
-    public void setPort(Integer port) {
-        this.port = port;
+    public void setConditions(List<Condition> conditions) {
+        this.conditions = conditions;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1462,6 +1462,13 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
+     * @return  The listener object from the CRD
+     */
+    public KafkaListeners getListeners() {
+        return listeners;
+    }
+
+    /**
      * Sets the object with Kafka authorization configuration
      *
      * @param authorization

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.zjsonpatch.JsonDiff;
+import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.operator.cluster.operator.resource.AbstractResourceDiff;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.regex.Pattern;
+
+import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
+
+public class StatusDiff extends AbstractResourceDiff {
+    private static final Logger log = LogManager.getLogger(StatusDiff.class.getName());
+
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
+            "^(/conditions/[0-9]+/lastTransitionTime)$");
+
+    private final boolean isEmpty;
+
+    public StatusDiff(Status current, Status desired) {
+        JsonNode source = patchMapper().valueToTree(current == null ? "{}" : current);
+        JsonNode target = patchMapper().valueToTree(desired == null ? "{}" : desired);
+        JsonNode diff = JsonDiff.asJson(source, target);
+
+        int num = 0;
+
+        for (JsonNode d : diff) {
+            String pathValue = d.get("path").asText();
+
+            if (IGNORABLE_PATHS.matcher(pathValue).matches()) {
+                log.debug("Ignoring Status diff {}", d);
+                continue;
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Status differs: {}", d);
+                log.debug("Current Status path {} has value {}", pathValue, lookupPath(source, pathValue));
+                log.debug("Desired Status path {} has value {}", pathValue, lookupPath(target, pathValue));
+            }
+
+            num++;
+        }
+
+        this.isEmpty = num == 0;
+    }
+
+    /**
+     * Returns whether the Diff is empty or not
+     *
+     * @return true when the storage configurations are the same
+     */
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+}

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -41,6 +41,7 @@ rules:
   - kafka.strimzi.io
   resources:
   - kafkas
+  - kafkas/status
   - kafkaconnects
   - kafkaconnects2is
   - kafkamirrormakers

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.KafkaStatusBuilder;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
+import io.strimzi.api.kafka.model.status.ListenerStatus;
+import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StatusDiffTest {
+    @Test
+    public void testStatusDiff()    {
+        ListenerStatus ls1 = new ListenerStatusBuilder()
+                .withNewType("plain")
+                .withAddresses(new ListenerAddressBuilder()
+                        .withHost("my-service.my-namespace.svc")
+                        .withPort(9092)
+                        .build())
+                .build();
+
+        ListenerStatus ls2 = new ListenerStatusBuilder()
+                .withNewType("tls")
+                .withAddresses(new ListenerAddressBuilder()
+                        .withHost("my-service.my-namespace.svc")
+                        .withPort(9093)
+                        .build())
+                .build();
+
+        ListenerStatus ls3 = new ListenerStatusBuilder()
+                .withNewType("tls")
+                .withAddresses(new ListenerAddressBuilder()
+                        .withHost("my-service.my-namespace.svc")
+                        .withPort(9094)
+                        .build())
+                .build();
+
+        Condition condition1 = new ConditionBuilder()
+                .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date()))
+                .withNewType("Ready")
+                .withNewStatus("True")
+                .build();
+
+        Condition condition2 = new ConditionBuilder()
+                .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date()))
+                .withNewType("Ready2")
+                .withNewStatus("True")
+                .build();
+
+        KafkaStatus status1 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls1)
+                .build();
+
+        KafkaStatus status2 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls1)
+                .build();
+
+        KafkaStatus status3 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls1, ls2)
+                .build();
+
+        KafkaStatus status4 = new KafkaStatusBuilder()
+                .withConditions(condition1, condition2)
+                .withListeners(ls1)
+                .build();
+
+        KafkaStatus status5 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls1, ls3)
+                .build();
+
+        KafkaStatus status6 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls3, ls1)
+                .build();
+
+        StatusDiff diff = new StatusDiff(status1, status2);
+        assertTrue(diff.isEmpty());
+
+        diff = new StatusDiff(status1, status3);
+        assertFalse(diff.isEmpty());
+
+        diff = new StatusDiff(status1, status4);
+        assertFalse(diff.isEmpty());
+
+        diff = new StatusDiff(status3, status4);
+        assertFalse(diff.isEmpty());
+
+        diff = new StatusDiff(status3, status5);
+        assertFalse(diff.isEmpty());
+
+        diff = new StatusDiff(status5, status6);
+        assertFalse(diff.isEmpty());
+    }
+
+    @Test
+    public void testTimestampDiff() throws ParseException {
+        ListenerStatus ls1 = new ListenerStatusBuilder()
+                .withNewType("plain")
+                .withAddresses(new ListenerAddressBuilder()
+                        .withHost("my-service.my-namespace.svc")
+                        .withPort(9092)
+                        .build())
+                .build();
+
+        ListenerStatus ls2 = new ListenerStatusBuilder()
+                .withNewType("tls")
+                .withAddresses(new ListenerAddressBuilder()
+                        .withHost("my-service.my-namespace.svc")
+                        .withPort(9093)
+                        .build())
+                .build();
+
+        Condition condition1 = new ConditionBuilder()
+                .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date()))
+                .withNewType("Ready")
+                .withNewStatus("True")
+                .build();
+
+        Condition condition2 = new ConditionBuilder()
+                .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
+                .withNewType("Ready")
+                .withNewStatus("True")
+                .build();
+
+        KafkaStatus status1 = new KafkaStatusBuilder()
+                .withConditions(condition1)
+                .withListeners(ls1, ls2)
+                .build();
+
+        KafkaStatus status2 = new KafkaStatusBuilder()
+                .withConditions(condition2)
+                .withListeners(ls1, ls2)
+                .build();
+
+        StatusDiff diff = new StatusDiff(status1, status2);
+        assertTrue(diff.isEmpty());
+    }
+}

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1001,9 +1001,60 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Field         |Description
-|state  1.2+<.<|the state.
+|Field              |Description
+|conditions  1.2+<.<|List of status conditions.
+|xref:type-Condition-{context}[`Condition`] array
+|listeners   1.2+<.<|Addresses of the internal and external listeners.
+|xref:type-ListenerStatus-{context}[`ListenerStatus`] array
+|====
+
+[id='type-Condition-{context}']
+### `Condition` schema reference
+
+Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
+
+
+[options="header"]
+|====
+|Field                      |Description
+|lastTransitionTime  1.2+<.<|Last time the condition of a type changes from one status to another.The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string
+|reason              1.2+<.<|One-word CamelCase reason for the condition's last transition.
+|string
+|status              1.2+<.<|The status of the condition, one of True, False, Unknown.
+|string
+|type                1.2+<.<|The unique identifier of a condition, used to distinguish between other conditions in the resource.
+|string
+|====
+
+[id='type-ListenerStatus-{context}']
+### `ListenerStatus` schema reference
+
+Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
+
+
+[options="header"]
+|====
+|Field             |Description
+|addresses  1.2+<.<|A list of the addresses for this listener.
+|xref:type-ListenerAddress-{context}[`ListenerAddress`] array
+|type       1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
+|string
+|====
+
+[id='type-ListenerAddress-{context}']
+### `ListenerAddress` schema reference
+
+Used in: xref:type-ListenerStatus-{context}[`ListenerStatus`]
+
+
+[options="header"]
+|====
+|Field        |Description
+|host  1.2+<.<|The DNS name or IP address of Kafka bootstrap service.
+|string
+|port  1.2+<.<|The port of the Kafka bootstrap service.
+|integer
 |====
 
 [id='type-KafkaConnect-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -46,6 +46,7 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkas
+  - kafkas/status
   - kafkaconnects
   - kafkaconnects2is
   - kafkamirrormakers

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -38,6 +38,8 @@ spec:
     JSONPath: .spec.zookeeper.replicas
     type: integer
     priority: 0
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -2732,4 +2734,36 @@ spec:
           required:
           - kafka
           - zookeeper
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            listeners:
+              type: array
+              items:
+                type: object
+                properties:
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                  type:
+                    type: string
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -772,8 +772,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             version:
               type: string
           required:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -759,8 +759,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -97,6 +97,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -118,8 +119,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - groupId
               - bootstrapServers
@@ -159,6 +158,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -180,8 +180,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - bootstrapServers
             resources:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2746,26 +2746,18 @@ spec:
                   type:
                     type: string
             listeners:
-              type: object
-              properties:
-                plain:
-                  type: object
-                  properties:
-                    host:
-                      type: string
-                    port:
-                      type: integer
-                tls:
-                  type: object
-                  properties:
-                    host:
-                      type: string
-                    port:
-                      type: integer
-                external:
-                  type: object
-                  properties:
-                    host:
-                      type: string
-                    port:
-                      type: integer
+              type: array
+              items:
+                type: object
+                properties:
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                  type:
+                    type: string

--- a/olm/kafkaconnects.crd.yaml
+++ b/olm/kafkaconnects.crd.yaml
@@ -767,8 +767,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             version:
               type: string
           required:

--- a/olm/kafkaconnects2is.crd.yaml
+++ b/olm/kafkaconnects2is.crd.yaml
@@ -754,8 +754,6 @@ spec:
                     required:
                     - certificate
                     - secretName
-              required:
-              - trustedCertificates
             tolerations:
               type: array
               items:

--- a/olm/kafkamirrormakers.crd.yaml
+++ b/olm/kafkamirrormakers.crd.yaml
@@ -92,6 +92,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -113,8 +114,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - groupId
               - bootstrapServers
@@ -154,6 +153,7 @@ spec:
                       enum:
                       - tls
                       - scram-sha-512
+                      - plain
                     username:
                       type: string
                   required:
@@ -175,8 +175,6 @@ spec:
                         required:
                         - certificate
                         - secretName
-                  required:
-                  - trustedCertificates
               required:
               - bootstrapServers
             resources:

--- a/olm/kafkas.crd.yaml
+++ b/olm/kafkas.crd.yaml
@@ -33,6 +33,8 @@ spec:
     JSONPath: .spec.zookeeper.replicas
     type: integer
     priority: 0
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -2727,3 +2729,35 @@ spec:
           required:
           - kafka
           - zookeeper
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            listeners:
+              type: array
+              items:
+                type: object
+                properties:
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                  type:
+                    type: string

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/CrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/CrdOperatorIT.java
@@ -104,7 +104,7 @@ public class CrdOperatorIT extends AbstractResourceOperatorIT<KubernetesClient, 
                 } else {
                     // k1 needs the same resourceID as k0 in order to update it
                     Kafka k1 = new KafkaBuilder(k0).withNewStatus().withConditions().addNewCondition().withStatus("test").endCondition().endStatus().build();
-                    crdOperator.updateStatus(k1);
+                    crdOperator.updateStatusAsync(k1);
                     Kafka k2 = crdOperator.get(namespace, RESOURCE_NAME);
                     assertEquals(k1.getStatus().toString(), k2.getStatus().toString());
 


### PR DESCRIPTION
This PR tries to move forward with the Status sub-resource work.

To avoid a loop when the status updates are triggering the watch, we update the status only when it really changed - the lastTransitionTime is ignored and not updated when the condition did not changed. That makes sure that the watch doesn't run in an infinite loop, because when nothing in status changes, not update is fired.

It does also following notable changes:
* Adds condition support
  * Successful reconciliation => Ready
  * Unsuccessful reconciliation => NotReady
* Does some refactoring to the status field:
  * It uses list for listeners as suggested in the review comments
  * It uses list for addresses (host & port) to allow to list multiple addresses where needed / appropriate
```yaml
  status:
    conditions:
    - lastTransitionTime: 2019-06-02T23:46:57+0000
      status: "True"
      type: Ready
    listeners:
    - addresses:
      - host: my-cluster-kafka-bootstrap.myproject.svc
        port: 9092
      type: plain
    - addresses:
      - host: my-cluster-kafka-bootstrap.myproject.svc
        port: 9093
      type: tls
    - addresses:
      - host: 172.29.49.180
        port: 9094
      type: external
```