### PR TITLE
Fix problem with non-matching namespace for broker ClusterRoleBinding

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1377,7 +1377,6 @@ public class KafkaCluster extends AbstractModel {
             return new ClusterRoleBindingBuilder()
                     .withNewMetadata()
                         .withName(initContainerClusterRoleBindingName(namespace, cluster))
-                        .withNamespace(assemblyNamespace)
                         .withOwnerReferences(createOwnerReference())
                         .withLabels(labels.toMap())
                     .endMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2120,14 +2120,14 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(testNamespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
-                .editKafka()
-                .withNewListeners()
-                .withNewKafkaListenerExternalNodePort()
-                .withNewKafkaListenerAuthenticationTlsAuth()
-                .endKafkaListenerAuthenticationTlsAuth()
-                .endKafkaListenerExternalNodePort()
-                .endListeners()
-                .endKafka()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
                 .endSpec()
                 .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -28,7 +28,16 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void checkKafkaInDiffNamespaceThanCO() {
         String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
         String previousNamespace = setNamespace(SECOND_NAMESPACE);
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3).done();
+        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3)
+                .editSpec()
+                    .editKafka()
+                        .editListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
         StUtils.waitForAllStatefulSetPodsReady(kafkaName, 3);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When user creates a KafkaCluster in different namespace and is using any feature which requires to give the Kafka broker its own ClusterRole using CLusterRoleBinding, it seems that we run into following exception:

```
2019-07-25 17:22:03 INFO  AbstractAssemblyOperator:186 - Reconciliation #41(timer) Kafka(kafka-cluster/ko-test): Assembly ko-test should be created or updated
2019-07-25 17:22:03 ERROR AbstractAssemblyOperator:195 - Reconciliation #41(timer) Kafka(kafka-cluster/ko-test): createOrUpdate failed
io.fabric8.kubernetes.client.KubernetesClientException: Namespace mismatch. Item namespace:kafka-cluster. Operation namespace:kafka-operator.
    at io.fabric8.kubernetes.client.dsl.base.OperationSupport.checkNamespace(OperationSupport.java:181) ~[io.fabric8.kubernetes-client-4.3.0.jar:?]
    at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:233) ~[io.fabric8.kubernetes-client-4.3.0.jar:?]
    at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:735) ~[io.fabric8.kubernetes-client-4.3.0.jar:?]
    at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:325) ~[io.fabric8.kubernetes-client-4.3.0.jar:?]
    at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:321) ~[io.fabric8.kubernetes-client-4.3.0.jar:?]
    at io.strimzi.operator.common.operator.resource.AbstractNonNamespacedResourceOperator.internalCreate(AbstractNonNamespacedResourceOperator.java:203) ~[io.strimzi.operator-common-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
    at io.strimzi.operator.common.operator.resource.AbstractNonNamespacedResourceOperator.lambda$reconcile$0(AbstractNonNamespacedResourceOperator.java:98) ~[io.strimzi.operator-common-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
    at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:272) ~[io.vertx.vertx-core-3.7.1.jar:3.7.1]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_222]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_222]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.34.Final.jar:4.1.34.Final]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_222]
```

This probably worked in the past but the behaviour changed in Fabric8. For a cluster-wide resources such as ClusterRoleBinding the namespace in metadata should anyway not matter. So the solution is to not set it. That seems to fix this issue.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally