### PR TITLE
Fix problems with certificate renewals caused by an incorrect commit

### DIFF
--- a/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -17,7 +17,7 @@ function create_truststore {
 # $5: CA public key to be imported
 # $6: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -chain -CAfile $5 -name $6 -password pass:$2 -out $1
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $6 -password pass:$2 -out $1
 }
 
 echo "Preparing truststore for replication listener"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the PR #1647 introduced a bug to certificate rotation caused by a file which was not supposed to be committed in that Pr but was added by mistake. This PR reverts the change and should get the certificate rotation working again.

This PR should be picked for the 0.12.0 release branch.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally