### PR TITLE
PR Job: correction of failed test parsing for  github notificaiton

### DIFF
--- a/systemtest/scripts/get_failures.sh
+++ b/systemtest/scripts/get_failures.sh
@@ -2,14 +2,14 @@
 
 JSON_FILE=failures.json
 
-FAILURES=$(find . -name 'TEST*.xml' -type f -print0 | xargs -0 grep "<testcase.*time=\"[0-9]\{1,\}\..*[^\/]>$" | cut -d '"'  -f 2,4)
+FAILURES=$(find . -name 'TEST*.xml' -type f -print0 | xargs -0 grep "<testcase.*time=\"[0-9]*,\{0,1\}[0-9]\{1,3\}\..*[^\/]>$" | cut -d '"'  -f 2,4)
 echo ${FAILURES} > ${JSON_FILE}
 cat ${JSON_FILE}
 
 echo "Creating body ..."
 
-TMP=$(cat ${JSON_FILE} | sed 's@ @\\n - @g' | sed 's@"@ in @g')
+TMP=$(cat ${JSON_FILE} | sed 's@ST @ST\\n - @g' | sed 's@"@ in @g')
 
 BODY="{\"body\":\"**Test Failures**\n- ${TMP}\"}"
 echo ${BODY} > ${JSON_FILE}
-cat ${JSON_FILE} 
+cat ${JSON_FILE}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Parsing of failed test during jenkins job wasn't correct. This changes allows parsing of parameterized tests and test with long run time (1000 seconds+)

### Checklist

- [ ] Make sure all tests pass

