### PR TITLE
Fix handling of user labels on custom resources

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -82,10 +82,8 @@ public class Labels {
     public static Labels userLabels(Map<String, String> userLabels) {
         if (userLabels != null) {
             for (String key : userLabels.keySet()) {
-                if (key.startsWith(STRIMZI_DOMAIN)
-                        && !key.equals(STRIMZI_KIND_LABEL)) {
-                    throw new IllegalArgumentException("User labels includes a Strimzi label that is not "
-                            + STRIMZI_KIND_LABEL + ": " + key);
+                if (key.startsWith(STRIMZI_DOMAIN)) {
+                    throw new IllegalArgumentException("Labels starting with " + STRIMZI_DOMAIN + " are not allowed at Custom Resources.");
                 }
             }
             return new Labels(userLabels);

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -83,7 +83,7 @@ public class Labels {
         if (userLabels != null) {
             for (String key : userLabels.keySet()) {
                 if (key.startsWith(STRIMZI_DOMAIN)) {
-                    throw new IllegalArgumentException("Labels starting with " + STRIMZI_DOMAIN + " are not allowed at Custom Resources.");
+                    throw new IllegalArgumentException("Labels starting with " + STRIMZI_DOMAIN + " are not allowed in Custom Resources, such labels should be removed.");
                 }
             }
             return new Labels(userLabels);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We do a validation of the labels set on the custom resources. They should not contain any `strimzi.io` labels. However, for legacy reasons from when we used ConfigMaps we allowed the `strimzi.io/kind` label which defined which resource should be created. This label is not needed anymore. This PR cleans the check and the error message which is raised when `strimzi.io` labels are used.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally