### PR TITLE
Added the Grafana YAML in the release

### DIFF
--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -7,11 +7,13 @@ RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/examples/$(PROJECT_NAME)
 
 release:
 	mkdir -p $(RELEASE_PATH)
+	mkdir -p $(RELEASE_PATH)/grafana-install
 	mkdir -p $(RELEASE_PATH)/grafana-dashboards
 	mkdir -p $(RELEASE_PATH)/prometheus-install
 	mkdir -p $(RELEASE_PATH)/prometheus-additional-properties
 	mkdir -p $(RELEASE_PATH)/prometheus-alertmanager-config
 	$(CP) -r ./examples/kafka/* $(RELEASE_PATH)/
+	$(CP) -r ./examples/grafana/*.yaml $(RELEASE_PATH)/grafana-install/
 	$(CP) -r ./examples/grafana/*.json $(RELEASE_PATH)/grafana-dashboards/
 	$(CP) -r ./examples/prometheus/install/*.yaml $(RELEASE_PATH)/prometheus-install/
 	$(CP) -r ./examples/prometheus/additional-properties/*.yaml $(RELEASE_PATH)/prometheus-additional-properties/


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The current documentation references the `grafana-install` folder where the Grafana YAML file should be. By the way that folder and file aren't there. This PR fixes it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

