### PR TITLE
Throw error when a TLS KafkaUser with name >64 chars is created

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 
 public interface CertManager {
-
     /**
      * Generate a self-signed certificate
      *

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -28,6 +28,7 @@ import static java.util.Arrays.asList;
  * An OpenSSL based certificates manager
  */
 public class OpenSslCertManager implements CertManager {
+    public static final int MAXIMUM_CN_LENGTH = 64;
 
     private static final Logger log = LogManager.getLogger(OpenSslCertManager.class);
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/InvalidResourceException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/InvalidResourceException.java
@@ -9,7 +9,7 @@ public class InvalidResourceException extends RuntimeException {
         super();
     }
 
-    protected InvalidResourceException(String s) {
+    public InvalidResourceException(String s) {
         super(s);
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
+import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.model.ClientsCa;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
@@ -96,7 +97,8 @@ public class KafkaUserModel {
         result.setAuthentication(kafkaUser.getSpec().getAuthentication());
 
         if (kafkaUser.getSpec().getAuthentication() instanceof KafkaUserTlsClientAuthentication) {
-            if (kafkaUser.getMetadata().getName().length() > 64)    {
+            //if (kafkaUser.getMetadata().getName().length() > 64)    {
+            if (kafkaUser.getMetadata().getName().length() > OpenSslCertManager.MAXIMUM_CN_LENGTH)    {
                 throw new InvalidResourceException("Users with TLS client authentication can have a username (name of the KafkaUser custom resource) only up to 64 characters long.");
             }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.model.ClientsCa;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.user.UserOperatorConfig;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
@@ -95,6 +96,10 @@ public class KafkaUserModel {
         result.setAuthentication(kafkaUser.getSpec().getAuthentication());
 
         if (kafkaUser.getSpec().getAuthentication() instanceof KafkaUserTlsClientAuthentication) {
+            if (kafkaUser.getMetadata().getName().length() > 64)    {
+                throw new InvalidResourceException("Users with TLS client authentication can have a username (name of the KafkaUser custom resource) only up to 64 characters long.");
+            }
+
             result.maybeGenerateCertificates(certManager, clientsCaCert, clientsCaKey, userSecret,
                     UserOperatorConfig.getClientsCaValidityDays(), UserOperatorConfig.getClientsCaRenewalDays());
         } else if (kafkaUser.getSpec().getAuthentication() instanceof KafkaUserScramSha512ClientAuthentication) {

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -230,7 +230,7 @@ public class KafkaUserModelTest {
         // 64 characters => Should be still OK
         KafkaUser notTooLong = new KafkaUserBuilder(tlsUser)
                 .editMetadata()
-                .withName("User123456789012345678901234567890123456789012345678901234567890")
+                    .withName("User123456789012345678901234567890123456789012345678901234567890")
                 .endMetadata()
                 .build();
 
@@ -242,7 +242,7 @@ public class KafkaUserModelTest {
         // 65 characters => should work with SCRAM-SHA-512
         KafkaUser tooLong = new KafkaUserBuilder(scramShaUser)
                 .editMetadata()
-                .withName("User-123456789012345678901234567890123456789012345678901234567890")
+                    .withName("User-123456789012345678901234567890123456789012345678901234567890")
                 .endMetadata()
                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #1694, openSSL cannot create TLS users with username (=> the CN in the certificate subject) longer than 64 characters. While this PR does not fix this, it at least throws a proper exception to make it more clear what the problem is.

This also moves the `InvalidResourceException` to the `operator-common` module so that it can be used in User Operator as well.

Tis issue should be picked for the 0.12.0 release branch.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging