### PR TITLE
Update Jackson to 2.9.9.2 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson-core.version>2.9.9</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.9.9.1</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-databind.version>2.9.9.2</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.9.9</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.9.8</fasterxml.jackson-annotations.version>
         <kafka.version>2.3.0</kafka.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This Pr updates the Jackson Databind dependency to 2.9.9.2 to address CVEs CVE-2019-14379 and CVE-2019-14439.