### PR TITLE
Workaround the versioning issues in CRDs with KafkaStatus after version upgrade

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -61,6 +61,7 @@ public class CrdOperator<C extends KubernetesClient,
 
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(future -> {
             try {
+
                 OkHttpClient client = this.client.adapt(OkHttpClient.class);
                 RequestBody postBody = RequestBody.create(OperationSupport.JSON, new ObjectMapper().writeValueAsString(resource));
 
@@ -82,6 +83,7 @@ public class CrdOperator<C extends KubernetesClient,
                                 && status.getDetails().getCauses() != null
                                 && status.getDetails().getCauses().size() > 0
                                 && status.getDetails().getCauses().stream().filter(cause -> "FieldValueInvalid".equals(cause.getReason()) && "apiVersion".equals(cause.getField())).findAny().orElse(null) != null)  {
+                            log.debug("Got semi-expected {} status code {}: {}", method, code, status);
                             log.warn("Cannot update status of resource {} named {}. The resource needs to be updated to newer apiVersion first.", resource.getKind(), resource.getMetadata().getName());
                         } else {
                             log.debug("Got unexpected {} status code {}: {}", method, code, status);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -6,10 +6,10 @@ package io.strimzi.operator.common.operator.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
@@ -69,17 +69,28 @@ public class CrdOperator<C extends KubernetesClient,
                                 + "/" + this.plural + "/" + resource.getMetadata().getName() + "/status").build();
 
                 String method = request.method();
-                log.debug("Making {} request {}", method, request);
                 Response response = client.newCall(request).execute();
 
                 try {
-                    log.debug("Got {} response {}", method, response);
                     final int code = response.code();
 
-                    if (code != 200) {
-                        log.debug("Got unexpected {} status code {}: {}", method, code, response.message());
-                        throw new KubernetesClientException("Got unexpected " + method + " status code " + code + ": " + response.message(),
-                                code, OperationSupport.createStatus(response));
+                    if (code == 422)    {
+                        Status status = OperationSupport.createStatus(response);
+
+                        if (status != null
+                                && status.getDetails() != null
+                                && status.getDetails().getCauses() != null
+                                && status.getDetails().getCauses().size() > 0
+                                && status.getDetails().getCauses().stream().filter(cause -> "FieldValueInvalid".equals(cause.getReason()) && "apiVersion".equals(cause.getField())).findAny().orElse(null) != null)  {
+                            log.warn("Cannot update status of resource {} named {}. The resource needs to be updated to newer apiVersion first.", resource.getKind(), resource.getMetadata().getName());
+                        } else {
+                            log.debug("Got unexpected {} status code {}: {}", method, code, status);
+                            throw OperationSupport.requestFailure(request, status);
+                        }
+                    } else if (code != 200) {
+                        Status status = OperationSupport.createStatus(response);
+                        log.debug("Got unexpected {} status code {}: {}", method, code, status);
+                        throw OperationSupport.requestFailure(request, status);
                     }
                 } catch (Exception e) {
                     throw e;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.model.DoneableKafka;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> {
+
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Kafka resource() {
+        return new KafkaBuilder()
+                .withApiVersion("kafka.strimzi.io/v1beta1")
+                .withNewMetadata()
+                .withName(RESOURCE_NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withReplicas(1)
+                .withNewListeners()
+                .withNewPlain()
+                .endPlain()
+                .endListeners()
+                .withNewEphemeralStorage()
+                .endEphemeralStorage()
+                .endKafka()
+                .withNewZookeeper()
+                .withReplicas(1)
+                .withNewEphemeralStorage()
+                .endEphemeralStorage()
+                .endZookeeper()
+                .endSpec()
+                .withNewStatus()
+                .endStatus()
+                .build();
+    }
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        when(mockClient.customResources(any(), any(), any(), any())).thenReturn(op);
+    }
+
+    @Override
+    protected CrdOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new CrdOperator(vertx, mockClient, Kafka.class, KafkaList.class, DoneableKafka.class);
+    }
+
+    @Test
+    public void testUpdateStatusAsync(TestContext context) throws IOException {
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+
+        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
+        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
+        URL fakeUrl = new URL("http", "my-host", 9443, "/");
+        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
+        Call mockCall = mock(Call.class);
+        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
+        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
+        Response response = new Response.Builder().code(200).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Created").protocol(Protocol.HTTP_1_1).build();
+        when(mockCall.execute()).thenReturn(response);
+
+        Async async = context.async();
+        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
+        op.updateStatusAsync(resource()).setHandler(res -> {
+           context.assertTrue(res.succeeded());
+           async.complete();
+        });
+
+        async.awaitSuccess();
+    }
+
+    @Test
+    public void testHttp422AfterUpgrade(TestContext context) throws IOException {
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+
+        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
+        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
+        URL fakeUrl = new URL("http", "my-host", 9443, "/");
+        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
+        Call mockCall = mock(Call.class);
+        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
+        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Kafka.kafka.strimzi.io \\\"my-cluster\\\" is invalid: apiVersion: Invalid value: \\\"kafka.strimzi.io/v1alpha1\\\": must be kafka.strimzi.io/v1beta1\",\"reason\":\"Invalid\",\"details\":{\"name\":\"my-cluster\",\"group\":\"kafka.strimzi.io\",\"kind\":\"Kafka\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"kafka.strimzi.io/v1alpha1\\\": must be kafka.strimzi.io/v1beta1\",\"field\":\"apiVersion\"}]},\"code\":422}");
+        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
+        when(mockCall.execute()).thenReturn(response);
+
+        Async async = context.async();
+        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
+        op.updateStatusAsync(resource()).setHandler(res -> {
+            context.assertTrue(res.succeeded());
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testHttp422DifferentError(TestContext context) throws IOException {
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+
+        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
+        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
+        URL fakeUrl = new URL("http", "my-host", 9443, "/");
+        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
+        Call mockCall = mock(Call.class);
+        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
+        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Kafka.kafka.strimzi.io \\\"my-cluster\\\" is invalid: apiVersion: Invalid value: \\\"kafka.strimzi.io/v1alpha1\\\": must be kafka.strimzi.io/v1beta1\",\"reason\":\"Invalid\",\"details\":{\"name\":\"my-cluster\",\"group\":\"kafka.strimzi.io\",\"kind\":\"Kafka\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"kafka.strimzi.io/v1alpha1\\\": must be kafka.strimzi.io/v1beta1\",\"field\":\"someOtherField\"}]},\"code\":422}");
+        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
+        when(mockCall.execute()).thenReturn(response);
+
+        Async async = context.async();
+        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
+        op.updateStatusAsync(resource()).setHandler(res -> {
+            context.assertFalse(res.succeeded());
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testHttp422NoBody(TestContext context) throws IOException {
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+
+        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
+        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
+        URL fakeUrl = new URL("http", "my-host", 9443, "/");
+        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
+        Call mockCall = mock(Call.class);
+        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
+        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
+        Response response = new Response.Builder().code(422).request(new Request.Builder().url(fakeUrl).build()).message("Unprocessable Entity").protocol(Protocol.HTTP_1_1).build();
+        when(mockCall.execute()).thenReturn(response);
+
+        Async async = context.async();
+        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
+        op.updateStatusAsync(resource()).setHandler(res -> {
+            context.assertFalse(res.succeeded());
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testHttp409(TestContext context) throws IOException {
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+
+        OkHttpClient mockOkHttp = mock(OkHttpClient.class);
+        when(mockClient.adapt(eq(OkHttpClient.class))).thenReturn(mockOkHttp);
+        URL fakeUrl = new URL("http", "my-host", 9443, "/");
+        when(mockClient.getMasterUrl()).thenReturn(fakeUrl);
+        Call mockCall = mock(Call.class);
+        when(mockOkHttp.newCall(any(Request.class))).thenReturn(mockCall);
+        ResponseBody body = ResponseBody.create(OperationSupport.JSON, "{ }");
+        Response response = new Response.Builder().code(409).request(new Request.Builder().url(fakeUrl).build()).body(body).message("Conflict").protocol(Protocol.HTTP_1_1).build();
+        when(mockCall.execute()).thenReturn(response);
+
+        Async async = context.async();
+        CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
+        op.updateStatusAsync(resource()).setHandler(res -> {
+            context.assertFalse(res.succeeded());
+            async.complete();
+        });
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -4,12 +4,6 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
-import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -30,13 +24,8 @@ import okhttp3.ResponseBody;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -99,8 +99,8 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         Async async = context.async();
         CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> op = createResourceOperations(vertx, mockClient);
         op.updateStatusAsync(resource()).setHandler(res -> {
-           context.assertTrue(res.succeeded());
-           async.complete();
+            context.assertTrue(res.succeeded());
+            async.complete();
         });
 
         async.awaitSuccess();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems that we have problem setting the status in the Kafka CR after version upgrade. While the resource pretends to be `v1beta1`, Kube tells us to go to hell with HTTP 422 complaining about the resource being `v1alpha1`.

This PR hacks around it by catching the specific error and triggering a warning instead of exception.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally