### PR TITLE
[DOC] Fixed Asciidoctor build error cause by cross-ref

### DIFF
--- a/documentation/book/assembly-logging.adoc
+++ b/documentation/book/assembly-logging.adoc
@@ -22,4 +22,4 @@ include::proc-kafka-inline-logging.adoc[leveloffset=+1]
 
 include::proc-kafka-external-logging.adoc[leveloffset=+1]
 
-Garbage collector (GC) logging can also be enabled (or disabled). For more information on GC, see xref:ref-jvm-options-{context}[]
+Garbage collector (GC) logging can also be enabled (or disabled). For more information on GC, see xref:ref-jvm-options-deployment-configuration-kafka[]


### PR DESCRIPTION
An undefined `{context}` attribute in a cross-reference in the Logging assembly was causing the Asciidoctor build to fail in safe mode. This has been fixed by setting the attribute to the context of the parent assembly.

I built the docs locally to check that the cross-reference works as expected.

### Type of change

- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

