### PR TITLE
Add support for PriorityClass name in Pod template - Closes #1753

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.13.0
 
-* Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
-* Add support for configuring a Priority Class name for Pods deployed by Strimzi.
+* Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator
+* Add support for configuring a Priority Class name for Pods deployed by Strimzi
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.13.0
 
 * Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
+* Add support for configuring Priority Class name for Pods deployed by Strimzi
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.13.0
 
 * Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator.
-* Add support for configuring Priority Class name for Pods deployed by Strimzi
+* Add support for configuring a Priority Class name for Pods deployed by Strimzi.
 
 ## 0.12.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -47,7 +47,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private String priorityClassName;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Metadata which should be applied to the resource.")
+    @Description("Metadata applied to the resource.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public MetadataTemplate getMetadata() {
         return metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -44,6 +44,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private int terminationGracePeriodSeconds = 30;
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private String priorityClassName;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metadata which should be applied to the resource.")
@@ -114,6 +115,16 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("The name of the Priority Class to which this pods should be assigned.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getPriorityClassName() {
+        return priorityClassName;
+    }
+
+    public void setPriorityClassName(String priorityClassName) {
+        this.priorityClassName = priorityClassName;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -117,7 +117,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
         this.tolerations = tolerations;
     }
 
-    @Description("The name of the Priority Class to which this pods should be assigned.")
+    @Description("The name of the Priority Class to which these pods will be assigned.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String getPriorityClassName() {
         return priorityClassName;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -170,6 +170,7 @@ public abstract class AbstractModel {
     protected Map<String, String> templatePodDisruptionBudgetLabels;
     protected Map<String, String> templatePodDisruptionBudgetAnnotations;
     protected int templatePodDisruptionBudgetMaxUnavailable = 1;
+    protected String templatePodPriorityClassName;
 
     // Owner Reference information
     private String ownerApiVersion;
@@ -836,6 +837,7 @@ public abstract class AbstractModel {
                             .withTerminationGracePeriodSeconds(Long.valueOf(templateTerminationGracePeriodSeconds))
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(securityContext)
+                            .withPriorityClassName(templatePodPriorityClassName)
                         .endSpec()
                     .endTemplate()
                     .withVolumeClaimTemplates(volumeClaims)
@@ -882,6 +884,7 @@ public abstract class AbstractModel {
                             .withTerminationGracePeriodSeconds(Long.valueOf(templateTerminationGracePeriodSeconds))
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(templateSecurityContext)
+                            .withPriorityClassName(templatePodPriorityClassName)
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -160,6 +160,7 @@ public class EntityOperator extends AbstractModel {
                     result.templateTerminationGracePeriodSeconds = pod.getTerminationGracePeriodSeconds();
                     result.templateImagePullSecrets = pod.getImagePullSecrets();
                     result.templateSecurityContext = pod.getSecurityContext();
+                    result.templatePodPriorityClassName = pod.getPriorityClassName();
                 }
             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -137,6 +137,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withTerminationGracePeriodSeconds(Long.valueOf(templateTerminationGracePeriodSeconds))
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(templateSecurityContext)
+                            .withPriorityClassName(templatePodPriorityClassName)
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -291,6 +291,7 @@ public class ModelUtils {
             model.templateTerminationGracePeriodSeconds = pod.getTerminationGracePeriodSeconds();
             model.templateImagePullSecrets = pod.getImagePullSecrets();
             model.templateSecurityContext = pod.getSecurityContext();
+            model.templatePodPriorityClassName = pod.getPriorityClassName();
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -182,6 +182,7 @@ public class EntityOperatorTest {
                                             .withLabels(podLabels)
                                             .withAnnotations(podAnots)
                                         .endMetadata()
+                                        .withNewPriorityClassName("top-priority")
                                     .endPod()
                                 .endTemplate()
                             .endEntityOperator()
@@ -193,6 +194,7 @@ public class EntityOperatorTest {
         Deployment dep = entityOperator.generateDeployment(true, Collections.EMPTY_MAP, null, null);
         assertTrue(dep.getMetadata().getLabels().entrySet().containsAll(depLabels.entrySet()));
         assertTrue(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()));
+        assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -366,6 +366,7 @@ public class KafkaBridgeClusterTest {
                                 .withLabels(podLabels)
                                 .withAnnotations(podAnots)
                             .endMetadata()
+                            .withNewPriorityClassName("top-priority")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -388,6 +389,7 @@ public class KafkaBridgeClusterTest {
         Deployment dep = kbc.generateDeployment(emptyMap(), true, null, null);
         assertTrue(dep.getMetadata().getLabels().entrySet().containsAll(depLabels.entrySet()));
         assertTrue(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()));
+        assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1047,6 +1047,7 @@ public class KafkaClusterTest {
                                     .withLabels(podLabels)
                                     .withAnnotations(podAnots)
                                 .endMetadata()
+                                .withNewPriorityClassName("top-priority")
                             .endPod()
                             .withNewBootstrapService()
                                 .withNewMetadata()
@@ -1100,6 +1101,7 @@ public class KafkaClusterTest {
         StatefulSet ss = kc.generateStatefulSet(true, null, null);
         assertTrue(ss.getMetadata().getLabels().entrySet().containsAll(ssLabels.entrySet()));
         assertTrue(ss.getMetadata().getAnnotations().entrySet().containsAll(ssAnots.entrySet()));
+        assertEquals("top-priority", ss.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(ss.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -411,6 +411,7 @@ public class KafkaConnectClusterTest {
                                 .withLabels(podLabels)
                                 .withAnnotations(podAnots)
                             .endMetadata()
+                            .withNewPriorityClassName("top-priority")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -433,6 +434,7 @@ public class KafkaConnectClusterTest {
         Deployment dep = kc.generateDeployment(emptyMap(), true, null, null);
         assertTrue(dep.getMetadata().getLabels().entrySet().containsAll(depLabels.entrySet()));
         assertTrue(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()));
+        assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -470,6 +470,7 @@ public class KafkaConnectS2IClusterTest {
                                 .withLabels(podLabels)
                                 .withAnnotations(podAnots)
                             .endMetadata()
+                            .withNewPriorityClassName("top-priority")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -492,6 +493,7 @@ public class KafkaConnectS2IClusterTest {
         DeploymentConfig dep = kc.generateDeploymentConfig(Collections.EMPTY_MAP, true, null, null);
         assertTrue(dep.getMetadata().getLabels().entrySet().containsAll(depLabels.entrySet()));
         assertTrue(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()));
+        assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -490,6 +490,7 @@ public class KafkaMirrorMakerClusterTest {
                                 .withLabels(podLabels)
                                 .withAnnotations(podAnots)
                             .endMetadata()
+                            .withNewPriorityClassName("top-priority")
                         .endPod()
                         .withNewPodDisruptionBudget()
                             .withNewMetadata()
@@ -506,6 +507,7 @@ public class KafkaMirrorMakerClusterTest {
         Deployment dep = mmc.generateDeployment(emptyMap(), true, null, null);
         assertTrue(dep.getMetadata().getLabels().entrySet().containsAll(depLabels.entrySet()));
         assertTrue(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()));
+        assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -330,6 +330,7 @@ public class ZookeeperClusterTest {
                                     .withLabels(podLabels)
                                     .withAnnotations(podAnots)
                                 .endMetadata()
+                                .withNewPriorityClassName("top-priority")
                             .endPod()
                             .withNewClientService()
                                 .withNewMetadata()
@@ -359,6 +360,7 @@ public class ZookeeperClusterTest {
         StatefulSet ss = zc.generateStatefulSet(true, null, null);
         assertTrue(ss.getMetadata().getLabels().entrySet().containsAll(ssLabels.entrySet()));
         assertTrue(ss.getMetadata().getAnnotations().entrySet().containsAll(ssAnots.entrySet()));
+        assertEquals("top-priority", ss.getSpec().getTemplate().getSpec().getPriorityClassName());
 
         // Check Pods
         assertTrue(ss.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -755,7 +755,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 [options="header"]
 |====
 |Property                              |Description
-|metadata                       1.2+<.<|Metadata which should be applied to the resource.
+|metadata                       1.2+<.<|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |imagePullSecrets               1.2+<.<|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core[core/v1 localobjectreference].
 
@@ -771,7 +771,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|priorityClassName              1.2+<.<|The name of the Priority Class to which this pods should be assigned.
+|priorityClassName              1.2+<.<|The name of the Priority Class to which these pods will be assigned.
 |string
 |tolerations                    1.2+<.<|The pod's tolerations.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -771,6 +771,8 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
+|priorityClassName              1.2+<.<|The name of the Priority Class to which this pods should be assigned.
+|string
 |tolerations                    1.2+<.<|The pod's tolerations.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 

--- a/documentation/book/con-customizing-pods.adoc
+++ b/documentation/book/con-customizing-pods.adoc
@@ -29,6 +29,10 @@ NOTE: When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Oper
 |Configures pod-level security attributes for containers running as part of a given Pod.
 For more information about configuring SecurityContext, see {K8sConfigureSecurityContext}.
 
+|`priorityClassName`
+|Configures the name of the Priority Class which will be used for given a Pod.
+For more information about Priority Classes, see {K8sPriorityClass}.
+
 |===
 
 These fields are effective on each type of cluster (Kafka and Zookeeper; Kafka Connect and Kafka Connect with S2I support; and Kafka Mirror Maker).

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -58,6 +58,7 @@
 :K8sImagePullPolicies: link:https://kubernetes.io/docs/concepts/containers/images/#updating-images[Disruptions^]
 :K8sCRDs: link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/[Extend the Kubernetes API with CustomResourceDefinitions^]
 :K8sResizingPersistentVolumesUsingKubernetes: link:https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/[Resizing Persistent Volumes using Kubernetes^]
+:K8sPriorityClass: link:https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption[Pod Priority and Preemption^]
 :NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller for Kubernetes^]
 :NginxIngressControllerTLSPassthrough: link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough[TLS passthrough documentation]
 :KubernetesExternalDNS: link:https://github.com/kubernetes-incubator/external-dns[External DNS^]

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1017,6 +1017,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -1789,6 +1791,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -2869,6 +2873,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -601,6 +601,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -586,6 +586,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -717,6 +717,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -457,6 +457,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1012,6 +1012,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -1784,6 +1786,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -2864,6 +2868,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -596,6 +596,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -581,6 +581,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -712,6 +712,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -452,6 +452,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/olm/kafkabridges.crd.yaml
+++ b/olm/kafkabridges.crd.yaml
@@ -452,6 +452,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/olm/kafkaconnects.crd.yaml
+++ b/olm/kafkaconnects.crd.yaml
@@ -596,6 +596,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/olm/kafkaconnects2is.crd.yaml
+++ b/olm/kafkaconnects2is.crd.yaml
@@ -581,6 +581,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/olm/kafkamirrormakers.crd.yaml
+++ b/olm/kafkamirrormakers.crd.yaml
@@ -712,6 +712,8 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                    priorityClassName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/olm/kafkas.crd.yaml
+++ b/olm/kafkas.crd.yaml
@@ -1012,6 +1012,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -1784,6 +1786,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -2864,6 +2868,8 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                        priorityClassName:
+                          type: string
                         tolerations:
                           type: array
                           items:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the possibility to configure the PriorityClass name in the Pod template. That allows users to configure the priority of the pods and prevent preemption when desired. (the PriorityClass it self has to be created by the user)

I decided against making it possible to also configure priority directly as that would possibly override each other with the PriorityClass. I think the PriorityClass name should be sufficient.

This should close #1753.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

