### PR TITLE
[DOC] Make clear the relationship between Entity Operator and TO/CO

### DIFF
--- a/documentation/book/assembly-kafka-entity-operator.adoc
+++ b/documentation/book/assembly-kafka-entity-operator.adoc
@@ -10,24 +10,18 @@
 
 = Entity Operator
 
-The Entity Operator is responsible for managing different entities in a running Kafka cluster.
-The currently supported entities are:
+The Entity Operator is responsible for managing entities in a running Kafka cluster.
 
-Kafka topics:: managed by the Topic Operator.
-Kafka users:: managed by the User Operator
+The Entity Operator comprises the:
 
-Both Topic and User Operators can be deployed on their own.
-But the easiest way to deploy them is together with the Kafka cluster as part of the Entity Operator.
-The Entity Operator can include either one or both of them depending on the configuration.
-They will be automatically configured to manage the topics and users of the Kafka cluster with which they are deployed.
+* xref:assembly-getting-started-topic-operator-str[Topic Operator] to manage Kafka topics
+* xref:assembly-getting-started-user-operator-str[User Operator] to manage Kafka users
 
-For more information about Topic Operator, see xref:deploying-the-topic-operator-str[].
-For more information about how to use Topic Operator to create or delete topics, see xref:using-the-topic-operator-str[].
+Through `kafka` resource configuration, the Cluster Operator can deploy the Entity Operator, including one or both operators, when deploying a Kafka cluster.
 
-// TODO:
-// Fix the links, add UO links
-// For more information about Topic Operator, visit xref:deploying-the-topic-operator-str[].
-// For more information about how to use Topic Operator to create or delete topics, visit xref:using-the-topic-operator-str[].
+NOTE: When deployed, the Entity Operator contains the operators according to the deployment configuration.
+
+The operators are automatically configured to manage the topics and users of the Kafka cluster.
 
 include::ref-kafka-entity-operator.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-kafka-entity-operator.adoc
+++ b/documentation/book/assembly-kafka-entity-operator.adoc
@@ -10,14 +10,14 @@
 
 = Entity Operator
 
-The Entity Operator is responsible for managing entities in a running Kafka cluster.
+The Entity Operator is responsible for managing Kafka-related entities in a running Kafka cluster.
 
 The Entity Operator comprises the:
 
 * xref:assembly-getting-started-topic-operator-str[Topic Operator] to manage Kafka topics
 * xref:assembly-getting-started-user-operator-str[User Operator] to manage Kafka users
 
-Through `kafka` resource configuration, the Cluster Operator can deploy the Entity Operator, including one or both operators, when deploying a Kafka cluster.
+Through `Kafka` resource configuration, the Cluster Operator can deploy the Entity Operator, including one or both operators, when deploying a Kafka cluster.
 
 NOTE: When deployed, the Entity Operator contains the operators according to the deployment configuration.
 

--- a/documentation/book/assembly-overview.adoc
+++ b/documentation/book/assembly-overview.adoc
@@ -17,6 +17,8 @@ Cluster Operator:: Responsible for deploying and managing Apache Kafka clusters 
 Topic Operator:: Responsible for managing Kafka topics within a Kafka cluster running within a Kubernetes cluster.
 User Operator:: Responsible for managing Kafka users within a Kafka cluster running within a Kubernetes cluster.
 
+NOTE: The Cluster Operator can deploy the Topic Operator and User Operator (as part of an Entity Operator configuration) at the same time as a Kafka cluster.
+
 .Operators within the {ProductName} architecture
 
 image:operators.png[Operators]

--- a/documentation/book/proc-changing-a-topic.adoc
+++ b/documentation/book/proc-changing-a-topic.adoc
@@ -10,7 +10,7 @@ This procedure describes how to change the configuration of an existing Kafka to
 .Prerequisites
 
 * A running Kafka cluster.
-* A running Topic Operator.
+* A running Topic Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 * An existing `KafkaTopic` to be changed.
 
 .Procedure

--- a/documentation/book/proc-changing-kafka-user.adoc
+++ b/documentation/book/proc-changing-kafka-user.adoc
@@ -10,8 +10,8 @@ This procedure describes how to change the configuration of an existing Kafka us
 .Prerequisites
 
 * A running Kafka cluster.
-* A running User Operator.
-* An existing `KafkaUser` to be changed
+* A running User Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
+* An existing `KafkaUser` to be changed.
 
 .Procedure
 

--- a/documentation/book/proc-creating-a-topic.adoc
+++ b/documentation/book/proc-creating-a-topic.adoc
@@ -10,7 +10,7 @@ This procedure describes how to create a Kafka topic using a `KafkaTopic` Kubern
 .Prerequisites
 
 * A running Kafka cluster.
-* A running Topic Operator.
+* A running Topic Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 
 .Procedure
 

--- a/documentation/book/proc-creating-kafka-user-scram-sha.adoc
+++ b/documentation/book/proc-creating-kafka-user-scram-sha.adoc
@@ -8,7 +8,7 @@
 .Prerequisites
 
 * A running Kafka cluster configured with a listener using SCRAM SHA authentication.
-* A running User Operator.
+* A running User Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 
 .Procedure
 

--- a/documentation/book/proc-creating-kafka-user-tls.adoc
+++ b/documentation/book/proc-creating-kafka-user-tls.adoc
@@ -8,7 +8,7 @@
 .Prerequisites
 
 * A running Kafka cluster configured with a listener using TLS authentication.
-* A running User Operator.
+* A running User Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 
 .Procedure
 

--- a/documentation/book/proc-deleting-a-topic.adoc
+++ b/documentation/book/proc-deleting-a-topic.adoc
@@ -10,7 +10,7 @@ This procedure describes how to delete a Kafka topic using a `KafkaTopic` Kubern
 .Prerequisites
 
 * A running Kafka cluster.
-* A running Topic Operator.
+* A running Topic Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 * An existing `KafkaTopic` to be deleted.
 * `delete.topic.enable=true` (default)
 

--- a/documentation/book/proc-deleting-kafka-user.adoc
+++ b/documentation/book/proc-deleting-kafka-user.adoc
@@ -10,7 +10,7 @@ This procedure describes how to delete a Kafka user created with `KafkaUser` Kub
 .Prerequisites
 
 * A running Kafka cluster.
-* A running User Operator.
+* A running User Operator (typically xref:assembly-kafka-entity-operator-deployment-configuration-kafka[deployed with the Entity Operator]).
 * An existing `KafkaUser` to be deleted.
 
 .Procedure


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Updated the following:

Overview of AMQ Streams: 
* Mention of Entity Operator in relation to User Operator and Topic Operator at start of guide
Entity Operator
* Rewrite of section to make clearer the encapsulation of the two operators
* * links to topic and user operator overviews
Task prereqs mentioning 'A running Topic Operator' or 'A running User Operator'
* Updated to refer and link to Entity operator section

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

