### PR TITLE
Default the topic operator logging to INFO, not DEBUG

### DIFF
--- a/topic-operator/src/main/resources/log4j2.properties
+++ b/topic-operator/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Default the topic operator logging to INFO, not DEBUG

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

