### PR TITLE
Fix some forgotten attributes which should not be used anymore

### DIFF
--- a/documentation/book/con-kafka-broker-exposing-external-listeners.adoc
+++ b/documentation/book/con-kafka-broker-exposing-external-listeners.adoc
@@ -1,0 +1,278 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring-kafka-listeners.adoc
+
+[id='con-kafka-broker-exposing-external-listeners-{context}']
+= Exposing Kafka using OpenShift `Routes`
+
+An external listener of type `route` exposes Kafka by using OpenShift `Routes` and the HAProxy router.
+A dedicated `Route` is created for every Kafka broker pod.
+An additional `Route` is created to serve as a Kafka bootstrap address.
+Kafka clients can use these `Routes` to connect to Kafka on port 443.
+
+When exposing Kafka using OpenShift `Routes`, TLS encryption is always used.
+
+By default, the route hosts are automatically assigned by OpenShift.
+However, you can override the assigned route hosts by specifying the requested hosts in the `overrides` property.
+{ProductName} will not perform any validation that the requested hosts are available; you must ensure that they are free and can be used.
+
+.Example of an external listener of type `routes` configured with overrides for OpenShift route hosts
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        host: bootstrap.myrouter.com
+      brokers:
+      - broker: 0
+        host: broker-0.myrouter.com
+      - broker: 1
+        host: broker-1.myrouter.com
+      - broker: 2
+        host: broker-2.myrouter.com
+# ...
+----
+
+For more information on using `Routes` to access Kafka, see xref:proc-accessing-kafka-using-routes-{context}[].
+
+= Exposing Kafka using loadbalancers
+
+External listeners of type `loadbalancer` expose Kafka by using `Loadbalancer` type `Services`.
+A new loadbalancer service is created for every Kafka broker pod.
+An additional loadbalancer is created to serve as a Kafka _bootstrap_ address.
+Loadbalancers listen to connections on port 9094.
+
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
+
+.Example of an external listener of type `loadbalancer`
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: loadbalancer
+    authentication:
+      type: tls
+# ...
+----
+
+For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
+
+= Exposing Kafka using node ports
+
+External listeners of type `nodeport` expose Kafka by using `NodePort` type `Services`.
+When exposing Kafka in this way, Kafka clients connect directly to the nodes of Kubernetes.
+You must enable access to the ports on the Kubernetes nodes for each client (for example, in firewalls or security groups).
+Each Kafka broker pod is then accessible on a separate port.
+Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
+
+When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
+When selecting the node address, the different address types are used with the following priority:
+
+. ExternalDNS
+. ExternalIP
+. Hostname
+. InternalDNS
+. InternalIP
+
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
+
+NOTE: TLS hostname verification is not currently supported when exposing Kafka clusters using node ports.
+
+By default, the port numbers used for the bootstrap and broker services are automatically assigned by Kubernetes.
+However, you can override the assigned node ports by specifying the requested port numbers in the `overrides` property.
+{ProductName} does not perform any validation on the requested ports; you must ensure that they are free and available for use.
+
+.Example of an external listener configured with overrides for node ports
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: nodeport
+    tls: true
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        nodePort: 32100
+      brokers:
+      - broker: 0
+        nodePort: 32000
+      - broker: 1
+        nodePort: 32001
+      - broker: 2
+        nodePort: 32002
+# ...
+----
+
+For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].
+
+= Exposing Kafka using Kubernetes `Ingress`
+
+An external listener of type `ingress` exposes Kafka by using Kubernetes `Ingress` and the {NginxIngressController}.
+A dedicated `Ingress` resource is created for every Kafka broker pod.
+An additional `Ingress` resource is created to serve as a Kafka bootstrap address.
+Kafka clients can use these `Ingress` resources to connect to Kafka on port 443.
+
+NOTE: External listeners using `Ingress` have been currently tested only with the {NginxIngressController}.
+
+{ProductName} uses the TLS passthrough feature of the {NginxIngressController}.
+Make sure TLS passthrough is enabled in your {NginxIngressController} deployment.
+For more information about enabling TLS passthrough see {NginxIngressControllerTLSPassthrough}.
+Because it is using the TLS passthrough functionality, TLS encryption cannot be disabled when exposing Kafka using `Ingress`.
+
+The Ingress controller does not assign any hostnames automatically.
+You have to specify the hostnames which should be used by the bootstrap and per-broker services in the `spec.kafka.listeners.external.configuration` section.
+You also have to make sure that the hostnames resolve to the Ingress endpoints.
+{ProductName} will not perform any validation that the requested hosts are available and properly routed to the Ingress endpoints.
+
+.Example of an external listener of type `ingress`
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: ingress
+    authentication:
+      type: tls
+    configuration:
+      bootstrap:
+        host: bootstrap.myingress.com
+      brokers:
+      - broker: 0
+        host: broker-0.myingress.com
+      - broker: 1
+        host: broker-1.myingress.com
+      - broker: 2
+        host: broker-2.myingress.com
+# ...
+----
+
+For more information on using `Ingress` to access Kafka, see xref:proc-accessing-kafka-using-ingress-{context}[].
+
+= Customizing advertised addresses on external listeners
+
+By default, {ProductName} tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
+This is not sufficient in all situations, because the infrastructure on which {ProductName} is running might not provide the right hostname or port through which Kafka can be accessed.
+You can customize the advertised hostname and port in the `overrides` property of the external listener.
+{ProductName} will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
+Overriding the advertised host and ports is available for all types of external listeners.
+
+.Example of an external listener configured with overrides for advertised addresses
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      brokers:
+      - broker: 0
+        advertisedHost: example.hostname.0
+        advertisedPort: 12340
+      - broker: 1
+        advertisedHost: example.hostname.1
+        advertisedPort: 12341
+      - broker: 2
+        advertisedHost: example.hostname.2
+        advertisedPort: 12342
+# ...
+----
+
+Additionally, you can specify the name of the bootstrap service.
+This name will be added to the broker certificates and can be used for TLS hostname verification.
+Adding the additional bootstrap address is available for all types of external listeners.
+
+.Example of an external listener configured with an additional bootstrap address
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        address: example.hostname
+# ...
+----
+
+= Customizing DNS names of external listeners
+
+On `loadbalancer` and `ingress` listeners, you can use the `dnsAnnotations` property to add additional annotations to the ingress resources or load balancer services.
+You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the ingress resources or services.
+
+.Example of an external listener of type `loadbalancer` using {KubernetesExternalDNS} annotations
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: loadbalancer
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      brokers:
+      - broker: 0
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 1
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 2
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+# ...
+----
+
+.Example of an external listener of type `ingress` using {KubernetesExternalDNS} annotations
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: ingress
+    authentication:
+      type: tls
+    configuration:
+      bootstrap:
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: bootstrap.myingress.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+        host: bootstrap.myingress.com
+      brokers:
+      - broker: 0
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: broker-0.myingress.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+        host: broker-0.myingress.com
+      - broker: 1
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: broker-1.myingress.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+        host: broker-1.myingress.com
+      - broker: 2
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: broker-2.myingress.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+        host: broker-2.myingress.com
+# ...
+----


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

There seem to be some forgotten `{KubernetesName}` and `{OpenShiftName}` attributes which should not be used anymore. This PR fixes that.