### PR TITLE
[DOC] Supporting doc changes for additional CRD status fields

### DIFF
--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1060,11 +1060,11 @@ Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-K
 |string
 |status              1.2+<.<|The status of the condition, one of True, False, Unknown.
 |string
-|lastTransitionTime  1.2+<.<|Last time the condition of a type changes from one status to another.The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
+|lastTransitionTime  1.2+<.<|Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string
-|reason              1.2+<.<|One-word CamelCase reason for the condition's last transition.
+|reason              1.2+<.<|The reason for the condition's last transition (a single word in CamelCase).
 |string
-|message             1.2+<.<|Human-readable message indicating details about last transition.
+|message             1.2+<.<|Human-readable message indicating details about the condition's last transition.
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1058,7 +1058,7 @@ Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-K
 |Property                   |Description
 |type                1.2+<.<|The unique identifier of a condition, used to distinguish between other conditions in the resource.
 |string
-|status              1.2+<.<|The status of the condition, one of True, False, Unknown.
+|status              1.2+<.<|The status of the condition, either True, False or Unknown.
 |string
 |lastTransitionTime  1.2+<.<|Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -19,9 +19,6 @@ Several resources have a `status` property, as described in the following table.
 m¦xref:type-KafkaStatus-reference[]
 ¦The Kafka cluster.
 
-m¦xref:type-KafkaTopicStatus-reference[]
-¦Kafka topics and their partitions.
-
 m¦xref:type-KafkaConnectStatus-reference[]
 ¦The Kafka Connect cluster, if deployed.
 
@@ -38,7 +35,7 @@ m¦xref:type-KafkaBridgeStatus-reference[]
 ¦The {ProductName} Kafka Bridge, if deployed.
 
 |===
-
+//When dev work is complete, add `KafkaTopicStatus` to the above table. `KafkaTopicStatus`: Kafka topics and their partitions
 The `status` property includes information on:
 
 * The _current state_ of the resource described in _status conditions_

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -6,48 +6,63 @@
 
 = {ProductName} custom resource status
 
-The `status` property of a {ProductName} custom resource publishes useful information about the resource to users and tools that need it.
+The `status` property of a {ProductName} custom resource publishes information about the resource to users and tools that need it.
 
 Several resources have a `status` property, as described in the following table.
 
-[cols="2*",options="header",stripes="none",separator=¦]
+[cols="3*",options="header",stripes="none",separator=¦]
 |===
 
-¦{ProductName} Resource
-¦Publishes information on...
+m¦{ProductName} resource
+¦Schema reference
+¦Publishes status information on...
 
-m¦xref:type-KafkaStatus-reference[]
+m¦Kafka
+¦xref:type-KafkaStatus-reference[]
 ¦The Kafka cluster.
 
-m¦xref:type-KafkaConnectStatus-reference[]
+m¦KafkaConnect
+¦xref:type-KafkaConnectStatus-reference[]
 ¦The Kafka Connect cluster, if deployed.
 
-m¦xref:type-KafkaConnectS2Istatus-reference[]
+m¦KafkaConnectS2I
+¦xref:type-KafkaConnectS2Istatus-reference[]
 ¦The Kafka Connect cluster with Source-to-Image support, if deployed.
 
-m¦xref:type-KafkaMirrorMakerStatus-reference[]
+m¦KafkaMirrorMaker
+¦xref:type-KafkaMirrorMakerStatus-reference[]
 ¦The Kafka MirrorMaker tool, if deployed.
 
-m¦xref:type-KafkaUserStatus-reference[]
-¦Kafka users.
+m¦KafkaUser
+¦xref:type-KafkaUserStatus-reference[]
+¦Kafka users in your cluster.
 
-m¦xref:type-KafkaBridgeStatus-reference[]
+m¦KafkaBridge
+¦xref:type-KafkaBridgeStatus-reference[]
 ¦The {ProductName} Kafka Bridge, if deployed.
 
 |===
 //When dev work is complete, add `KafkaTopicStatus` to the above table. `KafkaTopicStatus`: Kafka topics and their partitions
-The `status` property includes information on:
 
-* The _current state_ of the resource described in _status conditions_
+The `status` property of a resource provides information on the resource's:
 
-* The resource's last `observedGeneration` (the generation of the resource to which the status applies)
+* _Current state_, in the `status.conditions` property
 
-* Other information specific to the resource, for example the REST API endpoint for Kafka Connect connectors.
+* _Last observed generation_, in the `status.observedGeneration` property
 
-A resource's current state is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the operator from realizing the resource's desired state.
+The `status` property also provides resource-specific information. For example:
+
+* `KafkaConnectStatus` provides the REST API endpoint for Kafka Connect connectors.
+
+* `KafkaUserStatus` provides the user name of the Kafka user and the `Secret` in which their credentials are stored.
+
+* `KafkaBridgeStatus` provides the HTTP address at which external client applications can access the Bridge service.
+
+A resource's _current state_ is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the operator from realizing the resource's desired state.
+
+The _last observed generation_ is the generation of the resource that was most recently observed by the operator. If the value of `observedGeneration` is less than the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
-
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.
 
 Here we see the `status` property specified for a Kafka custom resource.

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -42,7 +42,6 @@ m¦KafkaBridge
 ¦The {ProductName} Kafka Bridge, if deployed.
 
 |===
-//When dev work is complete, add `KafkaTopicStatus` to the above table. `KafkaTopicStatus`: Kafka topics and their partitions
 
 The `status` property of a resource provides information on the resource's:
 

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -47,7 +47,7 @@ The `status` property includes information on:
 
 * Other information specific to the resource, for example the REST API endpoint for Kafka Connect connectors.
 
-A resource's current state is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
+A resource's current state is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the operator from realizing the resource's desired state.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -6,46 +6,48 @@
 
 = {ProductName} custom resource status
 
-The `status` property of a custom resource publishes the _current state_ of the resource to users and tools that need the information. 
+The `status` property of a {ProductName} custom resource publishes useful information about the resource to users and tools that need it.
+
+Several resources have a `status` property, as described in the following table.
 
 [cols="2*",options="header",stripes="none",separator=¦]
 |===
 
-¦Resource
-¦Provides status information on...
+¦{ProductName} Resource
+¦Publishes information on...
 
 m¦xref:type-KafkaStatus-reference[]
 ¦The Kafka cluster.
 
 m¦xref:type-KafkaTopicStatus-reference[]
-¦Kafka topics.
+¦Kafka topics and their partitions.
 
 m¦xref:type-KafkaConnectStatus-reference[]
-¦The Kafka Connect cluster, if available.
+¦The Kafka Connect cluster, if deployed.
 
 m¦xref:type-KafkaConnectS2Istatus-reference[]
-¦The Kafka Connect cluster with Source-to-Image support, if available.
+¦The Kafka Connect cluster with Source-to-Image support, if deployed.
 
 m¦xref:type-KafkaMirrorMakerStatus-reference[]
-¦The Kafka MirrorMaker tool, if available.
+¦The Kafka MirrorMaker tool, if deployed.
 
 m¦xref:type-KafkaUserStatus-reference[]
 ¦Kafka users.
 
 m¦xref:type-KafkaBridgeStatus-reference[]
-¦The {ProductName} Kafka Bridge, if available.
+¦The {ProductName} Kafka Bridge, if deployed.
 
 |===
 
+The `status` property includes information on:
 
-//* xref:type-ResourceName-reference[]
+* The _current state_ of the resource expressed as _status conditions_
 
-Status information is useful for tracking progress related to a resource achieving its _desired state_, as defined by the `spec` property. The `status` provides the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
+* The resource's last `observedGeneration` (the generation of the resource to which the status applies)
 
-// List out the common statuses:
-// - conditions - date and time resource last changed and the reason why
-// - The observedGeneration - the generation of the resource that was most recently observed by the Cluster Operator ?
-// - Additional status info specific to the resource, for example, the HTTP address of the Kafka Bridge or the name of the build configuration of a KafkaConnect S2I resource.
+* Other useful metadata specific to the resource (except `KafkaMirrorMaker`) 
+
+Information about a resource's _current state_ is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -60,7 +60,7 @@ The `status` property also provides resource-specific information. For example:
 
 A resource's _current state_ is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the operator from realizing the resource's desired state.
 
-The _last observed generation_ is the generation of the resource that was most recently observed by the operator. If the value of `observedGeneration` is less than the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
+The _last observed generation_ is the generation of the resource that was most recently observed by the operator. If the value of `observedGeneration` is different from the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -41,19 +41,17 @@ m¦xref:type-KafkaBridgeStatus-reference[]
 
 The `status` property includes information on:
 
-* The _current state_ of the resource expressed as _status conditions_
+* The _current state_ of the resource described in _status conditions_
 
 * The resource's last `observedGeneration` (the generation of the resource to which the status applies)
 
-* Other useful metadata specific to the resource (except `KafkaMirrorMaker`) 
+* Other information specific to the resource, for example the REST API endpoint for Kafka Connect connectors.
 
-Information about a resource's _current state_ is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
+A resource's current state is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.
-
-IMPORTANT: The status property feature for {ProductName}-specific custom resources is still under development and only available for Kafka resources.
 
 Here we see the `status` property specified for a Kafka custom resource.
 
@@ -67,10 +65,11 @@ spec:
   # ...
 status:
   conditions: <1>
-  - lastTransitionTime: 2019-06-02T23:46:57+0000
+  - lastTransitionTime: 2019-07-23T23:46:57+0000
     status: "True"
     type: Ready <2>
-  listeners: <3>
+  observedGeneration: 4 <3>
+  listeners: <4>
   - addresses:
     - host: my-cluster-kafka-bootstrap.myproject.svc
       port: 9092
@@ -87,7 +86,8 @@ status:
 ----
 <1> Status `conditions` describe criteria related to the status that cannot be deduced from the existing resource information, or are specific to the instance of a resource.
 <2> The `Ready` condition indicates whether the Cluster Operator currently considers the Kafka cluster able to handle traffic.
-<3> The `listeners` describe the current Kafka bootstrap addresses by type.
+<3> The `observedGeneration` indicates the generation of the `Kafka` custom resource that was last reconciled by the Cluster Operator.
+<4> The `listeners` describe the current Kafka bootstrap addresses by type.
 +
 IMPORTANT: The status for `external` listeners is still under development and does not provide a specific IP address for external listeners of type `nodeport`.
 

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -6,9 +6,46 @@
 
 = {ProductName} custom resource status
 
-The `status` property of a {ProductName}-specific custom resource publishes the _current_ state of the resource to users and tools that need the information.
+The `status` property of a custom resource publishes the _current state_ of the resource to users and tools that need the information. 
 
-Status information is useful for tracking progress related to a resource achieving its _desired_ state, as defined by the `spec` property. The `status` provides the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the desired state.
+[cols="2*",options="header",stripes="none",separator=¦]
+|===
+
+¦Resource
+¦Provides status information on...
+
+m¦xref:type-KafkaStatus-reference[]
+¦The Kafka cluster.
+
+m¦xref:type-KafkaTopicStatus-reference[]
+¦Kafka topics.
+
+m¦xref:type-KafkaConnectStatus-reference[]
+¦The Kafka Connect cluster, if available.
+
+m¦xref:type-KafkaConnectS2Istatus-reference[]
+¦The Kafka Connect cluster with Source-to-Image support, if available.
+
+m¦xref:type-KafkaMirrorMakerStatus-reference[]
+¦The Kafka MirrorMaker tool, if available.
+
+m¦xref:type-KafkaUserStatus-reference[]
+¦Kafka users.
+
+m¦xref:type-KafkaBridgeStatus-reference[]
+¦The {ProductName} Kafka Bridge, if available.
+
+|===
+
+
+//* xref:type-ResourceName-reference[]
+
+Status information is useful for tracking progress related to a resource achieving its _desired state_, as defined by the `spec` property. The `status` provides the time and reason the state of the resource changed and details of events preventing or delaying the Operator from realizing the resource's desired state.
+
+// List out the common statuses:
+// - conditions - date and time resource last changed and the reason why
+// - The observedGeneration - the generation of the resource that was most recently observed by the Cluster Operator ?
+// - Additional status info specific to the resource, for example, the HTTP address of the Kafka Bridge or the name of the build configuration of a KafkaConnect S2I resource.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 

--- a/documentation/book/proc-accessing-resource-status.adoc
+++ b/documentation/book/proc-accessing-resource-status.adoc
@@ -9,19 +9,19 @@ This procedure describes how to find the status of a custom resource.
 
 .Prerequisites
 
-* A Kubernetes cluster
-* A running Cluster Operator
+* A Kubernetes cluster.
+* The Cluster Operator is running.
 
 .Procedure
 
-* Specify the custom resource and use `-o jsonpath` option to apply a standard JSONPath expression to select the `status` property:
+* Specify the custom resource and use the `-o jsonpath` option to apply a standard JSONPath expression to select the `status` property:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
 kubectl get kafka _<kafka_resource_name>_ -o jsonpath='{.status}'
 ----
 +
-This expression returns all the status information for the specified custom resource. You can use dot notation, such as `status.listeners`, to fine-tune the status information you wish to see.
+This expression returns all the status information for the specified custom resource. You can use dot notation, such as `status.listeners` or `status.observedGeneration`, to fine-tune the status information you wish to see.
 
 .Additional resources
 * xref:con-custom-resources-status-{context}[]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

- Updated the existing _Strimzi custom resource status_ concept module to summarize every resource that now has `status` information. The `kafkaTopic` resource is included as a placeholder -- the development work is still outstanding.

- Explained the new `observedGeneration` information that is available for every custom resource. Can we add any more information about this?

- Removed the note that the status property is still under development and only available for `kafka`.

- Minor changes to the  _Checking the status of a custom resource_ procedure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

