### PR TITLE
Fix all Javadoc warnings @public visibility

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -16,7 +16,7 @@ public interface CertManager {
      * @param certFile path to the file which will contain the self signed certificate
      * @param sbj subject information
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException;
 
@@ -26,7 +26,7 @@ public interface CertManager {
      * @param keyFile path to the file which will contain the private key
      * @param certFile path to the file which will contain the self signed certificate
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateSelfSignedCert(File keyFile, File certFile, int days) throws IOException;
 
@@ -36,7 +36,7 @@ public interface CertManager {
      * @param certFile path to the file which will contain the new self signed certificate
      * @param sbj subject information
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException;
 
@@ -46,6 +46,7 @@ public interface CertManager {
      * @param keyFile path to the file which will contain the private key
      * @param csrFile path to the file which will contain the certificate sign request
      * @param sbj subject information
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateCsr(File keyFile, File csrFile, Subject sbj) throws IOException;
 
@@ -57,7 +58,7 @@ public interface CertManager {
      * @param caCert path to the file containing the CA certificate
      * @param crtFile path to the file which will contain the signed certificate
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateCert(File csrFile, File caKey, File caCert, File crtFile, int days) throws IOException;
 
@@ -70,7 +71,7 @@ public interface CertManager {
      * @param crtFile path to the file which will contain the signed certificate
      * @param sbj subject information
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException;
 
@@ -82,7 +83,7 @@ public interface CertManager {
      * @param caCert CA certificate bytes
      * @param crtFile path to the file which will contain the signed certificate
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, int days) throws IOException;
 
@@ -95,7 +96,7 @@ public interface CertManager {
      * @param crtFile path to the file which will contain the signed certificate
      * @param sbj subject information
      * @param days certificate duration
-     * @throws IOException
+     * @throws IOException If an input or output file could not be read/written.
      */
     void generateCert(File csrFile, byte[] caKey, byte[] caCert, File crtFile, Subject sbj, int days) throws IOException;
 }

--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -40,7 +40,7 @@ public class SecretCertProvider {
      * @param annotations annotations to add to the Secret
      * @param ownerReference owner of the Secret
      * @return the Secret
-     * @throws IOException
+     * @throws IOException If a file could not be read.
      */
     public Secret createSecret(String namespace, String name, File keyFile, File certFile, Map<String, String> labels, Map<String, String> annotations, OwnerReference ownerReference) throws IOException {
         return createSecret(namespace, name, DEFAULT_KEY_KEY, DEFAULT_KEY_CERT, keyFile, certFile, labels, annotations, ownerReference);
@@ -59,7 +59,7 @@ public class SecretCertProvider {
      * @param annotations annotations to add to the Secret
      * @param ownerReference owner of the Secret
      * @return the Secret
-     * @throws IOException
+     * @throws IOException If a file could not be read.
      */
     public Secret createSecret(String namespace, String name, String keyKey, String certKey, File keyFile, File certFile, Map<String, String> labels, Map<String, String> annotations, OwnerReference ownerReference) throws IOException {
         byte[] key = Files.readAllBytes(keyFile.toPath());
@@ -149,7 +149,7 @@ public class SecretCertProvider {
      * @param keyFile private key to store
      * @param certFile certificate to store
      * @return the Secret
-     * @throws IOException
+     * @throws IOException If a file could not be read.
      */
     public Secret addSecret(Secret secret, String keyKey, String certKey, File keyFile, File certFile) throws IOException {
         byte[] key = Files.readAllBytes(keyFile.toPath());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -216,23 +216,30 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Returns the Docker image which should be used by this cluster
-     *
-     * @return
+     * @return the Docker image which should be used by this cluster
      */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return The service name.
+     */
     public String getServiceName() {
         return serviceName;
     }
 
+    /**
+     * @return The name of the headless service.
+     */
     public String getHeadlessServiceName() {
         return headlessServiceName;
     }
 
 
+    /**
+     * @return The selector labels.
+     */
     public Map<String, String> getSelectorLabels() {
         return labels.withName(name).strimziLabels().toMap();
     }
@@ -254,6 +261,9 @@ public abstract class AbstractModel {
         return labels.withName(name).withUserLabels(userLabels).toMap();
     }
 
+    /**
+     * @return Whether metrics are enabled.
+     */
     public boolean isMetricsEnabled() {
         return isMetricsEnabled;
     }
@@ -276,6 +286,10 @@ public abstract class AbstractModel {
         return getOrderedProperties(getDefaultLogConfigFileName());
     }
 
+    /**
+     * @param configFileName The filename
+     * @return The OrderedProperties
+     */
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION") // InputStream is closed by properties.addStringPairs
     public static OrderedProperties getOrderedProperties(String configFileName) {
         OrderedProperties properties = new OrderedProperties();
@@ -303,6 +317,9 @@ public abstract class AbstractModel {
         return properties.asPairsWithComment("Do not change this generated file. Logging can be configured in the corresponding kubernetes/openshift resource.");
     }
 
+    /**
+     * @return The logging.
+     */
     public Logging getLogging() {
         return logging;
     }
@@ -311,6 +328,11 @@ public abstract class AbstractModel {
         this.logging = logging;
     }
 
+    /**
+     * @param logging The logging to parse.
+     * @param externalCm The external ConfigMap.
+     * @return The logging properties as a String in log4j properties file format.
+     */
     public String parseLogging(Logging logging, ConfigMap externalCm) {
         if (logging instanceof InlineLogging) {
             // validate all entries
@@ -379,8 +401,9 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Generates a metrics and logging ConfigMap according to configured defaults
-     * @return The generated ConfigMap
+     * Generates a metrics and logging ConfigMap according to configured defaults.
+     * @param cm The ConfigMap.
+     * @return The generated ConfigMap.
      */
     public ConfigMap generateMetricsAndLogConfigMap(ConfigMap cm) {
         Map<String, String> data = new HashMap<>();
@@ -396,18 +419,6 @@ public abstract class AbstractModel {
         return createConfigMap(getAncillaryConfigName(), data);
     }
 
-    public String getLogConfigName() {
-        return logConfigName;
-    }
-
-    /**
-     * Sets name of field in cluster config map, where logging configuration is stored
-     * @param logConfigName
-     */
-    protected void setLogConfigName(String logConfigName) {
-        this.logConfigName = logConfigName;
-    }
-
     protected Iterable<Map.Entry<String, Object>>  getMetricsConfig() {
         return metricsConfig;
     }
@@ -417,21 +428,20 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Returns name of config map used for storing metrics and logging configuration
-     * @return
+     * Returns name of config map used for storing metrics and logging configuration.
+     * @return The name of config map used for storing metrics and logging configuration.
      */
     public String getAncillaryConfigName() {
         return ancillaryConfigName;
-    }
-
-    protected void setMetricsConfigName(String metricsAndLogsConfigName) {
-        this.ancillaryConfigName = metricsAndLogsConfigName;
     }
 
     protected List<EnvVar> getEnvVars() {
         return null;
     }
 
+    /**
+     * @return The storage.
+     */
     public Storage getStorage() {
         return storage;
     }
@@ -482,10 +492,9 @@ public abstract class AbstractModel {
         this.configuration = configuration;
     }
 
-    public String getVolumeName() {
-        return this.VOLUME_NAME;
-    }
-
+    /**
+     * @return The image name.
+     */
     public String getImage() {
         return this.image;
     }
@@ -504,6 +513,11 @@ public abstract class AbstractModel {
         return cluster;
     }
 
+    /**
+     * Gets the name of a given pod in a StatefulSet.
+     * @param podId The Id of the pod.
+     * @return The name of the pod with the given name.
+     */
     public String getPodName(int podId) {
         return name + "-" + podId;
     }
@@ -525,6 +539,7 @@ public abstract class AbstractModel {
 
     /**
      * Gets the tolerations as configured by the user in the cluster CR
+     * @return The tolerations.
      */
     public List<Toleration> getTolerations() {
         return tolerations;
@@ -533,7 +548,7 @@ public abstract class AbstractModel {
     /**
      * Sets the tolerations as configured by the user in the cluster CR
      *
-     * @param tolerations
+     * @param tolerations The tolerations.
      */
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
@@ -907,6 +922,8 @@ public abstract class AbstractModel {
 
     /**
      * Gets the given container's environment.
+     * @param container The container
+     * @return The environment of the given container.
      */
     public static Map<String, String> containerEnvVars(Container container) {
         return container.getEnv().stream().collect(
@@ -915,14 +932,23 @@ public abstract class AbstractModel {
                 (u, v) -> v));
     }
 
+    /**
+     * @param resources The resource requirements.
+     */
     public void setResources(ResourceRequirements resources) {
         this.resources = resources;
     }
 
+    /**
+     * @return The resource requirements.
+     */
     public ResourceRequirements getResources() {
         return resources;
     }
 
+    /**
+     * @param jvmOptions The JVM options.
+     */
     public void setJvmOptions(JvmOptions jvmOptions) {
         this.jvmOptions = jvmOptions;
     }
@@ -1089,10 +1115,18 @@ public abstract class AbstractModel {
         return ANCILLARY_CM_KEY_LOG_CONFIG;
     }
 
+    /**
+     * @param cluster The cluster name
+     * @return The name of the Cluster CA certificate secret.
+     */
     public static String clusterCaCertSecretName(String cluster)  {
         return KafkaResources.clusterCaCertificateSecretName(cluster);
     }
 
+    /**
+     * @param cluster The cluster name
+     * @return The name of the Cluster CA key secret.
+     */
     public static String clusterCaKeySecretName(String cluster)  {
         return KafkaResources.clusterCaKeySecretName(cluster);
     }
@@ -1121,6 +1155,9 @@ public abstract class AbstractModel {
         return merged;
     }
 
+    /**
+     * @return The service account.
+     */
     public ServiceAccount generateServiceAccount() {
         return new ServiceAccountBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -57,6 +57,8 @@ public class ClusterCa extends Ca {
      * In Strimzi 0.6.0 the Secrets and keys used a different convention.
      * Here we adapt the keys in the {@code *-cluster-ca} Secret to match what
      * 0.7.0 expects.
+     * @param clusterCaKey The cluster CA key Secret
+     * @return The same Secret.
      */
     public static Secret adapt060ClusterCaSecret(Secret clusterCaKey) {
         if (clusterCaKey != null && clusterCaKey.getData() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -118,6 +118,7 @@ public class EntityOperator extends AbstractModel {
      * Create a Entity Operator from given desired resource
      *
      * @param kafkaAssembly desired resource with cluster configuration containing the Entity Operator one
+     * @param versions The versions.
      * @return Entity Operator instance, null if not configured in the ConfigMap
      */
     public static EntityOperator fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
@@ -283,7 +284,8 @@ public class EntityOperator extends AbstractModel {
      * internal communication with Kafka and Zookeeper.
      * It also contains the related Entity Operator private key.
      *
-     * @return The generated Secret
+     * @param clusterCa The cluster CA.
+     * @return The generated Secret.
      */
     public Secret generateSecret(ClusterCa clusterCa) {
         if (!isDeployed()) {
@@ -295,6 +297,8 @@ public class EntityOperator extends AbstractModel {
 
     /**
      * Get the name of the Entity Operator service account given the name of the {@code cluster}.
+     * @param cluster The cluster name
+     * @return The name of the EO service account.
      */
     public static String entityOperatorServiceAccountName(String cluster) {
         return entityOperatorName(cluster);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -166,6 +166,8 @@ public class EntityTopicOperator extends AbstractModel {
 
     /**
      * Get the name of the TO role binding given the name of the {@code cluster}.
+     * @param cluster The cluster name.
+     * @return The name of the role binding.
      */
     public static String roleBindingName(String cluster) {
         return "strimzi-" + cluster + "-entity-topic-operator";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -153,6 +153,8 @@ public class EntityUserOperator extends AbstractModel {
 
     /**
      * Get the name of the UO role binding given the name of the {@code cluster}.
+     * @param cluster The cluster name.
+     * @return The name of the role binding.
      */
     public static String roleBindingName(String cluster) {
         return "strimzi-" + cluster + "-entity-user-operator";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -474,7 +474,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     /**
      * Generates the PodDisruptionBudget
      *
-     * @return
+     * @return The pod disruption budget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
         return createPodDisruptionBudget();
@@ -487,6 +487,8 @@ public class KafkaBridgeCluster extends AbstractModel {
 
     /**
      * Get the name of the bridge service account given the name of the {@code bridgeResourceName}.
+     * @param bridgeResourceName  The name of the bridge resource
+     * @return The name of the service account.
      */
     public static String containerServiceAccountName(String bridgeResourceName) {
         return kafkaBridgeClusterName(bridgeResourceName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -257,42 +257,64 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generates the name of the service used as bootstrap service for external clients
+     * Generates the name of the service used as bootstrap service for external clients.
      *
-     * @param cluster Name of the cluster
-     * @return
+     * @param cluster The name of the cluster.
+     * @return The name of the external bootstrap service.
      */
     public static String externalBootstrapServiceName(String cluster) {
         return KafkaResources.externalBootstrapServiceName(cluster);
     }
 
     /**
-     * Generates the name of the service for exposing individual pods
+     * Generates the name of the service for exposing individual pods.
      *
-     * @param cluster Name of the cluster
-     * @param pod   Pod sequence number assign by StatefulSet
-     * @return
+     * @param cluster The name of the cluster.
+     * @param pod   Pod sequence number assign by StatefulSet.
+     * @return The name of the external service.
      */
     public static String externalServiceName(String cluster, int pod) {
         return kafkaClusterName(cluster) + "-" + pod;
     }
 
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the headless service.
+     */
     public static String headlessServiceName(String cluster) {
         return KafkaResources.brokersServiceName(cluster);
     }
 
+    /**
+     * Gets the name of the given Kafka pod.
+     * @param cluster The name of the cluster.
+     * @param pod The id of the pod
+     * @return The name of the pod.
+     */
     public static String kafkaPodName(String cluster, int pod) {
         return kafkaClusterName(cluster) + "-" + pod;
     }
 
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the clients CA key Secret.
+     */
     public static String clientsCaKeySecretName(String cluster) {
         return KafkaResources.clientsCaKeySecretName(cluster);
     }
 
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the brokers Secret.
+     */
     public static String brokersSecretName(String cluster) {
         return cluster + KafkaCluster.SECRET_BROKERS_SUFFIX;
     }
 
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the clients CA certificate Secret.
+     */
     public static String clientsCaCertSecretName(String cluster) {
         return KafkaResources.clientsCaCertificateSecretName(cluster);
     }
@@ -901,7 +923,9 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Generates a StatefulSet according to configured defaults
      * @param isOpenShift True iff this operator is operating within OpenShift.
-     * @return The generate StatefulSet
+     * @param imagePullPolicy  The image pull policy.
+     * @param imagePullSecrets The image pull secrets.
+     * @return The generated StatefulSet.
      */
     public StatefulSet generateStatefulSet(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         HashMap<String, String> annotations = new HashMap<>(2);
@@ -960,18 +984,30 @@ public class KafkaCluster extends AbstractModel {
         return portList;
     }
 
+    /**
+     * @return The port of the plain listener.
+     */
     public int getClientPort() {
         return this.CLIENT_PORT;
     }
 
+    /**
+     * @return The port of the tls listener
+     */
     public int getClientTlsPort() {
         return this.CLIENT_TLS_PORT;
     }
 
+    /**
+     * @return The port of loadbalancer for the external listener.
+     */
     public int getLoadbalancerPort() {
         return this.EXTERNAL_PORT;
     }
 
+    /**
+     * @return The port of route for the external listener.
+     */
     public int getRoutePort() {
         return this.ROUTE_PORT;
     }
@@ -1016,10 +1052,11 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Generate the persistent volume claims for the storage It's called recursively on the related inner volumes if the
-     * storage is of {@link Storage#TYPE_JBOD} type
+     * storage is of {@link Storage#TYPE_JBOD} type.
      *
      * @param storage the Storage instance from which building volumes, persistent volume claims and
-     *                related volume mount paths
+     *                related volume mount paths.
+     * @return The PersistentVolumeClaims.
      */
     public List<PersistentVolumeClaim> generatePersistentVolumeClaims(Storage storage) {
         List<PersistentVolumeClaim> pvcs = new ArrayList<>();
@@ -1290,6 +1327,8 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Get the name of the kafka service account given the name of the {@code kafkaResourceName}.
+     * @param kafkaResourceName The name of the Kafka resource.
+     * @return The name of the ServiceAccount.
      */
     public static String initContainerServiceAccountName(String kafkaResourceName) {
         return kafkaClusterName(kafkaResourceName);
@@ -1297,6 +1336,9 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Get the name of the kafka init container role binding given the name of the {@code namespace} and {@code cluster}.
+     * @param namespace The namespace.
+     * @param cluster The cluster name.
+     * @return The name of the init container's cluster role binding.
      */
     public static String initContainerClusterRoleBindingName(String namespace, String cluster) {
         return "strimzi-" + namespace + "-" + cluster + "-kafka-init";
@@ -1305,6 +1347,8 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Creates the ClusterRoleBinding which is used to bind the Kafka SA to the ClusterRole
      * which permissions the Kafka init container to access K8S nodes (necessary for rack-awareness).
+     * @param assemblyNamespace The namespace.
+     * @return The cluster role binding.
      */
     public KubernetesClusterRoleBinding generateClusterRoleBinding(String assemblyNamespace) {
         if (rack != null || isExposedWithNodePort()) {
@@ -1335,10 +1379,17 @@ public class KafkaCluster extends AbstractModel {
         }
     }
 
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the network policy.
+     */
     public static String policyName(String cluster) {
         return cluster + NETWORK_POLICY_KEY_SUFFIX + NAME_SUFFIX;
     }
 
+    /**
+     * @return The network policy.
+     */
     public NetworkPolicy generateNetworkPolicy() {
         List<NetworkPolicyIngressRule> rules = new ArrayList<>(5);
 
@@ -1436,52 +1487,52 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generates the PodDisruptionBudget
+     * Generates the PodDisruptionBudget.
      *
-     * @return
+     * @return The PodDisruptionBudget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
         return createPodDisruptionBudget();
     }
 
     /**
-     * Sets the object with Kafka listeners configuration
+     * Sets the object with Kafka listeners configuration.
      *
-     * @param listeners
+     * @param listeners The listeners.
      */
     public void setListeners(KafkaListeners listeners) {
         this.listeners = listeners;
     }
 
     /**
-     * @return  The listener object from the CRD
+     * @return  The listener object from the CRD.
      */
     public KafkaListeners getListeners() {
         return listeners;
     }
 
     /**
-     * Sets the object with Kafka authorization configuration
+     * Sets the object with Kafka authorization configuration.
      *
-     * @param authorization
+     * @param authorization The authorization.
      */
     public void setAuthorization(KafkaAuthorization authorization) {
         this.authorization = authorization;
     }
 
     /**
-     * Sets the Map with Kafka pod's external addresses
+     * Sets the Map with Kafka pod's external addresses.
      *
-     * @param externalAddresses Set with external addresses
+     * @param externalAddresses Set with external addresses.
      */
     public void setExternalAddresses(Set<String> externalAddresses) {
         this.externalAddresses = externalAddresses;
     }
 
     /**
-     * Returns true when the Kafka cluster is exposed to the outside of OpenShift / Kubernetes
+     * Returns true when the Kafka cluster is exposed to the outside of OpenShift / Kubernetes.
      *
-     * @return
+     * @return true when the Kafka cluster is exposed.
      */
     public boolean isExposed()  {
         return listeners != null && listeners.getExternal() != null;
@@ -1490,7 +1541,7 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns true when the Kafka cluster is exposed to the outside of OpenShift using OpenShift routes
      *
-     * @return
+     * @return true when the Kafka cluster is exposed using OpenShift routes.
      */
     public boolean isExposedWithRoute()  {
         return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalRoute;
@@ -1499,7 +1550,7 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns true when the Kafka cluster is exposed to the outside using LoadBalancers
      *
-     * @return
+     * @return true when the Kafka cluster is exposed using load balancer.
      */
     public boolean isExposedWithLoadBalancer()  {
         return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalLoadBalancer;
@@ -1508,7 +1559,7 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns true when the Kafka cluster is exposed to the outside using NodePort type services
      *
-     * @return
+     * @return true when the Kafka cluster is exposed to the outside using NodePort.
      */
     public boolean isExposedWithNodePort()  {
         return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalNodePort;
@@ -1517,16 +1568,14 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns true when the Kafka cluster is exposed to the outside of Kubernetes using Ingress
      *
-     * @return
+     * @return true when the Kafka cluster is exposed using Kubernetes Ingress.
      */
     public boolean isExposedWithIngress()  {
         return isExposed() && listeners.getExternal() instanceof KafkaListenerExternalIngress;
     }
 
     /**
-     * Returns the list broker overrides for external listeners
-     *
-     * @return
+     * Returns the list broker overrides for external listeners.
      */
     private List<ExternalListenerBrokerOverride> getExternalListenerBrokerOverride()  {
         List<ExternalListenerBrokerOverride> brokerOverride = new ArrayList<>();
@@ -1563,7 +1612,7 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns the bootstrap override for external listeners
      *
-     * @return
+     * @return The ExternalListenerBootstrapOverride.
      */
     public ExternalListenerBootstrapOverride getExternalListenerBootstrapOverride()  {
         ExternalListenerBootstrapOverride bootstrapOverride = null;
@@ -1598,9 +1647,10 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Returns advertised address of external nodeport service
+     * Returns the advertised address of external nodeport service.
      *
-     * @return
+     * @param podNumber The pod number.
+     * @return The advertised address of the external nodeport service.
      */
     public String getExternalServiceAdvertisedHostOverride(int podNumber) {
         String advertisedHost = null;
@@ -1621,9 +1671,10 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Returns advertised address of external nodeport service
+     * Returns advertised address of external nodeport service.
      *
-     * @return
+     * @param podNumber The pod number.
+     * @return The advertised address of external nodeport service.
      */
     public Integer getExternalServiceAdvertisedPortOverride(int podNumber) {
         Integer advertisedPort = null;
@@ -1667,7 +1718,7 @@ public class KafkaCluster extends AbstractModel {
     /**
      * Returns true when the Kafka cluster is exposed to the outside of OpenShift with TLS enabled
      *
-     * @return
+     * @return True when the Kafka cluster is exposed to the outside of OpenShift with TLS enabled
      */
     public boolean isExposedWithTls() {
         if (isExposed()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -606,7 +606,7 @@ public class KafkaConnectCluster extends AbstractModel {
     /**
      * Generates the PodDisruptionBudget
      *
-     * @return
+     * @return The PodDisruptionBudget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
         return createPodDisruptionBudget();
@@ -619,6 +619,8 @@ public class KafkaConnectCluster extends AbstractModel {
 
     /**
      * Get the name of the connect service account given the name of the {@code connectResourceName}.
+     * @param connectResourceName  The resource name.
+     * @return The service account name.
      */
     public static String containerServiceAccountName(String connectResourceName) {
         return kafkaConnectClusterName(connectResourceName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -68,7 +68,11 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     /**
      * Generate new DeploymentConfig
      *
-     * @return      Source ImageStream resource definition
+     * @param annotations The annotations.
+     * @param isOpenShift Whether we're on OpenShift.
+     * @param imagePullPolicy The image pull policy.
+     * @param imagePullSecrets The image pull secrets.
+     * @return Source ImageStream resource definition
      */
     public DeploymentConfig generateDeploymentConfig(Map<String, String> annotations, boolean isOpenShift, ImagePullPolicy imagePullPolicy,
                                                      List<LocalObjectReference> imagePullSecrets) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -479,9 +479,9 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     }
 
     /**
-     * Generates the PodDisruptionBudget
+     * Generates the PodDisruptionBudget.
      *
-     * @return
+     * @return The PodDisruptionBudget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
         return createPodDisruptionBudget();
@@ -535,6 +535,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
     /**
      * Get the name of the mirror maker service account given the name of the {@code mirrorMakerResourceName}.
+     * @param mirrorMakerResourceName The resource name
+     * @return The service account name.
      */
     public static String containerServiceAccountName(String mirrorMakerResourceName) {
         return kafkaMirrorMakerClusterName(mirrorMakerResourceName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaUpgrade.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaUpgrade.java
@@ -18,46 +18,57 @@ public class KafkaUpgrade {
         this.compare = from.compareTo(to);
     }
 
-    /** The version being upgraded from. */
+    /**
+     * The version being upgraded from.
+     * @return The version being upgraded from.
+     */
     public KafkaVersion from() {
         return from;
     }
 
-    /** The version being upgraded to. */
+    /**
+     * The version being upgraded to.
+     * @return The version being upgraded to.
+     */
     public KafkaVersion to() {
         return to;
     }
 
-    /** true if upgrading from {@link #from()} to {@code to} requires upgrading the inter broker protocol. */
+    /**
+     * true if upgrading from {@link #from()} to {@code to} requires upgrading the inter broker protocol.
+     * @return true if upgrading from {@link #from()} to {@code to} requires upgrading the inter broker protocol.
+     */
     public boolean requiresProtocolChange() {
         return !from.protocolVersion().equals(to.protocolVersion());
     }
 
-    /** true if upgrading from {@link #from()} to {@code to} requires upgrading the message format. */
+    /**
+     * true if upgrading from {@link #from()} to {@code to} requires upgrading the message format.
+     * @return true if upgrading from {@link #from()} to {@code to} requires upgrading the message format.
+     */
     public boolean requiresMessageFormatChange() {
         return !from.messageVersion().equals(to.messageVersion());
     }
 
+    /**
+     * @return true if this is an upgrade.
+     */
     public boolean isUpgrade() {
         return compare < 0;
     }
 
+    /**
+     * @return true if this is a downgrade.
+     */
     public boolean isDowngrade() {
         return compare > 0;
     }
 
+    /**
+     * @return true if there is no version change.
+     */
     public boolean isNoop() {
         return compare == 0;
-    }
-
-    public String description() {
-        if (isUpgrade()) {
-            return "upgrade";
-        } else if (isDowngrade()) {
-            return "downgrade";
-        } else {
-            return "no version change";
-        }
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -111,7 +111,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             return defaultVersion;
         }
 
-        /** Find the version from the given version string */
+        /** Find the version from the given version string.
+         * @param version The version.
+         * @return The KafkaVersion.
+         */
         public KafkaVersion version(String version) {
             KafkaVersion result;
             if (version == null) {
@@ -230,8 +233,8 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
 
     /**
      * Compare two decimal version strings, e.g. 1.10.1 &gt; 1.9.2
-     * @param version1
-     * @param version2
+     * @param version1 The first version.
+     * @param version2 The second version.
      * @return Zero if version1 == version2;
      * less than 1 if version1 &gt; version2;
      * greater than 1 if version1 &gt; version2.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -53,12 +53,9 @@ public class ModelUtils {
             System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
 
     /**
-     * Find the first secret in the given secrets with the given name
+     * @param certificateAuthority The CA configuration.
+     * @return The cert validity.
      */
-    public static Secret findSecretWithName(List<Secret> secrets, String sname) {
-        return secrets.stream().filter(s -> s.getMetadata().getName().equals(sname)).findFirst().orElse(null);
-    }
-
     public static int getCertificateValidity(CertificateAuthority certificateAuthority) {
         int validity = CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS;
         if (certificateAuthority != null
@@ -68,6 +65,10 @@ public class ModelUtils {
         return validity;
     }
 
+    /**
+     * @param certificateAuthority The CA configuration.
+     * @return The renewal days.
+     */
     public static int getRenewalDays(CertificateAuthority certificateAuthority) {
         int renewalDays = CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS;
 
@@ -99,8 +100,8 @@ public class ModelUtils {
      * image ::= [, \t\r\n]+
      * </code></pre>
      * For example {@code 2.0.0=strimzi/kafka:latest-kafka-2.0.0, 2.1.0=strimzi/kafka:latest-kafka-2.1.0}.
-     * @param str
-     * @return
+     * @param str The string to parse.
+     * @return The parsed map.
      */
     public static Map<String, String> parseImageMap(String str) {
         if (str != null) {
@@ -119,6 +120,10 @@ public class ModelUtils {
         }
     }
 
+    /**
+     * @param ss The StatefulSet
+     * @return The environment of the Kafka container in the SS.
+     */
     public static Map<String, String> getKafkaContainerEnv(StatefulSet ss) {
         for (Container container : ss.getSpec().getTemplate().getSpec().getContainers()) {
             if ("kafka".equals(container.getName())) {
@@ -294,6 +299,7 @@ public class ModelUtils {
      * a JBOD containing at least one persistent volume.
      *
      * @param storage the Storage instance to check
+     * @return Whether the give Storage contains any persistent storage.
      */
     public static boolean containsPersistentStorage(Storage storage) {
         boolean isPersistentClaimStorage = storage instanceof PersistentClaimStorage;
@@ -309,6 +315,7 @@ public class ModelUtils {
      * Returns the prefix used for volumes and persistent volume claims
      *
      * @param id identification number of the persistent storage
+     * @return The volume prefix.
      */
     public static String getVolumePrefix(Integer id) {
         return id == null ? AbstractModel.VOLUME_NAME : AbstractModel.VOLUME_NAME + "-" + id;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
@@ -101,6 +101,7 @@ public class OrderedProperties {
      * @param is The UTF-8 input stream containing name=value pairs separated by newlines.
      *
      * @return this instance for chaining
+     * @throws IOException If the input stream could not be read.
      */
     public OrderedProperties addStringPairs(InputStream is) throws IOException {
         new PropertiesReader(pairs).read(is);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -55,6 +55,7 @@ public class StatusDiff extends AbstractResourceDiff {
      *
      * @return true when the storage configurations are the same
      */
+    @Override
     public boolean isEmpty() {
         return isEmpty;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -114,6 +114,7 @@ public class StorageDiff extends AbstractResourceDiff {
      *
      * @return true when the storage configurations are the same
      */
+    @Override
     public boolean isEmpty() {
         return isEmpty;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -183,6 +183,8 @@ public class TopicOperator extends AbstractModel {
 
     /**
      * Get the name of the TO role binding given the name of the {@code cluster}.
+     * @param cluster The cluster name.
+     * @return The role binding name.
      */
     public static String roleBindingName(String cluster) {
         return "strimzi-" + cluster + "-topic-operator";
@@ -209,6 +211,7 @@ public class TopicOperator extends AbstractModel {
      * Create a Topic Operator from given desired resource
      *
      * @param kafkaAssembly desired resource with cluster configuration containing the topic operator one
+     * @param versions The versions.
      * @return Topic Operator instance, null if not configured in the ConfigMap
      */
     public static TopicOperator fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
@@ -325,6 +328,8 @@ public class TopicOperator extends AbstractModel {
 
     /**
      * Get the name of the topic operator service account given the name of the {@code cluster}.
+     * @param cluster The cluster name
+     * @return The service account name.
      */
     public static String topicOperatorServiceAccountName(String cluster) {
         return topicOperatorName(cluster);
@@ -389,6 +394,7 @@ public class TopicOperator extends AbstractModel {
     /**
      * Generate the Secret containing CA self-signed certificates for internal communication
      * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
+     * @param clusterCa The cluster CA
      * @return The generated Secret
      */
     public Secret generateSecret(ClusterCa clusterCa) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -430,7 +430,9 @@ public class ZookeeperCluster extends AbstractModel {
      * internal communication with Kafka.
      * It also contains the related Zookeeper nodes private keys.
      *
-     * @return The generated Secret
+     * @param clusterCa The cluster CA.
+     * @param kafka The Kafka resource.
+     * @return The generated Secret.
      */
     public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka) {
 
@@ -574,9 +576,9 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     /**
-     * Generates the PodDisruptionBudget
+     * Generates the PodDisruptionBudget.
      *
-     * @return
+     * @return The PodDisruptionBudget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
         return createPodDisruptionBudget();
@@ -593,6 +595,8 @@ public class ZookeeperCluster extends AbstractModel {
 
     /**
      * Get the name of the zookeeper service account given the name of the {@code zookeeperResourceName}.
+     * @param zookeeperResourceName The resource name.
+     * @return The service account name.
      */
     public static String containerServiceAccountName(String zookeeperResourceName) {
         return zookeeperClusterName(zookeeperResourceName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -137,6 +137,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * one resource means that all resources need to be created).
      * @param reconciliation Unique identification for the reconciliation
      * @param assemblyResource Resources with the desired cluster configuration.
+     * @return A future which is completed when the resource has been reconciled.
      */
     protected abstract Future<Void> createOrUpdate(Reconciliation reconciliation, T assemblyResource);
 
@@ -162,6 +163,8 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      * <li>An assembly will be {@linkplain #createOrUpdate(Reconciliation, HasMetadata) created or updated} if CustomResource is without same-named resources</li>
      * <li>An assembly will be deleted automatically by garbage collection when the custom resoruce is deleted</li>
      * </ul>
+     * @param reconciliation The reconciliation.
+     * @param handler The result handler.
      */
     public final void reconcileAssembly(Reconciliation reconciliation, Handler<AsyncResult<Void>> handler) {
         String namespace = reconciliation.namespace();
@@ -234,6 +237,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      *
      * @param trigger A description of the triggering event (timer or watch), used for logging
      * @param namespace The namespace
+     * @return A latch for knowing when reconciliation is complete.
      */
     public final CountDownLatch reconcileAll(String trigger, String namespace) {
 
@@ -259,6 +263,12 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         return latch;
     }
 
+    /**
+     * Creates a watch on resources in the given namespace.
+     * @param watchNamespace The namespace to watch.
+     * @param onClose A consumer for any exceptions causing the closing of the watcher.
+     * @return A future which completes when watcher has been created.
+     */
     public Future<Watch> createWatch(String watchNamespace, Consumer<KubernetesClientException> onClose) {
         Future<Watch> result = Future.future();
         vertx.<Watch>executeBlocking(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceDiff.java
@@ -25,9 +25,9 @@ public abstract class AbstractResourceDiff {
     }
 
     /**
-     * Returns whether the Diff is empty or not
+     * Returns whether the Diff is empty or not.
      *
-     * @return
+     * @return whether the Diff is empty or not.
      */
     public abstract boolean isEmpty();
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -21,6 +21,7 @@ public class KafkaSetOperator extends StatefulSetOperator {
      *
      * @param vertx  The Vertx instance
      * @param client The Kubernetes client
+     * @param operationTimeoutMs The timeout.
      */
     public KafkaSetOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
         super(vertx, client, operationTimeoutMs);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -145,31 +145,32 @@ public class StatefulSetDiff extends AbstractResourceDiff {
      *
      * @return true when the StatefulSets are identical
      */
+    @Override
     public boolean isEmpty() {
         return isEmpty;
     }
 
-    /** Returns true if there's a difference in {@code /spec/volumeClaimTemplates} but not to {@code /spec/volumeClaimTemplates/[0-9]+/spec/resources} */
+    /** @return True if there's a difference in {@code /spec/volumeClaimTemplates} but not to {@code /spec/volumeClaimTemplates/[0-9]+/spec/resources} */
     public boolean changesVolumeClaimTemplates() {
         return changesVolumeClaimTemplate;
     }
 
-    /** Returns true if there's a difference in {@code /spec/volumeClaimTemplates/[0-9]+/spec/resources} */
+    /** @return True if there's a difference in {@code /spec/volumeClaimTemplates/[0-9]+/spec/resources} */
     public boolean changesVolumeSize() {
         return changesVolumeSize;
     }
 
-    /** Returns true if there's a difference in {@code /spec/template/spec} */
+    /** @return True if there's a difference in {@code /spec/template/spec} */
     public boolean changesSpecTemplate() {
         return changesSpecTemplate;
     }
 
-    /** Returns true if there's a difference in {@code /metadata/labels} */
+    /** @return True if there's a difference in {@code /metadata/labels} */
     public boolean changesLabels() {
         return changesLabels;
     }
 
-    /** Returns true if there's a difference in {@code /spec/replicas} */
+    /** @return True if there's a difference in {@code /spec/replicas} */
     public boolean changesSpecReplicas() {
         return changesSpecReplicas;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -33,6 +33,8 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
      *
      * @param vertx  The Vertx instance
      * @param client The Kubernetes client
+     * @param leaderFinder The Zookeeper leader finder.
+     * @param operationTimeoutMs The timeout.
      */
     public ZookeeperSetOperator(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
         super(vertx, client, operationTimeoutMs);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -275,6 +275,16 @@ public class KafkaAssemblyOperatorTest {
         return result;
     }
 
+    /**
+     * Find the first secret in the given secrets with the given name.
+     * @param secrets The secrets to search.
+     * @param sname The secret name.
+     * @return The secret with that name.
+     */
+    public static Secret findSecretWithName(List<Secret> secrets, String sname) {
+        return secrets.stream().filter(s -> s.getMetadata().getName().equals(sname)).findFirst().orElse(null);
+    }
+
     public KafkaAssemblyOperatorTest(Params params) {
         this.openShift = params.openShift;
         this.metrics = params.metrics;
@@ -330,8 +340,8 @@ public class KafkaAssemblyOperatorTest {
 
     private void createCluster(TestContext context, Kafka clusterCm, List<Secret> secrets) {
         ClusterCa clusterCa = new ClusterCa(new MockCertManager(), clusterCm.getMetadata().getName(),
-                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaCertSecretName(clusterCm.getMetadata().getName())),
-                ModelUtils.findSecretWithName(secrets, AbstractModel.clusterCaKeySecretName(clusterCm.getMetadata().getName())));
+                findSecretWithName(secrets, AbstractModel.clusterCaCertSecretName(clusterCm.getMetadata().getName())),
+                findSecretWithName(secrets, AbstractModel.clusterCaKeySecretName(clusterCm.getMetadata().getName())));
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(clusterCm, VERSIONS);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(clusterCm, VERSIONS);
         TopicOperator topicOperator = TopicOperator.fromCrd(clusterCm, VERSIONS);
@@ -1027,11 +1037,11 @@ public class KafkaAssemblyOperatorTest {
                 bar.getSpec().getKafka().getReplicas(),
                 bar.getSpec().getZookeeper().getReplicas());
         ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
+                findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
+                findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
         ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
+                findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
+                findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
@@ -1114,11 +1124,11 @@ public class KafkaAssemblyOperatorTest {
                 bar.getSpec().getKafka().getReplicas(),
                 bar.getSpec().getZookeeper().getReplicas());
         ClusterCa barClusterCa = ResourceUtils.createInitialClusterCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
+                findSecretWithName(barSecrets, AbstractModel.clusterCaCertSecretName("bar")),
+                findSecretWithName(barSecrets, AbstractModel.clusterCaKeySecretName("bar")));
         ClientsCa barClientsCa = ResourceUtils.createInitialClientsCa("bar",
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
-                ModelUtils.findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
+                findSecretWithName(barSecrets, KafkaCluster.clientsCaCertSecretName("bar")),
+                findSecretWithName(barSecrets, KafkaCluster.clientsCaKeySecretName("bar")));
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
@@ -13,17 +13,17 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DeprecatedProperty {
 
-    /** The API version in which this property is scheduled to be removed. */
+    /** @return The API version in which this property is scheduled to be removed. */
     String removalVersion() default "";
 
     /**
-     * If this property has moved to a different location in the Custom Resource this is
+     * @return If this property has moved to a different location in the Custom Resource this is
      * the path it has moved to.
      */
     String movedToPath() default "";
 
     /**
-     * If this property has <strong>not</strong> moved to a different location in the Custom Resource this is
+     * @return If this property has <strong>not</strong> moved to a different location in the Custom Resource this is
      * a description of how the functionality can now be configured.
      */
     String description() default "";

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -20,12 +20,13 @@ public @interface Crd {
     /**
      * The {@code apiVersion} of the generated {@code CustomResourceDefinition}.
      * (Not the {@code apiVersion} of your custom resource instances, which is {@link Spec#version()}).
+     * @return The {@code apiVersion} of the generated {@code CustomResourceDefinition}
      */
     String apiVersion();
 
     /**
      * Info for the {@code spec} of the generated {@code CustomResourceDefinition}.
-     * @return
+     * @return The spec.
      */
     Spec spec();
 
@@ -36,7 +37,7 @@ public @interface Crd {
     @interface Spec {
 
         /**
-         * The API group for the custom resource instances
+         * @return The API group for the custom resource instances.
          */
         String group();
 
@@ -45,45 +46,45 @@ public @interface Crd {
         @Target({})
         @interface Names {
             /**
-             * The kind of the resource
+             * @return The kind of the resource
              */
             String kind();
 
             /**
-             * The list kind. Defaults to ${{@linkplain #kind()}}List.
+             * @return The list kind. Defaults to ${{@linkplain #kind()}}List.
              */
             String listKind() default "";
 
             /**
-             * The singular of the resource. Defaults to {@link #kind()}.
+             * @return The singular of the resource. Defaults to {@link #kind()}.
              */
             String singular() default "";
 
             /**
-             * The plural of the resource.
+             * @return The plural of the resource.
              */
             String plural();
 
             /**
-             * Short names (e.g. "svc" is the short name for the K8S "services" kind).
+             * @return Short names (e.g. "svc" is the short name for the K8S "services" kind).
              */
             String[] shortNames() default {};
         }
 
         /**
-         * The scope of the resources. E.g. "Namespaced".
+         * @return The scope of the resources. E.g. "Namespaced".
          */
         String scope();
 
         /**
-         * The version of custom resources that this is the definition for.
+         * @return The version of custom resources that this is the definition for.
          * @see <a href="https://v1-11.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcedefinitionversion-v1beta1-apiextensions">Kubernetes 1.11 API documtation</a>
          * @see #versions()
          */
         String version() default "";
 
         /**
-         * The version of custom resources that this is the definition for.
+         * @return The version of custom resources that this is the definition for.
          * @see <a href="https://v1-11.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcedefinitionversion-v1beta1-apiextensions">Kubernetes 1.11 API documtation</a>
          */
         Version[] versions() default {};
@@ -99,7 +100,7 @@ public @interface Crd {
         }
 
         /**
-         * The subresources of a custom resources that this is the definition for.
+         * @return The subresources of a custom resources that this is the definition for.
          * @see <a href="https://v1-11.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcedefinitionversion-v1beta1-apiextensions">Kubernetes 1.11 API documtation</a>
          */
         Subresources subresources() default @Subresources(status = {});
@@ -116,7 +117,7 @@ public @interface Crd {
         }
 
         /**
-         * Additional printer columns.
+         * @return Additional printer columns.
          * @see <a href="https://v1-11.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcecolumndefinition-v1beta1-apiextensions">Kubernetes 1.11 API documtation</a>
          */
         AdditionalPrinterColumn[] additionalPrinterColumns() default {};
@@ -126,9 +127,9 @@ public @interface Crd {
          * @see <a href="https://v1-11.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcecolumndefinition-v1beta1-apiextensions">Kubernetes 1.11 API documtation</a>
          */
         @interface AdditionalPrinterColumn {
-            /** JSON path into the CR for the value to show */
+            /** @return JSON path into the CR for the value to show */
             String jsonPath();
-            /** The description of the column */
+            /** @return The description of the column */
             String description();
             /**
              * One of:
@@ -140,11 +141,12 @@ public @interface Crd {
              * date
              * date-time
              * password
+             * @return The format
              */
             String format() default "";
-            /** The name of the column */
+            /** @return The name of the column */
             String name();
-            /** 0 to show in standard view, greater than zero to show only in wide view */
+            /** @return 0 to show in standard view, greater than zero to show only in wide view */
             int priority() default 0;
             /**
              * One of:
@@ -153,6 +155,7 @@ public @interface Crd {
              * string,
              * boolean,
              * date
+             * @return The JSON type.
              */
             String type();
         }

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -150,6 +150,7 @@ public class KafkaAgent {
 
     /**
      * Agent entry point
+     * @param agentArgs The agent arguments
      */
     public static void premain(String agentArgs) {
         int index = agentArgs.indexOf(':');

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -22,6 +22,8 @@ public class ClientsCa extends Ca {
      * In Strimzi 0.6.0 the Secrets and keys used a different convention.
      * Here we adapt the keys in the {@code *-clients-ca} Secret to match what
      * 0.7.0 expects.
+     * @param clientsCaKey The secret to adapt.
+     * @return The same Secret instance.
      */
     public static Secret adapt060ClientsCaSecret(Secret clientsCaKey) {
         if (clientsCaKey != null && clientsCaKey.getData() != null) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
@@ -34,6 +34,7 @@ public class BackOff {
 
     /**
      * Computes delays according to {@code 200 * 2^attempt} with the given maximum number of attempts.
+     * @param maxAttempts The maximum number of attempts.
      */
     public BackOff(int maxAttempts) {
         this(DEFAULT_SCALE_MS, DEFAULT_BASE, maxAttempts);
@@ -41,6 +42,9 @@ public class BackOff {
 
     /**
      * Computes delays according to {@code scaleMs * base^attempt} with the given maximum number of attempts.
+     * @param scaleMs The scale.
+     * @param base The base.
+     * @param maxAttempts The maximum number of attempts to make before {@code MaxAttemptsExceededException} is thrown.
      */
     public BackOff(long scaleMs, int base, int maxAttempts) {
         if (scaleMs <= 0) {
@@ -58,14 +62,14 @@ public class BackOff {
     }
 
     /**
-     * The maximum number of attempts.
+     * @return The maximum number of attempts.
      */
     public int maxAttempts() {
         return maxAttempts;
     }
 
     /**
-     * The maximum number of delays.
+     * @return The maximum number of delays.
      */
     public int maxNumDelays() {
         return maxAttempts - 1;
@@ -74,6 +78,7 @@ public class BackOff {
     /**
      * Return the next delay to use, in milliseconds.
      * The first delay is always zero, the 2nd delay is scaleMs, and the delay increases exponentially from there.
+     * @return Return the next delay to use, in milliseconds.
      * @throws MaxAttemptsExceededException if the next attempt would exceed the configured number of attempts.
      */
     public long delayMs() {
@@ -84,14 +89,14 @@ public class BackOff {
     }
 
     /**
-     * Returns whether the next call to {@link #delayMs()} will throw MaxAttemptsExceededException.
+     * @return Whether the next call to {@link #delayMs()} will throw MaxAttemptsExceededException.
      */
     public boolean done() {
         return attempt >= maxAttempts;
     }
 
     /**
-     * How much delay for attempt n?
+     * @return How much delay for attempt n?
      */
     private long delay(int n) {
         if (n == 0) {
@@ -116,7 +121,7 @@ public class BackOff {
     }
 
     /**
-     * The cumulative delay issued by {@link #delayMs()} so far.
+     * @return The cumulative delay issued by {@link #delayMs()} so far.
      */
     public long cumulativeDelayMs() {
         return cumulativeDelayAttemptMs(attempt);
@@ -125,6 +130,7 @@ public class BackOff {
     /**
      * The total possible delay for this BackOff.
      * This does not depend on how much delay has already been issued.
+     * @return The total possible delay for this BackOff.
      */
     public long totalDelayMs() {
         return cumulativeDelayAttemptMs(maxAttempts);

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -18,13 +18,12 @@ public class Util {
     private static final Logger LOGGER = LogManager.getLogger(Util.class);
 
     /**
-     * Returns a future that completes when the given {@code ready} indicates readiness.
-     *
-     * @param vertx The vertx instance
-     * @param logContext A string used for context in logging
+     * @param vertx The vertx instance.
+     * @param logContext A string used for context in logging.
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
      * @param ready Determines when the wait is complete by returning true.
+     * @return A future that completes when the given {@code ready} indicates readiness.
      */
     public static Future<Void> waitFor(Vertx vertx, String logContext, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
         Future<Void> fut = Future.future();

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -60,27 +60,25 @@ public class Labels {
     private final Map<String, String> labels;
 
     /**
-     * Returns the value of the {@code strimzi.io/cluster} label of the given {@code resource}.
+     * @return The value of the {@code strimzi.io/cluster} label of the given {@code resource}.
+     * @param resource The resource.
      */
     public static String cluster(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
     }
 
     /**
-     * Returns the value of the {@code strimzi.io/name} label of the given {@code resource}.
+     * @return the value of the {@code strimzi.io/name} label of the given {@code resource}.
+     * @param resource The resource.
      */
     public static String name(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL);
     }
 
     /**
-     * Returns the value of the {@code strimzi.io/kind} label of the given {@code resource}.
+     * @return A {@code Labels} instance from the given map
+     * @param userLabels The labels
      */
-    @Deprecated
-    public static String kind(HasMetadata resource) {
-        return resource.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL);
-    }
-
     public static Labels userLabels(Map<String, String> userLabels) {
         if (userLabels != null) {
             for (String key : userLabels.keySet()) {
@@ -96,6 +94,10 @@ public class Labels {
         return EMPTY;
     }
 
+    /**
+     * @param userLabels The labels to add.
+     * @return A new instances with the given {@code userLabels} added to the labels in this instance.
+     */
     public Labels withUserLabels(Map<String, String> userLabels) {
         Map<String, String> newLabels = new HashMap<>(labels.size());
         newLabels.putAll(labels);
@@ -105,14 +107,16 @@ public class Labels {
     }
 
     /**
-     * Returns the labels of the given {@code resource}.
+     * @param resource The resource to get the labels of
+     * @return the labels of the given {@code resource}.
      */
     public static Labels fromResource(HasMetadata resource) {
         return new Labels(resource.getMetadata().getLabels() != null ? resource.getMetadata().getLabels() : emptyMap());
     }
 
     /**
-     * Returns the labels from Map.
+     * @return A labels instance from Map.
+     * @param labels The map of labels.
      */
     public static Labels fromMap(Map<String, String> labels) {
         if (labels != null) {
@@ -127,7 +131,7 @@ public class Labels {
      *
      * @param stringLabels  String with labels
      * @return  Labels object with parsed labels
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException The string could not be parsed.
      */
     public static Labels fromString(String stringLabels) throws IllegalArgumentException {
         Map<String, String> labels = new HashMap<>();
@@ -158,29 +162,20 @@ public class Labels {
         return new Labels(newLabels);
     }
 
-    private Labels without(String label) {
-        Map<String, String> newLabels = new HashMap<>(labels);
-        newLabels.remove(label);
-        return new Labels(newLabels);
-    }
-
     /**
      * The same labels as this instance, but with the given {@code kind} for the {@code strimzi.io/kind} key.
+     * @param kind The kind to add.
+     * @return A new instance with the given kind added.
      */
     public Labels withKind(String kind) {
         return with(STRIMZI_KIND_LABEL, kind);
     }
 
-    /**
-     * The same labels as this instance, but without any {@code strimzi.io/kind} key.
-     */
-    @Deprecated
-    public Labels withoutKind() {
-        return without(STRIMZI_KIND_LABEL);
-    }
 
     /**
      * The same labels as this instance, but with the given {@code cluster} for the {@code strimzi.io/cluster} key.
+     * @param cluster The cluster to add.
+     * @return A new instance with the given cluster added.
      */
     public Labels withCluster(String cluster) {
         return with(STRIMZI_CLUSTER_LABEL, cluster);
@@ -188,39 +183,48 @@ public class Labels {
 
     /**
      * The same labels as this instance, but with the given {@code name} for the {@code strimzi.io/name} key.
+     * @param name The name to add
+     * @return A new instance with the given name added.
      */
     public Labels withName(String name) {
         return with(STRIMZI_NAME_LABEL, name);
     }
 
     /**
-     * The same labels as this instance, but with the given {@code name} for the {@code strimzi.io/name} key.
+     * The same labels as this instance, but with the given {@code name} for the {@code statefulset.kubernetes.io/pod-name} key.
+     * @param name The pod name to add
+     * @return A new instance with the given pod name added.
      */
     public Labels withStatefulSetPod(String name) {
         return with(KUBERNETES_STATEFULSET_POD_LABEL, name);
     }
 
     /**
-     * An unmodifiable map of the labels.
+     * @return an unmodifiable map of the labels.
      */
     public Map<String, String> toMap() {
         return labels;
     }
 
     /**
-     * A singleton instance with the given {@code cluster} for the {@code strimzi.io/cluster} key.
+     * @param cluster The cluster.
+     * @return A singleton instance with the given {@code cluster} for the {@code strimzi.io/cluster} key.
      */
     public static Labels forCluster(String cluster) {
         return new Labels(singletonMap(STRIMZI_CLUSTER_LABEL, cluster));
     }
 
     /**
-     * A singleton instance with the given {@code kind} for the {@code strimzi.io/kind} key.
+     * @param kind The kind.
+     * @return A singleton instance with the given {@code kind} for the {@code strimzi.io/kind} key.
      */
     public static Labels forKind(String kind) {
         return new Labels(singletonMap(STRIMZI_KIND_LABEL, kind));
     }
 
+    /**
+     * @return An instances containing just the strimzi.io labels present in this instance.
+     */
     public Labels strimziLabels() {
         Map<String, String> newLabels = new HashMap<>(3);
 
@@ -232,7 +236,7 @@ public class Labels {
 
         return new Labels(newLabels);
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -55,6 +55,7 @@ public class ResourceVisitor {
          * @param member The getter method or field for the property.
          * @param property abstraction for using the method.
          * @param propertyValue The value of the property.
+         * @param <M> The type of member ({@code Field} or {@code Method}).
          */
         <M extends AnnotatedElement & Member> void visitProperty(List<String> path, Object owner,
                                         M member, Property<M> property, Object propertyValue);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -61,6 +61,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * returning a future for the outcome.
      * If the resource with that name already exists the future completes successfully.
      * @param resource The resource to create.
+     * @return A future which completes when the resource was created or updated.
      */
     public Future<ReconcileResult<T>> createOrUpdate(T resource) {
         if (resource == null) {
@@ -72,6 +73,9 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
     /**
      * Asynchronously reconciles the resource with the given name to match the given
      * desired resource, returning a future for the result.
+     * @param name The name of the resource to reconcile.
+     * @param desired The desired state of the resource.
+     * @return A future which completes when the resource was reconciled.
      */
     public Future<ReconcileResult<T>> reconcile(String name, T desired) {
 
@@ -229,6 +233,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
      * @param predicate The predicate.
+     * @return a future that completes when the resource identified by the given {@code name} is ready.
      */
     public Future<Void> waitFor(String name, long pollIntervalMs, final long timeoutMs, Predicate<String> predicate) {
         return Util.waitFor(vertx,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
@@ -49,6 +49,7 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
      *
      * @param namespace The namespace.
      * @param name The resource name.
+     * @return Whether the resource in in the Ready state.
      */
     public boolean isReady(String namespace, String name) {
         R resourceOp = operation().inNamespace(namespace).withName(name);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -62,6 +62,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
      * returning a future for the outcome.
      * If the resource with that name already exists the future completes successfully.
      * @param resource The resource to create.
+     * @return A future which completes with the outcome.
      */
     public Future<ReconcileResult<T>> createOrUpdate(T resource) {
         if (resource == null) {
@@ -73,6 +74,10 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
     /**
      * Asynchronously reconciles the resource with the given namespace and name to match the given
      * desired resource, returning a future for the result.
+     * @param namespace The namespace of the resource to reconcile
+     * @param name The name of the resource to reconcile
+     * @param desired The desired state of the resource.
+     * @return A future which completes when the resource has been updated.
      */
     public Future<ReconcileResult<T>> reconcile(String namespace, String name, T desired) {
         if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
@@ -296,6 +301,8 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
      * @param pollIntervalMs The poll interval in milliseconds.
      * @param timeoutMs The timeout, in milliseconds.
      * @param predicate The predicate.
+     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
      */
     public Future<Void> waitFor(String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
         return Util.waitFor(vertx,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -37,6 +37,9 @@ public class CrdOperator<C extends KubernetesClient,
      * Constructor
      * @param vertx The Vertx instance
      * @param client The Kubernetes client
+     * @param cls The class of the CR
+     * @param listCls The class of the list.
+     * @param doneableCls The class of the CR's "doneable".
      */
     public CrdOperator(Vertx vertx, C client, Class<T> cls, Class<L> listCls, Class<D> doneableCls) {
         super(vertx, client, Crds.kind(cls));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -55,6 +55,10 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
     /**
      * Asynchronously roll the deployment returning a Future which will complete once all the pods have been rolled
      * and the Deployment is ready.
+     * @param namespace The namespace of the deployment
+     * @param name The name of the deployment
+     * @param operationTimeoutMs The timeout
+     * @return A future which completes when all the pods in the deployment have been restarted.
      */
     public Future<Void> rollingUpdate(String namespace, String name, long operationTimeoutMs) {
         return getAsync(namespace, name)
@@ -62,6 +66,12 @@ public class DeploymentOperator extends AbstractScalableResourceOperator<Kuberne
                 .compose(ignored -> readiness(namespace, name, 1_000, operationTimeoutMs));
     }
 
+    /**
+     * Asynchronously delete the given pod.
+     * @param namespace The namespace of the pod.
+     * @param name The name of the pod.
+     * @return A Future which will complete once all the pods has been deleted.
+     */
     public Future<ReconcileResult<Pod>> deletePod(String namespace, String name) {
         Labels labels = Labels.fromMap(null).withName(name);
         String podName = podOperations.list(namespace, labels).get(0).getMetadata().getName();

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
@@ -44,22 +44,41 @@ public abstract class ReconcileResult<R> {
         }
     }
 
-    /** The resource was patched. */
+    /**
+     * Return a reconciliation result that indicates the resource was patched.
+     * @return a reconciliation result that indicates the resource was patched.
+     * @param resource The patched resource.
+     * @param <D> The type of resource.
+     */
     public static final <D> Patched<D> patched(D resource) {
         return new Patched(resource);
     }
 
-    /** The resource was created. */
+    /**
+     * Return a reconciliation result that indicates the resource was created.
+     * @return a reconciliation result that indicates the resource was created.
+     * @param resource The created resource.
+     * @param <D> The type of resource.
+     */
     public static final <D> ReconcileResult<D> created(D resource) {
         return new Created<>(resource);
     }
 
-    /** The resource was deleted. */
+    /**
+     * Return a reconciliation result that indicates the resource was deleted.
+     * @return a reconciliation result that indicates the resource was deleted.
+     * @param <P> The type of resource.
+     */
     public static final <P> ReconcileResult<P> deleted() {
         return DELETED;
     }
 
-    /** No action was performed. */
+    /**
+     * Return a reconciliation result that indicates the resource was not modified.
+     * @return a reconciliation result that indicates the resource was not modified.
+     * @param resource The unmodified resource.
+     * @param <P> The type of resource.
+     */
     public static final <P> ReconcileResult<P> noop(P resource) {
         return new Noop<>(resource);
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -32,13 +32,13 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
     }
 
     /**
-     * Succeeds when the Route has an assigned address
+     * Succeeds when the Route has an assigned address.
      *
-     * @param namespace     Namespace
-     * @param name          Name of the route
-     * @param pollIntervalMs    Interval in which we poll
-     * @param timeoutMs     Timeout
-     * @return
+     * @param namespace     Namespace.
+     * @param name          Name of the route.
+     * @param pollIntervalMs    Interval in which we poll.
+     * @param timeoutMs     Timeout.
+     * @return A future that succeeds when the Route has an assigned address.
      */
     public Future<Void> hasAddress(String namespace, String name, long pollIntervalMs, long timeoutMs) {
         return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isAddressReady);
@@ -49,6 +49,7 @@ public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Rou
      *
      * @param namespace The namespace.
      * @param name The route name.
+     * @return Whether the address is ready.
      */
     public boolean isAddressReady(String namespace, String name) {
         Resource<Route, DoneableRoute> resourceOp = operation().inNamespace(namespace).withName(name);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -97,7 +97,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      * @param name          Name of the service
      * @param pollIntervalMs    Interval in which we poll
      * @param timeoutMs     Timeout
-     * @return
+     * @return A future that succeeds when the Service has an assigned address.
      */
     public Future<Void> hasIngressAddress(String namespace, String name, long pollIntervalMs, long timeoutMs) {
         return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isIngressAddressReady);
@@ -108,6 +108,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      *
      * @param namespace The namespace.
      * @param name The route name.
+     * @return Whether the Service already has assigned ingress address.
      */
     public boolean isIngressAddressReady(String namespace, String name) {
         ServiceResource<Service, DoneableService> resourceOp = operation().inNamespace(namespace).withName(name);
@@ -129,7 +130,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      * @param name          Name of the service
      * @param pollIntervalMs    Interval in which we poll
      * @param timeoutMs     Timeout
-     * @return
+     * @return A future that succeeds when the Service has an assigned node port
      */
     public Future<Void> hasNodePort(String namespace, String name, long pollIntervalMs, long timeoutMs) {
         return waitFor(namespace, name, pollIntervalMs, timeoutMs, this::isNodePortReady);
@@ -140,6 +141,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      *
      * @param namespace The namespace.
      * @param name The route name.
+     * @return Whether the Service already has assigned node ports.
      */
     public boolean isNodePortReady(String namespace, String name) {
         ServiceResource<Service, DoneableService> resourceOp = operation().inNamespace(namespace).withName(name);

--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,9 @@
                         </goals>
                         <configuration>
                             <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
+                            <show>public</show>
+                            <failOnError>true</failOnError>
+                            <failOnWarnings>true</failOnWarnings>
                         </configuration>
                     </execution>
                 </executions>

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/MsgCliApiClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/MsgCliApiClient.java
@@ -98,7 +98,7 @@ public class MsgCliApiClient {
      *
      * @param clientArguments list of arguments for kafka client (together with kafka client name!)
      * @param count           count of clients that will be started
-     * @return
+     * @return Some JSON.
      * @throws InterruptedException
      * @throws ExecutionException
      * @throws TimeoutException

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/MsgCliApiClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/MsgCliApiClient.java
@@ -99,9 +99,7 @@ public class MsgCliApiClient {
      * @param clientArguments list of arguments for kafka client (together with kafka client name!)
      * @param count           count of clients that will be started
      * @return Some JSON.
-     * @throws InterruptedException
-     * @throws ExecutionException
-     * @throws TimeoutException
+     * @throws Exception If something went wrong.
      */
     public JsonObject startClients(List<String> clientArguments, int count) throws Exception {
         CompletableFuture<JsonObject> responsePromise = new CompletableFuture<>();
@@ -176,6 +174,7 @@ public class MsgCliApiClient {
      * Send request with one kafka client and receive result
      * @param client kafka client
      * @return result of kafka client
+     * @throws Exception If something went wrong.
      */
     public JsonObject sendAndGetStatus(VerifiableClient client) throws Exception {
         List<String> apiArgument = new LinkedList<>();
@@ -197,6 +196,7 @@ public class MsgCliApiClient {
      * Send request with one kafka client and receive id
      * @param client kafka client
      * @return id of kafka client
+     * @throws Exception If something went wrong.
      */
     public String sendAndGetId(VerifiableClient client) throws Exception {
         List<String> apiArgument = new LinkedList<>();

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/VerifiableClient.java
@@ -40,9 +40,9 @@ public class VerifiableClient {
     }
 
     /**
-     * Get all kafka client arguments
+     * Get all kafka client arguments.
      *
-     * @return
+     * @return The kafka client arguments.
      */
     public ArrayList<String> getArguments() {
         return arguments;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/Matchers.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/Matchers.java
@@ -18,6 +18,7 @@ public class Matchers {
     /**
      * A matcher checks that examined object has a full match of reasons for actual events.
      * @param eventReasons - expected events for resource
+     * @return The matcher.
      */
     public static Matcher<List<Event>> hasAllOfReasons(Events... eventReasons) {
         return new HasAllOfReasons(eventReasons);
@@ -26,6 +27,7 @@ public class Matchers {
     /**
      * A matcher checks that examined object has at least one match of reasons for actual events.
      * @param eventReasons - expected events for resource
+     * @return The matcher.
      */
     public static Matcher<List<Event>> hasAnyOfReasons(Events... eventReasons) {
         return new HasAnyOfReasons(eventReasons);
@@ -42,6 +44,7 @@ public class Matchers {
 
     /**
      * A matcher checks that log doesn't have unexpected errors
+     * @return The matcher.
      */
     public static Matcher<String> logHasNoUnexpectedErrors() {
         return new LogHasNoUnexpectedErrors();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -55,14 +55,22 @@ public class StUtils {
                             pod -> pod.getMetadata().getUid()));
     }
 
-    /** Returns a map of pod name to resource version for the pods currently in the given statefulset */
+    /**
+     * Returns a map of pod name to resource version for the pods currently in the given statefulset.
+     * @param name  The StatefulSet name
+     * @return A map of pod name to resource version for pods in the given StatefulSet.
+     */
     public static Map<String, String> ssSnapshot(String name) {
         StatefulSet statefulSet = kubeClient().getStatefulSet(name);
         LabelSelector selector = statefulSet.getSpec().getSelector();
         return podSnapshot(selector);
     }
 
-    /** Returns a map of pod name to resource version for the pods currently in the given deployment */
+    /**
+     * Returns a map of pod name to resource version for the pods currently in the given deployment.
+     * @param name The Deployment name.
+     * @return A map of pod name to resource version for pods in the given Deployment.
+     */
     public static Map<String, String> depSnapshot(String name) {
         Deployment deployment = kubeClient().getDeployment(name);
         LabelSelector selector = deployment.getSpec().getSelector();
@@ -204,7 +212,10 @@ public class StUtils {
     }
 
     /**
-     * Wait until the SS is ready and all of its Pods are also ready
+     *
+     * Wait until the SS is ready and all of its Pods are also ready.
+     * @param name The name of the StatefulSet
+     * @param expectPods The number of pods expected.
      */
     public static void waitForAllStatefulSetPodsReady(String name, int expectPods) {
         LOGGER.debug("Waiting for StatefulSet {} to be ready", name);
@@ -254,7 +265,8 @@ public class StUtils {
     }
 
     /**
-     * Wait until the deployment will be deleted
+     * Wait until the given Deployment has been deleted.
+     * @param name The name of the Deployment.
      */
     public static void waitForDeploymentDeletion(String name) {
         LOGGER.info("Waiting for Deployment deletion {}", name);
@@ -264,7 +276,8 @@ public class StUtils {
     }
 
     /**
-     * Wait until the deployment is ready
+     * Wait until the given Deployment is ready.
+     * @param name The name of the Deployment.
      */
     public static void waitForDeploymentReady(String name) {
         LOGGER.info("Waiting for Deployment {}", name);
@@ -274,7 +287,9 @@ public class StUtils {
     }
 
     /**
-     * Wait until the deployment is ready
+     * Wait until the given Deployment is ready.
+     * @param name The name of the Deployment.
+     * @param expectPods The expected number of pods.
      */
     public static void waitForDeploymentReady(String name, int expectPods) {
         LOGGER.debug("Waiting for Deployment {}", name);
@@ -286,7 +301,8 @@ public class StUtils {
     }
 
     /**
-     * Wait until the deployment config is ready
+     * Wait until the given DeploymentConfig is ready.
+     * @param name The name of the DeploymentConfig.
      */
     public static void waitForDeploymentConfigReady(String name) {
         LOGGER.info("Waiting for Deployment Config {}", name);
@@ -296,7 +312,8 @@ public class StUtils {
     }
 
     /**
-     * Wait until the stateful set will be deleted
+     * Wait until the given StatefulSet has been deleted.
+     * @param name The name of the StatefulSet.
      */
     public static void waitForStatefulSetDeletion(String name) {
         LOGGER.info("Waiting for StatefulSet deletion {}", name);
@@ -306,7 +323,8 @@ public class StUtils {
     }
 
     /**
-     * Wait until the config map will be deleted
+     * Wait until the config map has been deleted.
+     * @param name The name of the ConfigMap.
      */
     public static void waitForConfigMapDeletion(String name) {
         LOGGER.info("Waiting for config map deletion {}", name);

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -408,7 +408,7 @@ public final class TestUtils {
      *
      * @param retry count of remaining retries
      * @param fn    request function
-     * @return
+     * @return The result of the successful call to {@code fn}.
      */
     public static <T> T doRequestTillSuccess(int retry, Callable<T> fn, Optional<Runnable> reconnect) throws Exception {
         try {

--- a/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
@@ -97,7 +97,7 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     /**
      * Wait for the deployment with the given {@code name} to
-     * have replicas==readyReplicas && replicas==expected.
+     * have {@code replicas==readyReplicas && replicas==expected}.
      * @param name The deployment name.
      * @param expected Number of expected pods
      * @return This kube client.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -13,20 +13,46 @@ import java.util.List;
 
 public interface K8s {
 
+    /**
+     * Asynchronously create the given resource.
+     * @param topicResource The resource to be created.
+     * @param handler The result handler.
+     */
     void createResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler);
 
+    /**
+     * Asynchronously update the given resource.
+     * @param topicResource The topic.
+     * @param handler The result handler.
+     */
     void updateResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler);
 
+    /**
+     * Asynchronously delete the given resource.
+     * @param resourceName The name of the resource to be deleted.
+     * @param handler The result handler.
+     */
     void deleteResource(ResourceName resourceName, Handler<AsyncResult<Void>> handler);
 
+    /**
+     * Asynchronously list the resources.
+     * @param handler The result handler.
+     */
     void listMaps(Handler<AsyncResult<List<KafkaTopic>>> handler);
 
     /**
      * Get the resource with the given name, invoking the given handler with the result.
      * If a resource with the given name does not exist, the handler will be called with
      * a null {@link AsyncResult#result() result()}.
+     * @param resourceName The name of the resource to get.
+     * @param handler The result handler.
      */
     void getFromName(ResourceName resourceName, Handler<AsyncResult<KafkaTopic>> handler);
 
+    /**
+     * Create an event.
+     * @param event The event.
+     * @param handler The result handler.
+     */
     void createEvent(Event event, Handler<AsyncResult<Void>> handler);
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -20,6 +20,8 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param newTopic The topic to create.
+     * @param handler The result handler.
      */
     void createTopic(Topic newTopic, Handler<AsyncResult<Void>> handler);
 
@@ -28,6 +30,8 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param topicName The name of the topic to delete.
+     * @param handler The result handler.
      */
     void deleteTopic(TopicName topicName, Handler<AsyncResult<Void>> handler);
 
@@ -36,6 +40,8 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param topic The topic config to update.
+     * @param handler The result handler.
      */
     void updateTopicConfig(Topic topic, Handler<AsyncResult<Void>> handler);
 
@@ -44,6 +50,8 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param topic The topic.
+     * @param handler The result handler.
      */
     void increasePartitions(Topic topic, Handler<AsyncResult<Void>> handler);
 
@@ -52,6 +60,8 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param topic The topic.
+     * @param handler The result handler.
      */
     void changeReplicationFactor(Topic topic, Handler<AsyncResult<Void>> handler);
 
@@ -61,6 +71,8 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * If the topic does not exist the {@link AsyncResult#result()} will be null.
+     * @param topicName The name of the topic to get the metadata of.
+     * @param handler The result handler.
      */
     void topicMetadata(TopicName topicName, Handler<AsyncResult<TopicMetadata>> handler);
 
@@ -69,6 +81,7 @@ public interface Kafka {
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
+     * @param handler The result handler.
      */
     void listTopics(Handler<AsyncResult<Set<String>>> handler);
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -19,7 +19,7 @@ import java.util.Set;
  *     TopicDiff.diff(topicA, topicB).apply(topicA).equals(topicB)
  * </code></pre>
  */
-public class TopicDiff {
+class TopicDiff {
 
     private final ObjectMeta objectMeta;
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.disjoint;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
-public class TopicOperator {
+class TopicOperator {
 
     private final static Logger LOGGER = LogManager.getLogger(TopicOperator.class);
     private final static Logger EVENT_LOGGER = LogManager.getLogger("Event");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -32,7 +32,7 @@ import static java.lang.String.format;
 /**
  * Serialization of a {@link }Topic} to and from various other representations.
  */
-public class TopicSerialization {
+class TopicSerialization {
 
     // These are the keys in the JSON we store in ZK
     public static final String JSON_KEY_TOPIC_NAME = "topic-name";

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
@@ -11,7 +11,7 @@ import io.vertx.core.Handler;
  * Represents a persistent data store where the operator can store its copy of the
  * topic state that won't be modified by either K8S or Kafka.
  */
-public interface TopicStore {
+interface TopicStore {
 
     public static class EntityExistsException extends Exception {
 
@@ -26,6 +26,8 @@ public interface TopicStore {
      * and run the given handler on the context with the resulting Topic.
      * If no topic with the given name exists, the handler will be called with
      * a null result.
+     * @param name The name of the topic.
+     * @param handler The result handler.
      */
     void read(TopicName name, Handler<AsyncResult<Topic>> handler);
 
@@ -35,6 +37,8 @@ public interface TopicStore {
      * If a topic with the given name already exists, the handler will be called with
      * a failed result whose {@code cause()} is
      * {@link EntityExistsException}.
+     * @param topic The topic.
+     * @param handler The result handler.
      */
     void create(Topic topic, Handler<AsyncResult<Void>> handler);
 
@@ -44,6 +48,8 @@ public interface TopicStore {
      * If no topic with the given name exists, the handler will be called with
      * a failed result whose {@code cause()} is
      * {@link NoSuchEntityExistsException}.
+     * @param topic The topic.
+     * @param handler The result handler.
      */
     void update(Topic topic, Handler<AsyncResult<Void>> handler);
 
@@ -53,6 +59,8 @@ public interface TopicStore {
      * If no topic with the given name exists, the handler wiil be called with
      * a failed result whose {@code cause()} is
      * {@link NoSuchEntityExistsException}.
+     * @param topic The topic.
+     * @param handler The result handler.
      */
     void delete(TopicName topic, Handler<AsyncResult<Void>> handler);
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/AclBuilder.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/AclBuilder.java
@@ -85,6 +85,8 @@ public class AclBuilder {
 
     /**
      * Set the given permissions for all users (including unauthenticated users).
+     * @param permissions The permissions.
+     * @return This instance.
      */
     public AclBuilder setWorld(Permission... permissions) {
         if (world == null) {
@@ -92,49 +94,6 @@ public class AclBuilder {
         }
         world.setId(new Id("world", "anyone"));
         world.setPerms(Permission.encode(permissions));
-        return this;
-    }
-
-    /**
-     * Set the given permissions for authenticated users.
-     */
-    public AclBuilder setAuthenticated(Permission... permissions) {
-        if (auth == null) {
-            auth = new ACL();
-        }
-        auth.setId(new Id("auth", null));
-        auth.setPerms(Permission.encode(permissions));
-        return this;
-    }
-
-    /**
-     * Set the given permissions for the given user authenticated with the given password.
-     */
-    public AclBuilder addDigest(String username, String password, Permission... permissions) {
-        Map<String, ACL> digests = getDigests();
-        ACL a = digests.get(username);
-        if (a == null) {
-            a = new ACL();
-            digests.put(username, a);
-        }
-        a.setId(new Id("digest", username + ":" + password));
-        a.setPerms(Permission.encode(permissions));
-        return this;
-    }
-
-    /**
-     * Set the given permissions for users connecting from the given host
-     * (as resolved on the Zookeeper server, from the client's IP address).
-     */
-    public AclBuilder addHost(String host, Permission... permissions) {
-        Map<String, ACL> hosts = getHosts();
-        ACL a = hosts.get(host);
-        if (a == null) {
-            a = new ACL();
-            hosts.put(host, a);
-        }
-        a.setId(new Id("host", host));
-        a.setPerms(Permission.encode(permissions));
         return this;
     }
 
@@ -148,6 +107,10 @@ public class AclBuilder {
     /**
      * Set the given permissions for users connecting from the most
      * significant {@code bits} given IP {@code address}.
+     * @param address The IP address to add.
+     * @param bits The number of bits in the IP address.
+     * @param permissions The permissions for users connecting from matching IP addresses.
+     * @return This instance.
      */
     public AclBuilder addIp(String address, int bits, Permission... permissions) {
         Map<String, ACL> ips = getIps();
@@ -170,7 +133,8 @@ public class AclBuilder {
     }
 
     /**
-     * Build a list of ACLs from the accumulated state.
+     * Build the result.
+     * @return a list of ACLs from the accumulated state.
      */
     public List<ACL> build() {
         List<ACL> result = new ArrayList<>();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public interface Zk {
 
-    public static void create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout,
+    static void create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout,
                               Handler<AsyncResult<Zk>> handler) {
         vertx.executeBlocking(f -> {
             try {
@@ -32,7 +32,7 @@ public interface Zk {
                 handler);
     }
 
-    public static Zk createSync(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
+    static Zk createSync(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
         return new ZkImpl(vertx,
                 new ZkClient(zkConnectionString, sessionTimeout, connectionTimeout,
                         new BytesPushThroughSerializer()));
@@ -40,18 +40,30 @@ public interface Zk {
 
     /**
      * Disconnect from the ZooKeeper server, asynchronously.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk disconnect(Handler<AsyncResult<Void>> handler);
 
     /**
      * Asynchronously create the znode at the given path and with the given data and ACL, using the
      * given createMode, then invoke the given handler with the result.
+     * @param path The path.
+     * @param data The data.
+     * @param acls The ACLs.
+     * @param createMode The create mode.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk create(String path, byte[] data, List<ACL> acls, CreateMode createMode, Handler<AsyncResult<Void>> handler);
 
     /**
      * Asynchronously delete the znode at the given path, iff the given version is -1 or matches the version of the znode,
      * then invoke the given handler with the result.
+     * @param path The path.
+     * @param version The version.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk delete(String path, int version, Handler<AsyncResult<Void>> handler);
 
@@ -59,12 +71,20 @@ public interface Zk {
      * Asynchronously set the data in the znode at the given path to the
      * given data iff the given version is -1, or matches the version of the znode,
      * then invoke the given handler with the result.
+     * @param path The path.
+     * @param data The data.
+     * @param version The version.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk setData(String path, byte[] data, int version, Handler<AsyncResult<Void>> handler);
 
     /**
      * Asynchronously fetch the children of the znode at the given {@code path}, calling the given
      * handler with the result.
+     * @param path The path.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk children(String path, Handler<AsyncResult<List<String>>> handler);
 
@@ -74,17 +94,25 @@ public interface Zk {
      * A subsequent call to {@link #children(String, Handler)} with the same path will register the child {@code watcher}
      * for the given {@code path} current at that time with zookeeper so
      * that that {@code watcher} is called when the children of the given {@code path} change.
+     * @param path The path.
+     * @param watcher The watcher.
+     * @return This instance.
      */
     Future<Zk> watchChildren(String path, Handler<AsyncResult<List<String>>> watcher);
 
     /**
      * Remove the children watcher, if any, for the given {@code path}.
+     * @param path The path.
+     * @return This instance.
      */
     Zk unwatchChildren(String path);
 
     /**
      * Asynchronously fetch the data of the given znode at the given path, calling the given handler
      * with the result.
+     * @param path The path.
+     * @param handler The result handler.
+     * @return This instance.
      */
     Zk getData(String path, Handler<AsyncResult<byte[]>> handler);
 
@@ -94,11 +122,16 @@ public interface Zk {
      * A subsequent call to {@link #getData(String, Handler)} with the same path will register the data {@code watcher}
      * for the given {@code path} current at that time with zookeeper so
      * that that {@code watcher} is called when the data of the given {@code path} changes.
+     * @param path The path.
+     * @param watcher The result handler.
+     * @return This instance
      */
     Future<Zk> watchData(String path, Handler<AsyncResult<byte[]>> watcher);
 
     /**
      * Remove the data watcher, if any, for the given {@code path}.
+     * @param path The path.
+     * @return This instance.
      */
     Zk unwatchData(String path);
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -42,13 +42,14 @@ public class UserOperatorConfig {
     /**
      * Constructor
      *
-     * @param namespace namespace in which the operator will run and create resources
-     * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
-     * @param zookeperConnect Connecton URL for Zookeeper
-     * @param zookeeperSessionTimeoutMs Session timeout for Zookeeper connections
-     * @param labels    Map with labels which should be used to find the KafkaUser resources
-     * @param caCertSecretName    Name of the secret containing the Certification Authority
-     * @param caNamespace   Namespace with the CA secret
+     * @param namespace namespace in which the operator will run and create resources.
+     * @param reconciliationIntervalMs How many milliseconds between reconciliation runs.
+     * @param zookeperConnect Connecton URL for Zookeeper.
+     * @param zookeeperSessionTimeoutMs Session timeout for Zookeeper connections.
+     * @param labels Map with labels which should be used to find the KafkaUser resources.
+     * @param caCertSecretName Name of the secret containing the Certification Authority certificate.
+     * @param caKeySecretName The name of the secret containing the Certification Authority key.
+     * @param caNamespace Namespace with the CA secret.
      */
     public UserOperatorConfig(String namespace,
                               long reconciliationIntervalMs,

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -74,13 +74,15 @@ public class KafkaUserModel {
     }
 
     /**
-     * Creates instance of KafkaUserModel from CRD definition
+     * Creates instance of KafkaUserModel from CRD definition.
      *
-     * @param certManager   CertManager instance for work with certificates
-     * @param passwordGenerator A password generator
-     * @param kafkaUser     The Custom Resource based on which the model should be created
-     * @param userSecret    Kubernetes secret with existing user certificate
-     * @return
+     * @param certManager CertManager instance for work with certificates.
+     * @param passwordGenerator A password generator.
+     * @param kafkaUser The Custom Resource based on which the model should be created.
+     * @param clientsCaCert The clients CA certificate Secret.
+     * @param clientsCaKey The clients CA key Secret.
+     * @param userSecret Kubernetes secret with existing user certificate.
+     * @return The user model.
      */
     public static KafkaUserModel fromCrd(CertManager certManager,
                                          PasswordGenerator passwordGenerator,
@@ -113,7 +115,7 @@ public class KafkaUserModel {
      * Generates secret containing the certificate for TLS client auth when TLS client auth is enabled for this user.
      * Returns null otherwise.
      *
-     * @return
+     * @return The secret.
      */
     public Secret generateSecret()  {
         if (authentication instanceof KafkaUserTlsClientAuthentication) {
@@ -135,7 +137,11 @@ public class KafkaUserModel {
      * Manage certificates generation based on those already present in the Secrets
      *
      * @param certManager CertManager instance for handling certificates creation
+     * @param clientsCaCertSecret The clients CA certificate Secret.
+     * @param clientsCaKeySecret The clients CA key Secret.
      * @param userSecret Secret with the user certificate
+     * @param validityDays The number of days the certificate should be valid for.
+     * @param renewalDays The renewal days.
      */
     public void maybeGenerateCertificates(CertManager certManager,
                                           Secret clientsCaCertSecret, Secret clientsCaKeySecret,
@@ -183,6 +189,10 @@ public class KafkaUserModel {
         }
     }
 
+    /**
+     * @param generator The password generator.
+     * @param userSecret The Secret containing any existing password.
+     */
     public void maybeGeneratePassword(PasswordGenerator generator, Secret userSecret) {
         if (userSecret != null) {
             // Secret already exists -> lets verify if it has a password
@@ -211,7 +221,7 @@ public class KafkaUserModel {
     /**
      * Creates secret with the data
      * @param data Map with the Secret content
-     * @return
+     * @return The secret.
      */
     protected Secret createSecret(Map<String, String> data) {
         Secret s = new SecretBuilder()
@@ -230,7 +240,7 @@ public class KafkaUserModel {
     /**
      * Generate the OwnerReference object to link newly created objects to their parent (the custom resource)
      *
-     * @return
+     * @return The owner reference.
      */
     protected OwnerReference createOwnerReference() {
         return new OwnerReferenceBuilder()
@@ -255,9 +265,10 @@ public class KafkaUserModel {
     }
 
     /**
-     * Generates the name of the User secret based on the username
+     * Decodes the name of the User secret based on the username
      *
-     * @return
+     * @param username The username.
+     * @return The decoded user name.
      */
     public static String decodeUsername(String username) {
         if (username.contains("CN="))   {
@@ -276,7 +287,8 @@ public class KafkaUserModel {
     /**
      * Generates the name of the User secret based on the username
      *
-     * @return
+     * @param username The username.
+     * @return The TLS user name.
      */
     public static String getTlsUserName(String username)    {
         return "CN=" + username;
@@ -285,7 +297,8 @@ public class KafkaUserModel {
     /**
      * Generates the name of the User secret based on the username
      *
-     * @return
+     * @param username The username.
+     * @return The SCRAM user name.
      */
     public static String getScramUserName(String username)    {
         return username;
@@ -294,7 +307,7 @@ public class KafkaUserModel {
     /**
      * Gets the Username
      *
-     * @return
+     * @return The user name.
      */
     public String getUserName()    {
         if (isTlsUser()) {
@@ -306,54 +319,54 @@ public class KafkaUserModel {
         }
     }
 
+    /**
+     * @return The name of the user.
+     */
     public String getName() {
         return name;
     }
 
     /**
-     * Generates the name of the USer secret based on the username
+     * Generates the name of the User secret based on the username.
      *
-     * @return
+     * @param username The username.
+     * @return The name of the user.
      */
     public static String getSecretName(String username)    {
         return username;
     }
 
     /**
-     * Gets the name of the User secret
+     * Gets the name of the User secret.
      *
-     * @return
+     * @return The name of the user secret.
      */
     public String getSecretName()    {
         return KafkaUserModel.getSecretName(name);
     }
 
     /**
-     * Sets authentication method
+     * Sets the authentication method.
      *
-     * @param authentication Authentication method
+     * @param authentication Authentication method.
      */
     public void setAuthentication(KafkaUserAuthentication authentication) {
         this.authentication = authentication;
     }
 
-    public KafkaUserAuthentication getAuthentication() {
-        return this.authentication;
-    }
-
     /**
-     * Get list of ACL rules for Simple Authorization which should apply to this user
+     * Get the list of ACL rules for Simple Authorization which should apply to this user.
      *
-     * @return
+     * @return The ACL rules.
      */
     public Set<SimpleAclRule> getSimpleAclRules() {
         return simpleAclRules;
     }
 
     /**
-     * Sets list of ACL rules for Simple authorization
+     * Sets the list of ACL rules for Simple authorization.
      *
-     * @param rules List of ACL rules which should be applied to this user
+     * @param rules List of ACL rules which should be applied to this user.
      */
     public void setSimpleAclRules(List<AclRule> rules) {
         Set<SimpleAclRule> simpleAclRules = new HashSet<SimpleAclRule>();
@@ -366,18 +379,18 @@ public class KafkaUserModel {
     }
 
     /**
-     * Returns true if the user is using TLS authentication
+     * Returns true if the user is using TLS authentication.
      *
-     * @return
+     * @return true if the user is using TLS authentication.
      */
     public boolean isTlsUser()  {
         return authentication instanceof KafkaUserTlsClientAuthentication;
     }
 
     /**
-     * Returns true if the user is using SCRAM-SHA-512 authentication
+     * Returns true if the user is using SCRAM-SHA-512 authentication.
      *
-     * @return
+     * @return true if the user is using SCRAM-SHA-512 authentication.
      */
     public boolean isScramUser()  {
         return authentication instanceof KafkaUserScramSha512ClientAuthentication;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -52,36 +52,36 @@ public class SimpleAclRule {
     }
 
     /**
-     * Returns the type of the ACL rule
+     * Returns the type of the ACL rule.
      *
-     * @return
+     * @return The type.
      */
     public AclRuleType getType() {
         return type;
     }
 
     /**
-     * Returns the resource to which this rule applies
+     * Returns the resource to which this rule applies.
      *
-     * @return
+     * @return The resource.
      */
     public SimpleAclRuleResource getResource() {
         return resource;
     }
 
     /**
-     * Returns the host from which this rule is allowed / denied
+     * Returns the host from which this rule is allowed / denied.
      *
-     * @return
+     * @return The host.
      */
     public String getHost() {
         return host;
     }
 
     /**
-     * Returns the operation which is allowed / denied
+     * Returns the operation which is allowed / denied.
      *
-     * @return
+     * @return The operation.
      */
     public AclOperation getOperation() {
         return operation;
@@ -121,8 +121,8 @@ public class SimpleAclRule {
     /**
      * Create Kafka's Acl object from SimpleAclRule object.
      *
-     * @param principal     Kafka prinmcipal needed to create Kafka's Acl object
-     * @return
+     * @param principal Kafka prinmcipal needed to create Kafka's Acl object.
+     * @return The Kafka ACL.
      */
     public Acl toKafkaAcl(KafkaPrincipal principal)   {
         PermissionType kafkaType;
@@ -185,7 +185,7 @@ public class SimpleAclRule {
      *
      * @param resource  The resource the newly created rule should apply to
      * @param acl       The Acl object which should be used to create the rule
-     * @return
+     * @return The SimpleAclRule.
      */
     public static SimpleAclRule fromKafkaAcl(SimpleAclRuleResource resource, Acl acl)   {
         AclRuleType type;
@@ -247,7 +247,7 @@ public class SimpleAclRule {
      * Creates SimpleAclRule object based on AclRule object which is received as part ofthe KafkaUser CRD.
      *
      * @param rule  AclRule object from KafkaUser CR
-     * @return
+     * @return The SimpleAclRule.
      */
     public static SimpleAclRule fromCrd(AclRule rule)   {
         return new SimpleAclRule(rule.getType(), SimpleAclRuleResource.fromCrd(rule.getResource()), rule.getHost(), rule.getOperation());

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -42,27 +42,27 @@ public class SimpleAclRuleResource {
     }
 
     /**
-     * Returns the name of the resource
+     * Returns the name of the resource.
      *
-     * @return
+     * @return The name.
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Returns the type of the resource
+     * Returns the type of the resource.
      *
-     * @return
+     * @return The type.
      */
     public SimpleAclRuleResourceType getType() {
         return type;
     }
 
     /**
-     * Returns the pattern used for this resource
+     * Returns the pattern used for this resource.
      *
-     * @return
+     * @return The pattern.
      */
     public AclResourcePatternType getPattern() {
         return pattern;
@@ -99,7 +99,7 @@ public class SimpleAclRuleResource {
     /**
      * Creates Kafka's Resource class from the current object
      *
-     * @return
+     * @return The resource.
      */
     public Resource toKafkaResource()   {
         ResourceType kafkaType;
@@ -149,7 +149,7 @@ public class SimpleAclRuleResource {
      * Creates SimpleAclRuleResource object based on Kafka's Resource object
      *
      * @param kafkaResource Kafka's Resource object
-     * @return
+     * @return The resource.
      */
     public static SimpleAclRuleResource fromKafkaResource(Resource kafkaResource)   {
         String resourceName;
@@ -220,7 +220,7 @@ public class SimpleAclRuleResource {
      * Creates SimpleAclRuleResource object based on the objects received as part fo the KAfkaUser CR
      *
      * @param resource  AclRuleResource as received in KafkaUser CR
-     * @return
+     * @return The resource.
      */
     public static SimpleAclRuleResource fromCrd(AclRuleResource resource)   {
         if (resource instanceof AclRuleTopicResource)   {

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -64,14 +64,15 @@ public class KafkaUserOperator {
                     "0123456789");
 
     /**
-     * @param vertx The Vertx instance
-     * @param certManager For managing certificates
-     * @param crdOperator For operating on Custom Resources
-     * @param secretOperations For operating on Secrets
-     * @param scramShaCredentialOperator For operating on SCRAM SHA credentials
-     * @param aclOperations For operating on ACLs
-     * @param caCertName The name of the Secret containing the clients CA certificate and private key
-     * @param caNamespace The namespace of the Secret containing the clients CA certificate and private key
+     * @param vertx The Vertx instance.
+     * @param certManager For managing certificates.
+     * @param crdOperator For operating on Custom Resources.
+     * @param secretOperations For operating on Secrets.
+     * @param scramShaCredentialOperator For operating on SCRAM SHA credentials.
+     * @param aclOperations For operating on ACLs.
+     * @param caCertName The name of the Secret containing the clients CA certificate.
+     * @param caKeyName The name of the Secret containing the clients CA private key.
+     * @param caNamespace The namespace of the Secret containing the clients CA certificate and private key.
      */
     public KafkaUserOperator(Vertx vertx,
                              CertManager certManager,
@@ -168,6 +169,8 @@ public class KafkaUserOperator {
      * Reconcile assembly resources in the given namespace having the given {@code name}.
      * Reconciliation works by getting the assembly resource (e.g. {@code KafkaUser}) in the given namespace with the given name and
      * comparing with the corresponding resource.
+     * @param reconciliation The reconciliation.
+     * @param handler The result handler.
      */
     public final void reconcile(Reconciliation reconciliation, Handler<AsyncResult<Void>> handler) {
         String namespace = reconciliation.namespace();
@@ -232,6 +235,7 @@ public class KafkaUserOperator {
      * @param trigger A description of the triggering event (timer or watch), used for logging
      * @param namespace The namespace
      * @param selector The labels used to select the resources
+     * @return A latch for awaiting the reconciliation.
      */
     public final CountDownLatch reconcileAll(String trigger, String namespace, Labels selector) {
         List<KafkaUser> desiredResources = crdOperator.list(namespace, selector);
@@ -277,13 +281,13 @@ public class KafkaUserOperator {
     }
 
     /**
-     * Create Kubernetes watch for KafkaUser resources
+     * Create Kubernetes watch for KafkaUser resources.
      *
-     * @param namespace Namespace where to watch for users
-     * @param selector  Labels which the Users should match
-     * @param onClose   Callbeck called when the watch is closed
+     * @param namespace Namespace where to watch for users.
+     * @param selector Labels which the Users should match.
+     * @param onClose Callback called when the watch is closed.
      *
-     * @return
+     * @return A future which completes when the watcher has been created.
      */
     public Future<Watch> createWatch(String namespace, Labels selector, Consumer<KubernetesClientException> onClose) {
         Future<Watch> result = Future.future();

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -179,10 +179,10 @@ public class SimpleAclOperator {
     }
 
     /**
-     * Returns Set of ACLs applying to single user
+     * Returns Set of ACLs applying to single user.
      *
-     * @param username  Name of the user
-     * @return
+     * @param username  Name of the user.
+     * @return The Set of ACLs applying to single user.
      */
     public Set<SimpleAclRule> getAcls(String username)   {
         log.debug("Searching for ACL rules of user {}", username);
@@ -214,9 +214,9 @@ public class SimpleAclOperator {
     }
 
     /**
-     * Returns set with all usernames which have some ACLs
+     * Returns set with all usernames which have some ACLs.
      *
-     * @return
+     * @return The set with all usernames which have some ACLs.
      */
     public Set<String> getUsersWithAcls()   {
         Set<String> result = new HashSet<String>();


### PR DESCRIPTION
And fail the build when warnings are generated.

### Type of change

- Documentation

### Description

This PR fixes all Javadoc warnings @public visibility and changes the pom.xml to fail the build on javadoc errors or warnings.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

