### PR TITLE
[DOC] Action if the resource upgrade does not take effect

### DIFF
--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -8,7 +8,22 @@ For this release of {ProductName}, resources that use the API version `{KafkaApi
 
 The `{KafkaApiVersionPrev}` API version is deprecated in release {ProductVersion}.
 
+This section describes the upgrade steps for the resources.
+
 IMPORTANT: The upgrade of resources _must_ be performed after xref:assembly-upgrade-{context}[upgrading the Cluster Operator], so the Cluster Operator can understand the resources.
+
+.What if the resource upgrade does not take effect?
+If the upgrade does not take effect and a warning is given on reconciliation, make a cosmetic change to the custom resource, such as adding an annotation, to trigger the update.
+
+For example:
+
+[source,shell,subs="+quotes,attributes"]
+----
+metadata:
+  # ...
+  annotations:
+    upgrade: "Upgraded to {KafkaApiVersion}"
+----
 
 include::proc-upgrading-kafka-resources.adoc[leveloffset=+1]
 include::proc-upgrading-kafka-connect-resources.adoc[leveloffset=+1]

--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -13,7 +13,7 @@ This section describes the upgrade steps for the resources.
 IMPORTANT: The upgrade of resources _must_ be performed after xref:assembly-upgrade-{context}[upgrading the Cluster Operator], so the Cluster Operator can understand the resources.
 
 .What if the resource upgrade does not take effect?
-If the upgrade does not take effect, a warning is given in the logs on reconciliation to say that the resource cannot be updated until the apiVersion is updated.
+If the upgrade does not take effect, a warning is given in the logs on reconciliation to indicate that the resource cannot be updated until the `apiVersion` is updated.
 
 To trigger the update, make a cosmetic change to the custom resource, such as adding an annotation.
 

--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -13,7 +13,7 @@ This section describes the upgrade steps for the resources.
 IMPORTANT: The upgrade of resources _must_ be performed after xref:assembly-upgrade-{context}[upgrading the Cluster Operator], so the Cluster Operator can understand the resources.
 
 .What if the resource upgrade does not take effect?
-If the upgrade does not take effect, a warning is given in the logs on reconciliation to say that the resource cannot be updated until the apiVersion is updated
+If the upgrade does not take effect, a warning is given in the logs on reconciliation to say that the resource cannot be updated until the apiVersion is updated.
 
 To trigger the update, make a cosmetic change to the custom resource, such as adding an annotation.
 

--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -13,9 +13,11 @@ This section describes the upgrade steps for the resources.
 IMPORTANT: The upgrade of resources _must_ be performed after xref:assembly-upgrade-{context}[upgrading the Cluster Operator], so the Cluster Operator can understand the resources.
 
 .What if the resource upgrade does not take effect?
-If the upgrade does not take effect and a warning is given on reconciliation, make a cosmetic change to the custom resource, such as adding an annotation, to trigger the update.
+If the upgrade does not take effect, a warning is given in the logs on reconciliation to say that the resource cannot be updated until the apiVersion is updated
 
-For example:
+To trigger the update, make a cosmetic change to the custom resource, such as adding an annotation.
+
+Example annotation:
 
 [source,shell,subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

It is possible that the custom resource upgrades don't take effect. It might be that deprecated properties aren't being used. 

A note has been added at the start the chapter to describe how to kick-start the upgrade with an annotation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

