### PR TITLE
[DOC] Clarify cluster label for topic and user resources

### DIFF
--- a/documentation/book/assembly-deploying-the-topic-operator.adoc
+++ b/documentation/book/assembly-deploying-the-topic-operator.adoc
@@ -14,6 +14,8 @@
 
 include::con-what-the-topic-operator-does.adoc[leveloffset=+1]
 
+include::con-topic-operator-cluster-label.adoc[leveloffset=+1]
+
 include::con-how-the-topic-operator-works.adoc[leveloffset=+1]
 
 include::proc-deploying-the-topic-operator-using-the-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/book/assembly-user-operator.adoc
+++ b/documentation/book/assembly-user-operator.adoc
@@ -9,9 +9,11 @@
 
 :context: deploying-uo
 
-The User Operator provides a way of managing Kafka users via Kubernetes resources.
+The User Operator provides a way of managing Kafka users through custom resources.
 
 include::con-what-the-user-operator-does.adoc[leveloffset=+1]
+
+include::con-user-operator-cluster-label.adoc[leveloffset=+1]
 
 include::proc-deploying-the-user-operator-using-the-cluster-operator.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-user-operator.adoc
+++ b/documentation/book/assembly-user-operator.adoc
@@ -9,7 +9,7 @@
 
 :context: deploying-uo
 
-The User Operator provides a way of managing Kafka users through custom resources.
+The User Operator manages Kafka users through custom resources.
 
 include::con-what-the-user-operator-does.adoc[leveloffset=+1]
 

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -64,8 +64,8 @@ kind: KafkaTopic <1>
 metadata:
   name: my-topic
   labels:
-    strimzi.io/cluster: my-cluster
-spec: <2>
+    strimzi.io/cluster: my-cluster <2>
+spec: <3>
   partitions: 1
   replicas: 1
   config:
@@ -73,7 +73,8 @@ spec: <2>
     segment.bytes: 1073741824
 ----
 <1> The `kind` and `apiVersion` identify the CRD of which the custom resource is an instance.
-<2> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log.
+<2> A `kafkaTopic` resource includes a label that defines the name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs. xref:con-topic-operator-cluster-label-deploying[The name is used by the Topic Operator to identify the Kafka cluster when creating the topic].
+<3> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log.
 
 Custom resources can be applied to a cluster through the platform CLI. When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -73,7 +73,7 @@ spec: <3>
     segment.bytes: 1073741824
 ----
 <1> The `kind` and `apiVersion` identify the CRD of which the custom resource is an instance.
-<2> A label, applicable only to `KafkaTopic` and `KafkaUser` resources, that defines the name of the Kafka cluster (derived from the name of the `Kafka` resource) to which a topic or user belongs.
+<2> A label, applicable only to `KafkaTopic` and `KafkaUser` resources, that defines the name of the Kafka cluster (which is same as the name of the `Kafka` resource) to which a topic or user belongs.
 +
 The name is used by the xref:con-topic-operator-cluster-label-deploying[Topic Operator] and xref:con-user-operator-cluster-label-deploying-uo[User Operator] to identify the Kafka cluster when creating a topic or user.
 <3> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log. A configuration may include many more parameters than shown here.

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -73,8 +73,10 @@ spec: <3>
     segment.bytes: 1073741824
 ----
 <1> The `kind` and `apiVersion` identify the CRD of which the custom resource is an instance.
-<2> A `kafkaTopic` resource includes a label that defines the name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs. xref:con-topic-operator-cluster-label-deploying[The name is used by the Topic Operator to identify the Kafka cluster when creating the topic].
-<3> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log.
+<2> A label, applicable only to `KafkaTopic` and `KafkaUser` resources, that defines the name of the Kafka cluster (derived from the name of the `Kafka` resource) to which a topic or user belongs.
++
+The name is used by the xref:con-topic-operator-cluster-label-deploying[Topic Operator] and xref:con-user-operator-cluster-label-deploying-uo[User Operator] to identify the Kafka cluster when creating a topic or user.
+<3> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log. A configuration may include many more parameters than shown here.
 
 Custom resources can be applied to a cluster through the platform CLI. When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -76,7 +76,7 @@ spec: <3>
 <2> A label, applicable only to `KafkaTopic` and `KafkaUser` resources, that defines the name of the Kafka cluster (which is same as the name of the `Kafka` resource) to which a topic or user belongs.
 +
 The name is used by the xref:con-topic-operator-cluster-label-deploying[Topic Operator] and xref:con-user-operator-cluster-label-deploying-uo[User Operator] to identify the Kafka cluster when creating a topic or user.
-<3> The spec shows the number of partitions and replicas for the topic as well as configuration for the retention period for a message to remain in the topic and the segment file size for the log. A configuration may include many more parameters than shown here.
+<3> The spec shows the number of partitions and replicas for the topic as well as the configuration parameters for the topic itself. In this example, the retention period for a message to remain in the topic and the segment file size for the log are specified.
 
 Custom resources can be applied to a cluster through the platform CLI. When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 

--- a/documentation/book/con-customizing-labels-and-annotations.adoc
+++ b/documentation/book/con-customizing-labels-and-annotations.adoc
@@ -6,7 +6,8 @@
 = Labels and Annotations
 
 For every resource, you can configure additional `Labels` and `Annotations`.
-`Labels` and `Annotations` are configured in the `metadata` property.
+`Labels` and `Annotations` are used to identify and organize resources, and are configured in the `metadata` property.
+
 For example:
 
 [source,yaml,subs=attributes+]
@@ -25,4 +26,4 @@ template:
 ----
 
 The `labels` and `annotations` fields can contain any labels or annotations that do not contain the reserved string `strimzi.io`.
-Labels and annotations containing `strimzi.io` are used internally by {ProductName} and cannot be configured by the user.
+Labels and annotations containing `strimzi.io` are used internally by {ProductName} and cannot be configured.

--- a/documentation/book/con-topic-operator-cluster-label.adoc
+++ b/documentation/book/con-topic-operator-cluster-label.adoc
@@ -10,6 +10,10 @@ A `KafkaTopic` resource includes a label that defines the appropriate name of th
 
 [source,yaml,subs="attributes+"]
 ----
+apiVersion: {KafkaApiVersion}
+kind: KafkaTopic
+metadata:
+  name: my-topic
   labels:
     strimzi.io/cluster: my-cluster
 ----

--- a/documentation/book/con-topic-operator-cluster-label.adoc
+++ b/documentation/book/con-topic-operator-cluster-label.adoc
@@ -20,4 +20,4 @@ metadata:
 
 The label is used by the Topic Operator to identify the `KafkaTopic` resource and create a new topic.
 
-If the label does not match the Kafka cluster, The Topic Operator cannot identify the `KafkaTopic` and the topic is not created.
+If the label does not match the Kafka cluster, the Topic Operator cannot identify the `KafkaTopic` and the topic is not created.

--- a/documentation/book/con-topic-operator-cluster-label.adoc
+++ b/documentation/book/con-topic-operator-cluster-label.adoc
@@ -4,9 +4,9 @@
 
 [id='con-topic-operator-cluster-label-{context}']
 
-= Identifying a Kafka cluster for topic creation
+= Identifying a Kafka cluster for topic handling
 
-A `kafkaTopic` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
+A `KafkaTopic` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
 
 [source,yaml,subs="attributes+"]
 ----
@@ -16,4 +16,4 @@ A `kafkaTopic` resource includes a label that defines the appropriate name of th
 
 The label is used by the Topic Operator to identify the `KafkaTopic` resource and create a new topic.
 
-If the label does not match the Kafka cluster, The Topic Operator cannot identify the `kafkaTopic` and the topic is not created.
+If the label does not match the Kafka cluster, The Topic Operator cannot identify the `KafkaTopic` and the topic is not created.

--- a/documentation/book/con-topic-operator-cluster-label.adoc
+++ b/documentation/book/con-topic-operator-cluster-label.adoc
@@ -18,6 +18,6 @@ metadata:
     strimzi.io/cluster: my-cluster
 ----
 
-The label is used by the Topic Operator to identify the `KafkaTopic` resource and create a new topic.
+The label is used by the Topic Operator to identify the `KafkaTopic` resource and create a new topic, and also in subsequent handling of the topic.
 
 If the label does not match the Kafka cluster, the Topic Operator cannot identify the `KafkaTopic` and the topic is not created.

--- a/documentation/book/con-topic-operator-cluster-label.adoc
+++ b/documentation/book/con-topic-operator-cluster-label.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// assembly-deploying-the-topic-operator.adoc
+
+[id='con-topic-operator-cluster-label-{context}']
+
+= Identifying a Kafka cluster for topic creation
+
+A `kafkaTopic` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
+
+[source,yaml,subs="attributes+"]
+----
+  labels:
+    strimzi.io/cluster: my-cluster
+----
+
+The label is used by the Topic Operator to identify the `KafkaTopic` resource and create a new topic.
+
+If the label does not match the Kafka cluster, The Topic Operator cannot identify the `kafkaTopic` and the topic is not created.

--- a/documentation/book/con-user-operator-cluster-label.adoc
+++ b/documentation/book/con-user-operator-cluster-label.adoc
@@ -10,6 +10,10 @@ A `KafkaUser` resource includes a label that defines the appropriate name of the
 
 [source,yaml,subs="attributes+"]
 ----
+apiVersion: {KafkaApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
   labels:
     strimzi.io/cluster: my-cluster
 ----

--- a/documentation/book/con-user-operator-cluster-label.adoc
+++ b/documentation/book/con-user-operator-cluster-label.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// assembly-getting-started-user-operator.adoc
+
+[id='con-user-operator-cluster-label-{context}']
+
+= Identifying a Kafka cluster for user creation
+
+A `kafkaUser` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
+
+[source,yaml,subs="attributes+"]
+----
+  labels:
+    strimzi.io/cluster: my-cluster
+----
+
+The label is used by the User Operator to identify the `KafkaUser` resource and create a new user.
+
+If the label does not match the Kafka cluster, The User Operator cannot identify the `kafkaUser` and the user is not created.

--- a/documentation/book/con-user-operator-cluster-label.adoc
+++ b/documentation/book/con-user-operator-cluster-label.adoc
@@ -20,4 +20,4 @@ metadata:
 
 The label is used by the User Operator to identify the `KafkaUser` resource and create a new user.
 
-If the label does not match the Kafka cluster, The User Operator cannot identify the `kafkaUser` and the user is not created.
+If the label does not match the Kafka cluster, the User Operator cannot identify the `kafkaUser` and the user is not created.

--- a/documentation/book/con-user-operator-cluster-label.adoc
+++ b/documentation/book/con-user-operator-cluster-label.adoc
@@ -18,6 +18,6 @@ metadata:
     strimzi.io/cluster: my-cluster
 ----
 
-The label is used by the User Operator to identify the `KafkaUser` resource and create a new user.
+The label is used by the User Operator to identify the `KafkaUser` resource and create a new user, and also in subsequent handling of the user.
 
 If the label does not match the Kafka cluster, the User Operator cannot identify the `kafkaUser` and the user is not created.

--- a/documentation/book/con-user-operator-cluster-label.adoc
+++ b/documentation/book/con-user-operator-cluster-label.adoc
@@ -4,9 +4,9 @@
 
 [id='con-user-operator-cluster-label-{context}']
 
-= Identifying a Kafka cluster for user creation
+= Identifying a Kafka cluster for user handling
 
-A `kafkaUser` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
+A `KafkaUser` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
 
 [source,yaml,subs="attributes+"]
 ----

--- a/documentation/book/con-what-the-user-operator-does.adoc
+++ b/documentation/book/con-what-the-user-operator-does.adoc
@@ -5,7 +5,7 @@
 [id='con-what-the-user-operator-does-{context}']
 = Overview of the User Operator component
 
-The User Operator manages Kafka users for a Kafka cluster by watching for `KafkaUser` Kubernetes resources that describe Kafka users and ensuring that they are configured properly in the Kafka cluster.
+The User Operator manages Kafka users for a Kafka cluster by watching for `KafkaUser` resources that describe Kafka users and ensuring that they are configured properly in the Kafka cluster.
 For example:
 
 * if a `KafkaUser` is created, the User Operator will create the user it describes
@@ -16,7 +16,7 @@ Unlike the xref:what-the-topic-operator-does-str[Topic Operator], the User Opera
 Unlike the Kafka topics which might be created by applications directly in Kafka, it is not expected that the users will be managed directly in the Kafka cluster in parallel with the User Operator, so this should not be needed.
 
 The User Operator allows you to declare a `KafkaUser` as part of your application's deployment.
-When the user is created, the credentials will be created in a `Secret`.
+When the user is created, the user credentials will be created in a `Secret`.
 Your application needs to use the user and its credentials for authentication and to produce or consume messages.
 
 In addition to managing credentials for authentication, the User Operator also manages authorization rules by including a description of the user's rights in the `KafkaUser` declaration.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

New concepts sections in the User Operator and Topic Operator chapters that describe the requirements (and importance) of the label that defines the kafka cluster to which the resource belongs.

Also added an additional callout against the label property in the KafkaTopic example, which links to the new Topic Operator section

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

