### PR TITLE
Fix error when the Kubernetes minor version doesn't contain a +

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -18,9 +18,8 @@ public abstract class AbstractCrdIT extends BaseITST {
 
     protected void assumeKube1_11Plus() {
         VersionInfo version = new DefaultKubernetesClient().getVersion();
-        String minor = version.getMinor();
         Assume.assumeTrue("1".equals(version.getMajor())
-                && Integer.parseInt(minor.substring(0, minor.indexOf('+'))) >= 11);
+                && Integer.parseInt(version.getMinor().split("\\D")[0]) >= 11);
     }
 
     protected <T extends CustomResource> void createDelete(Class<T> resourceClass, String resource) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a problem when checking for Kubernetes version in some of our tests. It looks like we assume that the minor version will always contain a `+`. But this is not the always the case and it might result in IOOBE. One example where it is not right is Minikube 1.1.0 with Kube 1.14.2. This PR fixes the parsing to use the same as we use in the cluster operator to fix this problem.