### PR TITLE
Add the dnsAnnotations overrides also to the node ports services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Add support for Kafka Connect S2I resource status
 * Add support for Kafka Bridge resource status
 * Add support for Kafka Mirror Maker resource status
-* Add support DNS annotations to `nodeport` type external listeners
+* Add support for DNS annotations to `nodeport` type external listeners
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add support for Kafka Connect S2I resource status
 * Add support for Kafka Bridge resource status
 * Add support for Kafka Mirror Maker resource status
+* Add support DNS annotations to `nodeport` type external listeners
 
 ## 0.12.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
@@ -40,8 +40,8 @@ public class IngressListenerBootstrapConfiguration extends ExternalListenerBoots
         this.host = host;
     }
 
-    @Description("Annotations which will be added to the Ingress resource. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Ingress` resource. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -42,8 +42,8 @@ public class IngressListenerBrokerConfiguration extends ExternalListenerBrokerOv
         this.host = host;
     }
 
-    @Description("Annotations which will be added to the Ingress resources for individual brokers. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Ingress` resources for individual brokers. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -27,8 +27,8 @@ public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBoots
 
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
 
-    @Description("Annotations which will be added to the Service resource. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Service` resource. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -29,8 +29,8 @@ public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOv
 
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
 
-    @Description("Annotations which will be added to the Service resources for individual brokers. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Service` resources for individual brokers. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
@@ -29,6 +29,7 @@ public class NodePortListenerBootstrapOverride extends ExternalListenerBootstrap
     private static final long serialVersionUID = 1L;
 
     private Integer nodePort;
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
     private Map<String, Object> additionalProperties;
 
     @Description("Node port for the bootstrap service")
@@ -39,6 +40,17 @@ public class NodePortListenerBootstrapOverride extends ExternalListenerBootstrap
 
     public void setNodePort(Integer nodePort) {
         this.nodePort = nodePort;
+    }
+
+    @Description("Annotations which will be added to the Service resource. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
@@ -42,8 +42,8 @@ public class NodePortListenerBootstrapOverride extends ExternalListenerBootstrap
         this.nodePort = nodePort;
     }
 
-    @Description("Annotations which will be added to the Service resource. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Service` resource. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
@@ -10,6 +10,9 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Configures external broker service and advertised addresses for NodePort listeners
  */
@@ -25,6 +28,7 @@ public class NodePortListenerBrokerOverride extends ExternalListenerBrokerOverri
     private static final long serialVersionUID = 1L;
 
     private Integer nodePort;
+    private Map<String, String> dnsAnnotations = new HashMap<>(0);
 
     @Description("Node port for the broker service")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -34,5 +38,16 @@ public class NodePortListenerBrokerOverride extends ExternalListenerBrokerOverri
 
     public void setNodePort(Integer nodePort) {
         this.nodePort = nodePort;
+    }
+
+    @Description("Annotations which will be added to the Service resources for individual brokers. " +
+            "You can use this field to instrument DNS providers such as External DNS.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDnsAnnotations() {
+        return dnsAnnotations;
+    }
+
+    public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
+        this.dnsAnnotations = dnsAnnotations;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
@@ -40,8 +40,8 @@ public class NodePortListenerBrokerOverride extends ExternalListenerBrokerOverri
         this.nodePort = nodePort;
     }
 
-    @Description("Annotations which will be added to the Service resources for individual brokers. " +
-            "You can use this field to instrument DNS providers such as External DNS.")
+    @Description("Annotations that will be added to the `Service` resources for individual brokers. " +
+            "You can use this field to configure DNS providers such as External DNS.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getDnsAnnotations() {
         return dnsAnnotations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -619,6 +619,12 @@ public class KafkaCluster extends AbstractModel {
                 if (externalLb.getOverrides() != null && externalLb.getOverrides().getBootstrap() != null) {
                     dnsAnnotations = externalLb.getOverrides().getBootstrap().getDnsAnnotations();
                 }
+            } else if (isExposedWithNodePort())    {
+                KafkaListenerExternalNodePort externalNp = (KafkaListenerExternalNodePort) listeners.getExternal();
+
+                if (externalNp.getOverrides() != null && externalNp.getOverrides().getBootstrap() != null) {
+                    dnsAnnotations = externalNp.getOverrides().getBootstrap().getDnsAnnotations();
+                }
             }
 
             return createService(externalBootstrapServiceName, getExternalServiceType(), ports,
@@ -661,6 +667,16 @@ public class KafkaCluster extends AbstractModel {
                     dnsAnnotations = externalLb.getOverrides().getBrokers().stream()
                             .filter(broker -> broker != null && broker.getBroker() == pod)
                             .map(LoadBalancerListenerBrokerOverride::getDnsAnnotations)
+                            .findAny()
+                            .orElse(Collections.emptyMap());
+                }
+            } else if (isExposedWithNodePort())    {
+                KafkaListenerExternalNodePort externalNp = (KafkaListenerExternalNodePort) listeners.getExternal();
+
+                if (externalNp.getOverrides() != null && externalNp.getOverrides().getBrokers() != null) {
+                    dnsAnnotations = externalNp.getOverrides().getBrokers().stream()
+                            .filter(broker -> broker != null && broker.getBroker() == pod)
+                            .map(NodePortListenerBrokerOverride::getDnsAnnotations)
                             .findAny()
                             .orElse(Collections.emptyMap());
                 }

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -372,7 +372,7 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |Property               |Description
 |address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
 |string
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resource. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
 |map
 |====
 
@@ -391,7 +391,7 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |string
 |advertisedPort  1.2+<.<|The port number which will be used in the brokers' `advertised.brokers`.
 |integer
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
 |====
 
@@ -446,7 +446,7 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 |Property               |Description
 |address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
 |string
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resource. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
 |map
 |nodePort        1.2+<.<|Node port for the bootstrap service.
 |integer
@@ -469,7 +469,7 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 |integer
 |nodePort        1.2+<.<|Node port for the broker service.
 |integer
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
 |====
 
@@ -522,7 +522,7 @@ Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfig
 |Property               |Description
 |address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
 |string
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Ingress resource. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Ingress` resource. You can use this field to configure DNS providers such as External DNS.
 |map
 |host            1.2+<.<|Host for the bootstrap route. This field will be used in the Ingress resource.
 |string
@@ -545,7 +545,7 @@ Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfig
 |integer
 |host            1.2+<.<|Host for the broker ingress. This field will be used in the Ingress resource.
 |string
-|dnsAnnotations  1.2+<.<|Annotations which will be added to the Ingress resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|dnsAnnotations  1.2+<.<|Annotations that will be added to the `Ingress` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -443,10 +443,12 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 
 [options="header"]
 |====
-|Property         |Description
-|address   1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
+|Property               |Description
+|address         1.2+<.<|Additional address name for the bootstrap service. The address will be added to the list of subject alternative names of the TLS certificates.
 |string
-|nodePort  1.2+<.<|Node port for the bootstrap service.
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resource. You can use this field to instrument DNS providers such as External DNS.
+|map
+|nodePort        1.2+<.<|Node port for the bootstrap service.
 |integer
 |====
 
@@ -467,6 +469,8 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 |integer
 |nodePort        1.2+<.<|Node port for the broker service.
 |integer
+|dnsAnnotations  1.2+<.<|Annotations which will be added to the Service resources for individual brokers. You can use this field to instrument DNS providers such as External DNS.
+|map
 |====
 
 [id='type-KafkaListenerExternalIngress-{context}']

--- a/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
@@ -53,3 +53,39 @@ listeners:
 ----
 
 For more information on using node ports to access Kafka, see xref:proc-accessing-kafka-using-nodeports-{context}[].
+
+= Customizing the DNS names of external node port listeners
+
+On `nodeport` listeners, you can use the `dnsAnnotations` property to add additional annotations to the nodeport services.
+You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the cluster nodes.
+
+.Example of an external listener of type `nodeport` using {KubernetesExternalDNS} annotations
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: nodeport
+    tls: true
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      brokers:
+      - broker: 0
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 1
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 2
+        dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+# ...
+----

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -348,6 +348,8 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                dnsAnnotations:
+                                  type: object
                                 nodePort:
                                   type: integer
                             brokers:
@@ -363,6 +365,8 @@ spec:
                                     type: integer
                                   nodePort:
                                     type: integer
+                                  dnsAnnotations:
+                                    type: object
                         tls:
                           type: boolean
                         type:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -343,6 +343,8 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                dnsAnnotations:
+                                  type: object
                                 nodePort:
                                   type: integer
                             brokers:
@@ -358,6 +360,8 @@ spec:
                                     type: integer
                                   nodePort:
                                     type: integer
+                                  dnsAnnotations:
+                                    type: object
                         tls:
                           type: boolean
                         type:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We currently support the `dnsAnnotations` field for Ingress and LoadBalancer type external listeners. But they could be useful also for NodePort listeners to attach the DNS names to the nodes (supported in last versions of ExternalDNS or in Kops DNS Controller). This PR adds the support for the `dnsAnnotations` field also there.

This should close the issue #1811 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

