### PR TITLE
Update kubernetes version used for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+dist: xenial
 sudo: required
 language: java
 notifications:
   slack:
     secure: c8TGIgFUIwQm/b4LKRjyqs+Lw4QCg2nd6lnwxjwsJKCJBUmJp5Pf+h8rznXJUglxytYWoLZQ7NFuFyt85L1RQQxK+rWeRn6mddEr5gR3vXJUvYycPAIWDGfVVkSsKdPVyxgbmlrSxbThB4lMHIeUUzE4ITTb9IyXxPcvTHSBPQVpED/MlJgYLucRKHpUbvNn8Bj+bKECDzbNoZTLc7gXDPIi3ejazLC2BYzxHfk52b7O18LhLMWVra8fccxlr1sBzprrzTKj10yDXrzuyv8YOcFTs/ru8wZyz+8hPk97KBk1wyEN7mFhFVPlTQP/cOMYUMM/iflWLV2iR0gmg7Y5LrBauR0CkLW30KOLR9p4B4Ygp5CuJPxrniYfKUXlB1KyUPLlDjMc8/CZ8Aunc4SniZqDg8Ow4vix/3PebGj+2rwjDL7KizMzxNSQa0ieMEUxgiWnPl5ZY8zXUkklHH+x7sB9aX3UpElnfREbq9d9w2Ak6EwvANTds4lPScieOY1gntvTCfcEethR3mMEY9vT4R9+ZXF54RKogbBFG89k+1J2Dv0rI8ZZTpwYIkNWHpxfIeKz4jekOm0lFJE/8/zWIgyZEZSqIi6GhfiFaEUzOKXG295VfDhE5KF+uzXVHeWPA8Hgy1aggCtXc/hBam3L8Ec2gaSEU547MNuLOMQkEhY=
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 services:
 - docker
@@ -29,10 +30,10 @@ env:
   - DOCKER_ORG=strimzici
   - DOCKER_REGISTRY=docker.io
   - TEST_CLUSTER=minikube
-  - TEST_KUBECTL_VERSION=v1.10.0
+  - TEST_KUBECTL_VERSION=v1.15.0
   - TEST_NSENTER_VERSION=2.32
   - TEST_HELM_VERSION=v2.9.1
-  - TEST_MINIKUBE_VERSION=v0.25.2
+  - TEST_MINIKUBE_VERSION=v1.2.0
   - STRIMZI_DEFAULT_LOG_LEVEL=DEBUG
   - MVN_ARGS="-q"
   - DOCKER_BUILD_ARGS="-q"

--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -91,10 +91,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     sudo chown -R travis: /home/travis/.minikube/
     sudo -E minikube addons enable default-storageclass
 
-    #wait_for_minikube
-    kubectl cluster-info
-    JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
-    JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
+    wait_for_minikube
 
     if [ $? -ne 0 ]
     then

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -263,6 +264,7 @@ public class KafkaConnectCrdOperatorIT {
      * @param context
      */
     @Test
+    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
-import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -264,7 +262,6 @@ public class KafkaConnectCrdOperatorIT {
      * @param context
      */
     @Test
-    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();
@@ -307,7 +304,7 @@ public class KafkaConnectCrdOperatorIT {
         log.info("Updating resource");
         KafkaConnect updated = new KafkaConnectBuilder(kafkaConnectOperator.get(namespace, RESOURCE_NAME))
                 .editSpec()
-                .withLogging(new InlineLogging())
+                .withNewLivenessProbe().withInitialDelaySeconds(14).endLivenessProbe()
                 .endSpec()
                 .build();
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -263,6 +264,7 @@ public class KafkaConnectS2IcrdOperatorIT {
      * @param context
      */
     @Test
+    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
-import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -264,7 +262,6 @@ public class KafkaConnectS2IcrdOperatorIT {
      * @param context
      */
     @Test
-    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();
@@ -307,7 +304,7 @@ public class KafkaConnectS2IcrdOperatorIT {
         log.info("Updating resource");
         KafkaConnectS2I updated = new KafkaConnectS2IBuilder(kafkaConnectS2Ioperator.get(namespace, RESOURCE_NAME))
                 .editSpec()
-                .withLogging(new InlineLogging())
+                .withNewLivenessProbe().withInitialDelaySeconds(14).endLivenessProbe()
                 .endSpec()
                 .build();
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -263,6 +264,7 @@ public class KafkaUserCrdOperatorIT {
      * @param context
      */
     @Test
+    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.KafkaUserAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.operator.KubernetesVersion;
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -264,7 +262,6 @@ public class KafkaUserCrdOperatorIT {
      * @param context
      */
     @Test
-    @Ignore
     public void testUpdateStatusWhileResourceUpdated(TestContext context)    {
         log.info("Getting Kubernetes version");
         Async versionAsync = context.async();
@@ -305,15 +302,9 @@ public class KafkaUserCrdOperatorIT {
                 .build();
 
         log.info("Updating resource");
-        KafkaUserAuthentication kua = new KafkaUserAuthentication() {
-            @Override
-            public String getType() {
-                return "tls";
-            }
-        };
         KafkaUser updated = new KafkaUserBuilder(kafkaUserOperator.get(namespace, RESOURCE_NAME))
                 .editSpec()
-                    .withAuthentication(kua)
+                    .withNewKafkaUserTlsClientAuthentication().endKafkaUserTlsClientAuthentication()
                 .endSpec()
                 .build();
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates travis to use more recent versions of kubectl, minikube and specifically kubernetes 1.15. The fixes to the ITs are necessary because those tests exit early on current 3.9 travis build, but don't work on minikube (they do on oc cluster up 3.11). There reason is that the patch wasn't actually changing anything, so the update in those tests did not result in increment of metadata.resourceVersion, which the test relied on in order to get and test for a resource conflict. Making different changes to the json ensures the patch does indeed result in a new version on the server.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

