### PR TITLE
Fix missing entrypoints in the TO and UO deployments and wrong version in Metrics example

### DIFF
--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -14,7 +14,9 @@ spec:
       serviceAccountName: strimzi-topic-operator
       containers:
         - name: strimzi-topic-operator
-          image: strimzi/topic-operator:latest
+          image: strimzi/operator:latest
+          args:
+          - /opt/strimzi/bin/topic_operator_run.sh
           env:
             - name: STRIMZI_RESOURCE_LABELS
               value: "strimzi.io/cluster=my-cluster"

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -14,7 +14,9 @@ spec:
       serviceAccountName: strimzi-user-operator
       containers:
         - name: strimzi-user-operator
-          image: strimzi/user-operator:latest
+          image: strimzi/operator:latest
+          args:
+          - /opt/strimzi/bin/user_operator_run.sh
           env:
             - name: STRIMZI_NAMESPACE
               valueFrom:

--- a/metrics/examples/kafka/kafka-connect-metrics.yaml
+++ b/metrics/examples/kafka/kafka-connect-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: my-connect-cluster
 spec:
-  version: 2.1.1
+  version: 2.2.1
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9092
   metrics:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With moving to less images, we removed the entry-points from the Dockerfiles. But we didn't added them to the standalone TO and UO deployments. This PR fixes that. It also fixes wrong version in the Kafka metrics example.

This should be picked for the 0.12.0 release branch.