### PR TITLE
[DOC] Create modules for external listener content

### DIFF
--- a/documentation/book/assembly-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners-ingress.adoc
@@ -1,0 +1,12 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners.adoc
+
+[id='assembly-kafka-broker-external-listeners-ingress{context}']
+= Kubernetes Ingress external listeners
+
+External listeners of type `ingress` exposes Kafka by using Kubernetes `Ingress` and the {NginxIngressController}.
+
+include::con-kafka-broker-external-listeners-ingress.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-ingress.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners-loadbalancers.adoc
@@ -1,0 +1,12 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners.adoc
+
+[id='assembly-kafka-broker-external-listeners-loadbalancers-{context}']
+= Loadbalancer external listeners
+
+External listeners of type `loadbalancer` expose Kafka by using `Loadbalancer` type `Services`.
+
+include::con-kafka-broker-external-listeners-loadbalancers.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners-nodeports.adoc
@@ -1,0 +1,12 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners.adoc
+
+[id='assembly-kafka-broker-external-listeners-nodeports-{context}']
+= Node Port external listeners
+
+External listeners of type `nodeport` expose Kafka by using `NodePort` type `Services`.
+
+include::con-kafka-broker-external-listeners-nodeports.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners-routes.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners-routes.adoc
@@ -1,0 +1,14 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners.adoc
+
+[id='assembly-kafka-broker-external-listeners-routes-{context}']
+= Route external listeners
+
+An external listener of type `route` exposes Kafka using OpenShift `Routes` and the HAProxy router.
+
+NOTE: `route` is only supported on OpenShift
+
+include::con-kafka-broker-external-listeners-routes.adoc[leveloffset=+1]
+
+include::proc-accessing-kafka-using-routes.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners.adoc
@@ -5,20 +5,12 @@
 [id='assembly-kafka-broker-external-listeners-{context}']
 = External listeners
 
-An external listener allows a client outside a Kubernetes environment to connect to a {ProductName} Kafka cluster.
-{ProductName} supports the following types of external listeners:
+Use an external listener to expose your {ProductName} Kafka cluster to a client outside a Kubernetes environment.
 
-* `route` (supported only on OpenShift)
-* `loadbalancer`
-* `nodeport`
-* `ingress`
+include::assembly-kafka-broker-external-listeners-routes.adoc[leveloffset=+1]
 
-include::con-kafka-broker-exposing-external-listeners.adoc[leveloffset=+1]
+include::assembly-kafka-broker-external-listeners-loadbalancers.adoc[leveloffset=+1]
 
-include::proc-accessing-kafka-using-routes.adoc[leveloffset=+1]
+include::assembly-kafka-broker-external-listeners-nodeports.adoc[leveloffset=+1]
 
-include::proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]
-
-include::proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
-
-include::proc-accessing-kafka-using-ingress.adoc[leveloffset=+1]
+include::assembly-kafka-broker-external-listeners-ingress.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners.adoc
@@ -7,6 +7,8 @@
 
 Use an external listener to expose your {ProductName} Kafka cluster to a client outside a Kubernetes environment.
 
+include::con-kafka-broker-external-listeners-addresses.adoc[leveloffset=+1]
+
 include::assembly-kafka-broker-external-listeners-routes.adoc[leveloffset=+1]
 
 include::assembly-kafka-broker-external-listeners-loadbalancers.adoc[leveloffset=+1]

--- a/documentation/book/assembly-kafka-broker-external-listeners.adoc
+++ b/documentation/book/assembly-kafka-broker-external-listeners.adoc
@@ -7,6 +7,10 @@
 
 Use an external listener to expose your {ProductName} Kafka cluster to a client outside a Kubernetes environment.
 
+.Additional resources
+
+* {Externallisteners}
+
 include::con-kafka-broker-external-listeners-addresses.adoc[leveloffset=+1]
 
 include::assembly-kafka-broker-external-listeners-routes.adoc[leveloffset=+1]

--- a/documentation/book/assembly-metrics-prometheus.adoc
+++ b/documentation/book/assembly-metrics-prometheus.adoc
@@ -9,7 +9,7 @@ link:https://prometheus.io/[Prometheus^] provides an open source set of componen
 
 We describe how you can use the link:https://github.com/coreos/prometheus-operator[CoreOS Prometheus Operator^] to run a Prometheus server that is suitable for use in production environments, but with the correct configuration you can run any Prometheus server.
 
-The {ProductName} repository contains link:https://github.com/strimzi/strimzi-kafka-operator/tree/{GithubVersion}/metrics/examples/prometheus/install[configuration files^] for the Prometheus server. When you apply these configuration files, the following resources are created in your {KubernetesName} cluster and managed by the Prometheus Operator:
+The {ProductName} repository contains link:https://github.com/strimzi/strimzi-kafka-operator/tree/{GithubVersion}/metrics/examples/prometheus/install[configuration files^] for the Prometheus server. When you apply these configuration files, the following resources are created in your Kubernetes cluster and managed by the Prometheus Operator:
 
 * A `ClusterRole` that grants permissions to Prometheus to read the health endpoints exposed by the Kafka and Zookeeper pods, cAdvisor and the kubelet for container metrics.
 * A `ServiceAccount` for the Prometheus pods to run under.
@@ -22,7 +22,7 @@ The {ProductName} repository contains link:https://github.com/strimzi/strimzi-ka
 
 [NOTE]
 ====
-The Prometheus server configuration uses the {KubernetesName} service discovery feature in order to discover the pods in the cluster from which it gets metrics.  For this feature to work correctly, the service account used for running the Prometheus service pod must have access to the API server so it can retrieve the pod list.
+The Prometheus server configuration uses service discovery to discover the pods in the cluster from which it gets metrics.  For this feature to work correctly, the service account used for running the Prometheus service pod must have access to the API server so it can retrieve the pod list.
 
 For more information, see {K8sServiceDiscovery}.
 ====

--- a/documentation/book/con-kafka-broker-external-listeners-addresses.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-addresses.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners.adoc
+
+[id='con-kafka-broker-external-listeners-addresses-{context}']
+
+= Customizing advertised addresses on external listeners
+
+By default, {ProductName} tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
+This is not sufficient in all situations, because the infrastructure on which {ProductName} is running might not provide the right hostname or port through which Kafka can be accessed.
+You can customize the advertised hostname and port in the `overrides` property of the external listener.
+{ProductName} will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
+Overriding the advertised host and ports is available for all types of external listeners.
+
+.Example of an external listener configured with overrides for advertised addresses
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      brokers:
+      - broker: 0
+        advertisedHost: example.hostname.0
+        advertisedPort: 12340
+      - broker: 1
+        advertisedHost: example.hostname.1
+        advertisedPort: 12341
+      - broker: 2
+        advertisedHost: example.hostname.2
+        advertisedPort: 12342
+# ...
+----
+
+Additionally, you can specify the name of the bootstrap service.
+This name will be added to the broker certificates and can be used for TLS hostname verification.
+Adding the additional bootstrap address is available for all types of external listeners.
+
+.Example of an external listener configured with an additional bootstrap address
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        address: example.hostname
+# ...
+----

--- a/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
@@ -46,90 +46,10 @@ listeners:
 
 For more information on using `Ingress` to access Kafka, see xref:proc-accessing-kafka-using-ingress-{context}[].
 
-= Customizing advertised addresses on external listeners
+= Customizing the DNS names of external ingress listeners
 
-By default, {ProductName} tries to automatically determine the hostnames and ports that your Kafka cluster advertises to its clients.
-This is not sufficient in all situations, because the infrastructure on which {ProductName} is running might not provide the right hostname or port through which Kafka can be accessed.
-You can customize the advertised hostname and port in the `overrides` property of the external listener.
-{ProductName} will then automatically configure the advertised address in the Kafka brokers and add it to the broker certificates so it can be used for TLS hostname verification.
-Overriding the advertised host and ports is available for all types of external listeners.
-
-.Example of an external listener configured with overrides for advertised addresses
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: route
-    authentication:
-      type: tls
-    overrides:
-      brokers:
-      - broker: 0
-        advertisedHost: example.hostname.0
-        advertisedPort: 12340
-      - broker: 1
-        advertisedHost: example.hostname.1
-        advertisedPort: 12341
-      - broker: 2
-        advertisedHost: example.hostname.2
-        advertisedPort: 12342
-# ...
-----
-
-Additionally, you can specify the name of the bootstrap service.
-This name will be added to the broker certificates and can be used for TLS hostname verification.
-Adding the additional bootstrap address is available for all types of external listeners.
-
-.Example of an external listener configured with an additional bootstrap address
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: route
-    authentication:
-      type: tls
-    overrides:
-      bootstrap:
-        address: example.hostname
-# ...
-----
-
-= Customizing DNS names of external listeners
-
-On `loadbalancer` and `ingress` listeners, you can use the `dnsAnnotations` property to add additional annotations to the ingress resources or load balancer services.
-You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the ingress resources or services.
-
-.Example of an external listener of type `loadbalancer` using {KubernetesExternalDNS} annotations
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: loadbalancer
-    authentication:
-      type: tls
-    overrides:
-      bootstrap:
-        dnsAnnotations:
-          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
-          external-dns.alpha.kubernetes.io/ttl: "60"
-      brokers:
-      - broker: 0
-        dnsAnnotations:
-          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
-          external-dns.alpha.kubernetes.io/ttl: "60"
-      - broker: 1
-        dnsAnnotations:
-          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
-          external-dns.alpha.kubernetes.io/ttl: "60"
-      - broker: 2
-        dnsAnnotations:
-          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
-          external-dns.alpha.kubernetes.io/ttl: "60"
-# ...
-----
+On `ingress` listeners, you can use the `dnsAnnotations` property to add additional annotations to the ingress resources.
+You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the ingress resources.
 
 .Example of an external listener of type `ingress` using {KubernetesExternalDNS} annotations
 [source,yaml,subs="attributes+"]

--- a/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
@@ -1,124 +1,12 @@
 // Module included in the following assemblies:
 //
-// assembly-configuring-kafka-listeners.adoc
+// assembly-kafka-broker-external-listeners-ingress.adoc
 
-[id='con-kafka-broker-exposing-external-listeners-{context}']
-= Exposing Kafka using {OpenShiftName} `Routes`
+[id='con-kafka-broker-external-listeners-ingress-{context}']
 
-An external listener of type `route` exposes Kafka by using {OpenShiftName} `Routes` and the HAProxy router.
-A dedicated `Route` is created for every Kafka broker pod.
-An additional `Route` is created to serve as a Kafka bootstrap address.
-Kafka clients can use these `Routes` to connect to Kafka on port 443.
+= Exposing Kafka using Kubernetes `Ingress`
 
-When exposing Kafka using {OpenShiftName} `Routes`, TLS encryption is always used.
-
-By default, the route hosts are automatically assigned by {OpenShiftName}.
-However, you can override the assigned route hosts by specifying the requested hosts in the `overrides` property.
-{ProductName} will not perform any validation that the requested hosts are available; you must ensure that they are free and can be used.
-
-.Example of an external listener of type `routes` configured with overrides for {OpenShiftName} route hosts
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: route
-    authentication:
-      type: tls
-    overrides:
-      bootstrap:
-        host: bootstrap.myrouter.com
-      brokers:
-      - broker: 0
-        host: broker-0.myrouter.com
-      - broker: 1
-        host: broker-1.myrouter.com
-      - broker: 2
-        host: broker-2.myrouter.com
-# ...
-----
-
-For more information on using `Routes` to access Kafka, see xref:proc-accessing-kafka-using-routes-{context}[].
-
-= Exposing Kafka using loadbalancers
-
-External listeners of type `loadbalancer` expose Kafka by using `Loadbalancer` type `Services`.
-A new loadbalancer service is created for every Kafka broker pod.
-An additional loadbalancer is created to serve as a Kafka _bootstrap_ address.
-Loadbalancers listen to connections on port 9094.
-
-By default, TLS encryption is enabled.
-To disable it, set the `tls` field to `false`.
-
-.Example of an external listener of type `loadbalancer`
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: loadbalancer
-    authentication:
-      type: tls
-# ...
-----
-
-For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
-
-= Exposing Kafka using node ports
-
-External listeners of type `nodeport` expose Kafka by using `NodePort` type `Services`.
-When exposing Kafka in this way, Kafka clients connect directly to the nodes of Kubernetes.
-You must enable access to the ports on the Kubernetes nodes for each client (for example, in firewalls or security groups).
-Each Kafka broker pod is then accessible on a separate port.
-Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
-
-When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
-When selecting the node address, the different address types are used with the following priority:
-
-. ExternalDNS
-. ExternalIP
-. Hostname
-. InternalDNS
-. InternalIP
-
-By default, TLS encryption is enabled.
-To disable it, set the `tls` field to `false`.
-
-NOTE: TLS hostname verification is not currently supported when exposing Kafka clusters using node ports.
-
-By default, the port numbers used for the bootstrap and broker services are automatically assigned by Kubernetes.
-However, you can override the assigned node ports by specifying the requested port numbers in the `overrides` property.
-{ProductName} does not perform any validation on the requested ports; you must ensure that they are free and available for use.
-
-.Example of an external listener configured with overrides for node ports
-[source,yaml,subs="attributes+"]
-----
-# ...
-listeners:
-  external:
-    type: nodeport
-    tls: true
-    authentication:
-      type: tls
-    overrides:
-      bootstrap:
-        nodePort: 32100
-      brokers:
-      - broker: 0
-        nodePort: 32000
-      - broker: 1
-        nodePort: 32001
-      - broker: 2
-        nodePort: 32002
-# ...
-----
-
-For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].
-
-= Exposing Kafka using {KubernetesName} `Ingress`
-
-An external listener of type `ingress` exposes Kafka by using {KubernetesName} `Ingress` and the {NginxIngressController}.
-A dedicated `Ingress` resource is created for every Kafka broker pod.
+When exposing Kafka using using Kubernetes `Ingress` and the {NginxIngressController}, a dedicated `Ingress` resource is created for every Kafka broker pod.
 An additional `Ingress` resource is created to serve as a Kafka bootstrap address.
 Kafka clients can use these `Ingress` resources to connect to Kafka on port 443.
 

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners-loadbalancers.adoc
+
+[id='con-kafka-broker-external-listeners-loadbalancers-{context}']
+
+= Exposing Kafka using loadbalancers
+
+When exposing Kafka using `Loadbalancer` type `Services`, a new loadbalancer service is created for every Kafka broker pod.
+An additional loadbalancer is created to serve as a Kafka _bootstrap_ address.
+Loadbalancers listen to connections on port 9094.
+
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
+
+.Example of an external listener of type `loadbalancer`
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: loadbalancer
+    authentication:
+      type: tls
+# ...
+----
+
+For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -26,3 +26,38 @@ listeners:
 ----
 
 For more information on using loadbalancers to access Kafka, see xref:proc-accessing-kafka-using-loadbalancers-{context}[].
+
+= Customizing the DNS names of external loadbalancer listeners
+
+On `loadbalancer` listeners, you can use the `dnsAnnotations` property to add additional annotations to the loadbalancer services.
+You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
+
+.Example of an external listener of type `loadbalancer` using {KubernetesExternalDNS} annotations
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: loadbalancer
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      brokers:
+      - broker: 0
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 1
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 2
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+# ...
+----

--- a/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners-nodeports.adoc
+
+[id='con-kafka-broker-external-listeners-nodeports-{context}']
+
+= Exposing Kafka using node ports
+
+When exposing Kafka using `NodePort` type `Services`, Kafka clients connect directly to the nodes of Kubernetes.
+You must enable access to the ports on the Kubernetes nodes for each client (for example, in firewalls or security groups).
+Each Kafka broker pod is then accessible on a separate port.
+Additional `NodePort` type `Service` is created to serve as a Kafka bootstrap address.
+
+When configuring the advertised addresses for the Kafka broker pods, {ProductName} uses the address of the node on which the given pod is running.
+When selecting the node address, the different address types are used with the following priority:
+
+. ExternalDNS
+. ExternalIP
+. Hostname
+. InternalDNS
+. InternalIP
+
+By default, TLS encryption is enabled.
+To disable it, set the `tls` field to `false`.
+
+NOTE: TLS hostname verification is not currently supported when exposing Kafka clusters using node ports.
+
+By default, the port numbers used for the bootstrap and broker services are automatically assigned by Kubernetes.
+However, you can override the assigned node ports by specifying the requested port numbers in the `overrides` property.
+{ProductName} does not perform any validation on the requested ports; you must ensure that they are free and available for use.
+
+.Example of an external listener configured with overrides for node ports
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: nodeport
+    tls: true
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        nodePort: 32100
+      brokers:
+      - broker: 0
+        nodePort: 32000
+      - broker: 1
+        nodePort: 32001
+      - broker: 2
+        nodePort: 32002
+# ...
+----
+
+For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].

--- a/documentation/book/con-kafka-broker-external-listeners-routes.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-routes.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-broker-external-listeners-routes.adoc
+
+[id='con-kafka-broker-external-listeners-routes-{context}']
+
+= Exposing Kafka using OpenShift `Routes`
+
+When exposing Kafka using OpenShift `Routes`  and the HAProxy router, a dedicated `Route` is created for every Kafka broker pod.
+An additional `Route` is created to serve as a Kafka bootstrap address.
+Kafka clients can use these `Routes` to connect to Kafka on port 443.
+
+TLS encryption is always used with `Routes`.
+
+By default, the route hosts are automatically assigned by OpenShift.
+However, you can override the assigned route hosts by specifying the requested hosts in the `overrides` property.
+{ProductName} will not perform any validation that the requested hosts are available; you must ensure that they are free and can be used.
+
+.Example of an external listener of type `routes` configured with overrides for OpenShift route hosts
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: route
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        host: bootstrap.myrouter.com
+      brokers:
+      - broker: 0
+        host: broker-0.myrouter.com
+      - broker: 1
+        host: broker-1.myrouter.com
+      - broker: 2
+        host: broker-2.myrouter.com
+# ...
+----
+
+For more information on using `Routes` to access Kafka, see xref:proc-accessing-kafka-using-routes-{context}[].

--- a/documentation/book/proc-using-openshift-builds-create-image.adoc
+++ b/documentation/book/proc-using-openshift-builds-create-image.adoc
@@ -6,7 +6,7 @@
 [id='using-openshift-s2i-create-image-{context}']
 = Creating a container image using OpenShift builds and Source-to-Image
 
-You can use {OpenShiftName} link:https://docs.okd.io/3.9/dev_guide/builds/index.html[builds^] and the  link:https://docs.okd.io/3.9/creating_images/s2i.html[Source-to-Image (S2I)^] framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in {OpenShiftName}'s local container image repository and are available for use in deployments.
+You can use OpenShift link:https://docs.okd.io/3.9/dev_guide/builds/index.html[builds^] and the  link:https://docs.okd.io/3.9/creating_images/s2i.html[Source-to-Image (S2I)^] framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift's local container image repository and are available for use in deployments.
 
 A Kafka Connect builder image with S2I support is provided on the {DockerRepository} as part of the `{DockerKafkaConnectS2I}` image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the `/tmp/kafka-plugins/s2i` directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the `/tmp/kafka-plugins/s2i` directory.
 

--- a/documentation/book/ref-kafka-listener-network-policy-example.adoc
+++ b/documentation/book/ref-kafka-listener-network-policy-example.adoc
@@ -43,4 +43,4 @@ The application pods must be running in the same namespace as the Kafka broker.
 The syntax of the `networkPolicyPeers` field is the same as the `from` field in `NetworkPolicy` resources.
 For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
-NOTE: Your configuration of Kubernetes must support Ingress NetworkPolicies in order to use network policies in {ProductName}.
+NOTE: Your configuration of Kubernetes must support ingress NetworkPolicies in order to use network policies in {ProductName}.

--- a/documentation/book/ref-kafka-listener-network-policy-example.adoc
+++ b/documentation/book/ref-kafka-listener-network-policy-example.adoc
@@ -40,7 +40,7 @@ In the example:
 The application pods must be running in the same namespace as the Kafka broker.
 * Only application pods running in namespaces matching the labels `project: myproject` and `project: myproject2` can connect to the `tls` listener.
 
-The syntax of the `networkPolicyPeers` field is the same as the `from` field in the `NetworkPolicy` resource in {KubernetesName}.
+The syntax of the `networkPolicyPeers` field is the same as the `from` field in `NetworkPolicy` resources.
 For more information about the schema, see {K8sNetworkPolicyPeerAPI} and the xref:type-KafkaListeners-reference[`KafkaListeners` schema reference].
 
 NOTE: Your configuration of Kubernetes must support Ingress NetworkPolicies in order to use network policies in {ProductName}.

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -62,7 +62,7 @@
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html[cron expression^]
 :PrometheusConfig: link:https://prometheus.io/docs/prometheus/latest/configuration/configuration[Configuration^]
-:ExternalListeners: link:https://strimzi.io/2019/04/17/accessing-kafka-part-1.html[Accessing Kafka^]
+:ExternalListeners: link:https://strimzi.io/2019/04/17/accessing-kafka-part-1.html[Accessing Apache Kafka in Strimzi^]
 
 :OperatorHub: link:https://operatorhub.io/[OperatorHub.io^]
 :OperatorLifecycleManager: link:https://github.com/operator-framework/operator-lifecycle-manager[Operator Lifecycle Manager^]

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -62,6 +62,7 @@
 :JMXExporter: link:https://github.com/prometheus/jmx_exporter[JMX Exporter documentation^]
 :CronExpression: link:http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html[cron expression^]
 :PrometheusConfig: link:https://prometheus.io/docs/prometheus/latest/configuration/configuration[Configuration^]
+:ExternalListeners: link:https://strimzi.io/2019/04/17/accessing-kafka-part-1.html[Accessing Kafka^]
 
 :OperatorHub: link:https://operatorhub.io/[OperatorHub.io^]
 :OperatorLifecycleManager: link:https://github.com/operator-framework/operator-lifecycle-manager[Operator Lifecycle Manager^]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The listener content has been split into separate assemblies for each listener type: route, loadbalancer, ingress and node port. This will make the content easier to manage and reuse.

Includes some clean-up of OpenShift and Kubernetes attributes

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

