### PR TITLE
[DOC] Clarify how `delete.topic.enable` operates

### DIFF
--- a/documentation/book/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/book/assembly-upgrade-cluster-operator.adoc
@@ -1,6 +1,6 @@
 // This assembly is included in the following assemblies:
 //
-// master.adoc
+// assembly-upgrade.adoc
 
 [id='assembly-upgrade-cluster-operator-{context}']
 = Upgrading the Cluster Operator
@@ -9,6 +9,6 @@ The steps to upgrade your Cluster Operator deployment to use {ProductName} {Prod
 
 The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.
 
-NOTE: Refer to previous {ProductName} documentation for information on upgrading from earlier Cluster Operation versions.
+NOTE: Refer to the documentation supporting a specific version of {ProductName} for information on how to upgrade to that version.
 
 include::proc-upgrading-the-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/book/proc-deleting-a-topic.adoc
+++ b/documentation/book/proc-deleting-a-topic.adoc
@@ -12,9 +12,9 @@ This procedure describes how to delete a Kafka topic using a `KafkaTopic` {Produ
 * A running Kafka cluster.
 * A running Topic Operator.
 * An existing `KafkaTopic` to be deleted.
-* `delete.topic.enable=true`
+* `delete.topic.enable=true` (default)
 
-NOTE: The `delete.topic.enable` property must be set to `true` in `Kafka.spec.kafka.config`. Otherwise, the steps outlined here will delete the `KafkaTopic` resource, but the Kafka topic and its data will remain. After reconciliation by the Cluster Operator, the custom resource is then recreated.
+NOTE: The `delete.topic.enable` property must be set to `true` in `Kafka.spec.kafka.config`. Otherwise, the steps outlined here will delete the `KafkaTopic` resource, but the Kafka topic and its data will remain. After reconciliation by the Topic Operator, the custom resource is then recreated.
 
 .Procedure
 

--- a/documentation/book/proc-deleting-a-topic.adoc
+++ b/documentation/book/proc-deleting-a-topic.adoc
@@ -12,6 +12,9 @@ This procedure describes how to delete a Kafka topic using a `KafkaTopic` {Produ
 * A running Kafka cluster.
 * A running Topic Operator.
 * An existing `KafkaTopic` to be deleted.
+* `delete.topic.enable=true`
+
+NOTE: The `delete.topic.enable` property must be set to `true` in `Kafka.spec.kafka.config`. Otherwise, the steps outlined here will delete the `KafkaTopic` resource, but the Kafka topic and its data will remain. After reconciliation by the Cluster Operator, the custom resource is then recreated.
 
 .Procedure
 
@@ -28,8 +31,6 @@ On {OpenShiftName} this can be done using `oc`:
 +
 [source,shell,subs=+quotes]
 oc delete kafkatopic _your-topic-name_
-
-NOTE: Whether the topic can actually be deleted depends on the value of the `delete.topic.enable` Kafka broker configuration specified in the `Kafka.spec.kafka.config` property.
 
 .Additional resources
 * For more information about deploying a Kafka cluster using the Cluster Operator, see xref:cluster-operator-str[].

--- a/documentation/book/ref-kafka-versions.adoc
+++ b/documentation/book/ref-kafka-versions.adoc
@@ -19,10 +19,9 @@ The format can change between Kafka releases, so messages include a version iden
 
 In Kafka, there are two different methods for setting the message format version:
 
+* The `message.format.version` property is set on topics.
 * The `log.message.format.version` property is set on Kafka brokers.
 
-* The `message.format.version` property is set on topics.
-
-The default value of `message.format.version` for a  topic is defined by the `log.message.format.version` that is set on the Kafka broker. You can manually set the `message.format.version` of a topic by modifying its topic configuration.
+The default value of `message.format.version` for a topic is defined by the `log.message.format.version` that is set on the Kafka broker. You can manually set the `message.format.version` of a topic by modifying its topic configuration.
 
 The upgrade tasks in this section assume that the message format version is defined by the `log.message.format.version`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In the documentation about deleting topic we have a note about the delete.topic.enble property. But it seems this note might be a bit confusing as some people might expect after reading it that they will not be able to delete the KAfkaTopic resource which is not true. The CR will be still deleted, but the Kafka topic (and its data) will stay. After another reconciliation loop, the KafkaTopic CR should get recreated again automatically from Kafka.

The note has been updated and moved to before the procedure. 
delete.topic.enble=true becomes a prerequisite

//Plus, couple of content tweaks


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

