### PR TITLE
Change order of environment variables to make removing TO from EO work

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -251,9 +251,9 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME, KafkaCluster.clientsCaKeySecretName(cluster)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME, KafkaCluster.clientsCaCertSecretName(cluster)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_NAMESPACE, namespace));
-        varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
+        varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         return varList;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -29,6 +29,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class EntityUserOperatorTest {
 
@@ -104,9 +105,17 @@ public class EntityUserOperatorTest {
         return expected;
     }
 
+    void checkEnvVars(List<EnvVar> expected, List<EnvVar> actual)   {
+        assertEquals(expected.size(), actual.size());
+
+        for (EnvVar var : expected) {
+            assertTrue(actual.contains(var));
+        }
+    }
+
     @Test
     public void testEnvVars()   {
-        Assert.assertEquals(getExpectedEnvVars(), entityUserOperator.getEnvVars());
+        checkEnvVars(getExpectedEnvVars(), entityUserOperator.getEnvVars());
     }
 
     @Test
@@ -188,7 +197,7 @@ public class EntityUserOperatorTest {
         Container container = containers.get(0);
         assertEquals(EntityUserOperator.USER_OPERATOR_CONTAINER_NAME, container.getName());
         assertEquals(entityUserOperator.getImage(), container.getImage());
-        assertEquals(getExpectedEnvVars(), container.getEnv());
+        checkEnvVars(getExpectedEnvVars(), container.getEnv());
         assertEquals(new Integer(livenessProbe.getInitialDelaySeconds()), container.getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(livenessProbe.getTimeoutSeconds()), container.getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(readinessProbe.getInitialDelaySeconds()), container.getReadinessProbe().getInitialDelaySeconds());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.operator.cluster.ResourceUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -105,7 +104,7 @@ public class EntityUserOperatorTest {
         return expected;
     }
 
-    void checkEnvVars(List<EnvVar> expected, List<EnvVar> actual)   {
+    private void checkEnvVars(List<EnvVar> expected, List<EnvVar> actual)   {
         assertEquals(expected.size(), actual.size());
 
         for (EnvVar var : expected) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This should add temporary workaround for issue #1777. Changing the order of the environment variables in the UO helps us to avoid the patching error which is probably somewhere deeper in Fabric8 or in Kubernetes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging