### PR TITLE
ST: fixes for several flaky tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -43,6 +43,10 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         CAUGHT_EXCEPTION_FOR_NETWORK_POLICY("Caught exception while patching NetworkPolicy"
                 + "(?s)(.*?)"
                 + "io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH"),
+        // fabric8 now throws exceptions, which doesn't influence kafka scaleup/scaledown
+        FABRIC_EIGHT_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:115 - Error while waiting for resource to be scaled."),
+        FABRIC_EIGHT_STATEFUL_SET_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:126 - 0/.* pod(s) ready for StatefulSet: .*  after waiting for 0 seconds so giving up"),
+        // This happen from time to time during CO startup, it doesn't influence CO behavior
         EXIT_ON_OUT_OF_MEMORY("ExitOnOutOfMemoryError");
 
         final String name;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.utils;
 
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
@@ -84,6 +85,16 @@ public class StUtils {
     }
 
     /**
+     * Returns a map of pod name to resource version for the pods currently in the given DeploymentConfig.
+     * @param name The DeploymentConfig name.
+     * @return A map of pod name to resource version for pods in the given DeploymentConfig.
+     */
+    public static Map<String, String> depConfigSnapshot(String name) {
+        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
+        return podSnapshot(selector);
+    }
+
+    /**
      * Method to check that all pods for expected StatefulSet were rolled
      * @param name StatefulSet name
      * @param snapshot Snapshot of pods for StatefulSet before the rolling update
@@ -158,6 +169,28 @@ public class StUtils {
     }
 
     /**
+     * Method to check that all pods for expected DeploymentConfig were rolled
+     * @param name DeploymentConfig name
+     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
+     * @return true when the pods for DeploymentConfig are recreated
+     */
+    public static boolean depConfigHasRolled(String name, Map<String, String> snapshot) {
+        LOGGER.info("Existing snapshot: {}", new TreeMap<>(snapshot));
+        LabelSelector selector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
+        Map<String, String> map = podSnapshot(selector);
+        LOGGER.info("Current  snapshot: {}", new TreeMap<>(map));
+        int current = map.size();
+        map.keySet().retainAll(snapshot.keySet());
+        if (current == snapshot.size() && map.isEmpty()) {
+            LOGGER.info("All pods seem to have rolled");
+            return true;
+        } else {
+            LOGGER.info("Some pods still to roll: {}", map);
+            return false;
+        }
+    }
+
+    /**
      *  Method to wait when StatefulSet will be recreated after rolling update
      * @param name StatefulSet name
      * @param expectedPods Expected number of pods
@@ -192,6 +225,21 @@ public class StUtils {
         StUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
         return depSnapshot(name);
     }
+
+    /**
+     * Method to wait when DeploymentConfig will be recreated after rolling update
+     * @param name DeploymentConfig name
+     * @param expectedPods Expected number of pods
+     * @param snapshot Snapshot of pods for DeploymentConfig before the rolling update
+     * @return The snapshot of the DeploymentConfig after rolling update with Uid for every pod
+     */
+    public static Map<String, String> waitTillDepConfigHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
+        TestUtils.waitFor("Deployment roll of " + name,
+                Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depConfigHasRolled(name, snapshot));
+        StUtils.waitForDeploymentConfigReady(name, expectedPods);
+        return depConfigSnapshot(name);
+    }
+
 
     public static File downloadAndUnzip(String url) throws IOException {
         InputStream bais = (InputStream) URI.create(url).toURL().openConnection().getContent();
@@ -310,11 +358,13 @@ public class StUtils {
      * Wait until the given DeploymentConfig is ready.
      * @param name The name of the DeploymentConfig.
      */
-    public static void waitForDeploymentConfigReady(String name) {
-        LOGGER.info("Waiting for Deployment Config {}", name);
+    public static void waitForDeploymentConfigReady(String name, int expectedPods) {
+        LOGGER.debug("Waiting for Deployment Config {}", name);
         TestUtils.waitFor("deployment config " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getDeploymentConfigStatus(name));
-        LOGGER.info("Deployment Config {} is ready", name);
+        LOGGER.debug("Deployment Config {} is ready", name);
+        LabelSelector deploymentConfigSelector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
+        waitForPodsReady(deploymentConfigSelector, expectedPods, true);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -367,7 +367,7 @@ public class StUtils {
      * Wait until the given DeploymentConfig is ready.
      * @param name The name of the DeploymentConfig.
      */
-    public static void waitForDeploymentConfigReady(String name) {
+    public static void waitForDeploymentConfigReady(String name, int expectedPods) {
         LOGGER.info("Waiting for Deployment Config {}", name);
         TestUtils.waitFor("deployment config "  + name + " to be ready", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getDeploymentConfigStatus(name));

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -34,7 +34,7 @@ class ConnectS2IST extends AbstractST {
     @Test
     @OpenShiftOnly
     @Tag(ACCEPTANCE)
-    void testDeployS2IWithMongoDBPlugin() throws IOException {
+    void testDeployS2IWithMongoDBPlugin() throws IOException, InterruptedException {
         testClassResources.kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1, CLUSTER_NAME)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
@@ -43,7 +43,9 @@ class ConnectS2IST extends AbstractST {
 
         Map<String, String> connectSnapshot = StUtils.depConfigSnapshot(CONNECT_DEPLOYMENT_NAME);
 
-        File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.3.0/debezium-connector-mongodb-0.3.0-plugin.zip");
+        File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.7.5/debezium-connector-mongodb-0.7.5-plugin.zip");
+
+        Thread.sleep(10000);
 
         // Start a new image build using the plugins directory
         cmdKubeClient().exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.FLAKY;
@@ -27,28 +28,28 @@ import static org.hamcrest.Matchers.containsString;
 class ConnectS2IST extends AbstractST {
 
     public static final String NAMESPACE = "connect-s2i-cluster-test";
-    public static final String CONNECT_CLUSTER_NAME = "connect-s2i-tests";
+    public static final String CONNECT_CLUSTER_NAME = "my-connect-cluster";
     public static final String CONNECT_DEPLOYMENT_NAME = CONNECT_CLUSTER_NAME + "-connect";
     private static final Logger LOGGER = LogManager.getLogger(ConnectS2IST.class);
 
     @Test
     @OpenShiftOnly
-    @Tag(FLAKY)
     @Tag(ACCEPTANCE)
     void testDeployS2IWithMongoDBPlugin() throws IOException {
-        testClassResources.kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1)
+        testClassResources.kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1, CLUSTER_NAME)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
             .endMetadata()
             .done();
 
+        Map<String, String> connectSnapshot = StUtils.depConfigSnapshot(CONNECT_DEPLOYMENT_NAME);
+
         File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.3.0/debezium-connector-mongodb-0.3.0-plugin.zip");
 
         // Start a new image build using the plugins directory
         cmdKubeClient().exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());
-
-        StUtils.waitForDeploymentConfigReady(CONNECT_DEPLOYMENT_NAME);
-
+        // Wait for rolling update connect pods
+        StUtils.waitTillDepConfigHasRolled(CONNECT_DEPLOYMENT_NAME, 1, connectSnapshot);
         String connectS2IPodName = kubeClient().listPods("type", "kafka-connect-s2i").get(0).getMetadata().getName();
         String plugins = cmdKubeClient().execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins").out();
 
@@ -73,7 +74,7 @@ class ConnectS2IST extends AbstractST {
     }
 
     void deployTestSpecificResources() {
-        testClassResources.kafkaEphemeral(CLUSTER_NAME, 3).done();
+        testClassResources.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -34,7 +34,7 @@ class ConnectS2IST extends AbstractST {
     @Test
     @OpenShiftOnly
     @Tag(ACCEPTANCE)
-    void testDeployS2IWithMongoDBPlugin() throws IOException, InterruptedException {
+    void testDeployS2IWithMongoDBPlugin() throws IOException {
         testClassResources.kafkaConnectS2I(CONNECT_CLUSTER_NAME, 1, CLUSTER_NAME)
             .editMetadata()
                 .addToLabels("type", "kafka-connect-s2i")
@@ -44,8 +44,6 @@ class ConnectS2IST extends AbstractST {
         Map<String, String> connectSnapshot = StUtils.depConfigSnapshot(CONNECT_DEPLOYMENT_NAME);
 
         File dir = StUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.7.5/debezium-connector-mongodb-0.7.5-plugin.zip");
-
-        Thread.sleep(10000);
 
         // Start a new image build using the plugins directory
         cmdKubeClient().exec("oc", "start-build", CONNECT_DEPLOYMENT_NAME, "--from-dir", dir.getAbsolutePath());

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.FLAKY;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
@@ -51,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.strimzi.test.BaseITST.kubeClient;
-
 
 public class KubeClient {
 
@@ -277,6 +277,21 @@ public class KubeClient {
      */
     public LabelSelector getDeploymentSelectors(String deploymentName) {
         return client.apps().deployments().inNamespace(getNamespace()).withName(deploymentName).get().getSpec().getSelector();
+    }
+
+    /**
+     * Gets deployment config
+     */
+    public DeploymentConfig getDeploymentConfig(String deploymentConfigName) {
+        return client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).get();
+    }
+
+
+    /**
+     * Gets deployment config selector
+     */
+    public Map<String, String> getDeploymentConfigSelectors(String deploymentConfigName) {
+        return client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).get().getSpec().getSelector();
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR contains fixes for several flaky tests:

- **MirrorMaker** - wrong teardown phase during pod deletion
- **ConnectS2I** - this test contained wrong checks for specific connects2i resources. Checks were added/fixed and whole test was upgraded.
- **KafkaST** - kafkaScaleUpScaleDown test always failed cause unexpected error in CO log. This log is caused by fabric8 so I added this error to whitelist. To be sure, that everything is fine, there is message exchange with topic `isr=currentBrokerCount` and with `ACKS_CONFIG=all`

### Checklist

- [x] Make sure all tests pass

