### PR TITLE
Topic operator status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -52,6 +53,9 @@ import static java.util.Collections.unmodifiableList;
                                 storage = false
                         )
                 },
+                subresources = @Crd.Spec.Subresources(
+                        status = @Crd.Spec.Subresources.Status()
+                ),
                 additionalPrinterColumns = {
                         @Crd.Spec.AdditionalPrinterColumn(
                                 name = "Partitions",
@@ -76,7 +80,7 @@ import static java.util.Collections.unmodifiableList;
         refs = {@BuildableReference(ObjectMeta.class)}
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
 public class KafkaTopic extends CustomResource implements UnknownPropertyPreserving {
 
@@ -99,6 +103,7 @@ public class KafkaTopic extends CustomResource implements UnknownPropertyPreserv
     private String apiVersion;
     private ObjectMeta metadata;
     private KafkaTopicSpec spec;
+    private KafkaTopicStatus status;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Override
@@ -128,6 +133,15 @@ public class KafkaTopic extends CustomResource implements UnknownPropertyPreserv
 
     public void setSpec(KafkaTopicSpec spec) {
         this.spec = spec;
+    }
+
+    @Description("The status of the topic.")
+    public KafkaTopicStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(KafkaTopicStatus status) {
+        this.status = status;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Represents a status of the KafkaTopic resource
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "conditions", "observedGeneration" })
+@EqualsAndHashCode
+public class KafkaTopicStatus extends Status {
+    private static final long serialVersionUID = 1L;
+}

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -9,6 +9,7 @@ rules:
   - kafka.strimzi.io
   resources:
   - kafkatopics
+  - kafkatopics/status
   verbs:
   - get
   - list

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -1086,7 +1086,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [id='type-Condition-{context}']
 ### `Condition` schema reference
 
-Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
+Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
 
 
 [options="header"]
@@ -1506,9 +1506,11 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 
 [options="header"]
 |====
-|Property     |Description
-|spec  1.2+<.<|The specification of the topic.
+|Property       |Description
+|spec    1.2+<.<|The specification of the topic.
 |xref:type-KafkaTopicSpec-{context}[`KafkaTopicSpec`]
+|status  1.2+<.<|The status of the topic.
+|xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`]
 |====
 
 [id='type-KafkaTopicSpec-{context}']
@@ -1528,6 +1530,21 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |map
 |topicName   1.2+<.<|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
 |string
+|====
+
+[id='type-KafkaTopicStatus-{context}']
+### `KafkaTopicStatus` schema reference
+
+Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
+
+
+[options="header"]
+|====
+|Property                   |Description
+|conditions          1.2+<.<|List of status conditions.
+|xref:type-Condition-{context}[`Condition`] array
+|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|integer
 |====
 
 [id='type-KafkaUser-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -14,6 +14,7 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkatopics
+  - kafkatopics/status
   verbs:
   - get
   - list

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -38,6 +38,8 @@ spec:
     JSONPath: .spec.replicas
     type: integer
     priority: 0
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -58,4 +60,24 @@ spec:
           required:
           - partitions
           - replicas
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
 {{- end -}}

--- a/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -9,6 +9,7 @@ rules:
   - kafka.strimzi.io
   resources:
   - kafkatopics
+  - kafkatopics/status
   verbs:
   - get
   - list

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -33,6 +33,8 @@ spec:
     JSONPath: .spec.replicas
     type: integer
     priority: 0
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -53,3 +55,23 @@ spec:
           required:
           - partitions
           - replicas
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer

--- a/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -9,6 +9,7 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkatopics
+  - kafkatopics/status
   verbs:
   - get
   - list

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -33,6 +33,8 @@ spec:
     JSONPath: .spec.replicas
     type: integer
     priority: 0
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -53,3 +55,23 @@ spec:
           required:
           - partitions
           - replicas
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -101,6 +101,10 @@
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -13,12 +13,14 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -26,6 +28,10 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
 
 public class CrdOperator<C extends KubernetesClient,
             T extends CustomResource,
@@ -64,6 +70,8 @@ public class CrdOperator<C extends KubernetesClient,
             this.plural = KafkaBridge.RESOURCE_PLURAL;
         } else if (cls.equals(KafkaMirrorMaker.class)) {
             this.plural = KafkaMirrorMaker.RESOURCE_PLURAL;
+        } else if (cls.equals(KafkaTopic.class)) {
+            this.plural = KafkaTopic.RESOURCE_PLURAL;
         } else {
             this.plural = null;
         }
@@ -74,8 +82,8 @@ public class CrdOperator<C extends KubernetesClient,
         return Crds.operation(client, cls, listCls, doneableCls);
     }
 
-    public Future<Void> updateStatusAsync(T resource) {
-        Future<Void> blockingFuture = Future.future();
+    public Future<T> updateStatusAsync(T resource) {
+        Future<T> blockingFuture = Future.future();
 
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(future -> {
             try {
@@ -89,7 +97,7 @@ public class CrdOperator<C extends KubernetesClient,
 
                 String method = request.method();
                 Response response = client.newCall(request).execute();
-
+                T returnedResource = null;
                 try {
                     final int code = response.code();
 
@@ -111,18 +119,22 @@ public class CrdOperator<C extends KubernetesClient,
                         Status status = OperationSupport.createStatus(response);
                         log.debug("Got unexpected {} status code {}: {}", method, code, status);
                         throw OperationSupport.requestFailure(request, status);
+                    } else {
+                        // Success!
+                        if (response.body() != null) {
+                            try (InputStream bodyInputStream = response.body().byteStream()) {
+                                returnedResource = Serialization.unmarshal(bodyInputStream, cls, Collections.emptyMap());
+                            }
+                        }
                     }
-                } catch (Exception e) {
-                    throw e;
                 } finally {
                     // Only messages with body should be closed
                     if (response.body() != null) {
                         response.close();
                     }
                 }
-
-                future.complete();
-            } catch (Exception e) {
+                future.complete(returnedResource);
+            } catch (IOException | RuntimeException e) {
                 log.debug("Updating status failed", e);
                 future.fail(e);
             }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.common.operator.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -16,9 +17,9 @@ import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
-import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
@@ -82,6 +83,8 @@ public class CrdOperator<C extends KubernetesClient,
         return Crds.operation(client, cls, listCls, doneableCls);
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
     public Future<T> updateStatusAsync(T resource) {
         Future<T> blockingFuture = Future.future();
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 
+@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+        justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
 public class CrdOperator<C extends KubernetesClient,
             T extends CustomResource,
             L extends CustomResourceList<T>,
@@ -83,8 +85,6 @@ public class CrdOperator<C extends KubernetesClient,
         return Crds.operation(client, cls, listCls, doneableCls);
     }
 
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-            justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
     public Future<T> updateStatusAsync(T resource) {
         Future<T> blockingFuture = Future.future();
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -11,24 +11,33 @@ import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
 import io.vertx.core.AsyncResult;
 
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.Date;
 
 public class StatusUtils {
     private static final String V1ALPHA1 = "kafka.strimzi.io/v1alpha1";
+
+    /**
+     * Returns the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     * @return the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     */
+    public static String iso8601Now() {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+    }
 
     public static Condition buildConditionFromReconciliationResult(AsyncResult<Void> reconciliationResult) {
         Condition readyCondition;
         if (reconciliationResult.succeeded()) {
             readyCondition = new ConditionBuilder()
-                    .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
+                    .withNewLastTransitionTime(iso8601Now())
                     .withNewType("Ready")
                     .withNewStatus("True")
                     .build();
         } else {
             readyCondition = new ConditionBuilder()
-                    .withNewLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
+                    .withNewLastTransitionTime(iso8601Now())
                     .withNewType("NotReady")
                     .withNewStatus("True")
                     .withNewReason(reconciliationResult.cause().getClass().getSimpleName())
@@ -36,10 +45,6 @@ public class StatusUtils {
                     .build();
         }
         return readyCondition;
-    }
-
-    private static Date dateSupplier() {
-        return new Date();
     }
 
     public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -31,17 +31,17 @@ public class StatusUtils {
         Condition readyCondition;
         if (reconciliationResult.succeeded()) {
             readyCondition = new ConditionBuilder()
-                    .withNewLastTransitionTime(iso8601Now())
-                    .withNewType("Ready")
-                    .withNewStatus("True")
+                    .withLastTransitionTime(iso8601Now())
+                    .withType("Ready")
+                    .withStatus("True")
                     .build();
         } else {
             readyCondition = new ConditionBuilder()
-                    .withNewLastTransitionTime(iso8601Now())
-                    .withNewType("NotReady")
-                    .withNewStatus("True")
-                    .withNewReason(reconciliationResult.cause().getClass().getSimpleName())
-                    .withNewMessage(reconciliationResult.cause().getMessage())
+                    .withLastTransitionTime(iso8601Now())
+                    .withType("NotReady")
+                    .withStatus("True")
+                    .withReason(reconciliationResult.cause().getClass().getSimpleName())
+                    .withMessage(reconciliationResult.cause().getMessage())
                     .build();
         }
         return readyCondition;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BaseKafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BaseKafkaImpl.java
@@ -152,10 +152,10 @@ public abstract class BaseKafkaImpl implements Kafka {
                 result = future.get();
                 LOGGER.trace("Future {} has result {}", future, result);
             } catch (ExecutionException e) {
-                LOGGER.debug("Future {} threw {}", future, e.toString());
                 if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                     result = null;
                 } else {
+                    LOGGER.debug("Future {} threw {}", future, e.toString());
                     if (!handled) {
                         handler.handle(Future.failedFuture(e.getCause()));
                     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -18,21 +18,21 @@ public interface K8s {
      * @param topicResource The resource to be created.
      * @return A future which completes when the topic has been created.
      */
-    Future<Void> createResource(KafkaTopic topicResource);
+    Future<KafkaTopic> createResource(KafkaTopic topicResource);
 
     /**
      * Asynchronously update the given resource.
      * @param topicResource The topic.
      * @return A future which completes when the topic has been updated.
      */
-    Future<Void> updateResource(KafkaTopic topicResource);
+    Future<KafkaTopic> updateResource(KafkaTopic topicResource);
 
     /**
      * Asynchronously update the given resource's status.
      * @param topicResource The topic.
      * @return A future which completes when the topic's status has been updated.
      */
-    Future<Void> updateResourceStatus(KafkaTopic topicResource);
+    Future<KafkaTopic> updateResourceStatus(KafkaTopic topicResource);
 
     /**
      * Asynchronously delete the given resource.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -28,6 +28,13 @@ public interface K8s {
     Future<Void> updateResource(KafkaTopic topicResource);
 
     /**
+     * Asynchronously update the given resource's status.
+     * @param topicResource The topic.
+     * @return A future which completes when the topic's status has been updated.
+     */
+    Future<Void> updateResourceStatus(KafkaTopic topicResource);
+
+    /**
      * Asynchronously delete the given resource.
      * @param resourceName The name of the resource to be deleted.
      * @return A future which completes when the topic has been deleted.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -42,14 +42,16 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public Future<Void> createResource(KafkaTopic topicResource) {
-        Future<Void> handler = Future.future();
+    public Future<KafkaTopic> createResource(KafkaTopic topicResource) {
+        Future<KafkaTopic> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 KafkaTopic kafkaTopic = operation().inNamespace(namespace).create(topicResource);
-                LOGGER.debug("KafkaTopic {} created with version {}", kafkaTopic.getMetadata().getName(),
+                LOGGER.debug("KafkaTopic {} created with version {}->{}",
+                        kafkaTopic.getMetadata().getName(),
+                        topicResource.getMetadata() != null ? topicResource.getMetadata().getResourceVersion() : null,
                         kafkaTopic.getMetadata().getResourceVersion());
-                future.complete();
+                future.complete(kafkaTopic);
             } catch (Exception e) {
                 future.fail(e);
             }
@@ -58,14 +60,16 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public Future<Void> updateResource(KafkaTopic topicResource) {
-        Future<Void> handler = Future.future();
+    public Future<KafkaTopic> updateResource(KafkaTopic topicResource) {
+        Future<KafkaTopic> handler = Future.future();
         vertx.executeBlocking(future -> {
             try {
                 KafkaTopic kafkaTopic = operation().inNamespace(namespace).withName(topicResource.getMetadata().getName()).patch(topicResource);
-                LOGGER.debug("KafkaTopic {} updated with version {}", kafkaTopic.getMetadata().getName(),
+                LOGGER.debug("KafkaTopic {} updated with version {}->{}",
+                        kafkaTopic.getMetadata().getName(),
+                        topicResource.getMetadata() != null ? topicResource.getMetadata().getResourceVersion() : null,
                         kafkaTopic.getMetadata().getResourceVersion());
-                future.complete();
+                future.complete(kafkaTopic);
             } catch (Exception e) {
                 future.fail(e);
             }
@@ -74,7 +78,7 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public Future<Void> updateResourceStatus(KafkaTopic topicResource) {
+    public Future<KafkaTopic> updateResourceStatus(KafkaTopic topicResource) {
         return crdOperator.updateStatusAsync(topicResource);
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -74,6 +74,11 @@ public class K8sImpl implements K8s {
     }
 
     @Override
+    public Future<Void> updateResourceStatus(KafkaTopic topicResource) {
+        return crdOperator.updateStatusAsync(topicResource);
+    }
+
+    @Override
     public Future<Void> deleteResource(ResourceName resourceName) {
         Future<Void> handler = Future.future();
         vertx.executeBlocking(future -> {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
@@ -20,9 +20,9 @@ class TopicConfigsWatcher extends ZkWatcher {
     @Override
     protected void notifyOperator(String child) {
         LogContext logContext = LogContext.zkWatch(CONFIGS_ZNODE, "=" + child);
-        log.info("{}: Config change {}: topic {}", logContext);
+        log.info("{}: Topic config change", logContext);
         topicOperator.onTopicConfigChanged(logContext, new TopicName(child)).setHandler(ar2 -> {
-            log.info("{} Reconciliation result due to topic config change on topic {}: {}", logContext, child, ar2);
+            log.info("{}: Reconciliation result due to topic config change on topic {}: {}", logContext, child, ar2);
         });
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -6,9 +6,14 @@ package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.Watcher;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
+import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.MaxAttemptsExceededException;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -33,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.disjoint;
 
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 class TopicOperator {
 
     private final static Logger LOGGER = LogManager.getLogger(TopicOperator.class);
@@ -61,13 +66,6 @@ class TopicOperator {
         private final String message;
         private final HasMetadata involvedObject;
         private final Handler<AsyncResult<Void>> handler;
-
-        public Event(OperatorException exception, Handler<AsyncResult<Void>> handler) {
-            this.involvedObject = exception.getInvolvedObject();
-            this.message = exception.getMessage();
-            this.handler = handler;
-            this.eventType = EventType.WARNING;
-        }
 
         public Event(HasMetadata involvedObject, String message, EventType eventType, Handler<AsyncResult<Void>> handler) {
             this.involvedObject = involvedObject;
@@ -114,13 +112,19 @@ class TopicOperator {
         }
     }
 
+    private Future<KafkaTopic> createResource(LogContext logContext, Topic topic) {
+        Future<KafkaTopic> result = Future.future();
+        enqueue(new CreateResource(logContext, topic, result));
+        return result;
+    }
+
     /** Topic created in ZK */
     class CreateResource implements Handler<Void> {
         private final Topic topic;
-        private final Handler<io.vertx.core.AsyncResult<Void>> handler;
+        private final Handler<io.vertx.core.AsyncResult<KafkaTopic>> handler;
         private final LogContext logContext;
 
-        public CreateResource(LogContext logContext, Topic topic, Handler<io.vertx.core.AsyncResult<Void>> handler) {
+        public CreateResource(LogContext logContext, Topic topic, Handler<io.vertx.core.AsyncResult<KafkaTopic>> handler) {
             this.logContext = logContext;
             this.topic = topic;
             this.handler = handler;
@@ -136,6 +140,12 @@ class TopicOperator {
         public String toString() {
             return "CreateResource(topicName=" + topic.getTopicName() + ",ctx=" + logContext + ")";
         }
+    }
+
+    private Future<Void> deleteResource(LogContext logContext, ResourceName resourceName) {
+        Future<Void> result = Future.future();
+        enqueue(new DeleteResource(logContext, resourceName, result));
+        return result;
     }
 
     /** Topic deleted in ZK */
@@ -154,6 +164,7 @@ class TopicOperator {
         @Override
         public void handle(Void v) {
             k8s.deleteResource(resourceName).setHandler(handler);
+            statusUpdateGeneration.remove(resourceName.toString());
         }
 
         @Override
@@ -162,14 +173,20 @@ class TopicOperator {
         }
     }
 
+    private Future<KafkaTopic> updateResource(LogContext logContext, Topic topic) {
+        Future<KafkaTopic> result = Future.future();
+        enqueue(new UpdateResource(logContext, topic, result));
+        return result;
+    }
+
     /** Topic config modified in ZK */
     class UpdateResource implements Handler<Void> {
 
         private final Topic topic;
-        private final Handler<io.vertx.core.AsyncResult<Void>> handler;
+        private final Handler<io.vertx.core.AsyncResult<KafkaTopic>> handler;
         private final LogContext logContext;
 
-        public UpdateResource(LogContext logContext, Topic topic, Handler<AsyncResult<Void>> handler) {
+        public UpdateResource(LogContext logContext, Topic topic, Handler<AsyncResult<KafkaTopic>> handler) {
             this.logContext = logContext;
             this.topic = topic;
             this.handler = handler;
@@ -187,8 +204,15 @@ class TopicOperator {
         }
     }
 
+    private Future<Void> createKafkaTopic(LogContext logContext, Topic topic,
+                                          HasMetadata involvedObject) {
+        Future<Void> result = Future.future();
+        enqueue(new CreateKafkaTopic(logContext, topic, involvedObject, result));
+        return result;
+    }
+
     /** Resource created in k8s */
-    class CreateKafkaTopic implements Handler<Void> {
+    private class CreateKafkaTopic implements Handler<Void> {
 
         private final Topic topic;
         private final HasMetadata involvedObject;
@@ -207,7 +231,8 @@ class TopicOperator {
         public void handle(Void v) throws OperatorException {
             kafka.createTopic(topic).setHandler(ar -> {
                 if (ar.succeeded()) {
-                    LOGGER.info("{}: Created topic '{}' for KafkaTopic '{}'", logContext, topic.getTopicName(), topic.getResourceName());
+                    LOGGER.debug("{}: Created topic '{}' for KafkaTopic '{}'",
+                            logContext, topic.getTopicName(), topic.getResourceName());
                     handler.handle(ar);
                 } else {
                     handler.handle(ar);
@@ -325,6 +350,12 @@ class TopicOperator {
         }
     }
 
+    private Future<Void> deleteKafkaTopic(LogContext logContext, TopicName topicName) {
+        Future<Void> result = Future.future();
+        enqueue(new DeleteKafkaTopic(logContext, topicName, result));
+        return result;
+    }
+
     /** KafkaTopic deleted in k8s */
     class DeleteKafkaTopic implements Handler<Void> {
 
@@ -365,6 +396,7 @@ class TopicOperator {
         this.config = config;
     }
 
+
     /**
      * Run the given {@code action} on the context thread,
      * immediately if there are currently no other actions with the given {@code key},
@@ -403,19 +435,24 @@ class TopicOperator {
         vertx.sharedData().getLockWithTimeout(lockName, timeoutMs, ar -> {
             if (ar.succeeded()) {
                 LOGGER.debug("{}: Lock acquired", logContext);
-                Future<Void> f = Future.future();
-                f.setHandler(ar2 -> {
-                    LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
-                    try {
-                        result.handle(ar2);
-                    } finally {
-                        ar.result().release();
-                        LOGGER.debug("{}: Lock released", logContext);
-                        inflight.compute(key, decrement);
-                    }
-                });
                 LOGGER.debug("{}: Executing action {} on topic {}", logContext, action, lockName);
-                action.handle(f);
+                action.execute().setHandler(ar2 -> {
+                    LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
+                    action.result = ar2;
+                    action.updateStatus(logContext).setHandler(ar3 -> {
+                        if (ar3.failed()) {
+                            LOGGER.error("{}: Error updating KafkaTopic.status for action {}", logContext, action,
+                                    ar3.cause());
+                        }
+                        try {
+                            result.handle(ar2);
+                        } finally {
+                            ar.result().release();
+                            LOGGER.debug("{}: Lock released", logContext);
+                            inflight.compute(key, decrement);
+                        }
+                    });
+                });
             } else {
                 LOGGER.warn("{}: Lock not acquired within {}ms: action {} will not be run", logContext, timeoutMs, action);
                 try {
@@ -451,9 +488,9 @@ class TopicOperator {
      * Topic identification should be by uid/cxid, not by name.
      * Topic identification should be by uid/cxid, not by name.
      */
-    Future<Void> reconcile(final LogContext logContext, final HasMetadata involvedObject,
+    Future<Void> reconcile(Reconciliation reconciliation, final LogContext logContext, final HasMetadata involvedObject,
                    final Topic k8sTopic, final Topic kafkaTopic, final Topic privateTopic) {
-        Future<Void> reconciliationResultHandler = Future.future();
+        final Future<Void> reconciliationResultHandler;
         {
             TopicName topicName = k8sTopic != null ? k8sTopic.getTopicName() : kafkaTopic != null ? kafkaTopic.getTopicName() : privateTopic != null ? privateTopic.getTopicName() : null;
             LOGGER.info("{}: Reconciling topic {}, k8sTopic:{}, kafkaTopic:{}, privateTopic:{}", logContext, topicName, k8sTopic == null ? "null" : "nonnull", kafkaTopic == null ? "null" : "nonnull", privateTopic == null ? "null" : "nonnull");
@@ -463,77 +500,83 @@ class TopicOperator {
                 if (kafkaTopic == null) {
                     // All three null: This happens reentrantly when a topic or KafkaTopic is deleted
                     LOGGER.debug("{}: All three topics null during reconciliation.", logContext);
-                    reconciliationResultHandler.handle(Future.succeededFuture());
+                    reconciliationResultHandler = Future.succeededFuture();
                 } else {
                     // it's been created in Kafka => create in k8s and privateState
                     LOGGER.debug("{}: topic created in kafka, will create KafkaTopic in k8s and topicStore", logContext);
-                    enqueue(new CreateResource(logContext, kafkaTopic, ar -> {
-                        // In all cases, create in privateState
-                        if (ar.succeeded()) {
-                            enqueue(new CreateInTopicStore(logContext, kafkaTopic, involvedObject, reconciliationResultHandler));
-                        } else {
-                            reconciliationResultHandler.handle(ar);
-                        }
-                    }));
+                    reconciliationResultHandler = createResource(logContext, kafkaTopic)
+                            .compose(createdKt -> {
+                                reconciliation.observedTopicFuture(createdKt);
+                                return createInTopicStore(logContext, kafkaTopic, involvedObject);
+                            });
                 }
             } else if (kafkaTopic == null) {
                 // it's been created in k8s => create in Kafka and privateState
                 LOGGER.debug("{}: KafkaTopic created in k8s, will create topic in kafka and topicStore", logContext);
-                enqueue(new CreateKafkaTopic(logContext, k8sTopic, involvedObject, ar -> {
-                    // In all cases, create in privateState
-                    if (ar.succeeded()) {
-                        enqueue(new CreateInTopicStore(logContext, k8sTopic, involvedObject, reconciliationResultHandler));
-                    } else {
-                        reconciliationResultHandler.handle(ar);
-                    }
-                }));
+                reconciliationResultHandler = createKafkaTopic(logContext, k8sTopic, involvedObject)
+                    .compose(ignore -> createInTopicStore(logContext, k8sTopic, involvedObject))
+                    // Kafka will set the message.format.version, so we need to update the KafkaTopic to reflect
+                    // that to avoid triggering another reconciliation
+                    /*.compose(createdKafkaTopic -> {
+                        LOGGER.debug("Getting post-create metadata");
+                        return kafka.topicMetadata(k8sTopic.getTopicName());
+                    })
+                    .compose(meta -> {
+                        LOGGER.debug("Post-create config {}", meta.getConfig());
+                        KafkaTopic topicResource = TopicSerialization.toTopicResource(TopicSerialization.fromTopicMetadata(meta), labels);
+                        LOGGER.debug("Post-create update {}", topicResource);
+                        return k8s.updateResource(topicResource);
+                    }).map((Void) null);*/
+                    .compose(ignored -> getFromKafka(k8sTopic.getTopicName()))
+                    .compose(kafkaTopic2 -> {
+                        LOGGER.debug("Post-create kafka {}", kafkaTopic2);
+                        return update3Way(reconciliation, logContext, involvedObject, k8sTopic, kafkaTopic2, k8sTopic);
+                    });
+                    //.compose(createdKafkaTopic -> update3Way(logContext, involvedObject, k8sTopic, createdKafkaTopic, k8sTopic));
             } else {
-                update2Way(logContext, involvedObject, k8sTopic, kafkaTopic, reconciliationResultHandler);
+                reconciliationResultHandler = update2Way(reconciliation, logContext, involvedObject, k8sTopic, kafkaTopic);
             }
         } else {
             if (k8sTopic == null) {
                 if (kafkaTopic == null) {
                     // delete privateState
                     LOGGER.debug("{}: KafkaTopic deleted in k8s and topic deleted in kafka => delete from topicStore", logContext);
-                    enqueue(new DeleteFromTopicStore(logContext, privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
+                    reconciliationResultHandler = deleteFromTopicStore(logContext, involvedObject, privateTopic.getTopicName());
                 } else {
                     // it was deleted in k8s so delete in kafka and privateState
                     LOGGER.debug("{}: KafkaTopic deleted in k8s => delete topic from kafka and from topicStore", logContext);
-                    enqueue(new DeleteKafkaTopic(logContext, kafkaTopic.getTopicName(), ar -> {
-                        if (ar.succeeded()) {
-                            enqueue(new DeleteFromTopicStore(logContext, privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
-                        } else {
-                            reconciliationResultHandler.handle(ar);
-                        }
-                    }));
-
+                    reconciliationResultHandler = deleteKafkaTopic(logContext, kafkaTopic.getTopicName())
+                        .compose(ignored -> deleteFromTopicStore(logContext, involvedObject, privateTopic.getTopicName()));
                 }
             } else if (kafkaTopic == null) {
                 // it was deleted in kafka so delete in k8s and privateState
                 LOGGER.debug("{}: topic deleted in kafkas => delete KafkaTopic from k8s and from topicStore", logContext);
-                enqueue(new DeleteResource(logContext, privateTopic.getOrAsKubeName(), ar -> {
-                    if (ar.succeeded()) {
-                        enqueue(new DeleteFromTopicStore(logContext, privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
-                    } else {
-                        reconciliationResultHandler.handle(ar);
-                    }
-                }));
+                reconciliationResultHandler = deleteResource(logContext, privateTopic.getOrAsKubeName())
+                        .compose(ignore -> deleteFromTopicStore(logContext, involvedObject, privateTopic.getTopicName()));
             } else {
                 // all three exist
                 LOGGER.debug("{}: 3 way diff", logContext);
-                update3Way(logContext, involvedObject, k8sTopic, kafkaTopic, privateTopic, reconciliationResultHandler);
+                reconciliationResultHandler = update3Way(reconciliation, logContext, involvedObject,
+                        k8sTopic, kafkaTopic, privateTopic);
             }
         }
         return reconciliationResultHandler;
     }
 
-    private void update2Way(LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic, Handler<AsyncResult<Void>> reconciliationResultHandler) {
+    private Future<Void> deleteFromTopicStore(LogContext logContext, HasMetadata involvedObject, TopicName topicName) {
+        Future<Void> reconciliationResultHandler = Future.future();
+        enqueue(new DeleteFromTopicStore(logContext, topicName, involvedObject, reconciliationResultHandler));
+        return reconciliationResultHandler;
+    }
+
+    private Future<Void> update2Way(Reconciliation reconciliation, LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic) {
+        final Future<Void> reconciliationResultHandler;
         TopicDiff diff = TopicDiff.diff(kafkaTopic, k8sTopic);
         if (diff.isEmpty()) {
             // they're the same => do nothing, but still create the private copy
             LOGGER.debug("{}: KafkaTopic created in k8s and topic created in kafka, but they're identical => just creating in topicStore", logContext);
             LOGGER.debug("{}: k8s and kafka versions of topic '{}' are the same", logContext, kafkaTopic.getTopicName());
-            enqueue(new CreateInTopicStore(logContext, kafkaTopic, involvedObject, reconciliationResultHandler));
+            reconciliationResultHandler = createInTopicStore(logContext, kafkaTopic, involvedObject);
         } else if (!diff.changesReplicationFactor()
                 && !diff.changesNumPartitions()
                 && diff.changesConfig()
@@ -542,45 +585,35 @@ class TopicOperator {
             Map<String, String> mergedConfigs = new HashMap<>(kafkaTopic.getConfig());
             mergedConfigs.putAll(k8sTopic.getConfig());
             Topic mergedTopic = new Topic.Builder(kafkaTopic).withConfig(mergedConfigs).build();
-            enqueue(new UpdateResource(logContext, mergedTopic, ar -> {
-                if (ar.succeeded()) {
-                    enqueue(new UpdateKafkaConfig(logContext, mergedTopic, involvedObject, ar2 -> {
-                        if (ar2.succeeded()) {
-                            enqueue(new CreateInTopicStore(logContext, mergedTopic, involvedObject, reconciliationResultHandler));
-                        } else {
-                            reconciliationResultHandler.handle(ar2);
-                        }
-                    }));
-                } else {
-                    reconciliationResultHandler.handle(ar);
-                }
-            }));
+            reconciliationResultHandler = updateResource(logContext, mergedTopic)
+                    .compose(updatedResource -> {
+                        reconciliation.observedTopicFuture(updatedResource);
+                        Future<Void> x = Future.future();
+                        enqueue(new UpdateKafkaConfig(logContext, mergedTopic, involvedObject, x));
+                        return x.compose(ignore -> createInTopicStore(logContext, mergedTopic, involvedObject));
+                    });
         } else {
             // Just use kafka version, but also create a warning event
             LOGGER.debug("{}: KafkaTopic created in k8s and topic created in kafka, and they are irreconcilably different => kafka version wins", logContext);
+            Future<Void> eventFuture = Future.future();
             enqueue(new Event(involvedObject, "KafkaTopic is incompatible with the topic metadata. " +
-                    "The topic metadata will be treated as canonical.", EventType.INFO, ar -> {
-                if (ar.succeeded()) {
-                    enqueue(new UpdateResource(logContext, kafkaTopic, ar2 -> {
-                        if (ar2.succeeded()) {
-                            enqueue(new CreateInTopicStore(logContext, kafkaTopic, involvedObject, reconciliationResultHandler));
-                        } else {
-                            reconciliationResultHandler.handle(ar2);
-                        }
-                    }));
-                } else {
-                    reconciliationResultHandler.handle(ar);
-                }
-            }));
+                    "The topic metadata will be treated as canonical.", EventType.INFO, eventFuture));
+            reconciliationResultHandler = eventFuture
+                .compose(ignored ->
+                    updateResource(logContext, kafkaTopic))
+                .compose(updatedResource -> {
+                    reconciliation.observedTopicFuture(updatedResource);
+                    return createInTopicStore(logContext, kafkaTopic, involvedObject);
+                });
         }
+        return reconciliationResultHandler;
     }
 
-    private void update3Way(LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic, Topic privateTopic,
-                            Handler<AsyncResult<Void>> reconciliationResultHandler) {
+    private Future<Void> update3Way(Reconciliation reconciliation, LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic, Topic privateTopic) {
+        final Future<Void> reconciliationResultHandler;
         if (!privateTopic.getResourceName().equals(k8sTopic.getResourceName())) {
-            reconciliationResultHandler.handle(Future.failedFuture(new OperatorException(involvedObject,
-                    "Topic '" + kafkaTopic.getTopicName() + "' is already managed via KafkaTopic '" + privateTopic.getResourceName() + "' it cannot also be managed via the KafkaTopic '" + k8sTopic.getResourceName() + "'")));
-            return;
+            return Future.failedFuture(new OperatorException(involvedObject,
+                    "Topic '" + kafkaTopic.getTopicName() + "' is already managed via KafkaTopic '" + privateTopic.getResourceName() + "' it cannot also be managed via the KafkaTopic '" + k8sTopic.getResourceName() + "'"));
         }
         TopicDiff oursKafka = TopicDiff.diff(privateTopic, kafkaTopic);
         LOGGER.debug("{}: topicStore->kafkaTopic: {}", logContext, oursKafka);
@@ -591,13 +624,13 @@ class TopicOperator {
             final String message = "KafkaTopic resource and Kafka topic both changed in a conflicting way: " + conflict;
             LOGGER.error("{}: {}", logContext, message);
             enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> { }));
-            reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
+            reconciliationResultHandler = Future.failedFuture(new Exception(message));
         } else {
             TopicDiff merged = oursKafka.merge(oursK8s);
             LOGGER.debug("{}: Diffs do not conflict, merged diff: {}", logContext, merged);
             if (merged.isEmpty()) {
                 LOGGER.info("{}: All three topics are identical", logContext);
-                reconciliationResultHandler.handle(Future.succeededFuture());
+                reconciliationResultHandler = Future.succeededFuture();
             } else {
                 Topic result = merged.apply(privateTopic);
                 int partitionsDelta = merged.numPartitionsDelta();
@@ -606,7 +639,7 @@ class TopicOperator {
                     LOGGER.error("{}: {}", logContext, message);
                     enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> {
                     }));
-                    reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
+                    reconciliationResultHandler = Future.failedFuture(new Exception(message));
                 } else {
                     if (merged.changesReplicationFactor()) {
                         LOGGER.error("{}: Changes replication factor", logContext);
@@ -618,40 +651,50 @@ class TopicOperator {
                     // we could decrease, so order of tasks in the queue will need to change
                     // depending on what the diffs are.
                     LOGGER.debug("{}: Updating KafkaTopic, kafka topic and topicStore", logContext);
-                    // TODO replace this with compose
-                    TopicDiff diff = TopicDiff.diff(k8sTopic, result);
-                    if (diff.isEmpty()) {
-                        LOGGER.debug("{}: No need to update KafkaTopic with {}", logContext, diff);
-                        enqueue(updateTopicStoreAndKafka(logContext, involvedObject, reconciliationResultHandler, merged, result, partitionsDelta));
-                    } else {
-                        LOGGER.debug("{}: Updating KafkaTopic with {}", logContext, diff);
-                        UpdateResource event = new UpdateResource(logContext, result, ar -> {
-                            enqueue(updateTopicStoreAndKafka(logContext, involvedObject, reconciliationResultHandler, merged, result, partitionsDelta));
+                    TopicDiff kubeDiff = TopicDiff.diff(k8sTopic, result);
+                    Future<KafkaTopic> resourceFuture;
+                    if (!kubeDiff.isEmpty()) {
+                        LOGGER.debug("{}: Updating KafkaTopic with {}", logContext, kubeDiff);
+                        resourceFuture = updateResource(logContext, result).map(updatedKafkaTopic -> {
+                            reconciliation.observedTopicFuture(updatedKafkaTopic);
+                            return updatedKafkaTopic;
                         });
-                        enqueue(event);
+                    } else {
+                        LOGGER.debug("{}: No need to update KafkaTopic {}", logContext, kubeDiff);
+                        resourceFuture = Future.succeededFuture();
                     }
+                    reconciliationResultHandler = resourceFuture
+                        .compose(updatedKafkaTopic -> {
+                            Future<Void> configFuture;
+                            TopicDiff kafkaDiff = TopicDiff.diff(kafkaTopic, result);
+                            if (merged.changesConfig()
+                                    && !kafkaDiff.isEmpty()) {
+                                configFuture = Future.future();
+                                LOGGER.debug("{}: Updating kafka config with {}", logContext, kafkaDiff);
+                                enqueue(new UpdateKafkaConfig(logContext, result, involvedObject, configFuture));
+                            } else {
+                                LOGGER.debug("{}: No need to update kafka topic with {}", logContext, kafkaDiff);
+                                configFuture = Future.succeededFuture();
+                            }
+                            return configFuture;
+                        })
+                        .compose(ignored -> {
+                            if (partitionsDelta > 0) {
+                                Future<Void> partitionsFuture = Future.future();
+                                enqueue(new IncreaseKafkaPartitions(logContext, result, involvedObject, partitionsFuture));
+                                return partitionsFuture;
+                            } else {
+                                return Future.succeededFuture();
+                            }
+                        }).compose(ignored -> {
+                            Future<Void> topicStoreFuture = Future.future();
+                            enqueue(new UpdateInTopicStore(logContext, result, involvedObject, topicStoreFuture));
+                            return topicStoreFuture;
+                        });
                 }
             }
         }
-    }
-
-    private Handler<Void> updateTopicStoreAndKafka(LogContext logContext, HasMetadata involvedObject, Handler<AsyncResult<Void>> reconciliationResultHandler, TopicDiff merged, Topic topic, int partitionsDelta) {
-        Handler<Void> topicStoreHandler =
-            ignored -> enqueue(new UpdateInTopicStore(logContext, topic, involvedObject, reconciliationResultHandler));
-        Handler<Void> partitionsHandler;
-        if (partitionsDelta > 0) {
-            partitionsHandler = ar4 -> enqueue(new IncreaseKafkaPartitions(logContext, topic, involvedObject, ar2 -> topicStoreHandler.handle(null)));
-        } else {
-            partitionsHandler = topicStoreHandler;
-        }
-
-        Handler<Void> result;
-        if (merged.changesConfig()) {
-            result = new UpdateKafkaConfig(logContext, topic, involvedObject, ar2 -> partitionsHandler.handle(null));
-        } else {
-            result = partitionsHandler;
-        }
-        return result;
+        return reconciliationResultHandler;
     }
 
     void enqueue(Handler<Void> event) {
@@ -659,35 +702,35 @@ class TopicOperator {
         vertx.runOnContext(event);
     }
 
+
     /** Called when a topic znode is deleted in ZK */
     Future<Void> onTopicDeleted(LogContext logContext, TopicName topicName) {
-        Reconciliation action = new Reconciliation("onTopicDeleted") {
-            @Override
-            public void handle(Future<Void> fut) {
-                reconcileOnTopicChange(logContext, topicName, null)
-                        .setHandler(fut);
-            }
-        };
-        return executeWithTopicLockHeld(logContext, topicName, action);
-
+        return executeWithTopicLockHeld(logContext, topicName,
+            new Reconciliation("onTopicDeleted") {
+                @Override
+                public Future<Void> execute() {
+                    return reconcileOnTopicChange(logContext, topicName, null, this);
+                }
+            });
     }
+
+    private Map<String, Long> statusUpdateGeneration = new HashMap<>();
 
     /**
      * Called when ZK watch notifies of change to topic's config
      */
     Future<Void> onTopicConfigChanged(LogContext logContext, TopicName topicName) {
-        Reconciliation action = new Reconciliation("onTopicConfigChanged") {
-            @Override
-            public void handle(Future<Void> fut) {
-                kafka.topicMetadata(topicName)
-                    .compose(metadata -> {
-                        Topic topic = TopicSerialization.fromTopicMetadata(metadata);
-                        return reconcileOnTopicChange(logContext, topicName, topic);
-                    })
-                    .setHandler(fut);
-            }
-        };
-        return executeWithTopicLockHeld(logContext, topicName, action);
+        return executeWithTopicLockHeld(logContext, topicName,
+                new Reconciliation("onTopicConfigChanged") {
+                    @Override
+                    public Future<Void> execute() {
+                        return kafka.topicMetadata(topicName)
+                                .compose(metadata -> {
+                                    Topic topic = TopicSerialization.fromTopicMetadata(metadata);
+                                    return reconcileOnTopicChange(logContext, topicName, topic, this);
+                                });
+                    }
+                });
     }
 
     /**
@@ -696,8 +739,9 @@ class TopicOperator {
     Future<Void> onTopicPartitionsChanged(LogContext logContext, TopicName topicName) {
         Reconciliation action = new Reconciliation("onTopicPartitionsChanged") {
             @Override
-            public void handle(Future<Void> fut) {
-
+            public Future<Void> execute() {
+                Reconciliation self = this;
+                Future<Void> fut = Future.future();
                 // getting topic information from the private store
                 topicStore.read(topicName).setHandler(topicResult -> {
 
@@ -714,7 +758,7 @@ class TopicOperator {
                                         retry();
                                     } else {
                                         LOGGER.info("Topic {} partitions changed to {}", topicName, kafkaTopic.getNumPartitions());
-                                        reconcileOnTopicChange(logContext, topicName, kafkaTopic)
+                                        reconcileOnTopicChange(logContext, topicName, kafkaTopic, self)
                                             .setHandler(fut);
                                     }
 
@@ -736,6 +780,7 @@ class TopicOperator {
                     };
                     kafka.topicMetadata(topicName).setHandler(handler);
                 });
+                return fut;
             }
         };
         return executeWithTopicLockHeld(logContext, topicName, action);
@@ -744,14 +789,16 @@ class TopicOperator {
     /**
      * Called when one of the ZK watches notifies of a change to the topic
      */
-    private Future<Void> reconcileOnTopicChange(LogContext logContext, TopicName topicName, Topic kafkaTopic) {
+    private Future<Void> reconcileOnTopicChange(LogContext logContext, TopicName topicName, Topic kafkaTopic,
+                                                Reconciliation reconciliation) {
         // Look up the private topic to discover the name of kube KafkaTopic
         return topicStore.read(topicName)
             .compose(storeTopic -> {
                 ResourceName resourceName = storeTopic != null ? storeTopic.getResourceName() : topicName.asKubeName();
                 return k8s.getFromName(resourceName).compose(topic -> {
+                    reconciliation.observedTopicFuture(topic);
                     Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
-                    return reconcile(logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
+                    return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
                 });
             });
     }
@@ -762,8 +809,9 @@ class TopicOperator {
         // is it better to put this check in the topic deleted event?
         Reconciliation action = new Reconciliation("onTopicCreated") {
             @Override
-            public void handle(Future<Void> fut) {
-
+            public Future<Void> execute() {
+                Reconciliation self = this;
+                Future<Void> fut = Future.future();
                 TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, topicMetadataBackOff()) {
 
                     @Override
@@ -779,11 +827,11 @@ class TopicOperator {
                                 // We now have the metadata we need to create the
                                 // resource...
                                 Topic kafkaTopic = TopicSerialization.fromTopicMetadata(metadataResult.result());
-                                reconcileOnTopicChange(logContext, topicName, kafkaTopic)
+                                reconcileOnTopicChange(logContext, topicName, kafkaTopic, self)
                                         .setHandler(fut);
                             }
                         } else {
-                            fut.handle(metadataResult.map((Void) null));
+                            fut.fail(metadataResult.cause());
                         }
                     }
 
@@ -793,13 +841,16 @@ class TopicOperator {
                     }
                 };
                 kafka.topicMetadata(topicName).setHandler(handler);
+                return fut;
             }
         };
         return executeWithTopicLockHeld(logContext, topicName, action);
     }
 
-    abstract class Reconciliation implements Handler<Future<Void>> {
+    abstract class Reconciliation {
         private final String name;
+        public AsyncResult<Void> result;
+        public volatile KafkaTopic topic;
 
         public Reconciliation(String name) {
             this.name = name;
@@ -809,27 +860,107 @@ class TopicOperator {
         public String toString() {
             return name;
         }
-    }
 
-    /** Called when a resource is modified in k8s */
-    Future<Void> onResourceAddedOrModified(LogContext logContext, KafkaTopic modifiedTopic, boolean modified) {
-        final Topic k8sTopic;
-        try {
-            k8sTopic = TopicSerialization.fromTopicResource(modifiedTopic);
-        } catch (InvalidTopicException e) {
-            return Future.failedFuture(e);
+        public abstract Future<Void> execute();
+
+        protected void observedTopicFuture(KafkaTopic observedTopic) {
+            topic = observedTopic;
         }
-        Reconciliation action = new Reconciliation("onResourceModified") {
-            @Override
-            public void handle(Future<Void> fut) {
-                reconcileOnResourceChange(logContext, modifiedTopic, k8sTopic, modified)
-                        .setHandler(fut);
+
+        private Future<Void> updateStatus(LogContext logContext) {
+            try {
+                KafkaTopic topic = this.topic;
+                Future<Void> statusFuture;
+                if (topic != null) {
+                    // Get the existing status and if it's og == g and is has same status then don't update
+                    LOGGER.debug("{}: There is a KafkaTopic to set status on, rv={}, generation={}",
+                            logContext,
+                            topic.getMetadata().getResourceVersion(),
+                            topic.getMetadata().getGeneration());
+                    KafkaTopicStatus kts = new KafkaTopicStatus();
+                    StatusUtils.setStatusConditionAndObservedGeneration(topic, kts, result);
+
+                    StatusDiff ksDiff = new StatusDiff(topic.getStatus(), kts);
+                    if (!ksDiff.isEmpty()) {
+                        statusFuture = Future.future();
+                        k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).setHandler(ar -> {
+                            if (ar.succeeded() && ar.result() != null) {
+                                LOGGER.debug("{}: status was set rv={}, generation={}, observedGeneration={}",
+                                        logContext,
+                                        ar.result().getMetadata().getResourceVersion(),
+                                        ar.result().getMetadata().getGeneration(),
+                                        ar.result().getStatus().getObservedGeneration());
+                                statusUpdateGeneration.put(
+                                        ar.result().getMetadata().getName(),
+                                        ar.result().getMetadata().getGeneration());
+                            } else {
+                                LOGGER.error("{}: Error setting resource status", logContext, ar.cause());
+                            }
+                            statusFuture.handle(ar.map((Void) null));
+                        });
+                    } else {
+                        statusFuture = Future.succeededFuture();
+                    }
+                } else {
+                    LOGGER.debug("{}: No KafkaTopic to set status", logContext);
+                    statusFuture = Future.succeededFuture();
+                }
+                return result.failed() ? Future.failedFuture(result.cause()) : statusFuture;
+            } catch (Throwable t) {
+                LOGGER.error("{}", logContext, t);
+                return Future.failedFuture(t);
             }
-        };
-        return executeWithTopicLockHeld(logContext, new TopicName(modifiedTopic), action);
+        }
     }
 
-    private Future<Void> reconcileOnResourceChange(LogContext logContext, KafkaTopic topicResource, Topic k8sTopic,
+    /** Called when a resource is isModify in k8s */
+    Future<Void> onResourceEvent(LogContext logContext, KafkaTopic modifiedTopic, Watcher.Action action) {
+        return executeWithTopicLockHeld(logContext, new TopicName(modifiedTopic),
+                new Reconciliation("onResourceEvent") {
+                    @Override
+                    public Future<Void> execute() {
+                        return k8s.getFromName(new ResourceName(modifiedTopic))
+                            .compose(mt ->  {
+                                final Topic k8sTopic;
+                                if (mt != null) {
+                                    observedTopicFuture(mt);
+                                    Long generation = statusUpdateGeneration.get(mt.getMetadata().getName());
+                                    LOGGER.debug("{}: last updated generation={}", logContext, generation);
+                                    if (mt.getMetadata() != null
+                                            && mt.getMetadata().getGeneration() != null) {
+                                        if (mt.getMetadata().getGeneration().equals(generation)) {
+                                            // TODO we might also need some way to avoid statusUpdateGeneration getting too big
+                                            // e.g. remove after 10 seconds, for example
+                                            // Or do we not care and maintain this map to avoid unnecessary work always
+                                            // It doesn't scale to many topics so well, but maybe that's not such a huge problem.
+                                            LOGGER.debug("{}: Ignoring modification event caused by my own status update on {}",
+                                                    logContext,
+                                                    mt.getMetadata().getName());
+                                            return Future.succeededFuture();
+                                        } else {
+                                            LOGGER.debug("{}: modifiedTopic.getMetadata().getGeneration()={}",
+                                                    logContext, mt.getMetadata().getGeneration());
+                                        }
+                                    } else {
+                                        LOGGER.debug("{}: modifiedTopic.getMetadata().getGeneration()=null", logContext);
+                                    }
+
+                                    try {
+                                        k8sTopic = TopicSerialization.fromTopicResource(mt);
+                                    } catch (InvalidTopicException e) {
+                                        return Future.failedFuture(e);
+                                    }
+                                } else {
+                                    observedTopicFuture(null);
+                                    k8sTopic = null;
+                                }
+                                return reconcileOnResourceChange(this, logContext, mt != null ? mt : modifiedTopic, k8sTopic, action == Watcher.Action.MODIFIED);
+                            });
+                    }
+                });
+    }
+
+    private Future<Void> reconcileOnResourceChange(Reconciliation reconciliation, LogContext logContext, KafkaTopic topicResource, Topic k8sTopic,
                                            boolean isModify) {
         TopicName topicName = new TopicName(topicResource);
         return CompositeFuture.all(getFromKafka(topicName), getFromTopicStore(topicName))
@@ -843,22 +974,10 @@ class TopicOperator {
                             "Kafka topics cannot be renamed, but KafkaTopic's spec.topicName has changed.",
                             EventType.WARNING, result));
                 } else {
-                    result = reconcile(logContext, topicResource, k8sTopic, kafkaTopic, privateTopic);
+                    result = reconcile(reconciliation, logContext, topicResource, k8sTopic, kafkaTopic, privateTopic);
                 }
                 return result;
             });
-    }
-
-    /** Called when a resource is deleted in k8s */
-    Future<Void> onResourceDeleted(LogContext logContext, KafkaTopic deletedTopic) {
-        Reconciliation action = new Reconciliation("onResourceDeleted") {
-            @Override
-            public void handle(Future<Void> fut) {
-                reconcileOnResourceChange(logContext, deletedTopic, null, false)
-                        .setHandler(fut);
-            }
-        };
-        return executeWithTopicLockHeld(logContext, new TopicName(deletedTopic), action);
     }
 
     private class UpdateInTopicStore implements Handler<Void> {
@@ -888,6 +1007,12 @@ class TopicOperator {
         public String toString() {
             return "UpdateInTopicStore(topicName=" + topic.getTopicName() + ",ctx=" + logContext + ")";
         }
+    }
+
+    private Future<Void> createInTopicStore(LogContext logContext, Topic topic, HasMetadata involvedObject) {
+        Future<Void> result = Future.future();
+        enqueue(new CreateInTopicStore(logContext, topic, involvedObject, result));
+        return result;
     }
 
     class CreateInTopicStore implements Handler<Void> {
@@ -1052,8 +1177,9 @@ class TopicOperator {
                     LogContext logContext = LogContext.periodic(reconciliationType + "-" + tn);
                     futs2.add(executeWithTopicLockHeld(logContext, tn, new Reconciliation("delete-remaining") {
                         @Override
-                        public void handle(Future<Void> event) {
-                            getKafkaAndReconcile(logContext, tn, null, null).setHandler(event);
+                        public Future<Void> execute() {
+                            observedTopicFuture(null);
+                            return getKafkaAndReconcile(this, logContext, tn, null, null);
                         }
                     }));
                 }
@@ -1080,8 +1206,8 @@ class TopicOperator {
                 LogContext logContext = LogContext.periodic(reconciliationType + "kafka " + topicName);
                 futures.add(executeWithTopicLockHeld(logContext, topicName, new Reconciliation("reconcile-from-kafka") {
                     @Override
-                    public void handle(Future<Void> fut) {
-                        getFromTopicStore(topicName).recover(error -> {
+                    public Future<Void> execute() {
+                        return getFromTopicStore(topicName).recover(error -> {
                             failed.put(topicName,
                                     new OperatorException("Error getting KafkaTopic " + topicName + " during "
                                             + reconciliationType + " reconciliation", error));
@@ -1092,17 +1218,16 @@ class TopicOperator {
                                 return Future.succeededFuture();
                             } else {
                                 LOGGER.debug("{}: Have private topic for topic {} in Kafka", logContext, topicName);
-                                return reconcileWithPrivateTopic(logContext, topicName, topic).otherwise(error -> {
-                                    failed.put(topicName, error);
-                                    return null;
-                                }).map(ignored -> {
-                                    succeeded.add(topicName);
-                                    return null;
-                                });
+                                return reconcileWithPrivateTopic(logContext, topicName, topic, this)
+                                    .otherwise(error -> {
+                                        failed.put(topicName, error);
+                                        return null;
+                                    })
+                                    .map(ignored -> {
+                                        succeeded.add(topicName);
+                                        return null;
+                                    });
                             }
-                        }).map(i ->  {
-                            fut.complete();
-                            return null;
                         });
                     }
                 }));
@@ -1124,11 +1249,13 @@ class TopicOperator {
     /**
      * Reconcile the given topic which has the given {@code privateTopic} in the topic store.
      */
-    private Future<Void> reconcileWithPrivateTopic(LogContext logContext, TopicName topicName, Topic privateTopic) {
-        Future<KafkaTopic> kubeFuture = k8s.getFromName(privateTopic.getResourceName());
-        return kubeFuture
+    private Future<Void> reconcileWithPrivateTopic(LogContext logContext, TopicName topicName,
+                                                   Topic privateTopic,
+                                                   Reconciliation reconciliation) {
+        return k8s.getFromName(privateTopic.getResourceName())
             .compose(kafkaTopicResource -> {
-                return getKafkaAndReconcile(logContext, topicName, privateTopic, kafkaTopicResource);
+                reconciliation.observedTopicFuture(kafkaTopicResource);
+                return getKafkaAndReconcile(reconciliation, logContext, topicName, privateTopic, kafkaTopicResource);
             })
             .recover(error -> {
                 LOGGER.error("{}: Error getting KafkaTopic {} for topic {}",
@@ -1138,7 +1265,7 @@ class TopicOperator {
             });
     }
 
-    private Future<Void> getKafkaAndReconcile(LogContext logContext, TopicName topicName,
+    private Future<Void> getKafkaAndReconcile(Reconciliation reconciliation, LogContext logContext, TopicName topicName,
                                               Topic privateTopic, KafkaTopic kafkaTopicResource) {
         logContext.withKubeTopic(kafkaTopicResource);
         Future<Void> topicFuture = Future.future();
@@ -1147,7 +1274,7 @@ class TopicOperator {
             kafka.topicMetadata(topicName)
                 .compose(kafkaTopicMeta -> {
                     Topic topicFromKafka = TopicSerialization.fromTopicMetadata(kafkaTopicMeta);
-                    return reconcile(logContext, kafkaTopicResource, k8sTopic, topicFromKafka, privateTopic);
+                    return reconcile(reconciliation, logContext, kafkaTopicResource, k8sTopic, topicFromKafka, privateTopic);
                 })
                 .setHandler(ar -> {
                     if (ar.failed()) {
@@ -1167,10 +1294,6 @@ class TopicOperator {
         return topicFuture;
     }
 
-    Future<KafkaTopic> getFromKube(ResourceName kubeName) {
-        return k8s.getFromName(kubeName);
-    }
-
     Future<Topic> getFromKafka(TopicName topicName) {
         return kafka.topicMetadata(topicName).map(TopicSerialization::fromTopicMetadata);
     }
@@ -1183,9 +1306,13 @@ class TopicOperator {
                                                 String reconciliationType, ResourceName kubeName, TopicName topicName) {
         return executeWithTopicLockHeld(logContext, topicName, new Reconciliation("reconcile-with-kube") {
             @Override
-            public void handle(Future<Void> fut) {
-                CompositeFuture.all(
-                        getFromKube(kubeName),
+            public Future<Void> execute() {
+                Reconciliation self = this;
+                return CompositeFuture.all(
+                        k8s.getFromName(kubeName).map(kt -> {
+                            observedTopicFuture(kt);
+                            return kt;
+                        }),
                         getFromKafka(topicName),
                         getFromTopicStore(topicName))
                     .compose(compositeResult -> {
@@ -1194,15 +1321,7 @@ class TopicOperator {
                         Topic k8sTopic = TopicSerialization.fromTopicResource(ktr);
                         Topic kafkaTopic = compositeResult.resultAt(1);
                         Topic privateTopic = compositeResult.resultAt(2);
-                        return reconcile(logContext, involvedObject, k8sTopic, kafkaTopic, privateTopic);
-                    })
-                    .setHandler(ar -> {
-                        if (ar.failed()) {
-                            LOGGER.error("{}: Error reconciling KafkaTopic {}", logContext, kubeName, ar.cause());
-                        } else {
-                            LOGGER.info("{}: Success reconciling KafkaTopic {}", logContext, logTopic(involvedObject));
-                        }
-                        fut.handle(ar);
+                        return reconcile(self, logContext, involvedObject, k8sTopic, kafkaTopic, privateTopic);
                     });
             }
         });

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -784,7 +784,7 @@ class TopicOperator {
             .compose(storeTopic -> {
                 ResourceName resourceName = storeTopic != null ? storeTopic.getResourceName() : topicName.asKubeName();
                 return k8s.getFromName(resourceName).compose(topic -> {
-                    reconciliation.observedTopicFuture(topic);
+                    reconciliation.observedTopicFuture(kafkaTopic != null ? topic : null);
                     Topic k8sTopic = TopicSerialization.fromTopicResource(topic);
                     return reconcile(reconciliation, logContext.withKubeTopic(topic), topic, k8sTopic, kafkaTopic, storeTopic);
                 });

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -665,7 +665,9 @@ class TopicOperator {
                             return configFuture;
                         })
                         .compose(ignored -> {
-                            if (partitionsDelta > 0) {
+                            if (partitionsDelta > 0
+                                    // Kafka throws an error if we attempt a noop change #partitions
+                                    && result.getNumPartitions() > kafkaTopic.getNumPartitions()) {
                                 Future<Void> partitionsFuture = Future.future();
                                 enqueue(new IncreaseKafkaPartitions(logContext, result, involvedObject, partitionsFuture));
                                 return partitionsFuture;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -872,7 +872,7 @@ class TopicOperator {
                     if (!ksDiff.isEmpty()) {
                         statusFuture = Future.future();
                         k8s.updateResourceStatus(new KafkaTopicBuilder(topic).withStatus(kts).build()).setHandler(ar -> {
-                            if (ar.succeeded()) {
+                            if (ar.succeeded() && ar.result() != null) {
                                 ObjectMeta metadata = ar.result().getMetadata();
                                 LOGGER.debug("{}: status was set rv={}, generation={}, observedGeneration={}",
                                         logContext,

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.strimzi.operator.common.operator.resource.StatusUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -158,14 +158,6 @@ class TopicSerialization {
                     .withReplicas((int) topic.getNumReplicas())
                     .withConfig(new LinkedHashMap<>(topic.getConfig()))
                 .endSpec()
-                .withNewStatus()
-                    .withObservedGeneration(om != null && om.getGeneration() != null ? om.getGeneration() : 0)
-                    .addNewCondition()
-                        .withLastTransitionTime(StatusUtils.iso8601Now())
-                        .withType("Ready")
-                        .withStatus("True")
-                    .endCondition()
-                .endStatus()
                 .build();
         // for some reason when the `topic.getMetadata().getAnnotations()` is null
         // topic is created with annotations={} (empty map but should be null as well)

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -152,11 +153,19 @@ class TopicSerialization {
                 .withMetadata(om)
                 // TODO .withUid()
                 .withNewSpec()
-                .withTopicName(topic.getTopicName().toString())
-                .withPartitions(topic.getNumPartitions())
-                .withReplicas((int) topic.getNumReplicas())
-                .withConfig(new LinkedHashMap<>(topic.getConfig()))
+                    .withTopicName(topic.getTopicName().toString())
+                    .withPartitions(topic.getNumPartitions())
+                    .withReplicas((int) topic.getNumReplicas())
+                    .withConfig(new LinkedHashMap<>(topic.getConfig()))
                 .endSpec()
+                .withNewStatus()
+                    .withObservedGeneration(om != null && om.getGeneration() != null ? om.getGeneration() : 0)
+                    .addNewCondition()
+                        .withLastTransitionTime(StatusUtils.iso8601Now())
+                        .withType("Ready")
+                        .withStatus("True")
+                    .endCondition()
+                .endStatus()
                 .build();
         // for some reason when the `topic.getMetadata().getAnnotations()` is null
         // topic is created with annotations={} (empty map but should be null as well)

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -117,6 +117,11 @@ class ZkTopicsWatcher {
                 List<String> result = childResult.result();
                 LOGGER.debug("Setting initial children {}", result);
                 this.children = result;
+                // Start watching existing children for config and partition changes
+                for (String child : result) {
+                    tcw.addChild(child);
+                    tw.addChild(child);
+                }
                 this.state = 1;
             });
             return Future.succeededFuture();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/Expt.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/Expt.java
@@ -1,8 +1,0 @@
-/*
- * Copyright 2019, Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
- */
-package io.strimzi.operator.topic;
-
-public class Expt {
-}

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/Expt.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/Expt.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+public class Expt {
+}

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
@@ -104,6 +104,11 @@ public class MockK8s implements K8s {
     }
 
     @Override
+    public Future<Void> updateResourceStatus(KafkaTopic topicResource) {
+        return null;
+    }
+
+    @Override
     public Future<Void> deleteResource(ResourceName resourceName) {
         Future<Void> handler = Future.future();
         AsyncResult<Void> response = deleteResponse.apply(resourceName);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
@@ -7,11 +7,14 @@ package io.strimzi.operator.topic;
 import io.fabric8.kubernetes.api.model.Event;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatusBuilder;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.ext.unit.TestContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,8 +120,15 @@ public class MockK8s implements K8s {
         return handler;
     }
 
+    private List<KafkaTopicStatus> statuses = new ArrayList<>();
+
+    public List<KafkaTopicStatus> getStatuses() {
+        return Collections.unmodifiableList(statuses);
+    }
+
     @Override
     public Future<KafkaTopic> updateResourceStatus(KafkaTopic topicResource) {
+        statuses.add(new KafkaTopicStatusBuilder(topicResource.getStatus()).build());
         Long generation = topicResource.getMetadata().getGeneration();
         return Future.succeededFuture(new KafkaTopicBuilder(topicResource)
                 .editMetadata()

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.topic;
 
+import io.fabric8.kubernetes.client.Watcher;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.Future;
 
@@ -113,14 +114,10 @@ class MockTopicOperator extends TopicOperator {
     }
 
     @Override
-    public Future<Void> onResourceAddedOrModified(LogContext logContext, KafkaTopic resource, boolean modified) {
-        mockOperatorEvents.add(new MockOperatorEvent(modified ? MockOperatorEvent.Type.MODIFY : MockOperatorEvent.Type.CREATE, resource));
+    public Future<Void> onResourceEvent(LogContext logContext, KafkaTopic resource, Watcher.Action action) {
+        mockOperatorEvents.add(new MockOperatorEvent(action == Watcher.Action.MODIFIED ? MockOperatorEvent.Type.MODIFY :
+                action == Watcher.Action.ADDED ? MockOperatorEvent.Type.CREATE :
+                MockOperatorEvent.Type.DELETE, resource));
         return resourceAddedResult;
-    }
-
-    @Override
-    public Future<Void> onResourceDeleted(LogContext logContext, KafkaTopic resource) {
-        mockOperatorEvents.add(new MockOperatorEvent(MockOperatorEvent.Type.DELETE, resource));
-        return resourceDeletedResult;
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
@@ -30,11 +30,10 @@ class MockZk implements Zk {
         }
     }
 
-    public void triggerData(AsyncResult<byte[]> dataResult) {
-        if (!dataHandlers.isEmpty()) {
-            for (Handler<AsyncResult<byte[]>> handler: dataHandlers.values()) {
-                handler.handle(dataResult);
-            }
+    public void triggerData(String path, AsyncResult<byte[]> dataResult) {
+        Handler<AsyncResult<byte[]>> asyncResultHandler = dataHandlers.get(path);
+        if (asyncResultHandler != null) {
+            asyncResultHandler .handle(dataResult);
         }
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -55,6 +55,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.HashMap;
@@ -107,7 +109,7 @@ public class TopicOperatorIT extends BaseITST {
     private Session session;
 
     @BeforeClass
-    public static void setupKubeCluster() {
+    public static void setupKubeCluster() throws IOException {
         try {
             KubeCluster.bootstrap();
         } catch (NoClusterException e) {
@@ -116,10 +118,16 @@ public class TopicOperatorIT extends BaseITST {
         cmdKubeClient()
                 .createNamespace(NAMESPACE);
         oldNamespace = setNamespace(NAMESPACE);
-        cmdKubeClient()
-                .create("../install/topic-operator/02-Role-strimzi-topic-operator.yaml")
-                .create(TestUtils.CRD_TOPIC)
-                .create("src/test/resources/TopicOperatorIT-rbac.yaml");
+        LOGGER.info("#### Creating " + "../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
+        LOGGER.info(new String(Files.readAllBytes(new File("../install/topic-operator/02-Role-strimzi-topic-operator.yaml").toPath())));
+        cmdKubeClient().create("../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
+        LOGGER.info("#### Creating " + TestUtils.CRD_TOPIC);
+        LOGGER.info(new String(Files.readAllBytes(new File(TestUtils.CRD_TOPIC).toPath())));
+        cmdKubeClient().create(TestUtils.CRD_TOPIC);
+        LOGGER.info("#### Creating " + "src/test/resources/TopicOperatorIT-rbac.yaml");
+        LOGGER.info(new String(Files.readAllBytes(new File("src/test/resources/TopicOperatorIT-rbac.yaml").toPath())));
+
+        cmdKubeClient().create("src/test/resources/TopicOperatorIT-rbac.yaml");
     }
 
     @AfterClass

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -72,7 +73,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
@@ -446,20 +446,13 @@ public class TopicOperatorIT extends BaseITST {
                     && kafkaTopic.getMetadata().getName().equals(evt.getInvolvedObject().getName())).
                     collect(Collectors.toList());
             LOGGER.debug("Waiting for events: {}", filtered.stream().map(evt -> evt.getMessage()).collect(Collectors.toList()));
-            if (!filtered.isEmpty()) {
-                assertEquals(1, filtered.size());
-                Event event = filtered.get(0);
-
-                assertEquals(expectedMessage, event.getMessage());
-                assertEquals(expectedType.name, event.getType());
-                assertNotNull(event.getInvolvedObject());
-                assertNotNull(event.getLastTimestamp());
-                assertEquals("KafkaTopic", event.getInvolvedObject().getKind());
-                assertEquals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName());
-                return true;
-            } else {
-                return false;
-            }
+            return filtered.stream().anyMatch(event ->
+                    Objects.equals(expectedMessage, event.getMessage()) &&
+                    Objects.equals(expectedType.name, event.getType()) &&
+                    event.getInvolvedObject() != null &&
+                    event.getLastTimestamp() != null &&
+                    Objects.equals("KafkaTopic", event.getInvolvedObject().getKind()) &&
+                    Objects.equals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName()));
         }, timeout, "Expected an error event");
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -105,7 +105,7 @@ public class TopicOperatorTest {
         KafkaTopic kafkaTopic = new KafkaTopicBuilder().withMetadata(new ObjectMetaBuilder().withName("non-topic").build()).build();
 
         Async async = context.async();
-        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator);
+        K8sTopicWatcher w = new K8sTopicWatcher(topicOperator, Future.succeededFuture());
         w.eventReceived(ADDED, kafkaTopic);
         mockKafka.assertEmpty(context);
         mockTopicStore.assertEmpty(context);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -385,7 +385,7 @@ public class TopicOperatorTest {
         mockK8s.createResource(topicResource).setHandler(ar -> async0.countDown());
 
         Async async = context.async(1);
-        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockKafka.assertExists(context, kubeTopic.getTopicName());
             mockTopicStore.assertExists(context, kubeTopic.getTopicName());
@@ -421,7 +421,7 @@ public class TopicOperatorTest {
 
         Async async = context.async();
 
-        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockKafka.assertNotExists(context, kubeTopic.getTopicName());
             mockTopicStore.assertNotExists(context, kubeTopic.getTopicName());
@@ -449,7 +449,7 @@ public class TopicOperatorTest {
         async0.await();
         LogContext logContext = LogContext.periodic(topicName.toString());
         Async async = context.async(2);
-        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
             mockK8s.assertExists(context, topicName.asKubeName());
@@ -488,7 +488,7 @@ public class TopicOperatorTest {
         async0.await();
         LogContext logContext = LogContext.periodic(topicName.toString());
         Async async = context.async();
-        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertNotExists(context, topicName);
             mockK8s.assertNotExists(context, topicName.asKubeName());
@@ -519,7 +519,7 @@ public class TopicOperatorTest {
         async0.await();
 
         Async async = context.async();
-        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, null, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
             mockK8s.assertExists(context, topicName.asKubeName());
@@ -560,7 +560,7 @@ public class TopicOperatorTest {
         async0.await();
 
         Async async = context.async(2);
-        topicOperator.reconcile(logContext, topic, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, topic, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockTopicStore.assertExists(context, topicName);
             mockK8s.assertExists(context, topicName.asKubeName());
@@ -602,7 +602,7 @@ public class TopicOperatorTest {
         async0.await();
 
         Async async = context.async(2);
-        topicOperator.reconcile(logContext, topic, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, topic, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockK8s.assertContainsEvent(context, e ->
                     e.getMessage().contains("KafkaTopic is incompatible with the topic metadata. " +
@@ -650,7 +650,7 @@ public class TopicOperatorTest {
         async0.await();
 
         Async async = context.async(3);
-        topicOperator.reconcile(logContext, resource, kubeTopic, kafkaTopic, privateTopic, reconcileResult -> {
+        topicOperator.reconcile(logContext, resource, kubeTopic, kafkaTopic, privateTopic).setHandler(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockK8s.assertNoEvents(context);
             mockTopicStore.read(topicName).setHandler(readResult -> {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR add support for `KafkaTopic.status` and fixes some bugs which were exposed in the process.

* `CrdOperations.updateStatus()` is changed so that it returns the updated CR
* The K8s interface is changed so that operations return the create/updated `KafkaTopic` (which we use at the end of the reconciliation)
* The TopicOperator is extensively refactored:
    * Where possible simplifications are made (taking advantage of introduction of Future in APIs of other classes)
    * We switch to using `Future` internally within the TopicOperator
    * The Reconciliation class is used to track the current version of the KafkaTopic being reconciled (making use of the changes in the K8s interface)
    * When a reconciliation happens due to kubernetes event received by the watcher we refetch the relevent topic with the topic lock held to avoid possible races.
    * We introduce a Map<ResourceName, metadata.generation> tracking which topics were successfully updated.
      This allows the operator to finish no-op reconciliations early and ignore events caused by status updates.
    * When a reconciliation happens due to kubernetes CREATED event it is necessary to fetch the topic metadata again (which will have `message.format.version`) and update the Kubernetes topic (to set its `message.format.version`). This is done using `update3way()` in this code path. This avoids a "thundering herd"-type problem which resulted in events causing reconciliations causing events. The aforementioned Map<ResourceName, metadata.generation> means that the notification due to topic update exits early.
    * At the end of the reconciliation, but still with the lock held we update the status. 
      It is necessary to do this with the lock held, otherwise the update triggers the watch which would otherwise proceed even though there's no work to do.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

