### PR TITLE
Bump apiVersion of our RBAC resources

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -124,7 +124,7 @@ public class Main {
         return CompositeFuture.join(futures);
     }
 
-    private static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
+    /*test*/ static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
         if (config.isCreateClusterRoles()) {
             List<Future> futures = new ArrayList<>();
             ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-namespaced

--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-global

--- a/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-kafka-broker

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-entity-operator

--- a/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/032-ClusterRole-strimzi-topic-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-topic-operator

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.operator.common.operator.resource.ClusterRoleOperator;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(VertxUnitRunner.class)
+public class MainIT {
+    private Vertx vertx;
+    private KubernetesClient client;
+
+    @Before
+    public void createClient(TestContext context) {
+        vertx = Vertx.vertx();
+        client = new DefaultKubernetesClient();
+    }
+
+    @After
+    public void closeClient() {
+        vertx.close();
+        client.close();
+    }
+
+    @Test
+    public void testCreateClusterRoles(TestContext context) {
+        Map<String, String> envVars = new HashMap<>(1);
+        envVars.put(ClusterOperatorConfig.STRIMZI_CREATE_CLUSTER_ROLES, "TRUE");
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars);
+
+        ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);
+
+        Async async = context.async();
+        Main.maybeCreateClusterRoles(vertx, config, client).setHandler(res -> {
+            context.assertTrue(res.succeeded());
+
+            context.assertNotNull(cro.get("strimzi-cluster-operator-namespaced"));
+            context.assertNotNull(cro.get("strimzi-cluster-operator-global"));
+            context.assertNotNull(cro.get("strimzi-kafka-broker"));
+            context.assertNotNull(cro.get("strimzi-entity-operator"));
+            context.assertNotNull(cro.get("strimzi-topic-operator"));
+
+            async.complete();
+        });
+
+        async.awaitSuccess();
+    }
+}

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-namespaced

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-global

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator

--- a/helm-charts/strimzi-kafka-operator/templates/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-kafka-broker

--- a/helm-charts/strimzi-kafka-operator/templates/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator-kafka-broker-delegation

--- a/helm-charts/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-entity-operator

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-entity-operator-delegation

--- a/helm-charts/strimzi-kafka-operator/templates/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-ClusterRole-strimzi-topic-operator.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createGlobalResources -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-topic-operator

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-topic-operator-delegation

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-namespaced

--- a/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-cluster-operator-global

--- a/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator

--- a/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
+++ b/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-kafka-broker

--- a/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: strimzi-cluster-operator-kafka-broker-delegation

--- a/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-entity-operator

--- a/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-entity-operator-delegation

--- a/install/cluster-operator/032-ClusterRole-strimzi-topic-operator.yaml
+++ b/install/cluster-operator/032-ClusterRole-strimzi-topic-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-topic-operator

--- a/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-cluster-operator-topic-operator-delegation

--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: strimzi-admin

--- a/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: strimzi-topic-operator

--- a/install/topic-operator/03-RoleBinding-strimzi-topic-operator.yaml
+++ b/install/topic-operator/03-RoleBinding-strimzi-topic-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-topic-operator

--- a/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: strimzi-user-operator

--- a/install/user-operator/03-RoleBinding-strimzi-user-operator.yaml
+++ b/install/user-operator/03-RoleBinding-strimzi-user-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-user-operator

--- a/systemtest/src/rbac/role-edit-kafka.yaml
+++ b/systemtest/src/rbac/role-edit-kafka.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: strimzi-edit-kafka
@@ -22,7 +22,7 @@ rules:
   - patch
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kafka-editors

--- a/systemtest/src/test/resources/helm/helm-service-account.yaml
+++ b/systemtest/src/test/resources/helm/helm-service-account.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tiller
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tiller

--- a/topic-operator/src/test/resources/TopicOperatorIT-rbac.yaml
+++ b/topic-operator/src/test/resources/TopicOperatorIT-rbac.yaml
@@ -1,6 +1,6 @@
 ---
 # Extra permissions required by the integration tests
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: strimzi-topic-operator-role-it
@@ -15,7 +15,7 @@ rules:
   - list
   - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-topic-operator-binding-it
@@ -29,7 +29,7 @@ roleRef:
   name: strimzi-topic-operator-role-it
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: strimzi-topic-operator-binding


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using Strimzi with OperatorHub.io, it has to create its own roles. But that currently doesn't seem to work, because our current version of the Fabric8 library seems to have problem with our v1beta1 roles. We have to update the roles to v1 to make that work.

This has to be picked for the 0.12.0 release.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally