### PR TITLE
Include HTTP Bridge in the periodical recocniliation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -162,6 +162,7 @@ public class ClusterOperator extends AbstractVerticle {
         kafkaAssemblyOperator.reconcileAll(trigger, namespace);
         kafkaMirrorMakerAssemblyOperator.reconcileAll(trigger, namespace);
         kafkaConnectAssemblyOperator.reconcileAll(trigger, namespace);
+        kafkaBridgeAssemblyOperator.reconcileAll(trigger, namespace);
 
         if (kafkaConnectS2IAssemblyOperator != null) {
             kafkaConnectS2IAssemblyOperator.reconcileAll(trigger, namespace);


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

It seems that we forgot to plug the HTTP Bridge into the periodical reconciliation. This PR adds it there.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally