### PR TITLE
Fix partially #1722

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -187,17 +187,17 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
             if (reconcileResult.succeeded())    {
                 readyCondition = new ConditionBuilder()
-                        .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
-                        .withNewType("Ready")
-                        .withNewStatus("True")
+                        .withLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
+                        .withType("Ready")
+                        .withStatus("True")
                         .build();
             } else {
                 readyCondition = new ConditionBuilder()
-                        .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
-                        .withNewType("NotReady")
-                        .withNewStatus("True")
-                        .withNewReason(reconcileResult.cause().getClass().getSimpleName())
-                        .withNewMessage(reconcileResult.cause().getMessage())
+                        .withLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
+                        .withType("NotReady")
+                        .withStatus("True")
+                        .withReason(reconcileResult.cause().getClass().getSimpleName())
+                        .withMessage(reconcileResult.cause().getMessage())
                         .build();
             }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes _one of_ the NPEs in #1722, which was cause by a null exception message. It turned out that `addNew*(String)` methods will make a copy of the string parameter, so NPE on a null argument. So for the time being we should avoid using `addNew*(String)` methods especially with non-literal arguments in order to avoid similar NPEs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

