### PR TITLE
Upgrade Prometheus JMX exporter 0.1.0 → 0.11.0

### DIFF
--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -24,7 +24,7 @@ ENV JMX_EXPORTER_VERSION=0.11.0
 
 # Set Kafka (SHA512) and Prometheus JMX exporter (SHA1) checksums
 ENV KAFKA_CHECKSUM="${KAFKA_SHA512}  kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-ENV JMX_EXPORTER_CHECKSUM="535a033b38298ee19d4faa458de8af4072e9fd3a jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
+ENV JMX_EXPORTER_CHECKSUM="535a033b38298ee19d4faa458de8af4072e9fd3a  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
 
 # Downloading Prometheus JMX exporter
 RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar \

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -20,11 +20,11 @@ RUN useradd -r -m -u 1001 -g 0 kafka
 ENV KAFKA_VERSION=${KAFKA_VERSION}
 ENV STRIMZI_VERSION=${strimzi_version}
 ENV SCALA_VERSION=2.12
-ENV JMX_EXPORTER_VERSION=0.1.0
+ENV JMX_EXPORTER_VERSION=0.11.0
 
 # Set Kafka (SHA512) and Prometheus JMX exporter (SHA1) checksums
 ENV KAFKA_CHECKSUM="${KAFKA_SHA512}  kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-ENV JMX_EXPORTER_CHECKSUM="6ab370edccc2eeb3985f4c95769c26c090d0e052 jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
+ENV JMX_EXPORTER_CHECKSUM="535a033b38298ee19d4faa458de8af4072e9fd3a jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
 
 # Downloading Prometheus JMX exporter
 RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar \


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Upgrade Prometheus JMX exporter 0.1.0 → 0.11.0

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

