### PR TITLE
Fix use of * in makefile avoid pb when it matched > 1 file

### DIFF
--- a/docker-images/operator/Makefile
+++ b/docker-images/operator/Makefile
@@ -1,28 +1,35 @@
-PROJECT_NAME=operator
+PROJECT_NAME := operator
+jar_version := $(shell cat ../../release.version)
+topic_operator_dist := ../../topic-operator/target/topic-operator-$(jar_version)-dist.zip
+user_operator_dist := ../../user-operator/target/user-operator-$(jar_version)-dist.zip
+cluster_operator_dist := ../../cluster-operator/target/cluster-operator-$(jar_version)-dist.zip
+kafka_init_dist := ../../kafka-init/target/kafka-init-$(jar_version)-dist.zip
 
-clean:
-	rm -rf lib
-	rm -rf tmp
-	rm -f .*.tmp
+clean: 
+	rm -f .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp
 
-.topic-operator.tmp: ../../topic-operator/target/*-dist.zip
+# We unzip each of the -dist.zip files into tmp which is then
+# COPYed in the Dockerfile, so can delete tmp on exit
+.INTERMEDIATE: tmp
+
+.topic-operator.tmp: $(topic_operator_dist)
 	test -d tmp || mkdir tmp
-	unzip -qo ../../topic-operator/target/*-dist.zip -d tmp
+	unzip -qo $(topic_operator_dist) -d tmp
 	touch .topic-operator.tmp
 
-.user-operator.tmp: ../../user-operator/target/*-dist.zip
+.user-operator.tmp: $(user_operator_dist)
 	test -d tmp || mkdir tmp
-	unzip -qo ../../user-operator/target/*-dist.zip -d tmp
+	unzip -qo $(user_operator_dist) -d tmp
 	touch .user-operator.tmp
 
-.kafka-init.tmp: ../../kafka-init/target/*-dist.zip
+.kafka-init.tmp: $(kafka_init_dist)
 	test -d tmp || mkdir tmp
-	unzip -qo ../../kafka-init/target/*-dist.zip -d tmp
+	unzip -qo $(kafka_init_dist) -d tmp
 	touch .kafka-init.tmp
 
-.cluster-operator.tmp: ../../cluster-operator/target/*-dist.zip
+.cluster-operator.tmp: $(cluster_operator_dist)
 	test -d tmp || mkdir tmp
-	unzip -qo ../../cluster-operator/target/*-dist.zip -d tmp
+	unzip -qo $(cluster_operator_dist) -d tmp
 	touch .cluster-operator.tmp
 
 docker_build: .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR fixes a bug in the operator `Makefile` caused when `*` matched more than one .zip file (which would happen when versions got upgraded between builds without using `make clean`). The bug exhibited with `make` exiting after `unzip` gave the message "caution: filename not matched: ../../topic-operator/target/topic-operator-0.13.0-SNAPSHOT-dist.zip".

I factored out variables to avoid repeating the same file names.

Also marked `tmp` directory as `.INTERMEDIATE` so it's deleted when make exists, otherwise there's the change that stale files could end up in there too.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

