### PR TITLE
ST: use test clinet only from strimzi organizaiton in docker hub

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -27,6 +27,18 @@ public class Environment {
      */
     private static final String STRIMZI_TAG_ENV = "DOCKER_TAG";
     /**
+     * Specify organization which owns test-client used in system tests.
+     */
+    private static final String TEST_CLIENT_ORG_ENV = "TEST_CLIENT_ORG";
+    /**
+     * Specify registry for test-client used in system tests.
+     */
+    private static final String TEST_CLIENT_REGISTRY_ENV = "TEST_CLIENT_REGISTRY";
+    /**
+     * Specify test-client tags used in system tests.
+     */
+    private static final String TEST_CLIENT_TAG_ENV = "TEST_CLIENT_TAG";
+    /**
      * Directory for store logs collected during the tests.
      */
     private static final String TEST_LOG_DIR_ENV = "TEST_LOG_DIR";
@@ -62,6 +74,9 @@ public class Environment {
     public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
     public static final String STRIMZI_TAG = System.getenv().getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
     public static final String STRIMZI_REGISTRY = System.getenv().getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
+    public static final String TEST_CLIENT_ORG = System.getenv().getOrDefault(TEST_CLIENT_ORG_ENV, STRIMZI_ORG);
+    public static final String TEST_CLIENT_TAG = System.getenv().getOrDefault(TEST_CLIENT_TAG_ENV, STRIMZI_TAG);
+    public static final String TEST_CLIENT_REGISTRY = System.getenv().getOrDefault(TEST_CLIENT_REGISTRY_ENV, STRIMZI_REGISTRY);
     static final String TEST_LOG_DIR = System.getenv().getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
     static final String ST_KAFKA_VERSION = System.getenv().getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);
     static final String STRIMZI_LOG_LEVEL = System.getenv().getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
@@ -78,6 +93,9 @@ public class Environment {
         LOGGER.info(debugFormat, STRIMZI_ORG_ENV, STRIMZI_ORG);
         LOGGER.info(debugFormat, STRIMZI_TAG_ENV, STRIMZI_TAG);
         LOGGER.info(debugFormat, STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY);
+        LOGGER.info(debugFormat, TEST_CLIENT_ORG_ENV, TEST_CLIENT_ORG);
+        LOGGER.info(debugFormat, TEST_CLIENT_TAG_ENV, TEST_CLIENT_TAG);
+        LOGGER.info(debugFormat, TEST_CLIENT_REGISTRY_ENV, TEST_CLIENT_REGISTRY);
         LOGGER.info(debugFormat, TEST_LOG_DIR_ENV, TEST_LOG_DIR);
         LOGGER.info(debugFormat, ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION);
         LOGGER.info(debugFormat, STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL);

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -76,7 +76,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import static io.strimzi.systemtest.utils.StUtils.changeOrgAndTag;
 import static io.strimzi.test.TestUtils.toYamlString;
 
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
@@ -906,7 +905,7 @@ public class Resources extends AbstractResources {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(Constants.KAFKA_CLIENTS)
-                .withImage(changeOrgAndTag("strimzi/test-client:latest-kafka-" + KAFKA_VERSION))
+                .withImage("strimzi/test-client:" + Environment.STRIMZI_TAG + "-kafka-" + KAFKA_VERSION)
                 .addNewPort()
                     .withContainerPort(4242)
                 .endPort()

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -905,7 +905,7 @@ public class Resources extends AbstractResources {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(Constants.KAFKA_CLIENTS)
-                .withImage("strimzi/test-client:" + Environment.STRIMZI_TAG + "-kafka-" + KAFKA_VERSION)
+                .withImage(StUtils.changeTestClientOrgAndTag("strimzi/test-client:latest-kafka-" + KAFKA_VERSION))
                 .addNewPort()
                     .withContainerPort(4242)
                 .endPort()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -404,6 +404,15 @@ public class StUtils {
         return changeOrgAndTag(image, Environment.STRIMZI_REGISTRY, Environment.STRIMZI_ORG, Environment.STRIMZI_TAG);
     }
 
+    /**
+     * The method to configure docker image to use proper docker registry, docker org and docker tag for test-client image.
+     * @param image Test-client image that needs to be changed
+     * @return Updated test-client image with a proper registry, org, tag
+     */
+    public static String changeTestClientOrgAndTag(String image) {
+        return changeOrgAndTag(image, Environment.TEST_CLIENT_REGISTRY, Environment.TEST_CLIENT_ORG, Environment.TEST_CLIENT_TAG);
+    }
+
     public static String changeOrgAndTagInImageMap(String imageMap) {
         Matcher m = VERSION_IMAGE_PATTERN.matcher(imageMap);
         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Tests should use test client, which is not depend on build Strimzi images and is stored only in strimzi organization on docker hub (quay.io in the future?). Currently, when we want to use different images for tests (kafka and operator) we need test-client image in same registries and org as strimzi images.

### Checklist

- [x] Make sure all tests pass

