### PR TITLE
[DOC] Updates to container image references

### DIFF
--- a/documentation/book/con-kafka-bridge-authentication.adoc
+++ b/documentation/book/con-kafka-bridge-authentication.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-kafka-bridge-tls.adoc
 
-[id='con-kafka-bridge-authentication{context}']
+[id='con-kafka-bridge-authentication-{context}']
 = Authentication support in Kafka Bridge
 
 Authentication is configured through the `authentication` property in `KafkaBridge.spec.kafka`.

--- a/documentation/book/con-securing-kafka-bridge.adoc
+++ b/documentation/book/con-securing-kafka-bridge.adoc
@@ -28,6 +28,6 @@ The Kafka Bridge supports TLS encryption and TLS and SASL authentication when co
 
 * A TLS-encrypted connection between the Kafka Bridge and your Kafka cluster.
 
-For more information, see xref:con-kafka-bridge-authentication-{context}[]. 
+For more information, see xref:con-kafka-bridge-authentication-deployment-configuration-kafka-bridge[]. 
 
 You can use ACLs in Kafka brokers to restrict the topics that can be consumed and produced using the Kafka Bridge.

--- a/documentation/book/con-supported-clients-kafka-bridge.adoc
+++ b/documentation/book/con-supported-clients-kafka-bridge.adoc
@@ -12,10 +12,9 @@ You can use the Kafka Bridge to integrate both _internal_ and _external_ HTTP cl
 
 * External clients are HTTP clients running _outside_ the {ProductPlatformName} cluster in which the Kafka Bridge is deployed and running.
 
-Internal clients can access the Kafka Bridge on the host and port defined in the `KafkaBridge` custom resource. External clients can access the Kafka Bridge through an {OpenShiftName} Route, a LoadBalancer Service, or a {KubernetesName} Ingress. 
+Internal clients can access the Kafka Bridge on the host and port defined in the `KafkaBridge` custom resource. External clients can access the Kafka Bridge through an {OpenShiftName} Route, a LoadBalancer Service, or a {KubernetesName} Ingress.
 
 .Additional resources
 
-* For more information on configuring the host and port for the `KafkaBridge` resource, see xref:ref-kafka-bridge-http-configuration-{context}[].
-
+* For more information on configuring the host and port for the `KafkaBridge` resource, see xref:ref-kafka-bridge-http-configuration-deployment-configuration-kafka-bridge[].
 * For more information on integrating external clients, see xref:con-accessing-kafka-bridge-from-outside-{context}[].

--- a/documentation/book/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/book/ref-operators-cluster-operator-configuration.adoc
@@ -33,7 +33,7 @@ increased when using {ProductName} on clusters where regular {ProductPlatformNam
 `STRIMZI_KAFKA_IMAGES`:: Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated `_<version>_=_<image>_` pairs.
-For example `2.0.0={DockerKafkaImage}:{DockerTag}-kafka-2.0.0, 2.1.0={DockerKafkaImage}:{DockerTag}-kafka-2.1.0`.
+For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
 This is used when a `Kafka.spec.kafka.version` property is specified but not the `Kafka.spec.kafka.image`, as described in xref:assembly-configuring-container-images-deployment-configuration-kafka[].
 
 `STRIMZI_DEFAULT_KAFKA_INIT_IMAGE`:: Optional, default `{DockerKafkaInit}`.
@@ -54,19 +54,19 @@ no image is specified as the `Kafka.spec.zookeeper.tlsSidecar.image` in the xref
 `STRIMZI_KAFKA_CONNECT_IMAGES`:: Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated `_<version>_=_<image>_` pairs.
-For example `2.0.0={DockerKafkaImage}:{DockerTag}-kafka-2.0.0, 2.1.0={DockerKafkaImage}:{DockerTag}-kafka-2.1.0`.
+For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
 This is used when a `KafkaConnect.spec.version` property is specified but not the `KafkaConnect.spec.image`, as described in xref:assembly-configuring-container-images-deployment-configuration-kafka-connect[].
 
 `STRIMZI_KAFKA_CONNECT_S2I_IMAGES`:: Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated `_<version>_=_<image>_` pairs.
-For example `2.0.0={DockerKafkaImage}:{DockerTag}-kafka-2.0.0, 2.1.0={DockerKafkaImage}:{DockerTag}-kafka-2.1.0`.
+For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
 This is used when a `KafkaConnectS2I.spec.version` property is specified but not the `KafkaConnectS2I.spec.image`, as described in xref:assembly-configuring-container-images-deployment-configuration-kafka-connect-s2i[].
 
 `STRIMZI_KAFKA_MIRROR_MAKER_IMAGES`:: Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated `_<version>_=_<image>_` pairs.
-For example `2.0.0={DockerKafkaImage}:{DockerTag}-kafka-2.0.0, 2.1.0={DockerKafkaImage}:{DockerTag}-kafka-2.1.0`.
+For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
 This is used when a `KafkaMirrorMaker.spec.version` property is specified but not the `KafkaMirrorMaker.spec.image`, as described in xref:assembly-configuring-container-images-deployment-configuration-kafka-mirror-maker[].
 
 `STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE`:: Optional, default `{DockerTopicOperator}`.

--- a/documentation/book/snip-images.adoc
+++ b/documentation/book/snip-images.adoc
@@ -15,7 +15,7 @@ a|
 {ProductName} image for running Kafka, including:
 
 * Kafka Broker
-* Kafka Connect
+* Kafka Connect / S2I
 * Kafka Mirror Maker
 * Zookeeper
 * TLS Sidecars
@@ -31,5 +31,12 @@ a|
 * Topic Operator
 * User Operator
 * Kafka Initializer
+
+|Kafka Bridge
+a|
+* {DockerOrg}/kafka-bridge:{DockerTag}
+
+a|
+{ProductName} image for running the {ProductName} Kafka Bridge
 
 |===

--- a/documentation/book/snip-images.adoc
+++ b/documentation/book/snip-images.adoc
@@ -6,7 +6,9 @@
 
 |Kafka
 a|
+* {DockerOrg}/kafka:{DockerTag}-kafka-2.1.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-2.1.1
+* {DockerOrg}/kafka:{DockerTag}-kafka-2.2.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-2.2.1
 
 a|
@@ -32,9 +34,9 @@ a|
 
 |Kafka Bridge
 a|
-* {DockerOrg}/kafka-bridge:{BridgeDockerTag}
+* {DockerOrg}/kafka-bridge:{DockerTag}
 
 a|
-{ProductName} image for running the {ProductName} Kafka Bridge
+{ProductName} image for running the {ProductName} kafka Bridge
 
 |===

--- a/documentation/book/snip-images.adoc
+++ b/documentation/book/snip-images.adoc
@@ -6,9 +6,7 @@
 
 |Kafka
 a|
-* {DockerOrg}/kafka:{DockerTag}-kafka-2.1.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-2.1.1
-* {DockerOrg}/kafka:{DockerTag}-kafka-2.2.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-2.2.1
 
 a|
@@ -37,6 +35,6 @@ a|
 * {DockerOrg}/kafka-bridge:{DockerTag}
 
 a|
-{ProductName} image for running the {ProductName} Kafka Bridge
+{ProductName} image for running the {ProductName} kafka Bridge
 
 |===

--- a/documentation/book/snip-images.adoc
+++ b/documentation/book/snip-images.adoc
@@ -32,9 +32,9 @@ a|
 
 |Kafka Bridge
 a|
-* {DockerOrg}/kafka-bridge:{DockerTag}
+* {DockerOrg}/kafka-bridge:{BridgeDockerTag}
 
 a|
-{ProductName} image for running the {ProductName} kafka Bridge
+{ProductName} image for running the {ProductName} Kafka Bridge
 
 |===

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -75,6 +75,7 @@
 // Container image names and repositories
 :DockerOrg: docker.io/strimzi
 :DockerTag: {ProductVersion}
+:BridgeDockerTag: {ProductVersion}
 :DockerRepository: https://hub.docker.com/u/strimzi[Docker Hub^]
 :DockerZookeeper: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerZookeeperStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -78,8 +78,10 @@
 :DockerRepository: https://hub.docker.com/u/strimzi[Docker Hub^]
 :DockerZookeeper: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerZookeeperStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerKafkaImage: strimzi/kafka
+:DockerKafkaImageCurrent: strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}
+:DockerKafkaImagePrevious: strimzi/kafka:{DockerTag}-kafka-{KafkaVersionLower}
 :DockerKafka: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
+:DockerKafkaBridge: strimzi/kafka:{DockerTag}-kafka-bridge-{DefaultKafkaVersion}
 :DockerKafkaStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaConnect: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaConnectS2I: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -81,7 +81,6 @@
 :DockerKafkaImageCurrent: strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}
 :DockerKafkaImagePrevious: strimzi/kafka:{DockerTag}-kafka-{KafkaVersionLower}
 :DockerKafka: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
-:DockerKafkaBridge: strimzi/kafka:{DockerTag}-kafka-bridge-{DefaultKafkaVersion}
 :DockerKafkaStunnel: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaConnect: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaConnectS2I: strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}

--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -25,7 +25,7 @@ a|
 {ProductName} image for running Kafka, including:
 
 * Kafka Broker
-* Kafka Connect
+* Kafka Connect / S2I
 * Kafka Mirror Maker
 * Zookeeper
 * TLS Sidecars
@@ -42,6 +42,12 @@ a|
 * User Operator
 * Kafka Initializer
 
+|Kafka Bridge
+a|
+* {DockerOrg}/kafka-bridge:{DockerTag}
+
+a|
+{ProductName} image for running the {ProductName} kafka Bridge
+
 |===
 EOF
-


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Updates to the container image references. Replaced with attributes that can be reused in Cluster Operator Configuration section.

The script to generate the content for the Container Images section has been updated. 

+ broken link fixes

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

