### PR TITLE
ST: add test for maintenance window

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -451,7 +451,7 @@ class SecurityST extends AbstractST {
 
         Map<String, String> kafkaPods = StUtils.ssSnapshot(kafkaStatefulSetName(CLUSTER_NAME));
 
-        LOGGER.info("Annotate secret {} with secret force renew annotation", secretName);
+        LOGGER.info("Annotate secret {} with secret force-renew annotation", secretName);
         Secret secret = new SecretBuilder(kubeClient().getSecret(secretName))
                 .editMetadata()
                 .addToAnnotations("strimzi.io/force-renew", "true")

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -461,7 +461,7 @@ class SecurityST extends AbstractST {
         LOGGER.info("Wait until maintenance windows starts");
         LocalDateTime finalMaintenanceWindowStart = maintenanceWindowStart;
         TestUtils.waitFor("Wait until maintenance window start",
-            Constants.GLOBAL_POLL_INTERVAL, Duration.ofMinutes(maintenanceWindowDuration).toMillis(),
+            Constants.GLOBAL_POLL_INTERVAL, Duration.ofMinutes(maintenanceWindowDuration).toMillis() - 10000,
             () -> LocalDateTime.now().isAfter(finalMaintenanceWindowStart));
 
         LOGGER.info("Maintenance window starts");

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HashMap;


### PR DESCRIPTION
### Type of change

- New Test

### Description

This PR introduce new system test, which check correct function of [Maintenance window](https://strimzi.io/docs/master/#assembly-maintenance-time-windows-deployment-configuration-kafka). This test doesn't check manual trigger of rolling update, only automatic trigger for CA renewal.

### Checklist

- [x] Make sure all tests pass

