### PR TITLE
Add Kubernetes Service DNS Domain environment variable to Helm chart.

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -49,8 +49,8 @@ spec:
               value: "{{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
-            - name: KUBERNETES_SERVICE_DNS_DOMAIN
-              value: {{ .Values.kubernetesServiceDnsDomain | quote }}
+            {{ if ne .Values.kubernetesServiceDnsDomain "cluster.local" }}- name: KUBERNETES_SERVICE_DNS_DOMAIN
+              value: {{ .Values.kubernetesServiceDnsDomain | quote }}{{ end }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -49,6 +49,8 @@ spec:
               value: "{{ default .Values.kafkaBridge.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.kafkaBridge.image.tag .Values.imageTagOverride }}"
             - name: STRIMZI_LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
+            - name: KUBERNETES_SERVICE_DNS_DOMAIN
+              value: {{ .Values.kubernetesServiceDnsDomain | quote }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -10,6 +10,7 @@ image:
 logLevel: INFO
 fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
+kubernetesServiceDnsDomain: cluster.local
 # Docker images that operator uses to provision various components of Strimzi.  To use your own registry prefix the
 # repository name with your registry URL.
 # Ex) repository: registry.xyzcorp.com/strimzi/zookeeper


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

In the Strimzi Kafka operator, an environment variable called "KUBERNETES_SERVICE_DNS_DOMAIN" is used to configure the DNS domain the operator uses. This domain is for example used by Strimzi to generate the certificates for the services. When a cluster uses a different domain than the default and Strimzi still uses the default name to generate the service certificates, this will cause the following error:
"no subject alternative DNS name matching... found".

Currently, the Helm chart doesn't provide a way to configure this environment variable. This PR adds this functionality.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

