### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)
 endif
 
-SUBDIRS=kafka-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples metrics test-client
+SUBDIRS=kafka-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init test-client docker-images helm-charts install examples metrics
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/docker-images/kafka/Makefile
+++ b/docker-images/kafka/Makefile
@@ -3,7 +3,7 @@ PROJECT_NAME=kafka
 
 clean:
 	rm -rf tmp
-	rm .*.tmp
+	rm -f .*.tmp
 
 .kafka-agent.tmp: ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp

--- a/docker-images/operator/Makefile
+++ b/docker-images/operator/Makefile
@@ -3,7 +3,7 @@ PROJECT_NAME=operator
 clean:
 	rm -rf lib
 	rm -rf tmp
-	rm .*.tmp
+	rm -f .*.tmp
 
 .topic-operator.tmp: ../../topic-operator/target/*-dist.zip
 	test -d tmp || mkdir tmp

--- a/docker-images/test-client/Makefile
+++ b/docker-images/test-client/Makefile
@@ -5,7 +5,7 @@ include ../../Makefile.os
 clean:
 	rm -rf lib
 	rm -rf tmp
-	rm .*.tmp
+	rm -f .*.tmp
 
 .test-client.tmp: ../../test-client/target/test-client*.jar
 	test -d tmp || mkdir tmp


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix two problems with the build:

1. Without the `-f` the `rm` command files if the glob has no matches. This will happen if trying to `make clean` an already clear tree.
2. `make all` requires the test-client to be built before the docker images. IOW `make all` will fail on a clean tree. This isn't detected by the travis build because travis does not do `make all`.

I think we should cherry-pick this to `release-0.12.x` branch because the latter problem requires people wanting to build a clean tree from source to understand/fix the build themselves.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

