### PR TITLE
[DOC] Document Forced CA Cert Renewal and Key Replacement

### DIFF
--- a/documentation/book/assembly-deployment-configuration-kafka.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka.adoc
@@ -69,6 +69,10 @@ include::proc-manual-delete-pod-pvc-kafka.adoc[leveloffset=+1]
 
 include::proc-manual-delete-pod-pvc-zookeeper.adoc[leveloffset=+1]
 
+include::proc-renewing-ca-certs-manually.adoc[leveloffset=+1]
+
+include::proc-replacing-private-keys.adoc[leveloffset=+1]
+
 include::assembly-maintenance-time-windows.adoc[leveloffset=+1]
 
 include::ref-list-of-kafka-cluster-resources.adoc[leveloffset=+1]

--- a/documentation/book/assembly-deployment-configuration-kafka.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka.adoc
@@ -69,11 +69,11 @@ include::proc-manual-delete-pod-pvc-kafka.adoc[leveloffset=+1]
 
 include::proc-manual-delete-pod-pvc-zookeeper.adoc[leveloffset=+1]
 
+include::assembly-maintenance-time-windows.adoc[leveloffset=+1]
+
 include::proc-renewing-ca-certs-manually.adoc[leveloffset=+1]
 
 include::proc-replacing-private-keys.adoc[leveloffset=+1]
-
-include::assembly-maintenance-time-windows.adoc[leveloffset=+1]
 
 include::ref-list-of-kafka-cluster-resources.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-security.adoc
+++ b/documentation/book/assembly-security.adoc
@@ -4,7 +4,7 @@
 
 [id='security-{context}']
 = Security
-test
+
 {ProductName} supports encrypted communication between the Kafka and {ProductName} components using the TLS protocol.
 Communication between Kafka brokers (interbroker communication), between Zookeeper nodes (internodal communication), and between these and the {ProductName} operators is always encrypted.
 Communication between Kafka clients and Kafka brokers is encrypted according to how the cluster is configured.

--- a/documentation/book/assembly-security.adoc
+++ b/documentation/book/assembly-security.adoc
@@ -4,7 +4,7 @@
 
 [id='security-{context}']
 = Security
-
+test
 {ProductName} supports encrypted communication between the Kafka and {ProductName} components using the TLS protocol.
 Communication between Kafka brokers (interbroker communication), between Zookeeper nodes (internodal communication), and between these and the {ProductName} operators is always encrypted.
 Communication between Kafka clients and Kafka brokers is encrypted according to how the cluster is configured.

--- a/documentation/book/assembly-security.adoc
+++ b/documentation/book/assembly-security.adoc
@@ -28,6 +28,10 @@ include::proc-installing-your-own-ca-certificates.adoc[leveloffset=+1]
 
 include::con-certificate-renewal.adoc[leveloffset=+1]
 
+include::proc-renewing-ca-certs-manually.adoc[leveloffset=+1]
+
+include::proc-replacing-private-keys.adoc[leveloffset=+1]
+
 //include::proc-renewing-your-own-ca-certificates.adoc[leveloffset=+1]
 
 include::con-tls-connections.adoc[leveloffset=+1]

--- a/documentation/book/proc-renewing-ca-certs-before-renewal-period.adoc
+++ b/documentation/book/proc-renewing-ca-certs-before-renewal-period.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// assembly-security.adoc
+
+[id='proc-renewing-ca-certs-manually-{context}']
+
+= Renewing CA certificates manually
+
+Depending on your Kafka cluster configuration, the cluster CA and clients CA certificates will auto-renew at the start of their defined renewal periods (30 days before the end of the validity period, by default). You can manually renew one or both of these certificates before the renewal period, if required for security reasons.  
+
+.Prerequisites
+
+* One
+* Two
+* Three
+
+.Procedure
+
+. View a description of the `Secret` that contains the CA certificate that you want to renew.
+
+.. To view the `Secret` for the cluster CA certificate: 
++ 
+[source,shell,subs="+quotes"]
+kubectl describe secret _<cluster-name>_-cluster-ca-cert
+
+.. To view the `Secret` for the clients CA certificate
++ 
+[source,shell,subs="+quotes"]
+kubectl describe secret _<cluster-name>_-clients-ca-cert
+
+. Annotate the `Secret` by applying the `strimzi.io/force-renew` annotation.
+
+.. To annotate the `Secret` for the cluster CA certificate:
++
+[source,shell,subs="+quotes"]
+kubectl annotate secret _<cluster-name>_-cluster-ca-cert strimzi.io/force-renew=true
+
+.. To annotate the `Secret` for the clients CA certificate:
++
+[source,shell,subs="+quotes"]
+kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-renew=true
+
+The Cluster Operator generates a new CA certificate for the `Secret` that you annotated.

--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -6,41 +6,46 @@
 
 = Renewing CA certificates manually
 
-If automatic CA certificate generation is enabled (`generateCertificateAuthority=true`), the cluster CA and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. You can manually renew one or both of these certificates before the certificate renewal period begins, if required for security reasons. A renewed certificate uses the same private key as the old certificate.
+Unless the `Kafka.spec.clusterCa` and `Kafka.spec.clientsCa` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
+You can manually renew one or both of these certificates before the certificate renewal period starts, if required for security reasons. 
+A renewed certificate uses the same private key as the old certificate.
 
 .Prerequisites
 
 * The Cluster Operator is running.
 * A Kafka cluster in which CA certificates and private keys are installed.
+* One or more maintenance time windows are configured for the Kafka cluster.
 
 .Procedure
 
-. View a description of the certificate authority `Secret` that contains the CA certificate that you want to renew.
-
-.. To view the `Secret` for the cluster CA certificate: 
-+ 
-[source,shell,subs="+quotes"]
-kubectl describe secret _<cluster-name>_-cluster-ca-cert
-
-.. To view the `Secret` for the clients CA certificate
-+ 
-[source,shell,subs="+quotes"]
-kubectl describe secret _<cluster-name>_-clients-ca-cert
-
-. Apply the `strimzi.io/force-renew` annotation to the `Secret`.
-
-.. To annotate the `Secret` for the cluster CA certificate:
+* Apply the `strimzi.io/force-renew` annotation to the `Secret` that contains the CA certificate that you want to renew.
 +
-[source,shell,subs="+quotes"]
-kubectl annotate secret _<cluster-name>_-cluster-ca-cert strimzi.io/force-renew=true
+[cols="3*",options="header",stripes="none",separator=¦]
+|===
 
-.. To annotate the `Secret` for the clients CA certificate:
-+
-[source,shell,subs="+quotes"]
-kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-renew=true
+¦Certificate
+¦Secret
+¦Annotate command
 
-The Cluster Operator generates a new CA certificate for the `Secret` that you annotated.
+¦Cluster CA
+¦_<cluster-name>_-cluster-ca-cert
+m¦kubectl annotate secret _<cluster-name>_-cluster-ca-cert strimzi.io/force-renew=true
+
+¦Clients CA
+¦_<cluster-name>_-clients-ca-cert
+m¦kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-renew=true
+
+|===
+
+If a maintenance time window is active, at the next reconciliation the Cluster Operator generates a new CA certificate for the `Secret` that you annotated. 
+Otherwise, the Cluster Operator will generate a new CA certificate within the next maintenance time window, at the first reconciliation. 
+
+Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 
 .Additional resources
 
-* xref:certificates-and-secrets-str[Certificates and Secrets].
+* xref:certificates-and-secrets-str[]
+
+* xref:assembly-maintenance-time-windows-{context}[]
+
+* xref:type-CertificateAuthority-reference[]

--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -6,7 +6,7 @@
 
 = Renewing CA certificates manually
 
-Unless the `Kafka.spec.clusterCa. generateCertificateAuthority ` and `Kafka.spec.clientsCa. generateCertificateAuthority ` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
+Unless the `Kafka.spec.clusterCa.generateCertificateAuthority` and `Kafka.spec.clientsCa.generateCertificateAuthority` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
 You can manually renew one or both of these certificates before the certificate renewal period starts, if required for security reasons. 
 A renewed certificate uses the same private key as the old certificate.
 
@@ -14,7 +14,6 @@ A renewed certificate uses the same private key as the old certificate.
 
 * The Cluster Operator is running.
 * A Kafka cluster in which CA certificates and private keys are installed.
-* One or more maintenance time windows are configured for the Kafka cluster.
 
 .Procedure
 
@@ -37,8 +36,8 @@ m¦kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-ren
 
 |===
 
-If a maintenance time window is active, at the next reconciliation the Cluster Operator generates a new CA certificate for the `Secret` that you annotated. 
-Otherwise, the Cluster Operator will generate a new CA certificate within the next maintenance time window, at the first reconciliation. 
+At the next reconciliation the Cluster Operator will generate a new CA certificate for the `Secret` that you annotated. 
+If maintenance time windows are configured, the Cluster Operator will generate the new CA certificate at the first reconciliation within the next maintenance time window.
 
 Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 

--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -27,7 +27,7 @@ kubectl describe secret _<cluster-name>_-cluster-ca-cert
 [source,shell,subs="+quotes"]
 kubectl describe secret _<cluster-name>_-clients-ca-cert
 
-. Annotate the `Secret` by applying the `strimzi.io/force-renew` annotation.
+. Apply the `strimzi.io/force-renew` annotation to the `Secret`.
 
 .. To annotate the `Secret` for the cluster CA certificate:
 +

--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -6,17 +6,16 @@
 
 = Renewing CA certificates manually
 
-Depending on your Kafka cluster configuration, the cluster CA and clients CA certificates will auto-renew at the start of their defined renewal periods (30 days before the end of the validity period, by default). You can manually renew one or both of these certificates before the renewal period, if required for security reasons.  
+If automatic CA certificate generation is enabled (`generateCertificateAuthority=true`), the cluster CA and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. You can manually renew one or both of these certificates before the certificate renewal period begins, if required for security reasons. A renewed certificate uses the same private key as the old certificate.
 
 .Prerequisites
 
-* One
-* Two
-* Three
+* The Cluster Operator is running.
+* A Kafka cluster in which CA certificates and private keys are installed.
 
 .Procedure
 
-. View a description of the `Secret` that contains the CA certificate that you want to renew.
+. View a description of the certificate authority `Secret` that contains the CA certificate that you want to renew.
 
 .. To view the `Secret` for the cluster CA certificate: 
 + 
@@ -41,3 +40,7 @@ kubectl annotate secret _<cluster-name>_-cluster-ca-cert strimzi.io/force-renew=
 kubectl annotate secret _<cluster-name>_-clients-ca-cert strimzi.io/force-renew=true
 
 The Cluster Operator generates a new CA certificate for the `Secret` that you annotated.
+
+.Additional resources
+
+* xref:certificates-and-secrets-str[Certificates and Secrets].

--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -6,7 +6,7 @@
 
 = Renewing CA certificates manually
 
-Unless the `Kafka.spec.clusterCa` and `Kafka.spec.clientsCa` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
+Unless the `Kafka.spec.clusterCa. generateCertificateAuthority ` and `Kafka.spec.clientsCa. generateCertificateAuthority ` objects are set to `false`, the cluster and clients CA certificates will auto-renew at the start of their respective certificate renewal periods. 
 You can manually renew one or both of these certificates before the certificate renewal period starts, if required for security reasons. 
 A renewed certificate uses the same private key as the old certificate.
 

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -4,7 +4,7 @@
 
 [id='proc-replacing-private-keys-{context}']
 
-= Replacing private keys
+= Replacing private keys TEST
 
 You can replace the private keys used by the cluster CA and clients CA certificates. 
 When a private key is replaced, the Cluster Operator generates a new CA certificate for the new private key.

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -13,7 +13,6 @@ When a private key is replaced, the Cluster Operator generates a new CA certific
 
 * The Cluster Operator is running.
 * A Kafka cluster in which CA certificates and private keys are installed.
-* One or more maintenance time windows are configured for the Kafka cluster.
 
 .Procedure
 
@@ -37,13 +36,13 @@ m¦kubectl annotate secret _<cluster-name>_-clients-ca strimzi.io/force-replace=
 
 |===
 
-If a maintenance time window is active, at the next reconciliation the Cluster Operator:
+At the next reconciliation the Cluster Operator will:
 
-* Generates a new private key for the `Secret` that you annotated
+* Generate a new private key for the `Secret` that you annotated
 
-* Generates a new CA certificate
+* Generate a new CA certificate
 
-Otherwise, the Cluster Operator will generate a new private key within the next maintenance time window, at the first reconciliation. 
+If maintenance time windows are configured, the Cluster Operator will generate the new private key and CA certificate at the first reconciliation within the next maintenance time window.
 
 Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -6,41 +6,49 @@
 
 = Replacing private keys
 
-You can replace the private keys used by the cluster CA and clients CA certificates. When a private key is replaced, the Cluster Operator generates a new CA certificate for the private key.
+You can replace the private keys used by the cluster CA and clients CA certificates. 
+When a private key is replaced, the Cluster Operator generates a new CA certificate for the new private key.
 
 .Prerequisites
 
 * The Cluster Operator is running.
 * A Kafka cluster in which CA certificates and private keys are installed.
+* One or more maintenance time windows are configured for the Kafka cluster.
 
 .Procedure
 
-. View a description of the private key `Secret` that contains the private key that you want to renew.
+* Apply the `strimzi.io/force-replace` annotation to the `Secret` that contains the private key that you want to renew.
 
-.. To view the `Secret` for the cluster CA certificate's private key: 
-+ 
-[source,shell,subs="+quotes"]
-kubectl describe secret _<cluster-name>_-cluster-ca
-
-.. To view the `Secret` for the clients CA certificate's private key:
-+ 
-[source,shell,subs="+quotes"]
-kubectl describe secret _<cluster-name>_-clients-ca
-
-. Apply the `strimzi.io/force-replace` annotation to the `Secret`.
-
-.. To annotate the `Secret` for the cluster CA certificate's private key:
 +
-[source,shell,subs="+quotes"]
-kubectl annotate secret _<cluster-name>_-cluster-ca strimzi.io/force-replace=true
+[cols="3*",options="header",stripes="none",separator=¦]
+|===
 
-.. To annotate the `Secret` for the clients CA certificate's private key:
-+
-[source,shell,subs="+quotes"]
-kubectl annotate secret _<cluster-name>_-clients-ca strimzi.io/force-replace=true
+¦Private key for
+¦Secret
+¦Annotate command
 
-The Cluster Operator generates a new private key for the `Secret` that you annotated.
+¦Cluster CA
+¦_<cluster-name>_-cluster-ca
+m¦kubectl annotate secret _<cluster-name>_-cluster-ca strimzi.io/force-replace=true
+
+¦Clients CA
+¦_<cluster-name>_-clients-ca
+m¦kubectl annotate secret _<cluster-name>_-clients-ca strimzi.io/force-replace=true
+
+|===
+
+If a maintenance time window is active, at the next reconciliation the Cluster Operator:
+
+* Generates a new private key for the `Secret` that you annotated
+
+* Generates a new CA certificate
+
+Otherwise, the Cluster Operator will generate a new private key within the next maintenance time window, at the first reconciliation. 
+
+Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 
 .Additional resources
 
-* xref:certificates-and-secrets-str[Certificates and Secrets]
+* xref:certificates-and-secrets-str[]
+
+* xref:assembly-maintenance-time-windows-{context}[]

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -27,7 +27,7 @@ kubectl describe secret _<cluster-name>_-cluster-ca
 [source,shell,subs="+quotes"]
 kubectl describe secret _<cluster-name>_-clients-ca
 
-. Annotate the `Secret` by applying the `strimzi.io/force-replace` annotation.
+. Apply the `strimzi.io/force-replace` annotation to the `Secret`.
 
 .. To annotate the `Secret` for the cluster CA certificate's private key:
 +

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -4,7 +4,7 @@
 
 [id='proc-replacing-private-keys-{context}']
 
-= Replacing private keys TEST
+= Replacing private keys
 
 You can replace the private keys used by the cluster CA and clients CA certificates. 
 When a private key is replaced, the Cluster Operator generates a new CA certificate for the new private key.

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// assembly-security.adoc
+
+[id='proc-replacing-private-keys-{context}']
+
+= Replacing private keys
+
+You can replace the private keys used by the cluster CA and clients CA certificates. When a private key is replaced, the Cluster Operator generates a new CA certificate for the private key.
+
+.Prerequisites
+
+* The Cluster Operator is running.
+* A Kafka cluster in which CA certificates and private keys are installed.
+
+.Procedure
+
+. View a description of the private key `Secret` that contains the private key that you want to renew.
+
+.. To view the `Secret` for the cluster CA certificate's private key: 
++ 
+[source,shell,subs="+quotes"]
+kubectl describe secret _<cluster-name>_-cluster-ca
+
+.. To view the `Secret` for the clients CA certificate's private key:
++ 
+[source,shell,subs="+quotes"]
+kubectl describe secret _<cluster-name>_-clients-ca
+
+. Annotate the `Secret` by applying the `strimzi.io/force-replace` annotation.
+
+.. To annotate the `Secret` for the cluster CA certificate's private key:
++
+[source,shell,subs="+quotes"]
+kubectl annotate secret _<cluster-name>_-cluster-ca strimzi.io/force-replace=true
+
+.. To annotate the `Secret` for the clients CA certificate's private key:
++
+[source,shell,subs="+quotes"]
+kubectl annotate secret _<cluster-name>_-clients-ca strimzi.io/force-replace=true
+
+The Cluster Operator generates a new private key for the `Secret` that you annotated.
+
+.Additional resources
+
+* xref:certificates-and-secrets-str[Certificates and Secrets]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This pull request adds new procedures for:

- Manually renewing the cluster and clients CA certificates
- Replacing the private keys for the above

It documents the annotations `strimzi.io/force-renew` and `strimzi.io/force-replace`, which were originally added in #1193 (see the discussion in the comments between @tombentley and @ppatierno for context).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

