### PR TITLE
Fix reconciliation of internal topics

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BaseKafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BaseKafkaImpl.java
@@ -11,6 +11,7 @@ import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
@@ -249,7 +250,11 @@ public abstract class BaseKafkaImpl implements Kafka {
     @Override
     public void listTopics(Handler<AsyncResult<Set<String>>> handler) {
         LOGGER.debug("Listing topics");
-        ListTopicsResult future = adminClient.listTopics();
+
+        ListTopicsOptions listOptions = new ListTopicsOptions();
+        listOptions.listInternal(true);
+
+        ListTopicsResult future = adminClient.listTopics(listOptions);
         queueWork(new UniWork<>("listTopics", future.names(), handler));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The periodical reconciliation is using the Kafka AdminClient to list the topics. This client by default doesn't list the internal topics such as `__consumer_offsets`. As a result, the `__consumer_offsets` topic is often not reconciled:
* The creation is often missed because the leader is not ready yet
* The reconciliation will not get it because it doesn't get the internal topics
and as a result it will be reconciled only if there is some other change.

This PR uses the `ListTopicsOptions` to make sure the AdminClient will list also the internal topics and thus they will be reconciled.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally