### PR TITLE
ST: skip docker tag replace in case it's not set

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -603,11 +603,13 @@ public class StUtils {
     }
 
     private static String buildTag(String currentTag) {
-        Matcher t = KAFKA_COMPONENT_PATTERN.matcher(currentTag);
-        if (t.find()) {
-            currentTag = Environment.STRIMZI_TAG + t.group("kafka") + t.group("version");
-        } else {
-            currentTag = Environment.STRIMZI_TAG;
+        if (!currentTag.equals(Environment.STRIMZI_TAG) && !Environment.STRIMZI_TAG_DEFAULT.equals(Environment.STRIMZI_TAG)) {
+            Matcher t = KAFKA_COMPONENT_PATTERN.matcher(currentTag);
+            if (t.find()) {
+                currentTag = Environment.STRIMZI_TAG + t.group("kafka") + t.group("version");
+            } else {
+                currentTag = Environment.STRIMZI_TAG;
+            }
         }
         return currentTag;
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Tags for images use din ST should not be changed, from defaults used in deployment files, if `DOCKER_TAG` is not set or it has default (`latest`) value.

### Checklist

- [x] Make sure all tests pass

