### PR TITLE
future

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -52,13 +52,13 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
             };
             switch (action) {
                 case ADDED:
-                    topicOperator.onResourceAdded(logContext, kafkaTopic, resultHandler);
+                    topicOperator.onResourceAddedOrModified(logContext, kafkaTopic, false).setHandler(resultHandler);
                     break;
                 case MODIFIED:
-                    topicOperator.onResourceModified(logContext, kafkaTopic, resultHandler);
+                    topicOperator.onResourceAddedOrModified(logContext, kafkaTopic, true).setHandler(resultHandler);
                     break;
                 case DELETED:
-                    topicOperator.onResourceDeleted(logContext, kafkaTopic, resultHandler);
+                    topicOperator.onResourceDeleted(logContext, kafkaTopic).setHandler(resultHandler);
                     break;
                 case ERROR:
                     LOGGER.error("Watch received action=ERROR for {} {}", kind, name);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.topic;
 
-import io.vertx.core.Handler;
-
 /**
  * ZooKeeper watcher for child znodes of {@code /configs/topics},
- * calling {@link TopicOperator#onTopicConfigChanged(LogContext, TopicName, Handler)}
+ * calling {@link TopicOperator#onTopicConfigChanged(LogContext, TopicName)}
  * for changed children.
  */
 class TopicConfigsWatcher extends ZkWatcher {
@@ -23,7 +21,7 @@ class TopicConfigsWatcher extends ZkWatcher {
     protected void notifyOperator(String child) {
         LogContext logContext = LogContext.zkWatch(CONFIGS_ZNODE, "=" + child);
         log.info("{}: Config change {}: topic {}", logContext);
-        topicOperator.onTopicConfigChanged(logContext, new TopicName(child), ar2 -> {
+        topicOperator.onTopicConfigChanged(logContext, new TopicName(child)).setHandler(ar2 -> {
             log.info("{} Reconciliation result due to topic config change on topic {}: {}", logContext, child, ar2);
         });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.topic;
 
-import io.vertx.core.Handler;
-
 /**
  * ZooKeeper watcher for child znodes of {@code /brokers/topics},
- * calling {@link TopicOperator#onTopicPartitionsChanged(LogContext, TopicName, Handler)}
+ * calling {@link TopicOperator#onTopicPartitionsChanged(LogContext, TopicName)}
  * for changed children.
  */
 public class ZkTopicWatcher extends ZkWatcher {
@@ -24,7 +22,7 @@ public class ZkTopicWatcher extends ZkWatcher {
         LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "=" + child);
         log.info("{}: Partitions change", logContext);
         topicOperator.onTopicPartitionsChanged(logContext,
-            new TopicName(child), ar -> {
+            new TopicName(child)).setHandler(ar -> {
                 log.info("{}: Reconciliation result due to topic partitions change on topic {}: {}", logContext, child, ar);
             });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -15,8 +15,8 @@ import java.util.Set;
 
 /**
  * ZooKeeper watcher for child znodes of {@code /brokers/topics},
- * calling {@link TopicOperator#onTopicCreated(LogContext, TopicName, io.vertx.core.Handler)} for new children and
- * {@link TopicOperator#onTopicDeleted(LogContext, TopicName, io.vertx.core.Handler)} for deleted children.
+ * calling {@link TopicOperator#onTopicCreated(LogContext, TopicName)} for new children and
+ * {@link TopicOperator#onTopicDeleted(LogContext, TopicName)} for deleted children.
  */
 class ZkTopicsWatcher {
 
@@ -82,7 +82,7 @@ class ZkTopicsWatcher {
                     tcw.removeChild(topicName);
                     tw.removeChild(topicName);
                     LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "-" + topicName);
-                    topicOperator.onTopicDeleted(logContext, new TopicName(topicName), ar -> {
+                    topicOperator.onTopicDeleted(logContext, new TopicName(topicName)).setHandler(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to deletion of topic {}", logContext, topicName);
                         } else {
@@ -98,7 +98,7 @@ class ZkTopicsWatcher {
                     tcw.addChild(topicName);
                     tw.addChild(topicName);
                     LogContext logContext = LogContext.zkWatch(TOPICS_ZNODE, "+" + topicName);
-                    topicOperator.onTopicCreated(logContext, new TopicName(topicName), ar -> {
+                    topicOperator.onTopicCreated(logContext, new TopicName(topicName)).setHandler(ar -> {
                         if (ar.succeeded()) {
                             LOGGER.debug("{}: Success responding to creation of topic {}", logContext, topicName);
                         } else {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
@@ -5,9 +5,7 @@
 package io.strimzi.operator.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,12 +72,12 @@ class MockTopicOperator extends TopicOperator {
         }
     }
 
-    public AsyncResult<Void> topicCreatedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicCreatedResult");
-    public AsyncResult<Void> topicDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicDeletedResult");
-    public AsyncResult<Void> topicModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicModifiedResult");
-    public AsyncResult<Void> resourceAddedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceAddedResult");
-    public AsyncResult<Void> resourceDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceDeletedResult");
-    public AsyncResult<Void> resourceModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceModifiedResult");
+    public Future<Void> topicCreatedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicCreatedResult");
+    public Future<Void> topicDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicDeletedResult");
+    public Future<Void> topicModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicModifiedResult");
+    public Future<Void> resourceAddedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceAddedResult");
+    public Future<Void> resourceDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceDeletedResult");
+    public Future<Void> resourceModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".resourceModifiedResult");
     private List<MockOperatorEvent> mockOperatorEvents = new ArrayList<>();
 
     public List<MockOperatorEvent> getMockOperatorEvents() {
@@ -91,44 +89,38 @@ class MockTopicOperator extends TopicOperator {
     }
 
     @Override
-    public void onTopicCreated(LogContext logContext, TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> onTopicCreated(LogContext logContext, TopicName topicName) {
         mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.CREATE, topicName));
-        handler.handle(topicCreatedResult);
+        return topicCreatedResult;
     }
 
     @Override
-    public void onTopicDeleted(LogContext logContext, TopicName topicName, Handler<AsyncResult<Void>> resultHandler) {
+    public Future<Void> onTopicDeleted(LogContext logContext, TopicName topicName) {
         mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.DELETE, topicName));
-        resultHandler.handle(topicDeletedResult);
+        return topicDeletedResult;
     }
 
     @Override
-    public void onTopicConfigChanged(LogContext logContext, TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> onTopicConfigChanged(LogContext logContext, TopicName topicName) {
         mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.MODIFY_CONFIG, topicName));
-        handler.handle(topicModifiedResult);
+        return topicModifiedResult;
     }
 
     @Override
-    public void onTopicPartitionsChanged(LogContext logContext, TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> onTopicPartitionsChanged(LogContext logContext, TopicName topicName) {
         mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.MODIFY_PARTITIONS, topicName));
-        handler.handle(topicModifiedResult);
+        return topicModifiedResult;
     }
 
     @Override
-    public void onResourceAdded(LogContext logContext, KafkaTopic resource, Handler<AsyncResult<Void>> resultHandler) {
-        mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.CREATE, resource));
-        resultHandler.handle(resourceAddedResult);
+    public Future<Void> onResourceAddedOrModified(LogContext logContext, KafkaTopic resource, boolean modified) {
+        mockOperatorEvents.add(new MockOperatorEvent(modified ? MockOperatorEvent.Type.MODIFY : MockOperatorEvent.Type.CREATE, resource));
+        return resourceAddedResult;
     }
 
     @Override
-    public void onResourceModified(LogContext logContext, KafkaTopic resource, Handler<AsyncResult<Void>> resultHandler) {
-        mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.MODIFY, resource));
-        resultHandler.handle(resourceModifiedResult);
-    }
-
-    @Override
-    public void onResourceDeleted(LogContext logContext, KafkaTopic resource, Handler<AsyncResult<Void>> resultHandler) {
+    public Future<Void> onResourceDeleted(LogContext logContext, KafkaTopic resource) {
         mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.DELETE, resource));
-        resultHandler.handle(resourceDeletedResult);
+        return resourceDeletedResult;
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -446,7 +446,7 @@ public class TopicOperatorIT extends BaseITST {
 
     @Test
     public void testTopicAddedWithEncodableName(TestContext context) throws Exception {
-        createTopic(context, "thest-TOPIC_ADDED");
+        createTopic(context, "test-TOPIC_ADDED_ENCODABLE");
     }
 
     @Test
@@ -456,7 +456,7 @@ public class TopicOperatorIT extends BaseITST {
 
     @Test
     public void testTopicDeletedWithEncodableName(TestContext context) throws Exception {
-        createAndDeleteTopic(context, "test-TOPIC_DELETED");
+        createAndDeleteTopic(context, "test-TOPIC_DELETED_ENCODABLE");
     }
 
     @Test
@@ -466,7 +466,7 @@ public class TopicOperatorIT extends BaseITST {
 
     @Test
     public void testTopicConfigChangedWithEncodableName(TestContext context) throws Exception {
-        createAndAlterTopicConfig(context, "test-TOPIC_CONFIG_CHANGED");
+        createAndAlterTopicConfig(context, "test-TOPIC_CONFIG_CHANGED_ENCODABLE");
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The PR refactors the TO so that the `on*()` methods (which are called from the various watchers) return Futures rather than accepting handlers. Using Futures will make it much simpler to `compose()` with a method which updates the `KafkaTopic.status`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

