### PR TITLE
ST: Configuring image name for test-client

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -73,7 +73,7 @@ public class Environment {
     static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = System.getenv().getOrDefault(STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_ENV, STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_DEFAULT);
     static final String SKIP_TEARDOWN = System.getenv(SKIP_TEARDOWN_ENV);
     // variables for test-client image
-    private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
+    private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
 
     private Environment() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -27,17 +27,9 @@ public class Environment {
      */
     private static final String STRIMZI_TAG_ENV = "DOCKER_TAG";
     /**
-     * Specify organization which owns test-client used in system tests.
+     * Specify test-client image used in system tests.
      */
-    private static final String TEST_CLIENT_ORG_ENV = "TEST_CLIENT_ORG";
-    /**
-     * Specify registry for test-client used in system tests.
-     */
-    private static final String TEST_CLIENT_REGISTRY_ENV = "TEST_CLIENT_REGISTRY";
-    /**
-     * Specify test-client tags used in system tests.
-     */
-    private static final String TEST_CLIENT_TAG_ENV = "TEST_CLIENT_TAG";
+    private static final String TEST_CLIENT_IMAGE_ENV = "TEST_CLIENT_IMAGE";
     /**
      * Directory for store logs collected during the tests.
      */
@@ -61,11 +53,12 @@ public class Environment {
 
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
 
+    private static final String ST_KAFKA_VERSION_DEFAULT = "2.2.1";
     private static final String STRIMZI_ORG_DEFAULT = "strimzi";
     private static final String STRIMZI_TAG_DEFAULT = "latest";
     private static final String STRIMZI_REGISTRY_DEFAULT = "docker.io";
+    private static final String TEST_CLIENT_IMAGE_DEFAULT = "strimzi/test-client:latest-kafka-" + ST_KAFKA_VERSION_DEFAULT;
     private static final String TEST_LOG_DIR_DEFAULT = "../systemtest/target/logs/";
-    private static final String ST_KAFKA_VERSION_DEFAULT = "2.2.1";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";
     private static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_DEFAULT = "30000";
@@ -74,9 +67,7 @@ public class Environment {
     public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
     public static final String STRIMZI_TAG = System.getenv().getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
     public static final String STRIMZI_REGISTRY = System.getenv().getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
-    public static final String TEST_CLIENT_ORG = System.getenv().getOrDefault(TEST_CLIENT_ORG_ENV, STRIMZI_ORG);
-    public static final String TEST_CLIENT_TAG = System.getenv().getOrDefault(TEST_CLIENT_TAG_ENV, STRIMZI_TAG);
-    public static final String TEST_CLIENT_REGISTRY = System.getenv().getOrDefault(TEST_CLIENT_REGISTRY_ENV, STRIMZI_REGISTRY);
+    public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
     static final String TEST_LOG_DIR = System.getenv().getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
     static final String ST_KAFKA_VERSION = System.getenv().getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);
     static final String STRIMZI_LOG_LEVEL = System.getenv().getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
@@ -93,9 +84,7 @@ public class Environment {
         LOGGER.info(debugFormat, STRIMZI_ORG_ENV, STRIMZI_ORG);
         LOGGER.info(debugFormat, STRIMZI_TAG_ENV, STRIMZI_TAG);
         LOGGER.info(debugFormat, STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY);
-        LOGGER.info(debugFormat, TEST_CLIENT_ORG_ENV, TEST_CLIENT_ORG);
-        LOGGER.info(debugFormat, TEST_CLIENT_TAG_ENV, TEST_CLIENT_TAG);
-        LOGGER.info(debugFormat, TEST_CLIENT_REGISTRY_ENV, TEST_CLIENT_REGISTRY);
+        LOGGER.info(debugFormat, TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE);
         LOGGER.info(debugFormat, TEST_LOG_DIR_ENV, TEST_LOG_DIR);
         LOGGER.info(debugFormat, ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION);
         LOGGER.info(debugFormat, STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL);

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -57,7 +57,6 @@ public class Environment {
     private static final String STRIMZI_ORG_DEFAULT = "strimzi";
     private static final String STRIMZI_TAG_DEFAULT = "latest";
     private static final String STRIMZI_REGISTRY_DEFAULT = "docker.io";
-    private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_ORG_DEFAULT + "/test-client:" + STRIMZI_TAG_DEFAULT + "-kafka-" + ST_KAFKA_VERSION_DEFAULT;
     private static final String TEST_LOG_DIR_DEFAULT = "../systemtest/target/logs/";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";
@@ -67,13 +66,15 @@ public class Environment {
     public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
     public static final String STRIMZI_TAG = System.getenv().getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
     public static final String STRIMZI_REGISTRY = System.getenv().getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
-    public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
     static final String TEST_LOG_DIR = System.getenv().getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
     static final String ST_KAFKA_VERSION = System.getenv().getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);
     static final String STRIMZI_LOG_LEVEL = System.getenv().getOrDefault(STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL_DEFAULT);
     static final String KUBERNETES_DOMAIN = System.getenv().getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
     static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = System.getenv().getOrDefault(STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_ENV, STRIMZI_FULL_RECONCILIATION_INTERVAL_MS_DEFAULT);
     static final String SKIP_TEARDOWN = System.getenv(SKIP_TEARDOWN_ENV);
+    // variables for test-client image
+    private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
+    public static final String TEST_CLIENT_IMAGE = System.getenv().getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);
 
     private Environment() {
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -57,7 +57,7 @@ public class Environment {
     private static final String STRIMZI_ORG_DEFAULT = "strimzi";
     private static final String STRIMZI_TAG_DEFAULT = "latest";
     private static final String STRIMZI_REGISTRY_DEFAULT = "docker.io";
-    private static final String TEST_CLIENT_IMAGE_DEFAULT = "strimzi/test-client:latest-kafka-" + ST_KAFKA_VERSION_DEFAULT;
+    private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_ORG_DEFAULT + "/test-client:" + STRIMZI_TAG_DEFAULT + "-kafka-" + ST_KAFKA_VERSION_DEFAULT;
     private static final String TEST_LOG_DIR_DEFAULT = "../systemtest/target/logs/";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -906,7 +906,7 @@ public class Resources extends AbstractResources {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(Constants.KAFKA_CLIENTS)
-                .withImage(StUtils.changeOrgAndTag(Environment.TEST_CLIENT_IMAGE))
+                .withImage(Environment.TEST_CLIENT_IMAGE)
                 .addNewPort()
                     .withContainerPort(4242)
                 .endPort()

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -906,7 +906,7 @@ public class Resources extends AbstractResources {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(Constants.KAFKA_CLIENTS)
-                .withImage(StUtils.changeTestClientOrgAndTag("strimzi/test-client:latest-kafka-" + KAFKA_VERSION))
+                .withImage(StUtils.changeOrgAndTag(Environment.TEST_CLIENT_IMAGE))
                 .addNewPort()
                     .withContainerPort(4242)
                 .endPort()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -422,15 +422,6 @@ public class StUtils {
         return changeOrgAndTag(image, Environment.STRIMZI_REGISTRY, Environment.STRIMZI_ORG, Environment.STRIMZI_TAG);
     }
 
-    /**
-     * The method to configure docker image to use proper docker registry, docker org and docker tag for test-client image.
-     * @param image Test-client image that needs to be changed
-     * @return Updated test-client image with a proper registry, org, tag
-     */
-    public static String changeTestClientOrgAndTag(String image) {
-        return changeOrgAndTag(image, Environment.TEST_CLIENT_REGISTRY, Environment.TEST_CLIENT_ORG, Environment.TEST_CLIENT_TAG);
-    }
-
     public static String changeOrgAndTagInImageMap(String imageMap) {
         Matcher m = VERSION_IMAGE_PATTERN.matcher(imageMap);
         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
### Type of change
- Refactoring


### Description
Due to the fact that the image name may contain a version of Kafka such as "2.2", the ability to set the full address of the `test-client` image was added. We have to do it in this way to avoid confusion when setting up different images.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass