### PR TITLE
Added check for bash >4 based on suggestion from @tombentley.

### DIFF
--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -45,6 +45,9 @@ function build {
     done
 }
 
+# Check for bash >= 4
+if [[ $(echo "${BASH_VERSION}" | cut -c 1) -lt 4 ]]; then echo -e "You need bash version >= 4 to build Strimzi.\nRefer to HACKING.md for more information"; fi
+
 load_checksums
 build $@
 


### PR DESCRIPTION
### Type of change

Added check to see if version of bash is >= 4

_Select the type of your PR_

- Enhancement / new feature

### Description

Fails with error message if ${BASH_VERSION} < 4
