### PR TITLE
ST: Removing TO and UO from EO

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -766,15 +766,6 @@ class KafkaST extends MessagingBaseST {
         assertThat(topics, not(hasItems("topic-from-cli")));
     }
 
-    /*
-
-
-    Test cases:
-    1. Remove TO and Create TO
-    2. Remove UO and Create UO
-    3. Remove TO and UO
-     */
-
     @Test
     void testRemoveTopicOperatorFromEntityOperator() {
         LOGGER.info("Deploying Kafka cluster {}", CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -770,11 +770,13 @@ class KafkaST extends MessagingBaseST {
     void testRemoveTopicOperatorFromEntityOperator() {
         LOGGER.info("Deploying Kafka cluster {}", CLUSTER_NAME);
         testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3).done();
+        String eoPodName = kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME))
+            .get(0).getMetadata().getName();
 
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getEntityOperator().setTopicOperator(null));
-
-        StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName(CLUSTER_NAME));
-        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME));
+        //Waiting when EO pod will be recreated without TO
+        StUtils.waitForPodDeletion(eoPodName);
+        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME), 1);
 
         //Checking that TO was removed
         kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -783,9 +785,13 @@ class KafkaST extends MessagingBaseST {
             });
         });
 
+        eoPodName = kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME))
+                .get(0).getMetadata().getName();
+
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getEntityOperator().setTopicOperator(new EntityTopicOperatorSpec()));
-        StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName(CLUSTER_NAME));
-        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME));
+        //Waiting when EO pod will be recreated with TO
+        StUtils.waitForPodDeletion(eoPodName);
+        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME), 1);
 
         //Checking that TO was created
         kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -804,11 +810,14 @@ class KafkaST extends MessagingBaseST {
         LOGGER.info("Deploying Kafka cluster {}", CLUSTER_NAME);
         operationID = startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT);
         testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3).done();
+        String eoPodName = kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME))
+                .get(0).getMetadata().getName();
 
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getEntityOperator().setUserOperator(null));
 
-        StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName(CLUSTER_NAME));
-        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME));
+        //Waiting when EO pod will be recreated without UO
+        StUtils.waitForPodDeletion(eoPodName);
+        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME), 1);
 
         //Checking that UO was removed
         kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -817,9 +826,13 @@ class KafkaST extends MessagingBaseST {
             });
         });
 
+        eoPodName = kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME))
+                .get(0).getMetadata().getName();
+
         replaceKafkaResource(CLUSTER_NAME, k -> k.getSpec().getEntityOperator().setUserOperator(new EntityUserOperatorSpec()));
-        StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName(CLUSTER_NAME));
-        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME));
+        //Waiting when EO pod will be recreated with UO
+        StUtils.waitForPodDeletion(eoPodName);
+        StUtils.waitForDeploymentReady(entityOperatorDeploymentName(CLUSTER_NAME), 1);
 
         //Checking that UO was created
         kubeClient().listPodsByPrefixInName(entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {


### PR DESCRIPTION
### Type of change
- New ST

### Description
Added new ST for the following test cases:
1. Removing TO form EO and then creating TO
2. Removing UO form EO and then creating UO
3. Remove TO + UO form EO and then creating UO + TO


### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

