### PR TITLE
Added Kafka Bridge loggers documentation

### DIFF
--- a/documentation/book/assembly-using-the-kafka-bridge.adoc
+++ b/documentation/book/assembly-using-the-kafka-bridge.adoc
@@ -19,4 +19,6 @@ include::con-accessing-kafka-bridge-from-outside.adoc[leveloffset=+1]
 
 include::con-requests-kafka-bridge.adoc[leveloffset=+1]
 
+include::con-loggers-kafka-bridge.adoc[leveloffset=+1]
+
 include::ref-api-resources-kafka-bridge.adoc[leveloffset=+1]

--- a/documentation/book/con-loggers-kafka-bridge.adoc
+++ b/documentation/book/con-loggers-kafka-bridge.adoc
@@ -39,7 +39,7 @@ Following is the list of operations defined by the OpenAPI specification:
 * `commit`
 * `send`
 * `sendToPartition`
-* `seelToBeginning`
+* `seekToBeginning`
 * `seekToEnd`
 * `seek`
 * `healthy`

--- a/documentation/book/con-loggers-kafka-bridge.adoc
+++ b/documentation/book/con-loggers-kafka-bridge.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-kafka-bridge.adoc
+
+[id='con-loggers-kafka-bridge-{context}']
+
+= Configuring loggers for the {ProductName} Kafka Bridge
+
+The {ProductName} Kafka bridge allows you to set a different log level for each operation that is defined by the related OpenAPI specification.
+
+Each operation has a corresponding API endpoint through which the bridge receives requests from HTTP clients.
+You can change the log level on each endpoint to produce more or less fine-grained logging information about the incoming and outgoing HTTP requests.
+
+Loggers are defined in the `log4j.properties` file, which has the following default configuration for `healthy` and `ready` endpoints:
+
+```
+log4j.logger.http.openapi.operation.healthy=WARN, out
+log4j.additivity.http.openapi.operation.healthy=false
+log4j.logger.http.openapi.operation.ready=WARN, out
+log4j.additivity.http.openapi.operation.ready=false
+```
+
+The log level of all other operations is set to `INFO` by default.
+Loggers are formatted as follows:
+
+```
+log4j.logger.http.openapi.operation.<operation-id>
+```
+
+Where `<operation-id>` is the identifier of the specific operation.
+Following is the list of operations defined by the OpenAPI specification:
+
+* `createConsumer`
+* `deleteConsumer`
+* `subscribe`
+* `unsubscribe`
+* `poll`
+* `assign`
+* `commit`
+* `send`
+* `sendToPartition`
+* `seelToBeginning`
+* `seekToEnd`
+* `seek`
+* `healthy`
+* `ready`
+* `openapi`


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR provides documentation about loggers configuration in the Kafka Bridge.
I opened the PR here after suggestion by @laidan6000 even if thinking more this section talks about to use log4j.properties file while using the CO, the configuration for the loggers should be different.
It'a about having a `logging` section in the `KafkaBridge` resource. Actually this section is missing in the current doc (as we have for all others resources).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

