### PR TITLE
Improve error handing in CrdOperator.updateStatusAsync()

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -6,10 +6,10 @@ package io.strimzi.operator.common.operator.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
@@ -77,9 +77,9 @@ public class CrdOperator<C extends KubernetesClient,
                     final int code = response.code();
 
                     if (code != 200) {
-                        log.debug("Got unexpected {} status code {}: {}", method, code, response.message());
-                        throw new KubernetesClientException("Got unexpected " + method + " status code " + code + ": " + response.message(),
-                                code, OperationSupport.createStatus(response));
+                        Status status = OperationSupport.createStatus(response);
+                        log.debug("Got unexpected {} status code {}: {}", method, code, status);
+                        throw OperationSupport.requestFailure(request, status);
                     }
                 } catch (Exception e) {
                     throw e;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR improves the error handling in `CrdOperator.updateStatusAsync()`. 

We use the Fabric8 `OperationSupport.requestFailure(request, status)` method to construct the `KubernetesClientException`, so exception should be consist with "real" Fabric8 exceptions. We also include the `Status` (which includes the error code, body response etc) in the log message.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

