### PR TITLE
Fix paths in the Metrics examples Makefile

### DIFF
--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -9,8 +9,8 @@ release:
 	mkdir -p $(RELEASE_PATH)
 	mkdir -p $(RELEASE_PATH)/grafana-dashboards
 	mkdir -p $(RELEASE_PATH)/prometheus-install
-	mkdir -p $(RELEASE_PATH)/prometheus-install-additional-properties
-	mkdir -p $(RELEASE_PATH)/prometheus-install-alertmanager-config
+	mkdir -p $(RELEASE_PATH)/prometheus-additional-properties
+	mkdir -p $(RELEASE_PATH)/prometheus-alertmanager-config
 	$(CP) -r ./examples/kafka/* $(RELEASE_PATH)/
 	$(CP) -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
 	$(CP) -r ./examples/prometheus/install/*.yaml $(RELEASE_PATH)/prometheus-install/


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the metrics example Makefile, the paths of the created directories and the paths where we try to copy the files do not match. That needs to be fixed before 0.12.0.