### PR TITLE
Make sure the Bridge examples are added to the releae files

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,6 +11,7 @@ release:
 	$(CP) -r ./kafka $(RELEASE_PATH)/
 	$(CP) -r ./kafka-connect $(RELEASE_PATH)/
 	$(CP) -r ./kafka-mirror-maker $(RELEASE_PATH)/
+	$(CP) -r ./kafka-bridge $(RELEASE_PATH)/
 	$(CP) -r ./user $(RELEASE_PATH)/
 	$(CP) -r ./topic $(RELEASE_PATH)/
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka Bridge examples are missing from the 0.12.0-rc1 release artefacts (ZIP and TAR.GZ) because they are not listed in the Makefile. This PR adds them there. This PR should be picked up into the 0.12.0 release branch as well.