### PR TITLE
Removed health check port which now is just the REST API one

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
@@ -41,7 +41,7 @@ public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving, Seriali
         this.port = port;
     }
 
-    @Description("The port which is the server listening on. Avoid using port 8081 which is used for readiness checking.")
+    @Description("The port which is the server listening on.")
     @DefaultValue("8080")
     @Minimum(1023)
     public int getPort() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -48,9 +48,6 @@ public class KafkaBridgeCluster extends AbstractModel {
     public static final int DEFAULT_REST_API_PORT = 8080;
     protected static final String REST_API_PORT_NAME = "rest-api";
 
-    protected static final int HEALTH_CHECK_PORT = 8081;
-    protected static final String HEALTH_CHECK_PORT_NAME = "healthcheck";
-
     private static final String NAME_SUFFIX = "-bridge";
     private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-api";
 
@@ -217,12 +214,7 @@ public class KafkaBridgeCluster extends AbstractModel {
 
         if (spec.getHttp() != null) {
             kafkaBridgeCluster.setHttpEnabled(true);
-            if (spec.getHttp().getPort() == HEALTH_CHECK_PORT) {
-                log.warn("HTTP port cannot be set to {}. This port is already used for heath check.", HEALTH_CHECK_PORT);
-                throw new InvalidResourceException("HTTP port cannot be set to " + HEALTH_CHECK_PORT + ". This port is already used for heath check.");
-            } else {
-                kafkaBridgeCluster.setKafkaBridgeHttpConfig(spec.getHttp());
-            }
+            kafkaBridgeCluster.setKafkaBridgeHttpConfig(spec.getHttp());
         } else {
             log.warn("No protocol specified.");
             throw new InvalidResourceException("No protocol for communication with Bridge specified. Use HTTP.");
@@ -239,7 +231,6 @@ public class KafkaBridgeCluster extends AbstractModel {
             port = http.getPort();
         }
         ports.add(createServicePort(REST_API_PORT_NAME, port, port, "TCP"));
-        ports.add(createServicePort(HEALTH_CHECK_PORT_NAME, HEALTH_CHECK_PORT, HEALTH_CHECK_PORT, "TCP"));
         if (isMetricsEnabled()) {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
@@ -250,7 +241,6 @@ public class KafkaBridgeCluster extends AbstractModel {
     protected List<ContainerPort> getContainerPortList() {
         List<ContainerPort> portList = new ArrayList<>(3);
         portList.add(createContainerPort(REST_API_PORT_NAME, DEFAULT_REST_API_PORT, "TCP"));
-        portList.add(createContainerPort(HEALTH_CHECK_PORT_NAME, HEALTH_CHECK_PORT, "TCP"));
         if (isMetricsEnabled) {
             portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }
@@ -349,8 +339,8 @@ public class KafkaBridgeCluster extends AbstractModel {
                 .withCommand("/opt/strimzi/bin/docker/kafka_bridge_run.sh")
                 .withEnv(getEnvVars())
                 .withPorts(getContainerPortList())
-                .withLivenessProbe(ModelUtils.createHttpProbe(livenessPath, HEALTH_CHECK_PORT_NAME, livenessProbeOptions))
-                .withReadinessProbe(ModelUtils.createHttpProbe(readinessPath, HEALTH_CHECK_PORT_NAME, readinessProbeOptions))
+                .withLivenessProbe(ModelUtils.createHttpProbe(livenessPath, REST_API_PORT_NAME, livenessProbeOptions))
+                .withReadinessProbe(ModelUtils.createHttpProbe(readinessPath, REST_API_PORT_NAME, readinessProbeOptions))
                 .withVolumeMounts(getVolumeMounts())
                 .withResources(getResources())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, getImage()))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -149,7 +149,7 @@ public class KafkaBridgeClusterTest {
         assertEquals("ClusterIP", svc.getSpec().getType());
         assertEquals(expectedLabels(kbc.getServiceName()), svc.getMetadata().getLabels());
         assertEquals(expectedSelectorLabels(), svc.getSpec().getSelector());
-        assertEquals(3, svc.getSpec().getPorts().size());
+        assertEquals(2, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaBridgeCluster.DEFAULT_REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaBridgeCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
         assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
@@ -176,7 +176,7 @@ public class KafkaBridgeClusterTest {
         assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
-        assertEquals(3, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
+        assertEquals(2, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
         assertEquals(new Integer(KafkaBridgeCluster.DEFAULT_REST_API_PORT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
         assertEquals(KafkaBridgeCluster.REST_API_PORT_NAME, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getName());
         assertEquals("TCP", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getProtocol());

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -2014,7 +2014,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 [options="header"]
 |====
 |Property     |Description
-|port  1.2+<.<|The port which is the server listening on. Avoid using port 8081 which is used for readiness checking.
+|port  1.2+<.<|The port which is the server listening on.
 |integer
 |====
 

--- a/documentation/book/ref-kafka-bridge-http-configuration.adoc
+++ b/documentation/book/ref-kafka-bridge-http-configuration.adoc
@@ -10,8 +10,6 @@ This property contains the Kafka Bridge HTTP configuration options.
 
 * `port`
 
-When configuring `port` property avoid the value `8081`. This port is used for the health checks.
-
 .Example Kafka Bridge HTTP configuration
 [source,yaml,subs="attributes+"]
 ----
@@ -25,5 +23,3 @@ spec:
     port: 8080
   # ...
 ----
-
-IMPORTANT: The port must not be set to 8081 as that will cause a conflict with the healthcheck settings.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #1830 removing the need for another health check port for the HTTP bridge because the liveness and readiness endpoints are now exposed through the REST API port.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

