### PR TITLE
Create resource classes for Connect, Connect S2I and MirrorMaker

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
+ * {@code KafkaConnect} cluster.
+ */
+public class KafkaConnectResources {
+    protected KafkaConnectResources() { }
+
+    /**
+     * Returns the name of the Kafka Connect {@code Deployment} for a {@code KafkaConnect} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding Kafka Connect {@code Deployment}.
+     */
+    public static String deploymentName(String clusterName) {
+        return clusterName + "-connect";
+    }
+
+    /**
+     * Returns the name of the Kafka Connect {@code ServiceAccount} for a {@code KafkaConnect} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding Kafka Connect {@code ServiceAccount}.
+     */
+    public static String serviceAccountName(String clusterName) {
+        return deploymentName(clusterName);
+    }
+
+    /**
+     * Returns the name of the HTTP REST {@code Service} for a {@code KafkaConnect} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding {@code Service}.
+     */
+    public static String serviceName(String clusterName) {
+        return clusterName + "-connect-api";
+    }
+
+    /**
+     * Returns the name of the Kafka Connect metrics and log {@code ConfigMap} for a {@code KafkaConnect} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @return The name of the corresponding KafkaConnect metrics and log {@code ConfigMap}.
+     */
+    public static String metricsAndLogConfigMapName(String clusterName) {
+        return clusterName + "-connect-config";
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
@@ -14,18 +14,18 @@ public class KafkaConnectS2IResources extends KafkaConnectResources {
     }
 
     /**
-     * Returns the name of the Kafka Connect S2I {@code BuildConfig} for a {@code KafkaConnectS2I} cluster of the given name.
+     * Returns the name of the Kafka Connect S2I source {@code BuildConfig} for a {@code KafkaConnectS2I} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnectS2I} resource.
-     * @return The name of the corresponding Kafka Connect S2I {@code BuildConfig}.
+     * @return The name of the corresponding Kafka Connect S2I source {@code BuildConfig}.
      */
     public static String buildConfigName(String clusterName) {
         return deploymentName(clusterName);
     }
 
     /**
-     * Returns the name of the Kafka Connect S2I {@code ImageStream} for a {@code KafkaConnectS2I} cluster of the given name.
+     * Returns the name of the Kafka Connect S2I target {@code ImageStream} for a {@code KafkaConnectS2I} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnectS2I} resource.
-     * @return The name of the corresponding Kafka Connect S2I {@code ImageStream}.
+     * @return The name of the corresponding Kafka Connect S2I target {@code ImageStream}.
      */
     public static String targetImageStreamName(String clusterName) {
         return deploymentName(clusterName);

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
+ * {@code KafkaConnectS2I} cluster.
+ */
+public class KafkaConnectS2IResources extends KafkaConnectResources {
+    private KafkaConnectS2IResources() {
+        super();
+    }
+
+    /**
+     * Returns the name of the Kafka Connect S2I {@code BuildConfig} for a {@code KafkaConnectS2I} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnectS2I} resource.
+     * @return The name of the corresponding Kafka Connect S2I {@code BuildConfig}.
+     */
+    public static String buildConfigName(String clusterName) {
+        return deploymentName(clusterName);
+    }
+
+    /**
+     * Returns the name of the Kafka Connect S2I {@code ImageStream} for a {@code KafkaConnectS2I} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnectS2I} resource.
+     * @return The name of the corresponding Kafka Connect S2I {@code ImageStream}.
+     */
+    public static String targetImageStreamName(String clusterName) {
+        return deploymentName(clusterName);
+    }
+
+    /**
+     * Returns the name of the Kafka Connect S2I {@code ImageStream} for a {@code KafkaConnectS2I} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnectS2I} resource.
+     * @return The name of the corresponding Kafka Connect S2I {@code ImageStream}.
+     */
+    public static String sourceImageStreamName(String clusterName) {
+        return deploymentName(clusterName) + "-source";
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerResources.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
+ * {@code KafkaMirrorMaker} cluster.
+ */
+public class KafkaMirrorMakerResources {
+    protected KafkaMirrorMakerResources() { }
+
+    /**
+     * Returns the name of the Kafka Mirror Maker {@code Deployment} for a {@code KafkaMirrorMaker} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker} resource.
+     * @return The name of the corresponding Kafka Mirror Maker {@code Deployment}.
+     */
+    public static String deploymentName(String clusterName) {
+        return clusterName + "-mirror-maker";
+    }
+
+    /**
+     * Returns the name of the Kafka Mirror Maker {@code ServiceAccount} for a {@code KafkaMirrorMaker} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker} resource.
+     * @return The name of the corresponding Kafka Mirror Maker {@code ServiceAccount}.
+     */
+    public static String serviceAccountName(String clusterName) {
+        return deploymentName(clusterName);
+    }
+
+    /**
+     * Returns the name of the Prometheus {@code Service} for a {@code KafkaMirrorMaker} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker} resource.
+     * @return The name of the corresponding {@code Service}.
+     */
+    public static String serviceName(String clusterName) {
+        return clusterName + "-mirror-maker";
+    }
+
+    /**
+     * Returns the name of the Kafka Mirror Maker metrics and log {@code ConfigMap} for a {@code KafkaMirrorMaker} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker} resource.
+     * @return The name of the corresponding Kafka Mirror Maker metrics and log {@code ConfigMap}.
+     */
+    public static String metricsAndLogConfigMapName(String clusterName) {
+        return clusterName + "-mirror-maker-config";
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -34,6 +34,7 @@ import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationPlain;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTls;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
 import io.strimzi.api.kafka.model.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.KafkaConnectTls;
@@ -60,10 +61,6 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static final int REST_API_PORT = 8083;
     protected static final String REST_API_PORT_NAME = "rest-api";
 
-    private static final String NAME_SUFFIX = "-connect";
-    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-api";
-
-    private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
     protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/connect-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT = "/opt/kafka/connect-password/";
     protected static final String EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH = "/opt/kafka/external-configuration/";
@@ -108,9 +105,9 @@ public class KafkaConnectCluster extends AbstractModel {
      */
     protected KafkaConnectCluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
-        this.name = kafkaConnectClusterName(cluster);
-        this.serviceName = serviceName(cluster);
-        this.ancillaryConfigName = logAndMetricsConfigName(cluster);
+        this.name = KafkaConnectResources.deploymentName(cluster);
+        this.serviceName = KafkaConnectResources.serviceName(cluster);
+        this.ancillaryConfigName = KafkaConnectResources.metricsAndLogConfigMapName(cluster);
         this.replicas = DEFAULT_REPLICAS;
         this.readinessPath = "/";
         this.readinessProbeOptions = DEFAULT_HEALTHCHECK_OPTIONS;
@@ -121,18 +118,6 @@ public class KafkaConnectCluster extends AbstractModel {
         this.mountPath = "/var/lib/kafka";
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
-    }
-
-    public static String kafkaConnectClusterName(String cluster) {
-        return cluster + KafkaConnectCluster.NAME_SUFFIX;
-    }
-
-    public static String serviceName(String cluster) {
-        return cluster + KafkaConnectCluster.SERVICE_NAME_SUFFIX;
-    }
-
-    public static String logAndMetricsConfigName(String cluster) {
-        return cluster + KafkaConnectCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
     }
 
     public static KafkaConnectCluster fromCrd(KafkaConnect kafkaConnect, KafkaVersion.Lookup versions) {
@@ -613,15 +598,6 @@ public class KafkaConnectCluster extends AbstractModel {
 
     @Override
     protected String getServiceAccountName() {
-        return containerServiceAccountName(cluster);
-    }
-
-    /**
-     * Get the name of the connect service account given the name of the {@code connectResourceName}.
-     * @param connectResourceName  The resource name.
-     * @return The service account name.
-     */
-    public static String containerServiceAccountName(String connectResourceName) {
-        return kafkaConnectClusterName(connectResourceName);
+        return KafkaConnectResources.serviceAccountName(cluster);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -27,6 +27,7 @@ import io.fabric8.openshift.api.model.TagImportPolicyBuilder;
 import io.fabric8.openshift.api.model.TagReference;
 import io.fabric8.openshift.api.model.TagReferencePolicyBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2ISpec;
 import io.strimzi.operator.common.model.Labels;
 
@@ -168,9 +169,9 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
         ImageStream imageStream = new ImageStreamBuilder()
                 .withNewMetadata()
-                    .withName(getSourceImageStreamName())
+                    .withName(KafkaConnectS2IResources.sourceImageStreamName(cluster))
                     .withNamespace(namespace)
-                    .withLabels(getLabelsWithName(getSourceImageStreamName()))
+                    .withLabels(getLabelsWithName(KafkaConnectS2IResources.sourceImageStreamName(cluster)))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withNewSpec()
@@ -190,7 +191,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     public ImageStream generateTargetImageStream() {
         ImageStream imageStream = new ImageStreamBuilder()
                 .withNewMetadata()
-                    .withName(name)
+                    .withName(KafkaConnectS2IResources.targetImageStreamName(cluster))
                     .withNamespace(namespace)
                     .withLabels(getLabelsWithName())
                     .withOwnerReferences(createOwnerReference())
@@ -218,7 +219,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
         BuildConfig build = new BuildConfigBuilder()
                 .withNewMetadata()
-                    .withName(name)
+                    .withName(KafkaConnectS2IResources.buildConfigName(cluster))
                     .withLabels(getLabelsWithName())
                     .withNamespace(namespace)
                     .withOwnerReferences(createOwnerReference())
@@ -242,7 +243,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withScripts("image:///opt/kafka/s2i")
                             .withNewFrom()
                                 .withKind("ImageStreamTag")
-                                .withName(getSourceImageStreamName() + ":" + sourceImageTag)
+                                .withName(KafkaConnectS2IResources.sourceImageStreamName(cluster) + ":" + sourceImageTag)
                             .endFrom()
                         .endSourceStrategy()
                     .endStrategy()
@@ -251,25 +252,6 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .build();
 
         return build;
-    }
-
-    /**
-     * Generates the name of the source ImageStream
-     *
-     * @return               Name of the source ImageStream instance
-     */
-    public String getSourceImageStreamName() {
-        return getSourceImageStreamName(name);
-    }
-
-    /**
-     * Generates the name of the source ImageStream
-     *
-     * @param baseName       Name of the Kafka Connect cluster
-     * @return               Name of the source ImageStream instance
-     */
-    public static String getSourceImageStreamName(String baseName) {
-        return baseName + "-source";
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -30,6 +30,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationTls;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerClientSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerSpec;
 import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.Probe;
@@ -43,10 +44,6 @@ import java.util.List;
 import java.util.Map;
 
 public class KafkaMirrorMakerCluster extends AbstractModel {
-
-    private static final String NAME_SUFFIX = "-mirror-maker";
-
-    private static final String METRICS_AND_LOG_CONFIG_SUFFIX = NAME_SUFFIX + "-config";
     protected static final String TLS_CERTS_VOLUME_MOUNT_CONSUMER = "/opt/kafka/consumer-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT_CONSUMER = "/opt/kafka/consumer-password/";
     protected static final String TLS_CERTS_VOLUME_MOUNT_PRODUCER = "/opt/kafka/producer-certs/";
@@ -109,9 +106,9 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
      */
     protected KafkaMirrorMakerCluster(String namespace, String cluster, Labels labels) {
         super(namespace, cluster, labels);
-        this.name = kafkaMirrorMakerClusterName(cluster);
-        this.serviceName = serviceName(cluster);
-        this.ancillaryConfigName = logAndMetricsConfigName(cluster);
+        this.name = KafkaMirrorMakerResources.deploymentName(cluster);
+        this.serviceName = KafkaMirrorMakerResources.serviceName(cluster);
+        this.ancillaryConfigName = KafkaMirrorMakerResources.metricsAndLogConfigMapName(cluster);
         this.replicas = DEFAULT_REPLICAS;
         this.readinessPath = "/";
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;
@@ -123,19 +120,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
     }
-
-    public static String kafkaMirrorMakerClusterName(String cluster) {
-        return cluster + KafkaMirrorMakerCluster.NAME_SUFFIX;
-    }
-
-    public static String serviceName(String cluster) {
-        return kafkaMirrorMakerClusterName(cluster);
-    }
-
-    public static String logAndMetricsConfigName(String cluster) {
-        return cluster + KafkaMirrorMakerCluster.METRICS_AND_LOG_CONFIG_SUFFIX;
-    }
-
 
     private static void setClientAuth(KafkaMirrorMakerCluster kafkaMirrorMakerCluster, KafkaMirrorMakerClientSpec client) {
         if (client != null && client.getAuthentication() != null) {
@@ -536,15 +520,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
     @Override
     protected String getServiceAccountName() {
-        return containerServiceAccountName(cluster);
-    }
-
-    /**
-     * Get the name of the mirror maker service account given the name of the {@code mirrorMakerResourceName}.
-     * @param mirrorMakerResourceName The resource name
-     * @return The service account name.
-     */
-    public static String containerServiceAccountName(String mirrorMakerResourceName) {
-        return kafkaMirrorMakerClusterName(mirrorMakerResourceName);
+        return KafkaMirrorMakerResources.serviceAccountName(cluster);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -94,7 +95,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
 
     Future<ReconcileResult<ServiceAccount>> connectServiceAccount(String namespace, KafkaConnectCluster connect) {
         return serviceAccountOperations.reconcile(namespace,
-                KafkaConnectCluster.containerServiceAccountName(connect.getCluster()),
+                KafkaConnectResources.serviceAccountName(connect.getCluster()),
                 connect.generateServiceAccount());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -86,7 +87,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
         log.debug("{}: Updating Kafka Mirror Maker cluster", reconciliation, name, namespace);
         return mirrorMakerServiceAccount(namespace, mirror)
                 .compose(i -> deploymentOperations.scaleDown(namespace, mirror.getName(), mirror.getReplicas()))
-                .compose(scale -> serviceOperations.reconcile(namespace, mirror.getServiceName(), mirror.generateService()))
+                .compose(scale -> serviceOperations.reconcile(namespace, KafkaMirrorMakerResources.serviceName(mirror.getCluster()), mirror.generateService()))
                 .compose(i -> configMapOperations.reconcile(namespace, mirror.getAncillaryConfigName(), logAndMetricsConfigMap))
                 .compose(i -> podDisruptionBudgetOperator.reconcile(namespace, mirror.getName(), mirror.generatePodDisruptionBudget()))
                 .compose(i -> deploymentOperations.reconcile(namespace, mirror.getName(), mirror.generateDeployment(annotations, pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
@@ -95,7 +96,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
 
     Future<ReconcileResult<ServiceAccount>> mirrorMakerServiceAccount(String namespace, KafkaMirrorMakerCluster mirror) {
         return serviceAccountOperations.reconcile(namespace,
-                KafkaMirrorMakerCluster.containerServiceAccountName(mirror.getCluster()),
+                KafkaMirrorMakerResources.serviceAccountName(mirror.getCluster()),
                 mirror.generateServiceAccount());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -28,6 +28,7 @@ import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnv;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder;
@@ -119,7 +120,7 @@ public class KafkaConnectClusterTest {
     }
 
     private Map<String, String> expectedLabels()    {
-        return expectedLabels(kc.kafkaConnectClusterName(cluster));
+        return expectedLabels(KafkaConnectResources.deploymentName(cluster));
     }
 
     protected List<EnvVar> getExpectedEnvVars() {
@@ -182,7 +183,7 @@ public class KafkaConnectClusterTest {
     public void testGenerateDeployment()   {
         Deployment dep = kc.generateDeployment(new HashMap<String, String>(), true, null, null);
 
-        assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
+        assertEquals(KafkaConnectResources.deploymentName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
         Map<String, String> expectedLabels = expectedLabels();
         assertEquals(expectedLabels, dep.getMetadata().getLabels());
@@ -190,7 +191,7 @@ public class KafkaConnectClusterTest {
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
         assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
-        assertEquals(kc.kafkaConnectClusterName(this.cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
+        assertEquals(KafkaConnectResources.deploymentName(this.cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         assertEquals(kc.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -25,6 +25,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -124,7 +125,7 @@ public class KafkaMirrorMakerClusterTest {
     }
 
     private Map<String, String> expectedLabels()    {
-        return expectedLabels(mm.kafkaMirrorMakerClusterName(cluster));
+        return expectedLabels(KafkaMirrorMakerResources.deploymentName(cluster));
     }
 
     protected List<EnvVar> getExpectedEnvVars() {
@@ -191,7 +192,7 @@ public class KafkaMirrorMakerClusterTest {
     public void testGenerateDeployment()   {
         Deployment dep = mm.generateDeployment(new HashMap<String, String>(), true, null, null);
 
-        assertEquals(mm.kafkaMirrorMakerClusterName(cluster), dep.getMetadata().getName());
+        assertEquals(KafkaMirrorMakerResources.deploymentName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
         Map<String, String> expectedLabels = expectedLabels();
         assertEquals(expectedLabels, dep.getMetadata().getLabels());
@@ -199,7 +200,7 @@ public class KafkaMirrorMakerClusterTest {
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
         assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
-        assertEquals(mm.kafkaMirrorMakerClusterName(this.cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
+        assertEquals(KafkaMirrorMakerResources.deploymentName(this.cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         assertEquals(mm.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -11,10 +11,10 @@ import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -97,10 +97,10 @@ public class KafkaConnectAssemblyOperatorMockTest {
         kco.reconcileAssembly(new Reconciliation("test-trigger", ResourceType.CONNECT, NAMESPACE, CLUSTER_NAME), ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.assertTrue(ar.succeeded());
-            context.assertNotNull(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectCluster.logAndMetricsConfigName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectCluster.serviceName(CLUSTER_NAME)).get());
-            context.assertNotNull(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaConnectCluster.kafkaConnectClusterName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaConnectResources.metricsAndLogConfigMapName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.services().inNamespace(NAMESPACE).withName(KafkaConnectResources.serviceName(CLUSTER_NAME)).get());
+            context.assertNotNull(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get());
             createAsync.complete();
         });
         createAsync.await();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -124,7 +125,7 @@ public class KafkaConnectAssemblyOperatorTest {
             // No metrics config  => no CMs created
             Set<String> metricsNames = new HashSet<>();
             if (connect.isMetricsEnabled()) {
-                metricsNames.add(KafkaConnectCluster.logAndMetricsConfigName(clusterCmName));
+                metricsNames.add(KafkaConnectResources.metricsAndLogConfigMapName(clusterCmName));
             }
 
             // Verify service
@@ -267,21 +268,21 @@ public class KafkaConnectAssemblyOperatorTest {
         // Mock CM get
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         ConfigMap metricsCm = new ConfigMapBuilder().withNewMetadata()
-                    .withName(KafkaConnectCluster.logAndMetricsConfigName(clusterCmName))
+                    .withName(KafkaConnectResources.metricsAndLogConfigMapName(clusterCmName))
                     .withNamespace(clusterCmNamespace)
                 .endMetadata()
                 .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
                 .build();
-        when(mockCmOps.get(clusterCmNamespace, KafkaConnectCluster.logAndMetricsConfigName(clusterCmName))).thenReturn(metricsCm);
+        when(mockCmOps.get(clusterCmNamespace, KafkaConnectResources.metricsAndLogConfigMapName(clusterCmName))).thenReturn(metricsCm);
 
         ConfigMap loggingCm = new ConfigMapBuilder().withNewMetadata()
-                    .withName(KafkaConnectCluster.logAndMetricsConfigName(clusterCmName))
+                    .withName(KafkaConnectResources.metricsAndLogConfigMapName(clusterCmName))
                     .withNamespace(clusterCmNamespace)
                     .endMetadata()
                     .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG, LOGGING_CONFIG))
                     .build();
 
-        when(mockCmOps.get(clusterCmNamespace, KafkaConnectCluster.logAndMetricsConfigName(clusterCmName))).thenReturn(metricsCm);
+        when(mockCmOps.get(clusterCmNamespace, KafkaConnectResources.metricsAndLogConfigMapName(clusterCmName))).thenReturn(metricsCm);
 
         // Mock CM patch
         Set<String> metricsCms = TestUtils.set();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
+import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -170,11 +171,11 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             // Verify Image Streams
             List<ImageStream> capturedIs = isCaptor.getAllValues();
             context.assertEquals(2, capturedIs.size());
-            int sisIndex = (connect.getSourceImageStreamName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
             int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
             ImageStream sis = capturedIs.get(sisIndex);
-            context.assertEquals(connect.getSourceImageStreamName(), sis.getMetadata().getName());
+            context.assertEquals(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()), sis.getMetadata().getName());
             context.assertEquals(connect.generateSourceImageStream(), sis, "Source Image Streams are not equal");
 
             ImageStream tis = capturedIs.get(tisIndex);
@@ -204,7 +205,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>(), true, null, null));
-        when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
         when(mockPdbOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generatePodDisruptionBudget());
@@ -304,7 +305,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>(), true, null, null));
-        when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
         when(mockPdbOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generatePodDisruptionBudget());
@@ -349,12 +350,12 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         // Mock CM get
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         ConfigMap metricsCm = new ConfigMapBuilder().withNewMetadata()
-                    .withName(KafkaConnectS2ICluster.logAndMetricsConfigName(clusterCmName))
+                    .withName(KafkaConnectS2IResources.metricsAndLogConfigMapName(clusterCmName))
                     .withNamespace(clusterCmNamespace)
                 .endMetadata()
                 .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
                 .build();
-        when(mockCmOps.get(clusterCmNamespace, KafkaConnectS2ICluster.logAndMetricsConfigName(clusterCmName))).thenReturn(metricsCm);
+        when(mockCmOps.get(clusterCmNamespace, KafkaConnectS2IResources.metricsAndLogConfigMapName(clusterCmName))).thenReturn(metricsCm);
 
         // Mock CM patch
         Set<String> metricsCms = TestUtils.set();
@@ -406,11 +407,11 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             // Verify Image Streams
             List<ImageStream> capturedIs = isCaptor.getAllValues();
             context.assertEquals(2, capturedIs.size());
-            int sisIndex = (compareTo.getSourceImageStreamName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
             int tisIndex = (compareTo.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
             ImageStream sis = capturedIs.get(sisIndex);
-            context.assertEquals(compareTo.getSourceImageStreamName(), sis.getMetadata().getName());
+            context.assertEquals(KafkaConnectS2IResources.sourceImageStreamName(compareTo.getCluster()), sis.getMetadata().getName());
             context.assertEquals(compareTo.generateSourceImageStream(), sis, "Source Image Streams are not equal");
 
             ImageStream tis = capturedIs.get(tisIndex);
@@ -444,9 +445,9 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>(), true, null, null));
-        when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
-        when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
-        when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))).thenReturn(connect.generateSourceImageStream());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.targetImageStreamName(connect.getCluster()))).thenReturn(connect.generateTargetImageStream());
+        when(mockBcOps.get(clusterCmNamespace, KafkaConnectS2IResources.buildConfigName(connect.getCluster()))).thenReturn(connect.generateBuildConfig());
         when(mockPdbOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generatePodDisruptionBudget());
 
         ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
@@ -521,7 +522,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>(), true, null, null));
-        when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
         when(mockPdbOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generatePodDisruptionBudget());
@@ -580,7 +581,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         when(mockConnectOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig(new HashMap<String, String>(), true, null, null));
-        when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());
+        when(mockIsOps.get(clusterCmNamespace, KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))).thenReturn(connect.generateSourceImageStream());
         when(mockIsOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateTargetImageStream());
         when(mockBcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateBuildConfig());
         when(mockPdbOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generatePodDisruptionBudget());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -150,7 +151,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             // No metrics config  => no CMs created
             Set<String> metricsNames = new HashSet<>();
             if (mirror.isMetricsEnabled()) {
-                metricsNames.add(KafkaMirrorMakerCluster.logAndMetricsConfigName(clusterCmName));
+                metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName));
             }
 
             // Verify Deployment
@@ -311,21 +312,21 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         // Mock CM get
         when(mockMirrorOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         ConfigMap metricsCm = new ConfigMapBuilder().withNewMetadata()
-                    .withName(KafkaMirrorMakerCluster.logAndMetricsConfigName(clusterCmName))
+                    .withName(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName))
                     .withNamespace(clusterCmNamespace)
                 .endMetadata()
                 .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
                 .build();
-        when(mockCmOps.get(clusterCmNamespace, KafkaMirrorMakerCluster.logAndMetricsConfigName(clusterCmName))).thenReturn(metricsCm);
+        when(mockCmOps.get(clusterCmNamespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName))).thenReturn(metricsCm);
 
         ConfigMap loggingCm = new ConfigMapBuilder().withNewMetadata()
-                    .withName(KafkaMirrorMakerCluster.logAndMetricsConfigName(clusterCmName))
+                    .withName(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName))
                     .withNamespace(clusterCmNamespace)
                     .endMetadata()
                     .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG, LOGGING_CONFIG))
                     .build();
 
-        when(mockCmOps.get(clusterCmNamespace, KafkaMirrorMakerCluster.logAndMetricsConfigName(clusterCmName))).thenReturn(metricsCm);
+        when(mockCmOps.get(clusterCmNamespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName))).thenReturn(metricsCm);
 
         // Mock CM patch
         Set<String> metricsCms = TestUtils.set();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Some time ago we created the class `KafkaResources` with methods for naming different resources related to Kafka clusters. This is among other currently used in tests. But we never moved forward with this for another custom Resources. This Pr does the same for Kafka Connect (including S2I), and Kafka Mirror Maker. Kafka Bridge will be done in other PR together with some tests using it. 

### Checklist

- [x] Make sure all tests pass