### PR TITLE
Update Jackson Databind dependency to 2.9.9.1 because of CVE-2019-12814

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson-core.version>2.9.9</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.9.9</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-databind.version>2.9.9.1</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.9.9</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
         <kafka.version>2.3.0</kafka.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a CVE in Jackson Databind. Updating it to 2.9.9.1 should fix it.