### PR TITLE
Add documentation for duplicate rolebindings if both watchNamespaces …

### DIFF
--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,6 +1,6 @@
 # Default values for strimzi-kafka-operator.
 
-# If you set `watchNamespaces` to the same value as ``.Release.Namespace` (e.g. `helm ... -n $NAMESPACE`), 
+# If you set `watchNamespaces` to the same value as ``.Release.Namespace` (e.g. `helm ... --namespace $NAMESPACE`), 
 # the chart will fail because duplicate RoleBindings will be attempted to be created in the same namespace
 watchNamespaces: []
 

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for strimzi-kafka-operator.
 
-# If you set `watchNamespaces` to the same value as `namespace` (e.g. `helm ... -n $NAMESPACE`), the chart will fail
-# because two RoleBindings will be attempted to be created under the same namespace
+# If you set `watchNamespaces` to the same value as ``.Release.Namespace` (e.g. `helm ... -n $NAMESPACE`), 
+# the chart will fail because duplicate RoleBindings will be attempted to be created in the same namespace
 watchNamespaces: []
 
 image:

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -1,5 +1,7 @@
 # Default values for strimzi-kafka-operator.
 
+# If you set `watchNamespaces` to the same value as `namespace` (e.g. `helm ... -n $NAMESPACE`), the chart will fail
+# because two RoleBindings will be attempted to be created under the same namespace
 watchNamespaces: []
 
 image:


### PR DESCRIPTION
…and namespace are set to the same value

### Type of change

- Documentation

### Description

If you set `watchNamespaces` to the same value as `.Release.Namespace` (e.g. `helm ... -n $NAMESPACE`), the chart will fail because two RoleBindings will be attempted to be created under the same namespace

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

