### PR TITLE
[DOC] Fix context attribute in cross reference

### DIFF
--- a/documentation/book/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/book/proc-renewing-ca-certs-manually.adoc
@@ -45,6 +45,6 @@ Client applications must reload the cluster and clients CA certificates that wer
 
 * xref:certificates-and-secrets-str[]
 
-* xref:assembly-maintenance-time-windows-{context}[]
+* xref:assembly-maintenance-time-windows-deployment-configuration-kafka[]
 
 * xref:type-CertificateAuthority-reference[]

--- a/documentation/book/proc-replacing-private-keys.adoc
+++ b/documentation/book/proc-replacing-private-keys.adoc
@@ -50,4 +50,4 @@ Client applications must reload the cluster and clients CA certificates that wer
 
 * xref:certificates-and-secrets-str[]
 
-* xref:assembly-maintenance-time-windows-{context}[]
+* xref:assembly-maintenance-time-windows-deployment-configuration-kafka[]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This pull request fixes a minor issue with a broken cross-reference in the recently added doc for CA cert renewal and private key replacement. It sets the context to match the parent assembly's context.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ X ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

