### PR TITLE
ST: tests for CR statuses

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -42,6 +42,7 @@ pipeline {
         stage('Parse parameters from comment') {
             steps {
                 script {
+                    echo "Comment body: ${env.ghprbCommentBody.contains}"
                     env.TEST_CASE = params.TEST_CASE
                     env.TEST_PROFILE = params.TEST_PROFILE
                     if (env.ghprbCommentBody.contains('testcase=')) {
@@ -52,7 +53,7 @@ pipeline {
                         env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
                     }
                     echo "TEST_PROFILE: ${env.TEST_PROFILE}"
-                    if (env.ghprbCommentBody.contains('testonly')) {
+                    if (env.ghprbCommentBody.contains('test_only')) {
                         env.TEST_ONLY = true
                         env.DOCKER_TAG = "latest"
                         env.DOCKER_REGISTRY = "docker.io"

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -42,7 +42,7 @@ pipeline {
         stage('Parse parameters from comment') {
             steps {
                 script {
-                    echo "Comment body: ${env.ghprbCommentBody.contains}"
+                    echo "Comment body: ${env.ghprbCommentBody}"
                     env.TEST_CASE = params.TEST_CASE
                     env.TEST_PROFILE = params.TEST_PROFILE
                     if (env.ghprbCommentBody.contains('testcase=')) {

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -77,13 +77,20 @@ pipeline {
                 }
             }
         }
+        stage('Build project') {
+            steps {
+                script {
+                    sh "mvn clean install -DskipTests"
+                }
+            }
+        }
         stage('Build images') {
             when {
                 environment name: 'TEST_ONLY', value: 'false'
             }
             steps {
                 script {
-                    lib.buildStrimzi()
+                    lib.buildStrimziImages()
                 }
             }
         }

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -17,16 +17,12 @@ pipeline {
         ansiColor('xterm')
     }
     environment {
-        DOCKER_ORG="strimzi"
-        DOCKER_REGISTRY="localhost:5000"
-        DOCKER_TAG="pr"
         OPENSHIFT_URL="https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz"
         // Workaround for skip flaky tests
         MVN_ARGS="-Dfailsafe.rerunFailingTestsCount=5"
 
         ARTIFACTS_DIR = 'systemtest/target/logs'
         JOB_NAME_SUB = "${String.format("%.15s", JOB_NAME).toLowerCase()}"
-        TEST_ONLY=false
     }
     stages {
         stage('Clean WS') {
@@ -55,8 +51,14 @@ pipeline {
                     echo "TEST_PROFILE: ${env.TEST_PROFILE}"
                     if (env.ghprbCommentBody.contains('test_only')) {
                         env.TEST_ONLY = true
-                        env.DOCKER_TAG = "latest"
                         env.DOCKER_REGISTRY = "docker.io"
+                        env.DOCKER_ORG="strimzi"
+                        env.DOCKER_TAG = "latest"
+                    } else {
+                        env.TEST_ONLY = false
+                        env.DOCKER_ORG="strimzi"
+                        env.DOCKER_REGISTRY="localhost:5000"
+                        env.DOCKER_TAG="pr"
                     }
                     echo "TEST_ONLY: ${env.TEST_ONLY}"
                     echo "DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}"

--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -26,7 +26,7 @@ pipeline {
 
         ARTIFACTS_DIR = 'systemtest/target/logs'
         JOB_NAME_SUB = "${String.format("%.15s", JOB_NAME).toLowerCase()}"
-        TEST_ONLY="false"
+        TEST_ONLY=false
     }
     stages {
         stage('Clean WS') {
@@ -53,9 +53,14 @@ pipeline {
                     }
                     echo "TEST_PROFILE: ${env.TEST_PROFILE}"
                     if (env.ghprbCommentBody.contains('testonly')) {
-                        env.TEST_ONLY = "true"
+                        env.TEST_ONLY = true
+                        env.DOCKER_TAG = "latest"
+                        env.DOCKER_REGISTRY = "docker.io"
                     }
                     echo "TEST_ONLY: ${env.TEST_ONLY}"
+                    echo "DOCKER_REGISTRY: ${env.DOCKER_REGISTRY}"
+                    echo "DOCKER_ORG: ${env.DOCKER_ORG}"
+                    echo "DOCKER_TAG: ${env.DOCKER_TAG}"
                 }
             }
         }
@@ -70,11 +75,12 @@ pipeline {
             }
         }
         stage('Build images') {
+            when {
+                environment name: 'TEST_ONLY', value: 'false'
+            }
             steps {
                 script {
-                    if (env.TEST_ONLY.equals("false")) {
-                        lib.buildStrimzi()
-                    }
+                    lib.buildStrimzi()
                 }
             }
         }

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -63,8 +63,7 @@ def clearImages() {
 }
 
 
-def buildStrimzi() {
-    sh "mvn clean install -DskipTests"
+def buildStrimziImages() {
     sh "make docker_build"
     sh "make docker_tag"
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -15,18 +15,24 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectS2IList;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.DoneableKafka;
+import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
@@ -206,6 +212,14 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
 
     void replaceMirrorMakerResource(String resourceName, Consumer<KafkaMirrorMaker> editor) {
         replaceCrdResource(KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class, resourceName, editor);
+    }
+
+    void replaceBridgeResource(String resourceName, Consumer<KafkaBridge> editor) {
+        replaceCrdResource(KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class, resourceName, editor);
+    }
+
+    void replaceConnectS2IResource(String resourceName, Consumer<KafkaConnectS2I> editor) {
+        replaceCrdResource(KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class, resourceName, editor);
     }
 
     String getBrokerApiVersions(String podName) {
@@ -941,6 +955,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
         if (Environment.SKIP_TEARDOWN == null) {
             if (context.getExecutionException().isPresent()) {
                 LOGGER.info("Test execution contains exception, going to recreate test environment");
+                context.getExecutionException().get().printStackTrace();
                 recreateTestEnv(clusterOperatorNamespace, bindingsNamespaces);
                 LOGGER.info("Env recreated.");
             }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -33,6 +33,8 @@ public interface Constants {
     long TIMEOUT_FOR_GET_SECRETS = Duration.ofMinutes(1).toMillis();
     long TIMEOUT_TEARDOWN = Duration.ofSeconds(10).toMillis();
     long GLOBAL_TIMEOUT = Duration.ofMinutes(5).toMillis();
+    long GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3).toMillis();
+    long CONNECT_STATUS_TIMEOUT = Duration.ofMinutes(5).toMillis();
     long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
 
     long CO_OPERATION_TIMEOUT = Duration.ofMinutes(1).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -52,6 +52,7 @@ import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -577,6 +578,8 @@ public class Resources extends AbstractResources {
 
     private void waitForDeletion(KafkaConnectS2I kafkaConnectS2I) {
         LOGGER.info("Waiting when all the pods are terminated for Kafka Connect S2I {}", kafkaConnectS2I.getMetadata().getName());
+
+        client().deleteDeploymentConfig(KafkaConnectS2IResources.buildConfigName(kafkaConnectS2I.getMetadata().getName()));
 
         client().listPods().stream()
                 .filter(p -> p.getMetadata().getName().contains("build"))

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -582,12 +583,11 @@ public class Resources extends AbstractResources {
         client().deleteDeploymentConfig(KafkaConnectS2IResources.buildConfigName(kafkaConnectS2I.getMetadata().getName()));
 
         client().listPods().stream()
-                .filter(p -> p.getMetadata().getName().contains("build"))
-                .forEach(p -> client().deletePod(p));
-
-        client().listPods().stream()
-                .filter(p -> p.getMetadata().getName().startsWith(kafkaConnectS2I.getMetadata().getName() + "-connect-"))
-                .forEach(p -> waitForPodDeletion(p.getMetadata().getName()));
+                .filter(p -> p.getMetadata().getName().contains("-connect-"))
+                .forEach(p -> {
+                    LOGGER.debug("Deleting: {}", p.getMetadata().getName());
+                    client().deletePod(p);
+                });
     }
 
     private void waitForDeletion(KafkaMirrorMaker kafkaMirrorMaker) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -398,7 +398,7 @@ public class StUtils {
         LabelSelector deploymentConfigSelector = new LabelSelectorBuilder().addToMatchLabels(kubeClient().getDeploymentConfigSelectors(name)).build();
         waitForPodsReady(deploymentConfigSelector, expectedPods, true);
         String clusterOperatorPodName = kubeClient().listPods("name", "strimzi-cluster-operator").get(0).getMetadata().getName();
-        String log = "BuildConfigOperator:191 - BuildConfig " + name + " in namespace connect-s2i-cluster-test has been created";
+        String log = "BuildConfigOperator:191 - BuildConfig " + name + " in namespace " + kubeClient().getNamespace() + " has been created";
 
         TestUtils.waitFor("build config creation " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().logs(clusterOperatorPodName).contains(log));

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -6,9 +6,20 @@ package io.strimzi.systemtest;
 
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBridge;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaBridgeStatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectS2Istatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.timemeasuring.Operation;
@@ -17,11 +28,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.strimzi.api.kafka.model.KafkaResources.externalBootstrapServiceName;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,6 +54,7 @@ class CustomResourceStatusST extends AbstractST {
         LOGGER.info("Kafka cluster is in desired state: Ready");
 
         waitForClusterAvailability(NAMESPACE, TOPIC_NAME);
+        assertKafkaStatus(1, "my-cluster-kafka-bootstrap.status-cluster-test.svc");
 
         replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().getZookeeper().setResources(new ResourceRequirementsBuilder()
@@ -57,6 +71,8 @@ class CustomResourceStatusST extends AbstractST {
                     .addToRequests("cpu", new Quantity("10m"))
                     .build());
         });
+        waitForKafkaStatus("Ready");
+        assertKafkaStatus(3, "my-cluster-kafka-bootstrap.status-cluster-test.svc");
     }
 
     @Test
@@ -93,15 +109,109 @@ class CustomResourceStatusST extends AbstractST {
         testMethodResources().deleteResources();
     }
 
-    @AfterEach
-    void checkClusterAvailability() {
-        LOGGER.info("Wait until status will be in Ready state (AfterEach phase) ...");
-        waitForKafkaStatus("Ready");
+    @Test
+    void testKafkaMirrorMakerStatus() {
+        createTestMethodResources();
+        // Deploy Mirror Maker
+        testMethodResources().kafkaMirrorMaker(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME, "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, false).done();
+        waitForKafkaMirrorMakerStatus("Ready");
+        assertKafkaMirrorMakerStatus(1);
+        // Corrupt Mirror Maker pods
+        replaceMirrorMakerResource(CLUSTER_NAME, mm -> mm.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("100000000m"))
+                .build()));
+        waitForKafkaMirrorMakerStatus("NotReady");
+        // Restore Mirror Maker pod
+        replaceMirrorMakerResource(CLUSTER_NAME, mm -> mm.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("10m"))
+                .build()));
+        waitForKafkaMirrorMakerStatus("Ready");
+        assertKafkaMirrorMakerStatus(3);
+    }
+
+    @Test
+    @Disabled("Currently, readiness check for MM is not working correctly so MM status is not set properly when MM confug is corrupted by wrong bootstrap server")
+    void testKafkaMirrorMakerStatusWrongBootstrap() {
+        createTestMethodResources();
+        testMethodResources().kafkaMirrorMaker(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME, "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, false).done();
+        waitForKafkaMirrorMakerStatus("Ready");
+        assertKafkaMirrorMakerStatus(1);
+        // Corrupt Mirror Maker pods
+        replaceMirrorMakerResource(CLUSTER_NAME, mm -> mm.getSpec().getConsumer().setBootstrapServers("non-exists-bootstrap"));
+        waitForKafkaMirrorMakerStatus("NotReady");
+        // Restore Mirror Maker pods
+        replaceMirrorMakerResource(CLUSTER_NAME, mm -> mm.getSpec().getConsumer().setBootstrapServers(CLUSTER_NAME));
+        waitForKafkaMirrorMakerStatus("Ready");
+        assertKafkaMirrorMakerStatus(3);
+    }
+
+    @Test
+    void testKafkaBridgeStatus() {
+        createTestMethodResources();
+
+        testMethodResources().kafkaBridge(CLUSTER_NAME, KafkaResources.plainBootstrapAddress(CLUSTER_NAME), 1, Constants.HTTP_BRIDGE_DEFAULT_PORT).done();
+        waitForKafkaBridgeStatus("Ready");
+        assertKafkaBridgeStatus(1, "my-cluster-bridge-service.status-cluster-test.svc:8080");
+
+        replaceBridgeResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("100000000m"))
+                .build()));
+        waitForKafkaBridgeStatus("NotReady");
+
+        replaceBridgeResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("10m"))
+                .build()));
+        waitForKafkaBridgeStatus("Ready");
+        assertKafkaBridgeStatus(3, "my-cluster-bridge-service.status-cluster-test.svc:8080");
+    }
+
+    @Test
+    void testKafkaConnectStatus() {
+        createTestMethodResources();
+        testMethodResources().kafkaConnect(CLUSTER_NAME, 1).done();
+        waitForKafkaConnectStatus("Ready");
+        assertKafkaConnectStatus(1);
+
+        replaceKafkaConnectResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("100000000m"))
+                .build()));
+        waitForKafkaConnectStatus("NotReady");
+
+        replaceKafkaConnectResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("10m"))
+                .build()));
+        waitForKafkaConnectStatus("Ready");
+        assertKafkaConnectStatus(3);
+    }
+
+    @Test
+    void testKafkaConnectS2IStatus() {
+        createTestMethodResources();
+
+        testMethodResources().kafkaConnectS2I(CLUSTER_NAME, 1, CLUSTER_NAME).done();
+        waitForKafkaConnectS2IStatus("Ready");
+        assertKafkaConnectS2IStatus(1, "my-cluster-connect-api.status-cluster-test.svc:8083");
+
+        replaceConnectS2IResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("100000000m"))
+                .build()));
+        waitForKafkaConnectS2IStatus("NotReady");
+
+        replaceConnectS2IResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
+                .addToRequests("cpu", new Quantity("10m"))
+                .build()));
+        waitForKafkaConnectS2IStatus("Ready");
+        assertKafkaConnectS2IStatus(3, "my-cluster-connect-api.status-cluster-test.svc:8083");
     }
 
     @BeforeAll
     void createClassResources() {
         createTestEnvironment();
+    }
+
+    @AfterEach
+    void deleteMethodResources() {
+        deleteTestMethodResources();
     }
 
     private String startDeploymentMeasuring() {
@@ -152,11 +262,100 @@ class CustomResourceStatusST extends AbstractST {
     }
 
     void waitForKafkaStatus(String status) {
-        TestUtils.waitFor("Wait until status is false", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT, () -> {
+        LOGGER.info("Wait until Kafka cluster is in desired state: {}", status);
+        TestUtils.waitFor("Kafka Cluster status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
             Condition kafkaCondition = testClassResources().kafka().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
             logCurrentStatus(kafkaCondition, Kafka.RESOURCE_KIND);
             return kafkaCondition.getType().equals(status);
         });
         LOGGER.info("Kafka cluster is in desired state: {}", status);
+    }
+
+    void waitForKafkaMirrorMakerStatus(String status) {
+        LOGGER.info("Wait until Kafka Mirror Maker cluster is in desired state: {}", status);
+        TestUtils.waitFor("Kafka Mirror Maker status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+            Condition kafkaCondition = testClassResources().kafkaMirrorMaker().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+            logCurrentStatus(kafkaCondition, KafkaMirrorMaker.RESOURCE_KIND);
+            return kafkaCondition.getType().equals(status);
+        });
+        LOGGER.info("Kafka Mirror Maker cluster is in desired state: {}", status);
+    }
+
+    void waitForKafkaBridgeStatus(String status) {
+        LOGGER.info("Wait until Kafka Bridge cluster is in desired state: {}", status);
+        TestUtils.waitFor("Kafka Bridge status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+            Condition kafkaCondition = testClassResources().kafkaBridge().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+            logCurrentStatus(kafkaCondition, KafkaBridge.RESOURCE_KIND);
+            return kafkaCondition.getType().equals(status);
+        });
+        LOGGER.info("Kafka Bridge cluster is in desired state: {}", status);
+    }
+
+    void waitForKafkaConnectStatus(String status) {
+        LOGGER.info("Wait until Kafka Connect cluster is in desired state: {}", status);
+        TestUtils.waitFor("Kafka Connect status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.CONNECT_STATUS_TIMEOUT, () -> {
+            Condition kafkaCondition = testClassResources().kafkaConnect().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+            logCurrentStatus(kafkaCondition, KafkaConnect.RESOURCE_KIND);
+            return kafkaCondition.getType().equals(status);
+        });
+        LOGGER.info("Kafka Connect cluster is in desired state: {}", status);
+    }
+
+    void waitForKafkaConnectS2IStatus(String status) {
+        LOGGER.info("Wait until Kafka ConnectS2I cluster is in desired state: {}", status);
+        TestUtils.waitFor("Kafka ConnectS2I status is not in desired state: " + status, Constants.GLOBAL_POLL_INTERVAL, Constants.CONNECT_STATUS_TIMEOUT, () -> {
+            Condition kafkaCondition = testClassResources().kafkaConnectS2I().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getConditions().get(0);
+            logCurrentStatus(kafkaCondition, KafkaConnectS2I.RESOURCE_KIND);
+            return kafkaCondition.getType().equals(status);
+        });
+        LOGGER.info("Kafka ConnectS2I cluster is in desired state: {}", status);
+    }
+
+    void assertKafkaStatus(long expectedObservedGeneration, String internalAddress) {
+        KafkaStatus kafkaStatus = testClassResources().kafka().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat("", kafkaStatus.getObservedGeneration(), is(expectedObservedGeneration));
+
+        for (ListenerStatus listener : kafkaStatus.getListeners()) {
+            switch (listener.getType()) {
+                case "tls":
+                    assertThat("", listener.getAddresses().get(0).getPort(), is(9093));
+                    assertThat("", listener.getAddresses().get(0).getHost(), is(internalAddress));
+                    break;
+                case "plain":
+                    assertThat("", listener.getAddresses().get(0).getPort(), is(9092));
+                    assertThat("", listener.getAddresses().get(0).getHost(), is(internalAddress));
+                    break;
+                case "external":
+                    Service extBootstrapService = kubeClient(NAMESPACE).getClient().services()
+                            .inNamespace(NAMESPACE)
+                            .withName(externalBootstrapServiceName(CLUSTER_NAME))
+                            .get();
+                    assertThat("", listener.getAddresses().get(0).getPort(), is(extBootstrapService.getSpec().getPorts().get(0).getNodePort()));
+                    assertThat("", listener.getAddresses().get(0).getHost() != null);
+                    break;
+            }
+        }
+    }
+
+    void assertKafkaMirrorMakerStatus(long expectedObservedGeneration) {
+        KafkaMirrorMakerStatus kafkaMirrorMakerStatus = testMethodResources().kafkaMirrorMaker().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat("", kafkaMirrorMakerStatus.getObservedGeneration(), is(expectedObservedGeneration));
+    }
+
+    void assertKafkaBridgeStatus(long expectedObservedGeneration, String bridgeAddress) {
+        KafkaBridgeStatus kafkaBridgeStatus = testClassResources().kafkaBridge().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat("", kafkaBridgeStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("", kafkaBridgeStatus.getHttpAddress(), is(bridgeAddress));
+    }
+
+    void assertKafkaConnectStatus(long expectedObservedGeneration) {
+        KafkaConnectStatus kafkaConnectStatus = testMethodResources().kafkaConnect().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat("", kafkaConnectStatus.getObservedGeneration(), is(expectedObservedGeneration));
+    }
+
+    void assertKafkaConnectS2IStatus(long expectedObservedGeneration, String expectedRestApi) {
+        KafkaConnectS2Istatus kafkaConnectS2IStatus = testMethodResources().kafkaConnectS2I().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
+        assertThat("", kafkaConnectS2IStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("", kafkaConnectS2IStatus.getRestApiAddress(), is(expectedRestApi));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -304,25 +304,25 @@ class CustomResourceStatusST extends AbstractST {
 
     void assertKafkaStatus(long expectedObservedGeneration, String internalAddress) {
         KafkaStatus kafkaStatus = testClassResources().kafka().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-        assertThat("", kafkaStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("Kafka cluster status has incorrect Observed Generation", kafkaStatus.getObservedGeneration(), is(expectedObservedGeneration));
 
         for (ListenerStatus listener : kafkaStatus.getListeners()) {
             switch (listener.getType()) {
                 case "tls":
-                    assertThat("", listener.getAddresses().get(0).getPort(), is(9093));
-                    assertThat("", listener.getAddresses().get(0).getHost(), is(internalAddress));
+                    assertThat("TLS bootstrap has incorrect port", listener.getAddresses().get(0).getPort(), is(9093));
+                    assertThat("TLS bootstrap has incorrect host", listener.getAddresses().get(0).getHost(), is(internalAddress));
                     break;
                 case "plain":
-                    assertThat("", listener.getAddresses().get(0).getPort(), is(9092));
-                    assertThat("", listener.getAddresses().get(0).getHost(), is(internalAddress));
+                    assertThat("Plain bootstrap has incorrect port", listener.getAddresses().get(0).getPort(), is(9092));
+                    assertThat("Plain bootstrap has incorrect host", listener.getAddresses().get(0).getHost(), is(internalAddress));
                     break;
                 case "external":
                     Service extBootstrapService = kubeClient(NAMESPACE).getClient().services()
                             .inNamespace(NAMESPACE)
                             .withName(externalBootstrapServiceName(CLUSTER_NAME))
                             .get();
-                    assertThat("", listener.getAddresses().get(0).getPort(), is(extBootstrapService.getSpec().getPorts().get(0).getNodePort()));
-                    assertThat("", listener.getAddresses().get(0).getHost() != null);
+                    assertThat("External bootstrap has incorrect port", listener.getAddresses().get(0).getPort(), is(extBootstrapService.getSpec().getPorts().get(0).getNodePort()));
+                    assertThat("External bootstrap has incorrect host", listener.getAddresses().get(0).getHost() != null);
                     break;
             }
         }
@@ -330,25 +330,25 @@ class CustomResourceStatusST extends AbstractST {
 
     void assertKafkaMirrorMakerStatus(long expectedObservedGeneration) {
         KafkaMirrorMakerStatus kafkaMirrorMakerStatus = testMethodResources().kafkaMirrorMaker().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-        assertThat("", kafkaMirrorMakerStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("Kafka MirrorMaker cluster status has incorrect Observed Generation", kafkaMirrorMakerStatus.getObservedGeneration(), is(expectedObservedGeneration));
     }
 
     void assertKafkaBridgeStatus(long expectedObservedGeneration, String bridgeAddress) {
         KafkaBridgeStatus kafkaBridgeStatus = testClassResources().kafkaBridge().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-        assertThat("", kafkaBridgeStatus.getObservedGeneration(), is(expectedObservedGeneration));
-        assertThat("", kafkaBridgeStatus.getUrl(), is(bridgeAddress));
+        assertThat("Kafka Bridge cluster status has incorrect Observed Generation", kafkaBridgeStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("Kafka Bridge cluster status has incorrect URL", kafkaBridgeStatus.getUrl(), is(bridgeAddress));
     }
 
     void assertKafkaConnectStatus(long expectedObservedGeneration, String expectedUrl) {
         KafkaConnectStatus kafkaConnectStatus = testMethodResources().kafkaConnect().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-        assertThat("", kafkaConnectStatus.getObservedGeneration(), is(expectedObservedGeneration));
-        assertThat("", kafkaConnectStatus.getUrl(), is(expectedUrl));
+        assertThat("Kafka Connect cluster status has incorrect Observed Generation", kafkaConnectStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("Kafka Connect cluster status has incorrect URL", kafkaConnectStatus.getUrl(), is(expectedUrl));
     }
 
     void assertKafkaConnectS2IStatus(long expectedObservedGeneration, String expectedUrl, String expectedConfigName) {
         KafkaConnectS2Istatus kafkaConnectS2IStatus = testMethodResources().kafkaConnectS2I().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus();
-        assertThat("", kafkaConnectS2IStatus.getObservedGeneration(), is(expectedObservedGeneration));
-        assertThat("", kafkaConnectS2IStatus.getUrl(), is(expectedUrl));
-        assertThat("", kafkaConnectS2IStatus.getBuildConfigName(), is(expectedConfigName));
+        assertThat("Kafka ConnectS2I cluster status has incorrect Observed Generation", kafkaConnectS2IStatus.getObservedGeneration(), is(expectedObservedGeneration));
+        assertThat("Kafka ConnectS2I cluster status has incorrect URL", kafkaConnectS2IStatus.getUrl(), is(expectedUrl));
+        assertThat("Kafka ConnectS2I cluster status has incorrect BuildConfigName", kafkaConnectS2IStatus.getBuildConfigName(), is(expectedConfigName));
     }
 }

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -117,7 +117,9 @@ public final class TestUtils {
             }
             if (timeLeft <= 0) {
                 onTimeout.run();
-                throw new TimeoutException("Timeout after " + timeoutMs + " ms waiting for " + description);
+                TimeoutException exception = new TimeoutException("Timeout after " + timeoutMs + " ms waiting for " + description);
+                exception.printStackTrace();
+                throw exception;
             }
             long sleepTime = Math.min(pollIntervalMs, timeLeft);
             if (LOGGER.isTraceEnabled()) {

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -295,12 +295,19 @@ public class KubeClient {
         return client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).get();
     }
 
-
     /**
      * Gets deployment config selector
      */
     public Map<String, String> getDeploymentConfigSelectors(String deploymentConfigName) {
         return client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).get().getSpec().getSelector();
+    }
+
+    /**
+     * Delete deployment config
+     * @param deploymentConfigName deployment config name
+     */
+    public void deleteDeploymentConfig(String deploymentConfigName) {
+        client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).delete();
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds more tests for better coverage of CR statuses.

Covers the following PRs (enhancements/features/issues):
- https://github.com/strimzi/strimzi-kafka-operator/pull/1828
- https://github.com/strimzi/strimzi-kafka-operator/pull/1739
- https://github.com/strimzi/strimzi-kafka-operator/pull/1746
- https://github.com/strimzi/strimzi-kafka-operator/pull/1748
- https://github.com/strimzi/strimzi-kafka-operator/pull/1814

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

