### PR TITLE
Add reason and message to NotReady condition and add observedGeneration

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
@@ -23,13 +23,14 @@ import static java.util.Collections.emptyMap;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "type", "status", "lastTransitionTime", "reason" })
+@JsonPropertyOrder({ "type", "status", "lastTransitionTime", "reason", "message" })
 @EqualsAndHashCode
 public class Condition implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String status;
     private String reason;
+    private String message;
     private String type;
     private String lastTransitionTime;
     private Map<String, Object> additionalProperties;
@@ -71,8 +72,14 @@ public class Condition implements UnknownPropertyPreserving, Serializable {
         this.lastTransitionTime = lastTransitionTime;
     }
 
-    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
-        this.additionalProperties = additionalProperties;
+    @Description("Human-readable message indicating details about last transition.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -21,7 +21,7 @@ import java.util.List;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "listeners" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners" })
 @EqualsAndHashCode
 public class KafkaStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -29,6 +29,7 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 public abstract class Status implements UnknownPropertyPreserving, Serializable {
     private List<Condition> conditions;
+    private long observedGeneration;
     private Map<String, Object> additionalProperties;
 
     @Description("List of status conditions")
@@ -38,6 +39,16 @@ public abstract class Status implements UnknownPropertyPreserving, Serializable 
 
     public void setConditions(List<Condition> conditions) {
         this.conditions = conditions;
+    }
+
+    @Description("The generation of the CRD which was last reconciled by the operator.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public long getObservedGeneration() {
+        return observedGeneration;
+    }
+
+    public void setObservedGeneration(long observedGeneration) {
+        this.observedGeneration = observedGeneration;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -181,6 +181,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             KafkaStatus status = reconcileState.kafkaStatus;
             Condition readyCondition;
 
+            if (kafkaAssembly.getMetadata().getGeneration() != null)    {
+                status.setObservedGeneration(kafkaAssembly.getMetadata().getGeneration());
+            }
+
             if (reconcileResult.succeeded())    {
                 readyCondition = new ConditionBuilder()
                         .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
@@ -192,6 +196,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
                         .withNewType("NotReady")
                         .withNewStatus("True")
+                        .withNewReason(reconcileResult.cause().getClass().getSimpleName())
+                        .withNewMessage(reconcileResult.cause().getMessage())
                         .build();
             }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -79,6 +79,7 @@ public class KafkaStatusTest {
                 .withNewMetadata()
                     .withName(clusterName)
                     .withNamespace(namespace)
+                    .withGeneration(2L)
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()
@@ -97,6 +98,7 @@ public class KafkaStatusTest {
                     .endZookeeper()
                 .endSpec()
                 .withNewStatus()
+                    .withObservedGeneration(1L)
                     .withConditions(new ConditionBuilder()
                             .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")))
                             .withNewType("NotReady")
@@ -142,6 +144,8 @@ public class KafkaStatusTest {
             assertEquals(1, status.getConditions().size());
             assertEquals("Ready", status.getConditions().get(0).getType());
             assertEquals("True", status.getConditions().get(0).getStatus());
+
+            assertEquals(2L, status.getObservedGeneration());
         });
     }
 
@@ -155,6 +159,7 @@ public class KafkaStatusTest {
 
         Kafka readyKafka = new KafkaBuilder(kafka)
                 .editStatus()
+                    .withObservedGeneration(2L)
                     .editCondition(0)
                         .withType("Ready")
                     .endCondition()
@@ -225,6 +230,10 @@ public class KafkaStatusTest {
             assertEquals(1, status.getConditions().size());
             assertEquals("NotReady", status.getConditions().get(0).getType());
             assertEquals("True", status.getConditions().get(0).getStatus());
+            assertEquals("RuntimeException", status.getConditions().get(0).getReason());
+            assertEquals("Something went wrong", status.getConditions().get(0).getMessage());
+
+            assertEquals(2L, status.getObservedGeneration());
         });
     }
 
@@ -238,6 +247,7 @@ public class KafkaStatusTest {
 
         Kafka readyKafka = new KafkaBuilder(kafka)
                 .editStatus()
+                    .withObservedGeneration(1L)
                     .editCondition(0)
                         .withType("Ready")
                     .endCondition()
@@ -283,6 +293,10 @@ public class KafkaStatusTest {
             assertEquals(1, status.getConditions().size());
             assertEquals("NotReady", status.getConditions().get(0).getType());
             assertEquals("True", status.getConditions().get(0).getStatus());
+            assertEquals("RuntimeException", status.getConditions().get(0).getReason());
+            assertEquals("Something went wrong", status.getConditions().get(0).getMessage());
+
+            assertEquals(2L, status.getObservedGeneration());
         });
     }
 
@@ -336,7 +350,7 @@ public class KafkaStatusTest {
 
             reconcileState.kafkaStatus.setListeners(singletonList(ls));
 
-            return Future.failedFuture("Something went wrong");
+            return Future.failedFuture(new RuntimeException("Something went wrong"));
         }
     }
 }

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1036,10 +1036,12 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Property           |Description
-|conditions  1.2+<.<|List of status conditions.
+|Property                   |Description
+|conditions          1.2+<.<|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|listeners   1.2+<.<|Addresses of the internal and external listeners.
+|observedGeneration  1.2+<.<|The generation of the CRD which was last reconciled by the operator.
+|integer
+|listeners           1.2+<.<|Addresses of the internal and external listeners.
 |xref:type-ListenerStatus-{context}[`ListenerStatus`] array
 |====
 
@@ -1059,6 +1061,8 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |lastTransitionTime  1.2+<.<|Last time the condition of a type changes from one status to another.The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string
 |reason              1.2+<.<|One-word CamelCase reason for the condition's last transition.
+|string
+|message             1.2+<.<|Human-readable message indicating details about last transition.
 |string
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -2939,6 +2939,10 @@ spec:
                     type: string
                   reason:
                     type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
             listeners:
               type: array
               items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -2934,6 +2934,10 @@ spec:
                     type: string
                   reason:
                     type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
             listeners:
               type: array
               items:

--- a/olm/kafkas.crd.yaml
+++ b/olm/kafkas.crd.yaml
@@ -2934,6 +2934,10 @@ spec:
                     type: string
                   reason:
                     type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
             listeners:
               type: array
               items:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR continues to improve the Status field of the Kafka custom resource. In this PR we add:
* The `status.observedGeneration` field which shows which generation of the custom resource was the last one reconciled by the operator.
* The `reason` and `message` fields to the `NotReady` condition. These fields can be used to show what exactly is the problem. For example:

```yaml
  status:
    conditions:
    - lastTransitionTime: 2019-06-06T17:45:13+0000
      message: You cannot configure TLS authentication on a plain listener.
      reason: InvalidResourceException
      status: "True"
      type: NotReady
    listeners: []
    observedGeneration: 5
```

or

```yaml
  status:
    conditions:
    - lastTransitionTime: 2019-06-06T17:22:16+0000
      message: Exceeded timeout of 300000ms while waiting for Pods resource my-cluster-kafka-0
        in namespace myproject to be ready
      reason: TimeoutException
      status: "True"
      type: NotReady
    listeners:
    - addresses:
      - host: my-cluster-kafka-bootstrap.myproject.svc
        port: 9092
      type: plain
    - addresses:
      - host: my-cluster-kafka-bootstrap.myproject.svc
        port: 9093
      type: tls
    - addresses:
      - host: my-cluster-kafka-bootstrap-myproject.192.168.64.47.nip.io
        port: 443
      type: external
    observedGeneration: 4
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally