### PR TITLE
Fix plugin isolation in Kafka Connect S2I

### DIFF
--- a/docker-images/kafka/s2i-scripts/assemble
+++ b/docker-images/kafka/s2i-scripts/assemble
@@ -15,9 +15,9 @@ export TARGET_DIR=/tmp/kafka-plugins
 
 echo "Assembling plugins into custom plugin directory $TARGET_DIR"
 
-mkdir -p $TARGET_DIR/s2i
+mkdir -p $TARGET_DIR
 
 if [ -d "$S2I_SOURCE_DIR" ] && [ "$(ls -A $S2I_SOURCE_DIR)" ]; then
   echo "Moving plugins to $TARGET_DIR"
-  mv $S2I_SOURCE_DIR/* $TARGET_DIR/s2i
+  mv $S2I_SOURCE_DIR/* $TARGET_DIR
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #1804, the path where we copy the plugins should change and not contain the `s2i` subdirectory. That should improve the isolation between the plugins.

CC @jpechane 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally