### PR TITLE
ST: add group instance ID only for clients 2.3.0 and higher

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
@@ -136,7 +136,9 @@ public class MessagingBaseST extends AbstractST {
         ClientArgumentMap consumerArguments = new ClientArgumentMap();
         consumerArguments.put(ClientArgument.BROKER_LIST, bootstrapServer);
         consumerArguments.put(ClientArgument.GROUP_ID, "my-group" + rng.nextInt(Integer.MAX_VALUE));
-        consumerArguments.put(ClientArgument.GROUP_INSTANCE_ID, "instance" + rng.nextInt(Integer.MAX_VALUE));
+        if (allowParameter("2.3.0")) {
+            consumerArguments.put(ClientArgument.GROUP_INSTANCE_ID, "instance" + rng.nextInt(Integer.MAX_VALUE));
+        }
         consumerArguments.put(ClientArgument.VERBOSE, "");
         consumerArguments.put(ClientArgument.TOPIC, topicName);
         consumerArguments.put(ClientArgument.MAX_MESSAGES, Integer.toString(messageCount));
@@ -239,5 +241,17 @@ public class MessagingBaseST extends AbstractST {
     void assertSentAndReceivedMessages(int sent, int received) {
         assertThat(String.format("Sent (%s) and receive (%s) message count is not equal", sent, received),
                 sent == received);
+    }
+
+    private boolean allowParameter(String minimalVersion) {
+        Pattern pattern = Pattern.compile("(?<major>[0-9]).(?<minor>[0-9]).(?<micro>[0-9])");
+        Matcher current = pattern.matcher(Environment.ST_KAFKA_VERSION);
+        Matcher minimal = pattern.matcher(minimalVersion);
+        if (current.find() && minimal.find()) {
+            return Integer.valueOf(current.group("major")) >= Integer.valueOf(minimal.group("major"))
+                    && Integer.valueOf(current.group("minor")) >= Integer.valueOf(minimal.group("minor"))
+                    && Integer.valueOf(current.group("micro")) >= Integer.valueOf(minimal.group("micro"));
+        }
+        return false;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -508,9 +508,9 @@ public class Resources extends AbstractResources {
         LOGGER.info("Zookeeper pods are ready");
         LOGGER.info("Waiting for Kafka pods");
         StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
-        LOGGER.info("Kafka pod are ready");
+        LOGGER.info("Kafka pods are ready");
         // EO should not be deployed if it does not contain UO and TO
-        if (kafka.getSpec().getEntityOperator().getUserOperator() != null || kafka.getSpec().getEntityOperator().getTopicOperator() != null) {
+        if (kafka.getSpec().getEntityOperator() != null) {
             LOGGER.info("Waiting for Entity Operator pods");
             StUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
             LOGGER.info("Entity Operator pods are ready");

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -212,6 +212,7 @@ class KafkaST extends MessagingBaseST {
         // Wait when EO(UO + TO) will be removed
         StUtils.waitForDeploymentDeletion(entityOperatorDeploymentName(CLUSTER_NAME));
         StUtils.waitForPodDeletion(pod.get().getMetadata().getName());
+        LOGGER.info("EO was deleted");
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1001,7 +1001,7 @@ class KafkaST extends MessagingBaseST {
         //Verifying docker image for zookeeper pods
         for (int i = 0; i < zkPods; i++) {
             String imgFromPod = getContainerImageNameFromPod(zookeeperPodName(clusterName, i), "zookeeper");
-            assertEquals(imgFromDeplConf.get(ZK_IMAGE), imgFromPod);
+            assertThat("Zookeeper image for pod " + i + " uses wrong image", imgFromPod.contains(Environment.ST_KAFKA_VERSION));
             imgFromPod = getContainerImageNameFromPod(zookeeperPodName(clusterName, i), "tls-sidecar");
             assertEquals(imgFromDeplConf.get(TLS_SIDECAR_ZOOKEEPER_IMAGE), imgFromPod);
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix for added option `--group-instance-id` for consumer for clients with version less than `2.3.0`.

### Checklist

- [x] Make sure all tests pass

