### PR TITLE
UO should ignore Kafka built-in special users - Closes #1371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.13.0
+
+* Allow users to manually configure ACL rules for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
+
 ## 0.12.0
 
 * **Drop support for Kubernetes 1.9 and 1.10 and OpenShift 3.9 and 3.10.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.0
 
-* Allow users to manually configure ACL rules for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
+* Allow users to manually configure ACL rules (for example, using using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.0
 
-* Allow users to manually configure ACL rules (for example, using using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
+* Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
 
 ## 0.12.0
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
@@ -62,6 +63,7 @@ public class KafkaUserOperator {
             "abcdefghijklmnopqrstuvwxyz" +
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
                     "0123456789");
+    private static final List<String> IGNORED_USERS = Arrays.asList("*", "ANONYMOUS");
 
     /**
      * @param vertx The Vertx instance.
@@ -247,7 +249,7 @@ public class KafkaUserOperator {
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
             future -> {
                 try {
-                    Set<String> usersWithAcls = aclOperations.getUsersWithAcls();
+                    Set<String> usersWithAcls = aclOperations.getUsersWithAcls().stream().filter(user -> !IGNORED_USERS.contains(user)).collect(Collectors.toSet());
                     future.complete(usersWithAcls);
                 } catch (Throwable t) {
                     future.failed();

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
@@ -63,7 +62,6 @@ public class KafkaUserOperator {
             "abcdefghijklmnopqrstuvwxyz" +
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
                     "0123456789");
-    private static final List<String> IGNORED_USERS = Arrays.asList("*", "ANONYMOUS");
 
     /**
      * @param vertx The Vertx instance.
@@ -249,7 +247,7 @@ public class KafkaUserOperator {
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
             future -> {
                 try {
-                    Set<String> usersWithAcls = aclOperations.getUsersWithAcls().stream().filter(user -> !IGNORED_USERS.contains(user)).collect(Collectors.toSet());
+                    Set<String> usersWithAcls = aclOperations.getUsersWithAcls();
                     future.complete(usersWithAcls);
                 } catch (Throwable t) {
                     future.failed();

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -71,10 +71,14 @@ public class SimpleAclOperatorTest {
         Acl barAcl = new Acl(bar, Allow$.MODULE$, "*", Read$.MODULE$);
         KafkaPrincipal baz = new KafkaPrincipal("User", "baz");
         Acl bazAcl = new Acl(baz, Allow$.MODULE$, "*", Read$.MODULE$);
+        KafkaPrincipal all = new KafkaPrincipal("User", "*");
+        Acl allAcl = new Acl(all, Allow$.MODULE$, "*", Read$.MODULE$);
+        KafkaPrincipal anonymous = new KafkaPrincipal("User", "ANONYMOUS");
+        Acl anonymousAcl = new Acl(anonymous, Allow$.MODULE$, "*", Read$.MODULE$);
         Resource res1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
         Resource res2 = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set2<>(fooAcl, barAcl);
-        scala.collection.immutable.Set<Acl> set2 = new scala.collection.immutable.Set.Set1<>(bazAcl);
+        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set3<>(fooAcl, barAcl, allAcl);
+        scala.collection.immutable.Set<Acl> set2 = new scala.collection.immutable.Set.Set2<>(bazAcl, anonymousAcl);
         scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map2<>(res1, set1, res2, set2);
         when(mockAuthorizer.getAcls()).thenReturn(map);
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, users cannot set manually ACL rules for users such as `User:ANONYMOUS` or `User:*` when UO is enabled because it would delete the ACL rules as a rules for non-existent user. At the same time, the UO cannot manage these rules because `ANONYMOUS` and `*` are not valid Kubernetes names.

This PR adds exception handling to ignore these special users (and just print an info log messages so that users are aware of it).

This should close #1371.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

