### PR TITLE
Fix null check in EU/UO role binding management

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2331,7 +2331,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityOperatorUserOpRoleBinding() {
-            if (eoDeployment != null && entityOperator.getTopicOperator() != null) {
+            if (eoDeployment != null && entityOperator.getUserOperator() != null) {
                 Future<ReconcileResult<RoleBinding>> ownNamespaceFuture;
                 Future<ReconcileResult<RoleBinding>> watchedNamespaceFuture;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When user deploys only TO inside of EO (i.e. without UO), we get an NPE because the null check in that function has a typo and checks for TO instead of UO. As a result the EO is not deployed in such scenario. 

This PR should be picked for 0.12.x release branch to have in possible next patch release.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally