### PR TITLE
ST: add test for statuses

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
@@ -63,7 +63,7 @@ abstract class AbstractResources {
         return client;
     }
 
-    MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafka() {
+    public MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafka() {
         return customResourcesWithCascading(Kafka.class, KafkaList.class, DoneableKafka.class);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -111,9 +111,9 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
 
     public static final String TEST_LOG_DIR = Environment.TEST_LOG_DIR;
 
-    public Resources testMethodResources;
-    public static Resources testClassResources;
-    static String operationID;
+    protected Resources testMethodResources;
+    protected static Resources testClassResources;
+    protected static String operationID;
     Random rng = new Random();
 
     protected HelmClient helmClient() {
@@ -184,7 +184,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
         namedResource.replace(resource);
     }
 
-    void replaceKafkaResource(String resourceName, Consumer<Kafka> editor) {
+    protected void replaceKafkaResource(String resourceName, Consumer<Kafka> editor) {
         replaceCrdResource(Kafka.class, KafkaList.class, DoneableKafka.class, resourceName, editor);
     }
 
@@ -436,6 +436,10 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
         return testMethodResources;
     }
 
+    public Resources testClassResources() {
+        return testClassResources;
+    }
+
     String startTimeMeasuring(Operation operation) {
         TimeMeasuringSystem.setTestName(testClass, testName);
         return TimeMeasuringSystem.startOperation(operation);
@@ -495,7 +499,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
      * @param coNamespace namespace where CO will be deployed to
      * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
      */
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         testClassResources.deleteResources();
 
         deleteClusterOperatorInstallFiles();
@@ -735,11 +739,11 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
         }
     }
 
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
     }
 
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
         testClassResources.deleteResources();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/HttpBridgeBaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/HttpBridgeBaseST.java
@@ -204,7 +204,7 @@ public class HttpBridgeBaseST extends MessagingBaseST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         LOGGER.info("Skipping env recreation after each test - deployment should be same for whole test class!");
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -244,7 +244,7 @@ public class Resources extends AbstractResources {
         return kafka(defaultKafka(name, kafkaReplicas, zookeeperReplicas).build());
     }
 
-    DoneableKafka kafkaJBOD(String name, int kafkaReplicas, JbodStorage jbodStorage) {
+    public DoneableKafka kafkaJBOD(String name, int kafkaReplicas, JbodStorage jbodStorage) {
         return kafka(defaultKafka(name, kafkaReplicas).
                 editSpec()
                     .editKafka()
@@ -257,11 +257,11 @@ public class Resources extends AbstractResources {
                 .build());
     }
 
-    KafkaBuilder defaultKafka(String name, int kafkaReplicas) {
+    public KafkaBuilder defaultKafka(String name, int kafkaReplicas) {
         return defaultKafka(name, kafkaReplicas, 3);
     }
 
-    KafkaBuilder defaultKafka(String name, int kafkaReplicas, int zookeeperReplicas) {
+    public KafkaBuilder defaultKafka(String name, int kafkaReplicas, int zookeeperReplicas) {
         String tOImage = StUtils.changeOrgAndTag(getImageValueFromCO("STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE"));
         String uOImage = StUtils.changeOrgAndTag(getImageValueFromCO("STRIMZI_DEFAULT_USER_OPERATOR_IMAGE"));
 
@@ -656,11 +656,11 @@ public class Resources extends AbstractResources {
         return TestUtils.configFromYaml(yamlPath, Deployment.class);
     }
 
-    DoneableDeployment clusterOperator(String namespace) {
+    public DoneableDeployment clusterOperator(String namespace) {
         return clusterOperator(namespace, "300000");
     }
 
-    DoneableDeployment clusterOperator(String namespace, String operationTimeout) {
+    public DoneableDeployment clusterOperator(String namespace, String operationTimeout) {
         return createNewDeployment(defaultCLusterOperator(namespace, operationTimeout).build(), namespace);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -11,6 +11,8 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.test.TestUtils;
@@ -394,6 +396,15 @@ public class StUtils {
 
         TestUtils.waitFor("namespace " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> !kubeClient().getNamespaceStatus(name));
+    }
+
+    public static void waitForKafkaCluster(Kafka kafka) {
+        String name = kafka.getMetadata().getName();
+        String namespace = kafka.getMetadata().getNamespace();
+        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(name), kafka.getSpec().getZookeeper().getReplicas());
+        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
+        StUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
+        LOGGER.info("Kafka cluster {} in namesapce {} is ready", name, namespace);
     }
 
     public static void waitForKafkaTopicDeletion(String topicName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -75,7 +75,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         setNamespace(SECOND_NAMESPACE);
         secondNamespaceResources.deleteResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -136,14 +136,14 @@ class AllNamespaceST extends AbstractNamespaceST {
     }
 
     @Override
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
         thirdNamespaceResources.deleteResources();
         testClassResources.deleteResources();
         teardownEnvForOperator();
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -75,7 +75,7 @@ class ConnectS2IST extends AbstractST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -268,7 +268,7 @@ class ConnectST extends AbstractST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.timemeasuring.Operation;
+import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(REGRESSION)
+class CustomResourceStatusST extends AbstractST {
+    static final String NAMESPACE = "status-cluster-test";
+    private static final Logger LOGGER = LogManager.getLogger(CustomResourceStatusST.class);
+    private static final String TOPIC_NAME = "status-topic";
+
+    @Test
+    void testKafkaStatus() throws Exception {
+        LOGGER.info("Checking status of deployed kafka cluster");
+        Condition kafkaCondition = testClassResources.kafka().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+        logCurrentStatus(kafkaCondition);
+        assertThat("Kafka cluster is in wrong state!", kafkaCondition.getType(), is("Ready"));
+        LOGGER.info("Kafka cluster is in desired state: Ready");
+
+        waitForClusterAvailability(NAMESPACE, TOPIC_NAME);
+
+        replaceKafkaResource(CLUSTER_NAME, k -> {
+            k.getSpec().getZookeeper().setResources(new ResourceRequirementsBuilder()
+                    .addToRequests("cpu", new Quantity("100000m"))
+                    .build());
+        });
+
+        LOGGER.info("Wait until cluster will be in NotReady state ...");
+        waitForKafkaStatus("NotReady");
+
+        LOGGER.info("Recovery cluster to Ready state ...");
+        replaceKafkaResource(CLUSTER_NAME, k -> {
+            k.getSpec().getZookeeper().setResources(new ResourceRequirementsBuilder()
+                    .addToRequests("cpu", new Quantity("10m"))
+                    .build());
+        });
+    }
+
+    @AfterEach
+    void checkClusterAvailability() {
+        LOGGER.info("Wait until status will be in Ready state (AfterEach phase) ...");
+        waitForKafkaStatus("Ready");
+    }
+
+    @BeforeAll
+    void createClassResources() {
+        createTestEnvironment();
+    }
+
+    private String startDeploymentMeasuring() {
+        TimeMeasuringSystem.setTestName(testClass, testClass);
+        return TimeMeasuringSystem.startOperation(Operation.CLASS_EXECUTION);
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        createTestEnvironment();
+    }
+
+    @Override
+    protected void tearDownEnvironmentAfterAll() {
+        teardownEnvForOperator();
+    }
+
+    void createTestEnvironment() {
+        LOGGER.info("Create resources for the tests");
+        prepareEnvForOperator(NAMESPACE);
+
+        createTestClassResources();
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        testClassResources.clusterOperator(NAMESPACE, Long.toString(Constants.CO_OPERATION_TIMEOUT)).done();
+
+        operationID = startDeploymentMeasuring();
+
+        testClassResources.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+                .editSpec()
+                .editKafka()
+                .editListeners()
+                .withNewKafkaListenerExternalNodePort()
+                .withTls(false)
+                .endKafkaListenerExternalNodePort()
+                .endListeners()
+                .endKafka()
+                .endSpec()
+                .done();
+
+        testClassResources.topic(CLUSTER_NAME, TOPIC_NAME);
+    }
+
+    void logCurrentStatus(Condition kafkaCondition) {
+        LOGGER.debug("Kafka Status: {}", kafkaCondition.getStatus());
+        LOGGER.debug("Kafka Type: {}", kafkaCondition.getType());
+        LOGGER.debug("Kafka Message: {}", kafkaCondition.getMessage());
+    }
+
+    void waitForKafkaStatus(String status) {
+        TestUtils.waitFor("Wait until status is false", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
+            Condition kafkaCondition = testClassResources().kafka().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+            logCurrentStatus(kafkaCondition);
+            return kafkaCondition.getType().equals(status);
+        });
+        LOGGER.info("Kafka cluster is in desired state: {}", status);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -46,19 +46,19 @@ class HelmChartST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }
 
     @Override
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
         deleteClusterOperatorViaHelmChart();
         deleteNamespaces();
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         deleteClusterOperatorViaHelmChart();
         deleteNamespaces();
         createNamespace(NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1182,7 +1182,7 @@ class KafkaST extends MessagingBaseST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -361,12 +361,12 @@ class LogSettingST extends AbstractST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         LOGGER.info("Skip env recreation after failed tests!");
     }
 
     @Override
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
         teardownEnvForOperator();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -85,7 +85,7 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
@@ -207,18 +207,18 @@ public class OpenShiftTemplatesST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
         deleteCustomResources();
         deleteNamespaces();
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() {
+    protected void tearDownEnvironmentAfterEach() {
 
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         LOGGER.info("Skip env recreation after failed tests!");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -204,7 +204,7 @@ class RecoveryST extends AbstractST {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces);
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -177,7 +177,7 @@ class RollingUpdateST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -439,7 +439,7 @@ class SecurityST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -267,18 +267,18 @@ public class StrimziUpgradeST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() {
+    protected void tearDownEnvironmentAfterEach() {
         deleteNamespaces();
     }
 
     // There is no value of having teardown logic for class resources due to the fact that
     // CO was deployed by method StrimziUpgradeST.copyModifyApply() and removed by method StrimziUpgradeST.deleteInstalledYamls()
     @Override
-    void tearDownEnvironmentAfterAll() {
+    protected void tearDownEnvironmentAfterAll() {
     }
 
     @Override
-    void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         deleteNamespaces();
         createNamespace(NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -106,7 +106,7 @@ class UserST extends AbstractST {
     }
 
     @Override
-    void tearDownEnvironmentAfterEach() throws Exception {
+    protected void tearDownEnvironmentAfterEach() throws Exception {
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

New system test for Kafka CR status. Test covers two scenarios:
* Check if cluster is in `Ready` state
* Break cluster and check, if status is in `NotReady` state

### Checklist

- [x] Make sure all tests pass

