### PR TITLE
Fix title for Kafka Bridge configuration

### DIFF
--- a/documentation/book/assembly-deployment-configuration-kafka-bridge.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-bridge.adoc
@@ -11,7 +11,7 @@
 :parent-context-deployment-configuration-kafka-bridge: {context}
 
 [id='assembly-deployment-configuration-kafka-bridge-{context}']
-= Kafka Bridge cluster configuration
+= Kafka Bridge configuration
 
 :context: deployment-configuration-kafka-bridge
 

--- a/documentation/book/proc-deploying-kafka-bridge.adoc
+++ b/documentation/book/proc-deploying-kafka-bridge.adoc
@@ -22,4 +22,4 @@ kubectl apply -f examples/kafka-bridge/kafka-bridge.yaml
 ----
 
 .Additional resources
-* xref:assembly-deployment-configuration-kafka-bridge-str[Kafka Bridge cluster configuration]
+* xref:assembly-deployment-configuration-kafka-bridge-str[Kafka Bridge configuration]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR fixes the title for the Kafka Bridge configuration not talking about "cluster".

### Checklist

- [x] Update documentation

