### PR TITLE
Use separate properties for jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,9 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
-        <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
+        <fasterxml.jackson-core.version>2.9.9</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.9.9</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.9.9</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
         <kafka.version>2.2.1</kafka.version>
         <zkclient.version>0.11</zkclient.version>
@@ -285,7 +287,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <version>${fasterxml.jackson-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -295,12 +297,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <version>${fasterxml.jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <version>${fasterxml.jackson-dataformat.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When overriding dependencies it cannot be assumed that the same version for each of the jackson jars should necessarily be used.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

