### PR TITLE
Rename fields in status subresource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -48,4 +48,14 @@ public class KafkaBridgeResources {
         return deploymentName(clusterName);
     }
 
+    /**
+     * Returns the URL the Kafka Bridge for a {@code KafkaBridge} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaBridge} resource.
+     * @param namespace The namespace where {@code KafkaBridge} cluster is running.
+     * @param port The port on which the {@code KafkaBridge} is available.
+     * @return The URL of {@code KafkaBridge}.
+     */
+    public static String url(String clusterName, String namespace, int port) {
+        return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -50,12 +50,12 @@ public class KafkaBridgeResources {
 
     /**
      * Returns the URL the Kafka Bridge for a {@code KafkaBridge} cluster of the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code KafkaBridge} resource.
+     * @param bridgeName  The {@code metadata.name} of the {@code KafkaBridge} resource.
      * @param namespace The namespace where {@code KafkaBridge} cluster is running.
      * @param port The port on which the {@code KafkaBridge} is available.
      * @return The URL of {@code KafkaBridge}.
      */
-    public static String url(String clusterName, String namespace, int port) {
-        return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
+    public static String url(String bridgeName, String namespace, int port) {
+        return "http://" + serviceName(bridgeName) + "." + namespace + ".svc:" + port;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -49,9 +49,9 @@ public class KafkaBridgeResources {
     }
 
     /**
-     * Returns the URL the Kafka Bridge for a {@code KafkaBridge} cluster of the given name.
+     * Returns the URL of the Kafka Bridge for a {@code KafkaBridge} cluster of the given name.
      * @param bridgeName  The {@code metadata.name} of the {@code KafkaBridge} resource.
-     * @param namespace The namespace where {@code KafkaBridge} cluster is running.
+     * @param namespace The namespace where the {@code KafkaBridge} cluster is running.
      * @param port The port on which the {@code KafkaBridge} is available.
      * @return The URL of {@code KafkaBridge}.
      */

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -48,13 +48,13 @@ public class KafkaConnectResources {
     }
 
     /**
-     * Returns the address the Kafka Connect REST API for a {@code KafkaConnect} cluster of the given name.
+     * Returns the URL the Kafka Connect REST API for a {@code KafkaConnect} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
      * @param namespace The namespace where {@code KafkaConnect} cluster is running.
      * @param port The port on which the {@code KafkaConnect} API is available.
      * @return The REST address of {@code KafkaConnect} API.
      */
-    public static String restApiAddress(String clusterName, String namespace, int port) {
+    public static String url(String clusterName, String namespace, int port) {
         return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -48,11 +48,11 @@ public class KafkaConnectResources {
     }
 
     /**
-     * Returns the URL the Kafka Connect REST API for a {@code KafkaConnect} cluster of the given name.
+     * Returns the URL of the Kafka Connect REST API for a {@code KafkaConnect} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
      * @param namespace The namespace where {@code KafkaConnect} cluster is running.
      * @param port The port on which the {@code KafkaConnect} API is available.
-     * @return The REST address of {@code KafkaConnect} API.
+     * @return The base URL of the {@code KafkaConnect} REST API.
      */
     public static String url(String clusterName, String namespace, int port) {
         return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -55,6 +55,6 @@ public class KafkaConnectResources {
      * @return The REST address of {@code KafkaConnect} API.
      */
     public static String restApiAddress(String clusterName, String namespace, int port) {
-        return serviceName(clusterName) + "." + namespace + ".svc:" + port;
+        return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
@@ -26,7 +26,7 @@ public class KafkaBridgeStatus extends Status {
 
     private String url;
 
-    @Description("The URL address at which external client applications can access the Kafka Bridge.")
+    @Description("The URL at which external client applications can access the Kafka Bridge.")
     public String getUrl() {
         return url;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
@@ -19,19 +19,19 @@ import lombok.EqualsAndHashCode;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "httpAddress" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
 @EqualsAndHashCode
 public class KafkaBridgeStatus extends Status {
     private static final long serialVersionUID = 1L;
 
-    private String httpAddress;
+    private String url;
 
-    @Description("The HTTP address at which external client applications can access the Kafka Bridge.")
-    public String getHttpAddress() {
-        return httpAddress;
+    @Description("The URL address at which external client applications can access the Kafka Bridge.")
+    public String getUrl() {
+        return url;
     }
 
-    public void setHttpAddress(String httpAddress) {
-        this.httpAddress = httpAddress;
+    public void setUrl(String url) {
+        this.url = url;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "restApiAddress", "buildConfigName" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "buildConfigName" })
 @EqualsAndHashCode(callSuper = true)
 public class KafkaConnectS2Istatus extends KafkaConnectStatus {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -26,7 +26,7 @@ public class KafkaConnectStatus extends Status {
 
     private String url;
 
-    @Description("URL of REST API endpoint for managing and monitoring Kafka Connect connectors.")
+    @Description("The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.")
     public String getUrl() {
         return url;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -19,19 +19,19 @@ import lombok.EqualsAndHashCode;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "restApiAddress" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
 @EqualsAndHashCode
 public class KafkaConnectStatus extends Status {
     private static final long serialVersionUID = 1L;
 
-    private String restApiAddress;
+    private String url;
 
-    @Description("REST API endpoint for managing and monitoring Kafka Connect connectors.")
-    public String getRestApiAddress() {
-        return restApiAddress;
+    @Description("URL of REST API endpoint for managing and monitoring Kafka Connect connectors.")
+    public String getUrl() {
+        return url;
     }
 
-    public void setRestApiAddress(String restApiAddress) {
-        this.restApiAddress = restApiAddress;
+    public void setUrl(String url) {
+        this.url = url;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -108,7 +108,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 if (bridge.getHttp() != null) {
                     port = bridge.getHttp().getPort();
                 }
-                kafkaBridgeStatus.setUrl("http://" + bridge.getServiceName() + "." + namespace + ".svc:" + port);
+                kafkaBridgeStatus.setUrl(KafkaBridgeResources.url(bridge.getName(), namespace, port));
 
                 updateStatus(assemblyResource, reconciliation, kafkaBridgeStatus).setHandler(statusResult -> {
                     // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -108,7 +108,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 if (bridge.getHttp() != null) {
                     port = bridge.getHttp().getPort();
                 }
-                kafkaBridgeStatus.setHttpAddress(bridge.getServiceName() + "." + namespace + ".svc:" + port);
+                kafkaBridgeStatus.setUrl("http://" + bridge.getServiceName() + "." + namespace + ".svc:" + port);
 
                 updateStatus(assemblyResource, reconciliation, kafkaBridgeStatus).setHandler(statusResult -> {
                     // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -104,7 +104,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                 .compose(i -> chainFuture.complete(), chainFuture)
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
-                    kafkaConnectStatus.setRestApiAddress(KafkaConnectResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
+                    kafkaConnectStatus.setUrl(KafkaConnectResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
 
                     updateStatus(kafkaConnect, reconciliation, kafkaConnectStatus).setHandler(statusResult -> {
                         // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -104,7 +104,7 @@ public class KafkaConnectAssemblyOperator extends AbstractAssemblyOperator<Kuber
                 .compose(i -> chainFuture.complete(), chainFuture)
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
-                    kafkaConnectStatus.setUrl(KafkaConnectResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
+                    kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
 
                     updateStatus(kafkaConnect, reconciliation, kafkaConnectStatus).setHandler(statusResult -> {
                         // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -115,7 +115,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                     .compose(i -> chainFuture.complete(), chainFuture)
                     .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
-                        kafkaConnectS2Istatus.setRestApiAddress(KafkaConnectS2IResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
+                        kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
                         kafkaConnectS2Istatus.setBuildConfigName(KafkaConnectS2IResources.buildConfigName(connect.getCluster()));
 
                         updateStatus(kafkaConnectS2I, reconciliation, kafkaConnectS2Istatus).setHandler(statusResult -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -115,7 +115,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractAssemblyOperator<Op
                     .compose(i -> chainFuture.complete(), chainFuture)
                     .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
-                        kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.restApiAddress(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
+                        kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
                         kafkaConnectS2Istatus.setBuildConfigName(KafkaConnectS2IResources.buildConfigName(connect.getCluster()));
 
                         updateStatus(kafkaConnectS2I, reconciliation, kafkaConnectS2Istatus).setHandler(statusResult -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -170,7 +170,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getHttpAddress(), "foo-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "Ready");
 
@@ -658,7 +658,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getHttpAddress(), "foo-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -170,7 +170,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "Ready");
 
@@ -658,7 +658,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -159,7 +159,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
             // Verify status
             List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.assertEquals(capturedConnects.get(0).getStatus().getRestApiAddress(), "foo-connect-api.test.svc:8083");
+            context.assertEquals(capturedConnects.get(0).getStatus().getUrl(), "http://foo-connect-api.test.svc:8083");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), "Ready");
             async.complete();
@@ -604,7 +604,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
             // Verify status
             List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
-            context.assertEquals(capturedConnects.get(0).getStatus().getRestApiAddress(), "foo-connect-api.test.svc:8083");
+            context.assertEquals(capturedConnects.get(0).getStatus().getUrl(), "http://foo-connect-api.test.svc:8083");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), failureMsg);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -190,7 +190,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
             // Verify status
             List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.assertEquals(capturedConnects.get(0).getStatus().getRestApiAddress(), "foo-connect-api.test.svc:8083");
+            context.assertEquals(capturedConnects.get(0).getStatus().getUrl(), "http://foo-connect-api.test.svc:8083");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), "Ready");
 
@@ -747,7 +747,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
             // Verify status
             List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.assertEquals(capturedConnects.get(0).getStatus().getRestApiAddress(), "foo-connect-api.test.svc:8083");
+            context.assertEquals(capturedConnects.get(0).getStatus().getUrl(), "http://foo-connect-api.test.svc:8083");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
             context.assertEquals(capturedConnects.get(0).getStatus().getConditions().get(0).getMessage(), failureMessage);

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1381,7 +1381,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|restApiAddress      1.2+<.<|REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<|URL of REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
 |====
 
@@ -1462,7 +1462,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|restApiAddress      1.2+<.<|REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<|URL of REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
 |buildConfigName     1.2+<.<|The name of the build configuration.
 |string
@@ -2076,7 +2076,7 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|httpAddress         1.2+<.<|The HTTP address at which external client applications can access the Kafka Bridge.
+|url                 1.2+<.<|The URL address at which external client applications can access the Kafka Bridge.
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1381,7 +1381,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|URL of REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
 |====
 
@@ -1462,7 +1462,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|URL of REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
 |buildConfigName     1.2+<.<|The name of the build configuration.
 |string

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -2076,7 +2076,7 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<|The URL address at which external client applications can access the Kafka Bridge.
+|url                 1.2+<.<|The URL at which external client applications can access the Kafka Bridge.
 |string
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -812,6 +812,6 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            restApiAddress:
+            url:
               type: string
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -814,7 +814,7 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            restApiAddress:
+            url:
               type: string
             buildConfigName:
               type: string

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -521,6 +521,6 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            httpAddress:
+            url:
               type: string
 {{- end -}}

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -807,5 +807,5 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            restApiAddress:
+            url:
               type: string

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -809,7 +809,7 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            restApiAddress:
+            url:
               type: string
             buildConfigName:
               type: string

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -516,5 +516,5 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            httpAddress:
+            url:
               type: string


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
Adding `http://` scheme as prefix to `service:port`, renaming `*address*` to `url`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

