### PR TITLE
Use Future in TopicStore

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -700,7 +700,7 @@ class TopicOperator {
             public void handle(Future<Void> fut) {
 
                 // getting topic information from the private store
-                topicStore.read(topicName, topicResult -> {
+                topicStore.read(topicName).setHandler(topicResult -> {
 
                     TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, topicMetadataBackOff()) {
                         @Override
@@ -748,7 +748,7 @@ class TopicOperator {
         // TODO Here I need to lookup the name of the kafkatopic from the name of the topic.
         // I can either do that from the topicStore, or maintain an in-memory map
         // I can then look up the KafkaTopic from k8s
-        topicStore.read(topicName, storeResult -> {
+        topicStore.read(topicName).setHandler(storeResult -> {
             if (storeResult.succeeded()) {
                 Topic storeTopic = storeResult.result();
                 ResourceName resourceName = null;
@@ -889,7 +889,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            topicStore.update(topic, ar -> {
+            topicStore.update(topic).setHandler(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -920,7 +920,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) throws OperatorException {
             LOGGER.debug("Executing {}", this);
-            topicStore.create(topic, ar -> {
+            topicStore.create(topic).setHandler(ar -> {
                 LOGGER.debug("Completing {}", this);
                 if (ar.failed()) {
                     LOGGER.debug("{} failed", this);
@@ -954,7 +954,7 @@ class TopicOperator {
 
         @Override
         public void handle(Void v) throws OperatorException {
-            topicStore.delete(topicName, ar -> {
+            topicStore.delete(topicName).setHandler(ar -> {
                 if (ar.failed()) {
                     enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
@@ -1195,9 +1195,7 @@ class TopicOperator {
     }
 
     Future<Topic> getFromTopicStore(TopicName topicName) {
-        Future<Topic> f = Future.future();
-        topicStore.read(topicName, f);
-        return f;
+        return topicStore.read(topicName);
     }
 
     private Future<Void> reconcileWithKubeTopic(LogContext logContext, HasMetadata involvedObject, String reconciliationType, ResourceName kubeName, TopicName topicName) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
@@ -4,8 +4,7 @@
  */
 package io.strimzi.operator.topic;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * Represents a persistent data store where the operator can store its copy of the
@@ -23,45 +22,42 @@ interface TopicStore {
 
     /**
      * Asynchronously get the topic with the given name
-     * and run the given handler on the context with the resulting Topic.
-     * If no topic with the given name exists, the handler will be called with
+     * completing the returned future when done.
+     * If no topic with the given name exists, the future will complete with
      * a null result.
      * @param name The name of the topic.
-     * @param handler The result handler.
+     * @return A future which completes with the given topic.
      */
-    void read(TopicName name, Handler<AsyncResult<Topic>> handler);
+    Future<Topic> read(TopicName name);
 
     /**
      * Asynchronously persist the given topic in the store
-     * and run the given handler on the context when done.
-     * If a topic with the given name already exists, the handler will be called with
-     * a failed result whose {@code cause()} is
+     * completing the returned future when done.
+     * If a topic with the given name already exists, the future will complete with an
      * {@link EntityExistsException}.
      * @param topic The topic.
-     * @param handler The result handler.
+     * @return A future which completes when the given topic has been created.
      */
-    void create(Topic topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> create(Topic topic);
 
     /**
      * Asynchronously update the given topic in the store
-     * and run the given handler on the context when done.
-     * If no topic with the given name exists, the handler will be called with
-     * a failed result whose {@code cause()} is
+     * completing the returned future when done.
+     * If no topic with the given name exists, the future will complete with a
      * {@link NoSuchEntityExistsException}.
      * @param topic The topic.
-     * @param handler The result handler.
+     * @return A future which completes when the given topic has been updated.
      */
-    void update(Topic topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> update(Topic topic);
 
     /**
      * Asynchronously delete the given topic from the store
-     * and run the given handler on the context when done.
-     * If no topic with the given name exists, the handler wiil be called with
-     * a failed result whose {@code cause()} is
+     * completing the returned future when done.
+     * If no topic with the given name exists, the future will complete with a
      * {@link NoSuchEntityExistsException}.
      * @param topic The topic.
-     * @param handler The result handler.
+     * @return A future which completes when the given topic has been deleted.
      */
-    void delete(TopicName topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> delete(TopicName topic);
 }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
@@ -8,7 +8,6 @@ import io.strimzi.operator.topic.zk.AclBuilder;
 import io.strimzi.operator.topic.zk.Zk;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.apache.logging.log4j.LogManager;
@@ -61,7 +60,8 @@ public class ZkTopicStore implements TopicStore {
     }
 
     @Override
-    public void read(TopicName topicName, Handler<AsyncResult<Topic>> handler) {
+    public Future<Topic> read(TopicName topicName) {
+        Future<Topic> handler = Future.future();
         String topicPath = getTopicPath(topicName);
         zk.getData(topicPath, result -> {
             final AsyncResult<Topic> fut;
@@ -76,10 +76,12 @@ public class ZkTopicStore implements TopicStore {
             }
             handler.handle(fut);
         });
+        return handler;
     }
 
     @Override
-    public void create(Topic topic, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> create(Topic topic) {
+        Future<Void> handler = Future.future();
         byte[] data = TopicSerialization.toJson(topic);
         String topicPath = getTopicPath(topic.getTopicName());
         LOGGER.debug("create znode {}", topicPath);
@@ -90,19 +92,23 @@ public class ZkTopicStore implements TopicStore {
                 handler.handle(result);
             }
         });
+        return handler;
     }
 
     @Override
-    public void update(Topic topic, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> update(Topic topic) {
+        Future<Void> handler = Future.future();
         byte[] data = TopicSerialization.toJson(topic);
         // TODO pass a non-zero version
         String topicPath = getTopicPath(topic.getTopicName());
         LOGGER.debug("update znode {}", topicPath);
         zk.setData(topicPath, data, -1, handler);
+        return handler;
     }
 
     @Override
-    public void delete(TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> delete(TopicName topicName) {
+        Future<Void> handler = Future.future();
         // TODO pass a non-zero version
         String topicPath = getTopicPath(topicName);
         LOGGER.debug("delete znode {}", topicPath);
@@ -113,5 +119,6 @@ public class ZkTopicStore implements TopicStore {
                 handler.handle(result);
             }
         });
+        return handler;
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -337,7 +337,7 @@ public class TopicOperatorTest {
         //mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> { });
+                .create(privateTopic);
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setCreateResponse(resourceName, null)
@@ -348,7 +348,7 @@ public class TopicOperatorTest {
         topicOperator.onTopicConfigChanged(logContext, topicName).setHandler(ar -> {
             assertSucceeded(context, ar);
             context.assertEquals("baz", mockKafka.getTopicState(topicName).getConfig().get("cleanup.policy"));
-            mockTopicStore.read(topicName, ar2 -> {
+            mockTopicStore.read(topicName).setHandler(ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -390,7 +390,7 @@ public class TopicOperatorTest {
             mockKafka.assertExists(context, kubeTopic.getTopicName());
             mockTopicStore.assertExists(context, kubeTopic.getTopicName());
             mockK8s.assertNoEvents(context);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kubeTopic, readResult.result());
                 async.countDown();
@@ -416,7 +416,7 @@ public class TopicOperatorTest {
                 .createResource(topicResource).setHandler(ar -> async0.countDown());
         mockK8s.setDeleteResponse(resourceName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> async0.countDown());
+                .create(privateTopic).setHandler(ar -> async0.countDown());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
 
         Async async = context.async();
@@ -455,7 +455,7 @@ public class TopicOperatorTest {
             mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
             mockK8s.assertNoEvents(context);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
@@ -483,7 +483,7 @@ public class TopicOperatorTest {
         mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
         mockKafka.setDeleteTopicResponse(topicName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockTopicStore.create(kafkaTopic, ar -> async0.countDown());
+        mockTopicStore.create(kafkaTopic).setHandler(ar -> async0.countDown());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
         async0.await();
         LogContext logContext = LogContext.periodic(topicName.toString());
@@ -525,7 +525,7 @@ public class TopicOperatorTest {
             mockK8s.assertExists(context, topicName.asKubeName());
             mockK8s.assertNoEvents(context);
             mockKafka.assertExists(context, topicName);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kubeTopic, readResult.result());
                 async.complete();
@@ -565,7 +565,7 @@ public class TopicOperatorTest {
             mockTopicStore.assertExists(context, topicName);
             mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(mergedTopic, readResult.result());
                 async.countDown();
@@ -610,7 +610,7 @@ public class TopicOperatorTest {
             mockTopicStore.assertExists(context, topicName);
             mockK8s.assertExists(context, topicName.asKubeName());
             mockKafka.assertExists(context, topicName);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(kafkaTopic, readResult.result());
                 async.countDown();
@@ -646,14 +646,14 @@ public class TopicOperatorTest {
         mockK8s.createResource(resource).setHandler(ar -> async0.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockTopicStore.create(privateTopic, ar -> async0.countDown());
+        mockTopicStore.create(privateTopic).setHandler(ar -> async0.countDown());
         async0.await();
 
         Async async = context.async(3);
         topicOperator.reconcile(logContext, resource, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockK8s.assertNoEvents(context);
-            mockTopicStore.read(topicName, readResult -> {
+            mockTopicStore.read(topicName).setHandler(readResult -> {
                 assertSucceeded(context, readResult);
                 context.assertEquals(resultTopic, readResult.result());
                 async.countDown();
@@ -688,7 +688,7 @@ public class TopicOperatorTest {
         mockKafka.setDeleteTopicResponse(topicName, deleteTopicException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> { });
+                .create(privateTopic);
         mockTopicStore.setDeleteTopicResponse(topicName, storeException);
 
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, labels);
@@ -729,7 +729,7 @@ public class TopicOperatorTest {
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> { });
+                .create(privateTopic);
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setCreateResponse(resourceName, null);
@@ -742,7 +742,7 @@ public class TopicOperatorTest {
         topicOperator.onResourceAddedOrModified(logContext, resource, true).setHandler(ar -> {
             assertSucceeded(context, ar);
             context.assertEquals("baz", mockKafka.getTopicState(topicName).getConfig().get("cleanup.policy"));
-            mockTopicStore.read(topicName, ar2 -> {
+            mockTopicStore.read(topicName).setHandler(ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -788,7 +788,7 @@ public class TopicOperatorTest {
         mockK8s.setDeleteResponse(resourceName, k8sException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> { });
+                .create(privateTopic);
         mockTopicStore.setDeleteTopicResponse(topicName, storeException);
         LogContext logContext = LogContext.zkWatch("///", topicName.toString());
         Async async = context.async();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -62,7 +62,7 @@ public class ZkTopicStoreTest {
 
         // Create the topic
         Async async0 = context.async();
-        store.create(topic, ar -> {
+        store.create(topic).setHandler(ar -> {
             async0.complete();
         });
         async0.await();
@@ -70,7 +70,7 @@ public class ZkTopicStoreTest {
         // Read the topic
         Async async1 = context.async();
         Future<Topic> topicFuture = Future.future();
-        store.read(new TopicName("my_topic"), ar -> {
+        store.read(new TopicName("my_topic")).setHandler(ar -> {
             topicFuture.complete(ar.result());
             async1.complete();
 
@@ -85,7 +85,7 @@ public class ZkTopicStoreTest {
         assertEquals(topic.getConfig(), readTopic.getConfig());
 
         // try to create it again: assert an error
-        store.create(topic, ar -> {
+        store.create(topic).setHandler(ar -> {
             if (ar.succeeded()) {
                 context.fail("Should throw");
             } else {
@@ -100,13 +100,13 @@ public class ZkTopicStoreTest {
         Topic updated = new Topic.Builder(topic)
                 .withNumPartitions(3)
                 .withConfigEntry("fruit", "apple").build();
-        store.update(updated, ar -> async2.complete());
+        store.update(updated).setHandler(ar -> async2.complete());
         async2.await();
 
         // re-read it and assert equal
         Async async3 = context.async();
         Future<Topic> fut = Future.future();
-        store.read(new TopicName("my_topic"), ar -> {
+        store.read(new TopicName("my_topic")).setHandler(ar -> {
             fut.complete(ar.result());
             async3.complete();
         });
@@ -121,12 +121,12 @@ public class ZkTopicStoreTest {
 
         // delete it
         Async async4 = context.async();
-        store.delete(updated.getTopicName(), ar -> async4.complete());
+        store.delete(updated.getTopicName()).setHandler(ar -> async4.complete());
         async4.await();
 
         // assert we can't read it again
         Async async5 = context.async();
-        store.read(new TopicName("my_topic"), ar -> {
+        store.read(new TopicName("my_topic")).setHandler(ar -> {
             async5.complete();
             if (ar.succeeded()) {
                 context.assertNull(ar.result());
@@ -138,7 +138,7 @@ public class ZkTopicStoreTest {
 
         // delete it again: assert an error
         Async async6 = context.async();
-        store.delete(updated.getTopicName(), ar -> {
+        store.delete(updated.getTopicName()).setHandler(ar -> {
             async6.complete();
             if (ar.succeeded()) {
                 context.fail("Should throw");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

This PR changes the TO's `TopicStore` interface and implementations to use `Future` rather than `Handler`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

