### PR TITLE
ST: change registry, org and tag for images correctly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -54,9 +54,9 @@ public class Environment {
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = "2.2.1";
-    private static final String STRIMZI_ORG_DEFAULT = "strimzi";
-    private static final String STRIMZI_TAG_DEFAULT = "latest";
-    private static final String STRIMZI_REGISTRY_DEFAULT = "docker.io";
+    public static final String STRIMZI_ORG_DEFAULT = "strimzi";
+    public static final String STRIMZI_TAG_DEFAULT = "latest";
+    public static final String STRIMZI_REGISTRY_DEFAULT = "docker.io";
     private static final String TEST_LOG_DIR_DEFAULT = "../systemtest/target/logs/";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -427,7 +427,7 @@ public class StUtils {
             String org = setImageProperties(m.group("org"), Environment.STRIMZI_ORG, Environment.STRIMZI_ORG_DEFAULT);
             String tag = setImageProperties(m.group("tag"), newTag, Environment.STRIMZI_TAG_DEFAULT);
 
-            return org + "/" + m.group("image") + ":" + tag;
+            return Environment.STRIMZI_REGISTRY + "/" + org + "/" + m.group("image") + ":" + tag;
         }
         return image;
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Feature for changing registries/org/tags for images loaded from installation files worked correctly only with image names which started with `strimzi`. This PR add option to change each part of image (instead image name) via env variables.

### Checklist

- [x] Make sure all tests pass


