### PR TITLE
Fix incorrect JVM options example - remove end of line commas

### DIFF
--- a/documentation/book/ref-jvm-options.adoc
+++ b/documentation/book/ref-jvm-options.adoc
@@ -90,10 +90,10 @@ The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE
 ----
 jvmOptions:
   "-XX":
-    "UseG1GC": true,
-    "MaxGCPauseMillis": 20,
-    "InitiatingHeapOccupancyPercent": 35,
-    "ExplicitGCInvokesConcurrent": true,
+    "UseG1GC": true
+    "MaxGCPauseMillis": 20
+    "InitiatingHeapOccupancyPercent": 35
+    "ExplicitGCInvokesConcurrent": true
     "UseParNewGC": false
 ----
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

We seem to have a bug in one of the examples in the [JVM configuration section in docs](https://strimzi.io/docs/latest/full.html#ref-jvm-options-deployment-configuration-kafka). The example has JSON-style commas at the end of lines. This will get misinterpreted in YAML as part of the value and the example doesn't work. This PR removes the commas. and fixes it.