### PR TITLE
Added mention to KafkaBridge when uninstalling Strimzi

### DIFF
--- a/documentation/book/proc-uninstalling.adoc
+++ b/documentation/book/proc-uninstalling.adoc
@@ -16,7 +16,7 @@ Such resources include:
 * Secrets (Custom CAs and certificates, Kafka Connect secrets, and other Kafka secrets)
 * Logging `ConfigMaps` (of type `external`)
 
-These are resources referenced by `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, or `KafkaMirrorMaker` configuration.
+These are resources referenced by `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, `KafkaMirrorMaker`, or `KafkaBridge` configuration.
 
 .Procedure
 
@@ -27,6 +27,6 @@ These are resources referenced by `Kafka`, `KafkaConnect`, `KafkaConnectS2I`, or
 {cmdcli} delete -f install/cluster-operator
 ----
 +
-WARNING: Deleting `CustomResourceDefinitions` results in the garbage collection of the corresponding custom resources (`Kafka`, `KafkaConnect`, `KafkaConnectS2I`, or `KafkaMirrorMaker`) and the resources dependent on them (Deployments, StatefulSets, and other dependent resources).
+WARNING: Deleting `CustomResourceDefinitions` results in the garbage collection of the corresponding custom resources (`Kafka`, `KafkaConnect`, `KafkaConnectS2I`, `KafkaMirrorMaker`, or `KafkaBridge`) and the resources dependent on them (Deployments, StatefulSets, and other dependent resources).
 
 . Delete the resources you identified in the prerequisites.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Trivial PR for mentioning `KafkaBridge` resource when talking about uninstalling Strimzi.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

