### PR TITLE
Report-bug script improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,9 @@ A clear and concise description of what you expected to happen.
 Attach or copy paste the custom resources you used to deploy the Kafka cluster and the relevant YAMLs created by the Cluster Operator.
 Attach or copy and paste also the relevant logs.
 
-*To easily collect all YAMLs and logs, you can use our [report script](https://github.com/strimzi/strimzi-kafka-operator/blob/master/tools/report.sh) which will automatically collect all files and prepare a ZIP archive which can be easily attached to this issue.*
+*To easily collect all YAMLs and logs, you can use our [report script](https://github.com/strimzi/strimzi-kafka-operator/blob/master/tools/report.sh) which will automatically collect all files and prepare a ZIP archive which can be easily attached to this issue.
+The usage of this script is:
+`./report.sh [--namespace <string>] [--cluster <string>]`*
 
 **Additional context**
 Add any other context about the problem here.

--- a/tools/report.sh
+++ b/tools/report.sh
@@ -48,13 +48,18 @@ while getopts "$optspec" optchar; do
 done
 shift $((OPTIND-1))
 
+if [ -z $cluster ] && [ -z $namespace ]; then
+   echo "Cluster and namespace was not specified. Use --cluster and --namespace options to specify it."
+   usage
+fi
+
 if [ -z $cluster ]; then
-   echo "Cluster was not specified"
+   echo "Cluster was not specified. Use --cluster option to specify it."
    usage
 fi
 
 if [ -z $namespace ]; then
-   echo "Namespace was not specified"
+   echo "Namespace was not specified. Use --namespace option to specify it."
    usage
 fi
 

--- a/tools/report.sh
+++ b/tools/report.sh
@@ -23,13 +23,9 @@ if [[ $oc_installed = false && $kubectl_installed = false ]]; then
 	exit 1
 fi
 
-# default values
-cluster="my-cluster"
-namespace="myproject"
 
 usage() {
 	echo "Usage: $0 [--namespace <string>] [--cluster <string>]" 1>&2; 
-	echo "Default values namespace=my-project cluster=my-cluster" 1>&2; 
 	exit 1; 
 }
 
@@ -48,13 +44,19 @@ while getopts "$optspec" optchar; do
                     usage
                     ;;
             esac;;
-        *)
-            cluster="my-cluster"
-            namespace="myproject"
-            ;;
     esac
 done
 shift $((OPTIND-1))
+
+if [ -z $cluster ]; then
+   echo "Cluster was not specified"
+   usage
+fi
+
+if [ -z $namespace ]; then
+   echo "Namespace was not specified"
+   usage
+fi
 
 direct=`mktemp -d`
 resources_to_fetch=(


### PR DESCRIPTION
### Type of change
- Enhancement

### Description
Reporting script used default values for cluster and namespace when the user did not specify them. Without any warning. It is better to not use default values and force the user to specify them.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

