### PR TITLE
EntityOperatorReady Status Condition

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -297,7 +297,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.entityOperatorUserOpAncillaryCm())
                 .compose(state -> state.entityOperatorSecret())
                 .compose(state -> state.entityOperatorDeployment())
-                .compose(state -> state.entityOperatorReady())
 
                 .compose(state -> chainFuture.complete(), chainFuture);
 
@@ -2386,14 +2385,14 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     Annotations.annotations(eoDeployment.getSpec().getTemplate()).put(
                             Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(clientsCaCertGeneration));
                     return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), eoDeployment));
+                })
+                .compose(dep -> {
+                    // Completes successfully when the deployment is ready
+                    return withVoid(deploymentOperations.readiness(namespace, this.entityOperator.getName(), 1_000, operationTimeoutMs));
                 }).map(i -> this);
             } else  {
                 return withVoid(deploymentOperations.reconcile(namespace, EntityOperator.entityOperatorName(name), null));
             }
-        }
-
-        Future<ReconciliationState> entityOperatorReady() {
-            return withVoid(deploymentOperations.readiness(namespace, this.entityOperator.getName(), 1_000, operationTimeoutMs));
         }
 
         Future<ReconciliationState> entityOperatorSecret() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -82,7 +82,6 @@ import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import java.util.Collections;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.CronExpression;
@@ -90,6 +89,7 @@ import org.quartz.CronExpression;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2609,7 +2609,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         String getInternalServiceHostname(String serviceName)    {
             return serviceName + "." + namespace + ".svc";
         }
-
     }
 
     private Date dateSupplier() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -460,6 +460,9 @@ public class KafkaAssemblyOperatorTest {
         when(mockDepOps.getAsync(anyString(), anyString())).thenReturn(
                 Future.succeededFuture()
         );
+        when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(
+                Future.succeededFuture()
+        );
 
         when(mockSecretOps.list(anyString(), any())).thenReturn(
                 secrets
@@ -887,6 +890,9 @@ public class KafkaAssemblyOperatorTest {
             );
             when(mockDepOps.getAsync(clusterNamespace, EntityOperator.entityOperatorName(clusterName))).thenReturn(
                     Future.succeededFuture(originalEntityOperator.generateDeployment(true, Collections.EMPTY_MAP, null, null))
+            );
+            when(mockDepOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(
+                    Future.succeededFuture()
             );
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -109,36 +109,6 @@ public class KafkaStatusTest {
     }
 
     @Test
-    public void testStatusEntityOperatorReadiness() throws ParseException {
-        Kafka kafka = getKafkaCrd();
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        // Mock the Kafka Operator
-        CrdOperator mockKafkaOps = supplier.kafkaOperator;
-
-        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(getKafkaCrd()));
-
-        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
-        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
-
-        MockWorkingKafkaAssemblyOperator kao = new MockWorkingKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
-                certManager,
-                supplier,
-                config);
-
-        kao.createOrUpdate(new Reconciliation("test-trigger", ResourceType.KAFKA, namespace, clusterName), kafka).setHandler(res -> {
-            assertTrue(res.succeeded());
-
-            assertNotNull(kafkaCaptor.getValue());
-            assertNotNull(kafkaCaptor.getValue().getStatus());
-            KafkaStatus status = kafkaCaptor.getValue().getStatus();
-
-            assertEquals("NotReady", status.getConditions().get(0).getType());
-            assertEquals("True", status.getConditions().get(0).getStatus());
-        });
-    }
-
-    @Test
     public void testStatusAfterSuccessfulReconciliationWithPreviousFailure() throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, the Kafka Ready status field is set as true even before the Entity Operator deployment has completed successfully. The Kafka Ready status field should be set as false until the Entity Operator deployment and the pods in that deployment are running and ready. This enhancement ensures that the Kafka Ready status is set as true after the the pods of the Entity Operator deployment are ready.               

For the following reasons, I don't think any additional tests are necessary for this enhancement and have stripped out the mock tests I was working:

1.) The existing KafkaStatusTests thoroughly cover the Kafka Ready status based on the success or failure of the chainFuture returned by the reconcile() method. Like the other futures of the chainFuture, the future returned by the entityOperatorReady() method will cause the chainFuture to fail if it fails.

2.) The enhancement primarily relies on the Fabric8 isReady() method to determine deployment readiness (based on the readiness of the pods in that deployment) [1]. If we were to add tests for this, I feel we would essentially be testing Fabric8 code functionality instead of Strimzi code.


[1]  https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java#L115

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

