### PR TITLE
Add support for configuring the jute.maxbuffer Java property in jvmOptions

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -33,6 +33,7 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
     private String xms;
     private Boolean server;
     private boolean gcLoggingEnabled = true;
+    private int juteMaxbuffer;
     private Map<String, String> xx;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -85,6 +86,16 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     public void setXx(Map<String, String> xx) {
         this.xx = xx;
+    }
+
+    @Description("Configures the `jute.maxbuffer` option for Zookeeper clients and servers")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public int getJuteMaxbuffer() {
+        return juteMaxbuffer;
+    }
+
+    public void setJuteMaxbuffer(int juteMaxbuffer) {
+        this.juteMaxbuffer = juteMaxbuffer;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1004,9 +1004,14 @@ public abstract class AbstractModel {
     protected void jvmPerformanceOptions(List<EnvVar> envVars) {
         StringBuilder jvmPerformanceOpts = new StringBuilder();
         Boolean server = jvmOptions != null ? jvmOptions.isServer() : null;
+        int juteMaxbuffer = jvmOptions != null ? jvmOptions.getJuteMaxbuffer() : null;
 
         if (server != null && server) {
             jvmPerformanceOpts.append("-server");
+        }
+
+        if (jvmOptions != null && jvmOptions.getJuteMaxbuffer() > 0) {
+            jvmPerformanceOpts.append(" ").append("-Djute.maxbuffer=").append(jvmOptions.getJuteMaxbuffer());
         }
 
         Map<String, String> xx = jvmOptions != null ? jvmOptions.getXx() : null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -92,6 +92,7 @@ public abstract class AbstractModel {
     public static final String ANCILLARY_CM_KEY_LOG_CONFIG = "log4j.properties";
     public static final String ENV_VAR_DYNAMIC_HEAP_FRACTION = "DYNAMIC_HEAP_FRACTION";
     public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
+    public static final String ENV_VAR_KAFKA_OPTS = "KAFKA_OPTS";
     public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
     public static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
@@ -1004,14 +1005,9 @@ public abstract class AbstractModel {
     protected void jvmPerformanceOptions(List<EnvVar> envVars) {
         StringBuilder jvmPerformanceOpts = new StringBuilder();
         Boolean server = jvmOptions != null ? jvmOptions.isServer() : null;
-        int juteMaxbuffer = jvmOptions != null ? jvmOptions.getJuteMaxbuffer() : null;
 
         if (server != null && server) {
             jvmPerformanceOpts.append("-server");
-        }
-
-        if (jvmOptions != null && jvmOptions.getJuteMaxbuffer() > 0) {
-            jvmPerformanceOpts.append(" ").append("-Djute.maxbuffer=").append(jvmOptions.getJuteMaxbuffer());
         }
 
         Map<String, String> xx = jvmOptions != null ? jvmOptions.getXx() : null;
@@ -1032,6 +1028,24 @@ public abstract class AbstractModel {
         String trim = jvmPerformanceOpts.toString().trim();
         if (!trim.isEmpty()) {
             envVars.add(buildEnvVar(ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS, trim));
+        }
+    }
+
+    /**
+     * Adds KAFKA_OPTS variable to the EnvVar list if any relevant jvmOptions are specified.
+     *
+     * @param envVars List of Environment Variables
+     */
+    protected void jvmKafkaOptions(List<EnvVar> envVars) {
+        StringBuilder kafkaOpts = new StringBuilder();
+
+        if (jvmOptions != null && jvmOptions.getJuteMaxbuffer() > 0) {
+            kafkaOpts.append("-Djute.maxbuffer=").append(jvmOptions.getJuteMaxbuffer());
+        }
+
+        String trim = kafkaOpts.toString().trim();
+        if (!trim.isEmpty()) {
+            envVars.add(buildEnvVar(ENV_VAR_KAFKA_OPTS, trim));
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1248,6 +1248,7 @@ public class KafkaCluster extends AbstractModel {
 
         heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);
+        jvmKafkaOptions(varList);
 
         if (configuration != null && !configuration.getConfiguration().isEmpty()) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -480,6 +480,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);
+        jvmKafkaOptions(varList);
 
         if (tls != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_TLS, "true"));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -420,6 +420,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);
+        jvmKafkaOptions(varList);
 
         /** consumer */
         if (consumer.getTls() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -514,6 +514,8 @@ public class ZookeeperCluster extends AbstractModel {
 
         heapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L);
         jvmPerformanceOptions(varList);
+        jvmKafkaOptions(varList);
+        
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));
         return varList;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2097,7 +2097,7 @@ public class KafkaClusterTest {
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"));
-        assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Djute.maxbuffer=4194304"));
+        assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Djute.maxbuffer=4194304"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -951,7 +951,7 @@ public class ZookeeperClusterTest {
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-server"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"));
-        assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Djute.maxbuffer=4194304"));
+        assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Djute.maxbuffer=4194304"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"));
     }

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -33,7 +33,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
+  export KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -49,7 +49,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
+  export KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -23,7 +23,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 fi
 
 rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/kafka-agent-${STRIMZI_VERSION}.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
+export KAFKA_OPTS="${KAFKA_OPTS} -javaagent:${KAFKA_HOME}/libs/kafka-agent-${STRIMZI_VERSION}.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then

--- a/docker-images/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka/scripts/zookeeper_run.sh
@@ -35,7 +35,7 @@ fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$ZOOKEEPER_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
+  export KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -613,6 +613,8 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-Kafka
 |string
 |gcLoggingEnabled  1.2+<.<|Specifies whether the Garbage Collection logging is enabled. The default is true.
 |boolean
+|juteMaxbuffer     1.2+<.<|Configures the `jute.maxbuffer` option for Zookeeper clients and servers.
+|integer
 |====
 
 [id='type-ResourceRequirements-{context}']

--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -106,6 +106,21 @@ The example configuration above will result in the following JVM options:
 
 NOTE: When neither of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
 
+.juteMaxbuffer
+
+`juteMaxbuffer` specifies the maximum size of the data that can be stored in a znode.
+The default is 1048575 bytes.
+If this option is changed, it must be set in both Zookeeper and Kafka `jvmOptions`.
+
+.Example fragment configuring `-server`
+[source,yaml,subs=attributes+]
+----
+# ...
+jvmOptions:
+  juteMaxbuffer: 5000000
+# ...
+----
+
 == Garbage collector logging
 
 The `jvmOptions` section also allows you to enable and disable garbage collector (GC) logging.

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -665,6 +665,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:
@@ -1439,6 +1441,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -86,6 +86,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -86,6 +86,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -429,6 +429,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -135,6 +135,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -660,6 +660,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:
@@ -1434,6 +1436,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -81,6 +81,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -81,6 +81,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -424,6 +424,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -130,6 +130,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/olm/kafkabridges.crd.yaml
+++ b/olm/kafkabridges.crd.yaml
@@ -130,6 +130,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/olm/kafkaconnects.crd.yaml
+++ b/olm/kafkaconnects.crd.yaml
@@ -81,6 +81,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/olm/kafkaconnects2is.crd.yaml
+++ b/olm/kafkaconnects2is.crd.yaml
@@ -81,6 +81,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             affinity:
               type: object
               properties:

--- a/olm/kafkamirrormakers.crd.yaml
+++ b/olm/kafkamirrormakers.crd.yaml
@@ -424,6 +424,8 @@ spec:
                   pattern: '[0-9]+[mMgG]?'
                 gcLoggingEnabled:
                   type: boolean
+                juteMaxbuffer:
+                  type: integer
             logging:
               type: object
               properties:

--- a/olm/kafkas.crd.yaml
+++ b/olm/kafkas.crd.yaml
@@ -660,6 +660,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:
@@ -1434,6 +1436,8 @@ spec:
                       pattern: '[0-9]+[mMgG]?'
                     gcLoggingEnabled:
                       type: boolean
+                    juteMaxbuffer:
+                      type: integer
                 resources:
                   type: object
                   properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the #1773 and allows users to configure the `jute.maxbuffer` as part of the `jvmOptions`. 

The related minor documentation change in included in this PR as well.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging