### PR TITLE
future

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 
 import java.util.List;
 
@@ -39,7 +38,7 @@ public interface K8s {
      * Asynchronously list the resources.
      * @return A future which completes with the topics.
      */
-    Future<List<KafkaTopic>> listMaps();
+    Future<List<KafkaTopic>> listResources();
 
     /**
      * Get the resource with the given name, invoking the given handler with the result.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.Event;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 import java.util.List;
@@ -16,43 +17,43 @@ public interface K8s {
     /**
      * Asynchronously create the given resource.
      * @param topicResource The resource to be created.
-     * @param handler The result handler.
+     * @return A future which completes when the topic has been created.
      */
-    void createResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler);
+    Future<Void> createResource(KafkaTopic topicResource);
 
     /**
      * Asynchronously update the given resource.
      * @param topicResource The topic.
-     * @param handler The result handler.
+     * @return A future which completes when the topic has been updated.
      */
-    void updateResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler);
+    Future<Void> updateResource(KafkaTopic topicResource);
 
     /**
      * Asynchronously delete the given resource.
      * @param resourceName The name of the resource to be deleted.
-     * @param handler The result handler.
+     * @return A future which completes when the topic has been deleted.
      */
-    void deleteResource(ResourceName resourceName, Handler<AsyncResult<Void>> handler);
+    Future<Void> deleteResource(ResourceName resourceName);
 
     /**
      * Asynchronously list the resources.
-     * @param handler The result handler.
+     * @return A future which completes with the topics.
      */
-    void listMaps(Handler<AsyncResult<List<KafkaTopic>>> handler);
+    Future<List<KafkaTopic>> listMaps();
 
     /**
      * Get the resource with the given name, invoking the given handler with the result.
      * If a resource with the given name does not exist, the handler will be called with
      * a null {@link AsyncResult#result() result()}.
      * @param resourceName The name of the resource to get.
-     * @param handler The result handler.
+     * @return A future which completes with the topic
      */
-    void getFromName(ResourceName resourceName, Handler<AsyncResult<KafkaTopic>> handler);
+    Future<KafkaTopic> getFromName(ResourceName resourceName);
 
     /**
      * Create an event.
      * @param event The event.
-     * @param handler The result handler.
+     * @return A future which completes when the event has been created.
      */
-    void createEvent(Event event, Handler<AsyncResult<Void>> handler);
+    Future<Void> createEvent(Event event);
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
@@ -40,7 +41,8 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public void createResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> createResource(KafkaTopic topicResource) {
+        Future<Void> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 KafkaTopic kafkaTopic = operation().inNamespace(namespace).create(topicResource);
@@ -51,10 +53,12 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
+        return handler;
     }
 
     @Override
-    public void updateResource(KafkaTopic topicResource, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> updateResource(KafkaTopic topicResource) {
+        Future<Void> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 KafkaTopic kafkaTopic = operation().inNamespace(namespace).withName(topicResource.getMetadata().getName()).patch(topicResource);
@@ -65,10 +69,12 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
+        return handler;
     }
 
     @Override
-    public void deleteResource(ResourceName resourceName, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> deleteResource(ResourceName resourceName) {
+        Future<Void> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 // Delete the resource by the topic name, because neither ZK nor Kafka know the resource name
@@ -79,6 +85,7 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
+        return handler;
     }
 
     private MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
@@ -86,7 +93,8 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public void listMaps(Handler<AsyncResult<List<KafkaTopic>>> handler) {
+    public Future<List<KafkaTopic>> listMaps() {
+        Future<List<KafkaTopic>> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 future.complete(operation().inNamespace(namespace).withLabels(labels.labels()).list().getItems());
@@ -94,10 +102,12 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
+        return handler;
     }
 
     @Override
-    public void getFromName(ResourceName resourceName, Handler<AsyncResult<KafkaTopic>> handler) {
+    public Future<KafkaTopic> getFromName(ResourceName resourceName) {
+        Future<KafkaTopic> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 future.complete(operation().inNamespace(namespace).withName(resourceName.toString()).get());
@@ -105,14 +115,15 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
-
+        return handler;
     }
 
     /**
      * Create the given k8s event
      */
     @Override
-    public void createEvent(Event event, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> createEvent(Event event) {
+        Future<Void> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 try {
@@ -126,5 +137,6 @@ public class K8sImpl implements K8s {
                 future.fail(e);
             }
         }, handler);
+        return handler;
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1036,7 +1036,7 @@ class TopicOperator {
                 reconcileFromKafka(reconciliationType, topicNamesFromKafka.stream().map(TopicName::new).collect(Collectors.toList()))
 
         ).compose(reconcileState -> {
-            Future<List<KafkaTopic>> ktFut = k8s.listMaps();
+            Future<List<KafkaTopic>> ktFut = k8s.listResources();
             return ktFut.recover(ex -> Future.failedFuture(
                     new OperatorException("Error listing existing KafkaTopics during " + reconciliationType + " reconciliation", ex)
             )).map(ktList -> {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -106,7 +106,7 @@ class TopicOperator {
                     LOGGER.warn("{}", message);
                     break;
             }
-            k8s.createEvent(event, handler);
+            k8s.createEvent(event).setHandler(handler);
         }
 
         public String toString() {
@@ -129,7 +129,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) throws OperatorException {
             KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(this.topic, labels);
-            k8s.createResource(kafkaTopic, handler);
+            k8s.createResource(kafkaTopic).setHandler(handler);
         }
 
         @Override
@@ -153,7 +153,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) {
-            k8s.deleteResource(resourceName, handler);
+            k8s.deleteResource(resourceName).setHandler(handler);
         }
 
         @Override
@@ -178,7 +178,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) {
             KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(this.topic, labels);
-            k8s.updateResource(kafkaTopic, handler);
+            k8s.updateResource(kafkaTopic).setHandler(handler);
         }
 
         @Override
@@ -530,7 +530,7 @@ class TopicOperator {
     private void update2Way(LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic, Handler<AsyncResult<Void>> reconciliationResultHandler) {
         TopicDiff diff = TopicDiff.diff(kafkaTopic, k8sTopic);
         if (diff.isEmpty()) {
-            // they're the same => do nothing, but stil create the private copy
+            // they're the same => do nothing, but still create the private copy
             LOGGER.debug("{}: KafkaTopic created in k8s and topic created in kafka, but they're identical => just creating in topicStore", logContext);
             LOGGER.debug("{}: k8s and kafka versions of topic '{}' are the same", logContext, kafkaTopic.getTopicName());
             enqueue(new CreateInTopicStore(logContext, kafkaTopic, involvedObject, reconciliationResultHandler));
@@ -757,7 +757,7 @@ class TopicOperator {
                 } else {
                     resourceName = topicName.asKubeName();
                 }
-                k8s.getFromName(resourceName, kubeResult -> {
+                k8s.getFromName(resourceName).setHandler(kubeResult -> {
                     if (kubeResult.succeeded()) {
                         KafkaTopic topic = kubeResult.result();
                         Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
@@ -1036,9 +1036,7 @@ class TopicOperator {
                 reconcileFromKafka(reconciliationType, topicNamesFromKafka.stream().map(TopicName::new).collect(Collectors.toList()))
 
         ).compose(reconcileState -> {
-            Future<List<KafkaTopic>> ktFut = Future.future();
-            // Find all the topics in kube
-            k8s.listMaps(ktFut);
+            Future<List<KafkaTopic>> ktFut = k8s.listMaps();
             return ktFut.recover(ex -> Future.failedFuture(
                     new OperatorException("Error listing existing KafkaTopics during " + reconciliationType + " reconciliation", ex)
             )).map(ktList -> {
@@ -1159,8 +1157,7 @@ class TopicOperator {
      * Reconcile the given topic which has the given {@code privateTopic} in the topic store.
      */
     private Future<Void> reconcileWithPrivateTopic(LogContext logContext, TopicName topicName, Topic privateTopic) {
-        Future<KafkaTopic> kubeFuture = Future.future();
-        k8s.getFromName(privateTopic.getResourceName(), kubeFuture);
+        Future<KafkaTopic> kubeFuture = k8s.getFromName(privateTopic.getResourceName());
         return kubeFuture
             .compose(kafkaTopicResource -> {
                 return getKafkaAndReconcile(logContext, topicName, privateTopic, kafkaTopicResource);
@@ -1207,9 +1204,7 @@ class TopicOperator {
     }
 
     Future<KafkaTopic> getFromKube(ResourceName kubeName) {
-        Future<KafkaTopic> f = Future.future();
-        k8s.getFromName(kubeName, f);
-        return f;
+        return k8s.getFromName(kubeName);
     }
 
     Future<Topic> getFromKafka(TopicName topicName) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -52,7 +52,7 @@ public class K8sImplTest {
 
         K8sImpl k8s = new K8sImpl(vertx, mockClient, new Labels("foo", "bar"), "default");
 
-        k8s.listMaps(ar -> {
+        k8s.listResources().setHandler(ar -> {
             if (ar.failed()) {
                 ar.cause().printStackTrace();
             }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -342,7 +342,7 @@ public class TopicOperatorTest {
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setCreateResponse(resourceName, null)
-                .createResource(resource, ar -> { });
+                .createResource(resource);
         mockK8s.setModifyResponse(resourceName, null);
         LogContext logContext = LogContext.zkWatch("///", topicName.toString());
         Async async = context.async(3);
@@ -354,7 +354,7 @@ public class TopicOperatorTest {
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(resourceName, ar2 -> {
+            mockK8s.getFromName(resourceName).setHandler(ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", TopicSerialization.fromTopicResource(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -383,7 +383,7 @@ public class TopicOperatorTest {
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.kubeWatch(Watcher.Action.ADDED, topicResource);
-        mockK8s.createResource(topicResource, ar -> async0.countDown());
+        mockK8s.createResource(topicResource).setHandler(ar -> async0.countDown());
 
         Async async = context.async(1);
         topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
@@ -414,7 +414,7 @@ public class TopicOperatorTest {
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.kubeWatch(Watcher.Action.DELETED, topicResource);
         mockK8s.setCreateResponse(resourceName, null)
-                .createResource(topicResource, ar -> async0.countDown());
+                .createResource(topicResource).setHandler(ar -> async0.countDown());
         mockK8s.setDeleteResponse(resourceName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null)
                 .create(privateTopic, ar -> async0.countDown());
@@ -461,7 +461,7 @@ public class TopicOperatorTest {
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName()).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -515,7 +515,7 @@ public class TopicOperatorTest {
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
-        mockK8s.createResource(topicResource, ar -> async0.countDown());
+        mockK8s.createResource(topicResource).setHandler(ar -> async0.countDown());
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
 
@@ -555,7 +555,7 @@ public class TopicOperatorTest {
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(topic, ar -> async0.countDown());
+        mockK8s.createResource(topic).setHandler(ar -> async0.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
@@ -571,7 +571,7 @@ public class TopicOperatorTest {
                 context.assertEquals(mergedTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName()).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(mergedTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -597,7 +597,7 @@ public class TopicOperatorTest {
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(topic, ar -> async0.countDown());
+        mockK8s.createResource(topic).setHandler(ar -> async0.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         async0.await();
@@ -616,7 +616,7 @@ public class TopicOperatorTest {
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName()).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -644,7 +644,7 @@ public class TopicOperatorTest {
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(resource, ar -> async0.countDown());
+        mockK8s.createResource(resource).setHandler(ar -> async0.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         mockTopicStore.create(privateTopic, ar -> async0.countDown());
@@ -659,7 +659,7 @@ public class TopicOperatorTest {
                 context.assertEquals(resultTopic, readResult.result());
                 async.countDown();
             });
-            mockK8s.getFromName(topicName.asKubeName(), readResult -> {
+            mockK8s.getFromName(topicName.asKubeName()).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(resultTopic, TopicSerialization.fromTopicResource(readResult.result()));
                 async.countDown();
@@ -734,7 +734,7 @@ public class TopicOperatorTest {
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setCreateResponse(resourceName, null);
-        mockK8s.createResource(resource, ar -> {
+        mockK8s.createResource(resource).setHandler(ar -> {
             assertSucceeded(context, ar);
         });
         mockK8s.setModifyResponse(resourceName, null);
@@ -748,7 +748,7 @@ public class TopicOperatorTest {
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(resourceName, ar2 -> {
+            mockK8s.getFromName(resourceName).setHandler(ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertNotNull(ar2.result());
                 context.assertEquals("baz", TopicSerialization.fromTopicResource(ar2.result()).getConfig().get("cleanup.policy"));
@@ -785,7 +785,7 @@ public class TopicOperatorTest {
         Topic privateTopic = kubeTopic;
 
         mockK8s.setCreateResponse(resourceName, null)
-                .createResource(TopicSerialization.toTopicResource(kubeTopic, labels), ar -> { });
+                .createResource(TopicSerialization.toTopicResource(kubeTopic, labels));
         mockK8s.setDeleteResponse(resourceName, k8sException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is mostly a refactoring to use `Futures` in the Topic Operator where currently we use `Handlers`. This makes it more consistent with the other operators. The PR also starts using the `CrdOperator` within `K8sImpl`. When we support `KafkaTopic.status` we will use the `CrdOperator` for updating the status.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

