### PR TITLE
Topic operator future 4

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.topic;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 import java.util.Set;
 
@@ -21,9 +21,9 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * @param newTopic The topic to create.
-     * @param handler The result handler.
+     * @return A future which is completed once the topic has been created.
      */
-    void createTopic(Topic newTopic, Handler<AsyncResult<Void>> handler);
+    Future<Void> createTopic(Topic newTopic);
 
     /**
      * Asynchronously delete the given topic in Kafka. Invoke the given
@@ -31,9 +31,9 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * @param topicName The name of the topic to delete.
-     * @param handler The result handler.
+     * @return A future which is completed once the topic has been deleted.
      */
-    void deleteTopic(TopicName topicName, Handler<AsyncResult<Void>> handler);
+    Future<Void> deleteTopic(TopicName topicName);
 
     /**
      * Asynchronously update the topic config in Kafka. Invoke the given
@@ -41,9 +41,9 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * @param topic The topic config to update.
-     * @param handler The result handler.
+     * @return A future which is completed once the topic has been updated.
      */
-    void updateTopicConfig(Topic topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> updateTopicConfig(Topic topic);
 
     /**
      * Asynchronously increase the topic's partitions in Kafka. Invoke the given
@@ -51,9 +51,9 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * @param topic The topic.
-     * @param handler The result handler.
+     * @return A future which is completed once the topic has been updated.
      */
-    void increasePartitions(Topic topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> increasePartitions(Topic topic);
 
     /**
      * Asynchronously change the topic's replication factor in Kafka. Invoke the given
@@ -61,9 +61,9 @@ public interface Kafka {
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
      * @param topic The topic.
-     * @param handler The result handler.
+     * @return A future which is completed once the topic has been updated.
      */
-    void changeReplicationFactor(Topic topic, Handler<AsyncResult<Void>> handler);
+    Future<Void> changeReplicationFactor(Topic topic);
 
     /**
      * Asynchronously fetch the topic metadata in Kafka. Invoke the given
@@ -72,18 +72,18 @@ public interface Kafka {
      * KafkaException (not an ExecutionException).
      * If the topic does not exist the {@link AsyncResult#result()} will be null.
      * @param topicName The name of the topic to get the metadata of.
-     * @param handler The result handler.
+     * @return A future which is completed with the requested metadata.
      */
-    void topicMetadata(TopicName topicName, Handler<AsyncResult<TopicMetadata>> handler);
+    Future<TopicMetadata> topicMetadata(TopicName topicName);
 
     /**
      * Asynchronously list the topics available in Kafka. Invoke the given
      * handler with the result. If the operation fails the given handler
      * will be called with a failed AsyncResult whose {@code cause()} is the
      * KafkaException (not an ExecutionException).
-     * @param handler The result handler.
+     * @return A future which is completed with the list of topics.
      */
-    void listTopics(Handler<AsyncResult<Set<String>>> handler);
+    Future<Set<String>> listTopics();
 
 }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.topic;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 
 import java.util.Set;
@@ -16,9 +15,9 @@ import java.util.Set;
 public interface Kafka {
 
     /**
-     * Asynchronously create the given topic in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously create the given topic in Kafka,
+     * completing the returned Future when the topic has been created.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @param newTopic The topic to create.
      * @return A future which is completed once the topic has been created.
@@ -26,9 +25,9 @@ public interface Kafka {
     Future<Void> createTopic(Topic newTopic);
 
     /**
-     * Asynchronously delete the given topic in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously delete the given topic in Kafka,
+     * completing the returned Future when the topic has been deleted.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @param topicName The name of the topic to delete.
      * @return A future which is completed once the topic has been deleted.
@@ -36,9 +35,9 @@ public interface Kafka {
     Future<Void> deleteTopic(TopicName topicName);
 
     /**
-     * Asynchronously update the topic config in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously update the topic config in Kafka,
+     * completing the returned Future when the topic has been updated.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @param topic The topic config to update.
      * @return A future which is completed once the topic has been updated.
@@ -46,9 +45,9 @@ public interface Kafka {
     Future<Void> updateTopicConfig(Topic topic);
 
     /**
-     * Asynchronously increase the topic's partitions in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously increase the topic's partitions in Kafka,
+     * completing the returned Future when the topic has been updated.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @param topic The topic.
      * @return A future which is completed once the topic has been updated.
@@ -56,9 +55,9 @@ public interface Kafka {
     Future<Void> increasePartitions(Topic topic);
 
     /**
-     * Asynchronously change the topic's replication factor in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously change the topic's replication factor in Kafka,
+     * completing the returned Future when the topic has been updated.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @param topic The topic.
      * @return A future which is completed once the topic has been updated.
@@ -66,20 +65,20 @@ public interface Kafka {
     Future<Void> changeReplicationFactor(Topic topic);
 
     /**
-     * Asynchronously fetch the topic metadata in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously fetch the topic metadata in Kafka,
+     * completing the returned Future with the requested metadata.
+     * If the topic does not exist the returned Future will be completed with null result.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
-     * If the topic does not exist the {@link AsyncResult#result()} will be null.
      * @param topicName The name of the topic to get the metadata of.
      * @return A future which is completed with the requested metadata.
      */
     Future<TopicMetadata> topicMetadata(TopicName topicName);
 
     /**
-     * Asynchronously list the topics available in Kafka. Invoke the given
-     * handler with the result. If the operation fails the given handler
-     * will be called with a failed AsyncResult whose {@code cause()} is the
+     * Asynchronously list the names of the topics available in Kafka,
+     * completing the returned Future with the topic names.
+     * If the operation fails the returned Future will be failed with the
      * KafkaException (not an ExecutionException).
      * @return A future which is completed with the list of topics.
      */

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
@@ -72,10 +72,10 @@ public abstract class TopicMetadataHandler implements Handler<AsyncResult<TopicM
 
         if (delay < 1) {
             // vertx won't tolerate a zero delay
-            vertx.runOnContext(timerId -> kafka.topicMetadata(topicName, this));
+            vertx.runOnContext(timerId -> kafka.topicMetadata(topicName).setHandler(this));
         } else {
             vertx.setTimer(TimeUnit.MILLISECONDS.convert(delay, TimeUnit.MILLISECONDS),
-                timerId -> kafka.topicMetadata(topicName, this));
+                timerId -> kafka.topicMetadata(topicName).setHandler(this));
         }
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.operator.topic;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.ext.unit.TestContext;
 import org.apache.kafka.clients.admin.NewTopic;
 
@@ -24,17 +22,17 @@ public class MockKafka implements Kafka {
 
     private Map<TopicName, Topic> topics = new HashMap<>();
 
-    private AsyncResult<Set<String>> topicsListResponse = Future.succeededFuture(Collections.emptySet());
-    private Function<TopicName, AsyncResult<TopicMetadata>> topicMetadataRespose =
+    private Future<Set<String>> topicsListResponse = Future.succeededFuture(Collections.emptySet());
+    private Function<TopicName, Future<TopicMetadata>> topicMetadataRespose =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a topicMetadataResponse.");
-    private Function<String, AsyncResult<Void>> createTopicResponse =
+    private Function<String, Future<Void>> createTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a createTopicResponse.");
-    private Function<TopicName, AsyncResult<Void>> deleteTopicResponse =
+    private Function<TopicName, Future<Void>> deleteTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a deleteTopicResponse.");
-    private Function<TopicName, AsyncResult<Void>> updateTopicResponse =
+    private Function<TopicName, Future<Void>> updateTopicResponse =
         t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a updateTopicResponse.");
 
-    public MockKafka setTopicsListResponse(AsyncResult<Set<String>> topicsListResponse) {
+    public MockKafka setTopicsListResponse(Future<Set<String>> topicsListResponse) {
         this.topicsListResponse = topicsListResponse;
         return this;
     }
@@ -44,13 +42,13 @@ public class MockKafka implements Kafka {
         return this;
     }
 
-    public MockKafka setTopicMetadataResponse(Function<TopicName, AsyncResult<TopicMetadata>> topicMetadataRespose) {
+    public MockKafka setTopicMetadataResponse(Function<TopicName, Future<TopicMetadata>> topicMetadataRespose) {
         this.topicMetadataRespose = topicMetadataRespose;
         return this;
     }
 
     public MockKafka setTopicMetadataResponse(TopicName topic, TopicMetadata topicMetadata, Exception exception) {
-        Function<TopicName, AsyncResult<TopicMetadata>> old = this.topicMetadataRespose;
+        Function<TopicName, Future<TopicMetadata>> old = this.topicMetadataRespose;
         this.topicMetadataRespose = t -> {
             if (t.equals(topic)) {
                 if (exception != null) {
@@ -65,13 +63,13 @@ public class MockKafka implements Kafka {
         return this;
     }
 
-    public MockKafka setCreateTopicResponse(Function<String, AsyncResult<Void>> createTopicResponse) {
+    public MockKafka setCreateTopicResponse(Function<String, Future<Void>> createTopicResponse) {
         this.createTopicResponse = createTopicResponse;
         return this;
     }
 
     public MockKafka setCreateTopicResponse(String createTopic, Exception exception) {
-        Function<String, AsyncResult<Void>> old = this.createTopicResponse;
+        Function<String, Future<Void>> old = this.createTopicResponse;
         this.createTopicResponse = t -> {
             if (t.equals(createTopic)) {
                 if (exception != null) {
@@ -86,13 +84,13 @@ public class MockKafka implements Kafka {
         return this;
     }
 
-    public MockKafka setDeleteTopicResponse(Function<TopicName, AsyncResult<Void>> deleteTopicResponse) {
+    public MockKafka setDeleteTopicResponse(Function<TopicName, Future<Void>> deleteTopicResponse) {
         this.deleteTopicResponse = deleteTopicResponse;
         return this;
     }
 
     public MockKafka setDeleteTopicResponse(TopicName topic, Exception exception) {
-        Function<TopicName, AsyncResult<Void>> old = this.deleteTopicResponse;
+        Function<TopicName, Future<Void>> old = this.deleteTopicResponse;
         this.deleteTopicResponse = t -> {
             if (t.equals(topic)) {
                 if (exception != null) {
@@ -108,9 +106,9 @@ public class MockKafka implements Kafka {
     }
 
     @Override
-    public void createTopic(Topic t, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> createTopic(Topic t) {
         NewTopic newTopic = TopicSerialization.toNewTopic(t, null);
-        AsyncResult<Void> event = createTopicResponse.apply(newTopic.name());
+        Future<Void> event = createTopicResponse.apply(newTopic.name());
         if (event.succeeded()) {
             Topic.Builder topicBuilder = new Topic.Builder()
                     .withTopicName(newTopic.name())
@@ -127,26 +125,26 @@ public class MockKafka implements Kafka {
             Topic topic = topicBuilder.build();
             topics.put(topic.getTopicName(), topic);
         }
-        handler.handle(event);
+        return event;
     }
 
     @Override
-    public void deleteTopic(TopicName topicName, Handler<AsyncResult<Void>> handler) {
-        AsyncResult<Void> event = deleteTopicResponse.apply(topicName);
+    public Future<Void> deleteTopic(TopicName topicName) {
+        Future<Void> event = deleteTopicResponse.apply(topicName);
         if (event.succeeded()) {
             topics.remove(topicName);
         }
-        handler.handle(event);
+        return event;
     }
 
-    public MockKafka setUpdateTopicResponse(Function<TopicName, AsyncResult<Void>> updateTopicResponse) {
+    public MockKafka setUpdateTopicResponse(Function<TopicName, Future<Void>> updateTopicResponse) {
         this.updateTopicResponse = updateTopicResponse;
         return this;
     }
 
     @Override
-    public void updateTopicConfig(Topic topic, Handler<AsyncResult<Void>> handler) {
-        AsyncResult<Void> event = updateTopicResponse.apply(topic.getTopicName());
+    public Future<Void> updateTopicConfig(Topic topic) {
+        Future<Void> event = updateTopicResponse.apply(topic.getTopicName());
         if (event.succeeded()) {
             Topic t = topics.get(topic.getTopicName());
             if (t == null) {
@@ -155,12 +153,12 @@ public class MockKafka implements Kafka {
             t = new Topic.Builder(t).withConfig(topic.getConfig()).build();
             topics.put(topic.getTopicName(), t);
         }
-        handler.handle(event);
+        return event;
     }
 
     @Override
-    public void increasePartitions(Topic topic, Handler<AsyncResult<Void>> handler) {
-        AsyncResult<Void> event = updateTopicResponse.apply(topic.getTopicName());
+    public Future<Void> increasePartitions(Topic topic) {
+        Future<Void> event = updateTopicResponse.apply(topic.getTopicName());
         if (event.succeeded()) {
             Topic t = topics.get(topic.getTopicName());
             if (t == null) {
@@ -169,12 +167,12 @@ public class MockKafka implements Kafka {
             t = new Topic.Builder(t).withNumPartitions(topic.getNumPartitions()).build();
             topics.put(topic.getTopicName(), t);
         }
-        handler.handle(event);
+        return event;
     }
 
     @Override
-    public void changeReplicationFactor(Topic topic, Handler<AsyncResult<Void>> handler) {
-        AsyncResult<Void> event = updateTopicResponse.apply(topic.getTopicName());
+    public Future<Void> changeReplicationFactor(Topic topic) {
+        Future<Void> event = updateTopicResponse.apply(topic.getTopicName());
         if (event.succeeded()) {
             Topic t = topics.get(topic.getTopicName());
             if (t == null) {
@@ -183,17 +181,17 @@ public class MockKafka implements Kafka {
             t = new Topic.Builder(t).withNumReplicas(topic.getNumReplicas()).build();
             topics.put(topic.getTopicName(), t);
         }
-        handler.handle(event);
+        return event;
     }
 
     @Override
-    public void topicMetadata(TopicName topicName, Handler<AsyncResult<TopicMetadata>> handler) {
-        handler.handle(topicMetadataRespose.apply(topicName));
+    public Future<TopicMetadata> topicMetadata(TopicName topicName) {
+        return topicMetadataRespose.apply(topicName);
     }
 
     @Override
-    public void listTopics(Handler<AsyncResult<Set<String>>> handler) {
-        handler.handle(topicsListResponse);
+    public Future<Set<String>> listTopics() {
+        return topicsListResponse;
     }
 
     public void assertExists(TestContext context, TopicName topicName) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorAssignedKafkaImplTest.java
@@ -127,7 +127,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyInProgress(partitions),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             context.assertFalse(ar.succeeded());
             final String message = ar.cause().getMessage();
             context.assertTrue(message.contains("lacks an executable arg[0]")
@@ -149,7 +149,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyInProgress(partitions),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             context.assertFalse(ar.succeeded());
             final String message = ar.cause().getMessage();
             context.assertTrue(message.contains("lacks an executable arg[0]")
@@ -171,7 +171,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyInProgress(partitions),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             context.assertTrue(ar.succeeded());
             async.complete();
         });
@@ -196,7 +196,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.fail("Bang!"),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             // We should retry anf ultimately succeed
             context.assertTrue(ar.succeeded());
             async.complete();
@@ -217,7 +217,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyFail("Bang!"),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             // We should retry anf ultimately succeed
             context.assertTrue(ar.succeeded());
             async.complete();
@@ -242,7 +242,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyInProgress(partitions),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             context.assertFalse(ar.succeeded());
             context.assertEquals("Reassigment failed: There is an existing assignment running.", ar.cause().getMessage());
             async.complete();
@@ -268,7 +268,7 @@ public class TopicOperatorAssignedKafkaImplTest {
                 Subclass.verifyInProgress(partitions),
                 Subclass.verifySuccess(partitions)));
         Async async = context.async();
-        sub.changeReplicationFactor(topic, ar -> {
+        sub.changeReplicationFactor(topic).setHandler(ar -> {
             context.assertFalse(ar.succeeded());
             context.assertTrue(ar.cause().getMessage().contains("Failed to reassign partitions"));
             async.complete();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -214,8 +214,7 @@ public class TopicOperatorMockTest {
     Topic getFromKafka(TestContext context, String topicName) {
         AtomicReference<Topic> ref = new AtomicReference<>();
         Async async = context.async();
-        Future<TopicMetadata> kafkaMetadata = Future.future();
-        session.kafka.topicMetadata(new TopicName(topicName), kafkaMetadata.completer());
+        Future<TopicMetadata> kafkaMetadata = session.kafka.topicMetadata(new TopicName(topicName));
         kafkaMetadata.map(metadata -> TopicSerialization.fromTopicMetadata(metadata)).setHandler(fromKafka -> {
             if (fromKafka.succeeded()) {
                 ref.set(fromKafka.result());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -332,7 +332,7 @@ public class TopicOperatorTest {
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, labels);
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> { });
+                .createTopic(kafkaTopic);
         mockKafka.setTopicMetadataResponse(topicName, Utils.getTopicMetadata(kafkaTopic), null);
         //mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
@@ -445,7 +445,7 @@ public class TopicOperatorTest {
         mockTopicStore.setCreateTopicResponse(topicName, null);
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(kafkaTopic, ar -> async0.complete());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.complete());
         async0.await();
         LogContext logContext = LogContext.periodic(topicName.toString());
         Async async = context.async(2);
@@ -480,7 +480,7 @@ public class TopicOperatorTest {
         Topic privateTopic = kafkaTopic;
 
         Async async0 = context.async(2);
-        mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.countDown());
         mockKafka.setDeleteTopicResponse(topicName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         mockTopicStore.create(kafkaTopic).setHandler(ar -> async0.countDown());
@@ -510,7 +510,7 @@ public class TopicOperatorTest {
 
         Async async0 = context.async(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.countDown());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
@@ -548,7 +548,7 @@ public class TopicOperatorTest {
 
         Async async0 = context.async(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.countDown());
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
@@ -591,7 +591,7 @@ public class TopicOperatorTest {
 
         Async async0 = context.async(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.countDown());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString());
@@ -637,7 +637,7 @@ public class TopicOperatorTest {
 
         Async async0 = context.async(3);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(kafkaTopic, ar -> async0.countDown());
+        mockKafka.createTopic(kafkaTopic).setHandler(ar -> async0.countDown());
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, labels);
@@ -683,7 +683,7 @@ public class TopicOperatorTest {
         Topic privateTopic = kubeTopic;
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> { });
+                .createTopic(kafkaTopic);
         mockKafka.setTopicMetadataResponse(topicName, Utils.getTopicMetadata(kubeTopic), null);
         mockKafka.setDeleteTopicResponse(topicName, deleteTopicException);
 
@@ -724,7 +724,7 @@ public class TopicOperatorTest {
         LogContext logContext = LogContext.zkWatch("///", topicName.toString());
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> { });
+                .createTopic(kafkaTopic);
         mockKafka.setTopicMetadataResponse(topicName, Utils.getTopicMetadata(kafkaTopic), null);
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

_Please describe your pull request_

### Checklist

This PR changes the methods of the `Kafka` interface and it's implementations to return `Futures` rather than having a `Handler` parameter.

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

