### PR TITLE
Added container environment variables to Kafka template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.0
 
 * Add support for configuring Ingress class (#1716)
+* Add support for setting custom environment variables in the Kafka broker containers
 
 ## 0.13.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
@@ -26,6 +26,8 @@ import java.util.Map;
 @EqualsAndHashCode
 public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private String name;
     private String value;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
@@ -1,44 +1,51 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright 2017-2018, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.api.kafka.model.template;
+
+package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.strimzi.api.kafka.model.ContainerEnvVar;
-import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
- * Representation of a template for Strimzi containers.
+ * Representation for environment variables for Strimzi containers.
  */
 @Buildable(
         editableEnabled = false,
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
-public class ContainerTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {
 
-    private List<ContainerEnvVar> env;
+    private String name;
+    private String value;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Environment variables which should be applied to the container.")
-    public List<ContainerEnvVar> getEnv() {
-        return env;
+    @Description("The environment variable key.")
+    public String getName() {
+        return name;
     }
 
-    public void setEnv(List<ContainerEnvVar> env) {
-        this.env = env;
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Description("The environment variable value.")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
     }
 
     @Override
@@ -50,4 +57,5 @@ public class ContainerTemplate implements Serializable, UnknownPropertyPreservin
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
+
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
@@ -5,7 +5,6 @@
 package io.strimzi.api.kafka.model.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -24,25 +23,12 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({
-        "metadata", "env"})
 @EqualsAndHashCode
 public class ContainerTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private MetadataTemplate metadata;
     private Map<String, String> env;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
-
-    @Description("Metadata which should be applied to the container.")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public MetadataTemplate getMetadata() {
-        return metadata;
-    }
-
-    public void setMetadata(MetadataTemplate metadata) {
-        this.metadata = metadata;
-    }
 
     @Description("Environment variables which should be applied to the container.")
     public Map<String, String> getEnv() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of a template for Strimzi containers.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "metadata", "env"})
+@EqualsAndHashCode
+public class ContainerTemplate implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private MetadataTemplate metadata;
+    private Map<String, String> env;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Metadata which should be applied to the container.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public MetadataTemplate getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(MetadataTemplate metadata) {
+        this.metadata = metadata;
+    }
+
+    @Description("Environment variables which should be applied to the container.")
+    public Map<String, String> getEnv() {
+        return env;
+    }
+
+    public void setEnv(Map<String, String> env) {
+        this.env = env;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -41,6 +41,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private ResourceTemplate externalBootstrapIngress;
     private ResourceTemplate perPodIngress;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
+    private ContainerTemplate kafkaContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka `StatefulSet`.")
@@ -151,6 +152,16 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setPerPodRoute(ResourceTemplate perPodRoute) {
         this.perPodRoute = perPodRoute;
+    }
+
+    @Description("Template for the Kafka broker container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getKafkaContainer() {
+        return kafkaContainer;
+    }
+
+    public void setKafkaContainer(ContainerTemplate kafkaContainer) {
+        this.kafkaContainer = kafkaContainer;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1336,7 +1336,6 @@ public class KafkaCluster extends AbstractModel {
             // Set custom env vars from the user defined template
             for (ContainerEnvVar templateEnvVar : templateKafkaContainerEnvVars) {
                 if (predefinedEnvs.contains(templateEnvVar.getName())) {
-                    // Do we want to throw an error here?
                     log.warn("User defined container template environment variable " + templateEnvVar.getName() + " is already in use and will be ignored");
                 } else {
                     varList.add(buildEnvVar(templateEnvVar.getName(), templateEnvVar.getValue()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -188,8 +188,6 @@ public class KafkaCluster extends AbstractModel {
     protected Map<String, String> templateExternalBootstrapIngressAnnotations;
     protected Map<String, String> templatePerPodIngressLabels;
     protected Map<String, String> templatePerPodIngressAnnotations;
-    protected Map<String, String> templateKafkaContainerLabels;
-    protected Map<String, String> templateKafkaContainerAnnotations;
     protected Map<String, String> templateKafkaContainerEnvVars;
 
     // Configuration defaults
@@ -467,11 +465,6 @@ public class KafkaCluster extends AbstractModel {
             if (template.getPerPodIngress() != null && template.getPerPodIngress().getMetadata() != null)  {
                 result.templatePerPodIngressLabels = template.getPerPodIngress().getMetadata().getLabels();
                 result.templatePerPodIngressAnnotations = template.getPerPodIngress().getMetadata().getAnnotations();
-            }
-
-            if (template.getKafkaContainer() != null && template.getKafkaContainer().getMetadata() != null) {
-                result.templateKafkaContainerLabels = template.getKafkaContainer().getMetadata().getLabels();
-                result.templateKafkaContainerAnnotations = template.getKafkaContainer().getMetadata().getAnnotations();
             }
 
             if (template.getKafkaContainer() != null && template.getKafkaContainer().getEnv() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -49,6 +49,7 @@ import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAuthorization;
@@ -188,7 +189,7 @@ public class KafkaCluster extends AbstractModel {
     protected Map<String, String> templateExternalBootstrapIngressAnnotations;
     protected Map<String, String> templatePerPodIngressLabels;
     protected Map<String, String> templatePerPodIngressAnnotations;
-    protected Map<String, String> templateKafkaContainerEnvVars;
+    protected List<ContainerEnvVar> templateKafkaContainerEnvVars;
 
     // Configuration defaults
     private static final int DEFAULT_REPLICAS = 3;
@@ -1335,12 +1336,12 @@ public class KafkaCluster extends AbstractModel {
             }
 
             // Set custom env vars from the user defined template
-            for (Map.Entry<String, String> templateEnvVar : templateKafkaContainerEnvVars.entrySet()) {
-                if (predefinedEnvs.contains(templateEnvVar.getKey())) {
+            for (ContainerEnvVar templateEnvVar : templateKafkaContainerEnvVars) {
+                if (predefinedEnvs.contains(templateEnvVar.getName())) {
                     // Do we want to throw an error here?
-                    log.warn("User defined container template environment variable " + templateEnvVar.getKey() + " is already in use and will be ignored");
+                    log.warn("User defined container template environment variable " + templateEnvVar.getName() + " is already in use and will be ignored");
                 } else {
-                    varList.add(buildEnvVar(templateEnvVar.getKey(), templateEnvVar.getValue()));
+                    varList.add(buildEnvVar(templateEnvVar.getName(), templateEnvVar.getValue()));
                 }
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1273,8 +1273,6 @@ public class KafkaCluster extends AbstractModel {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-
-
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.openshift.api.model.Route;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBootstrapOverrideBuilder;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBrokerOverrideBuilder;
 import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
@@ -2233,14 +2234,21 @@ public class KafkaClusterTest {
     @Test
     public void testKafkaContainerEnvVars() {
 
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
         String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
         String testEnvTwoKey = "TEST_ENV_2";
         String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
 
-        Map<String, String> testEnvs = new HashMap<>();
-        testEnvs.put(testEnvOneKey, testEnvOneValue);
-        testEnvs.put(testEnvTwoKey, testEnvTwoValue);
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
         ContainerTemplate kafkaContainer = new ContainerTemplate();
         kafkaContainer.setEnv(testEnvs);
 
@@ -2263,8 +2271,8 @@ public class KafkaClusterTest {
 
         for (EnvVar envVar : kafkaEnvVars) {
 
-            if (testEnvs.containsKey(envVar.getName())) {
-                if (testEnvs.get(envVar.getName()).equals(envVar.getValue())) {
+            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
+                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
                     keyCount++;
                 }
             }
@@ -2276,21 +2284,35 @@ public class KafkaClusterTest {
 
     @Test
     public void testKafkaContainerEnvVarsConflict() {
-
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = KafkaCluster.ENV_VAR_KAFKA_LOG_DIRS;
-        String testEnvOneValue = "test.env.three";
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
         String testEnvTwoKey = "TEST_ENV_2";
         String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        ContainerEnvVar envVar3 = new ContainerEnvVar();
         String testEnvThreeKey = KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION;
         String testEnvThreeValue = "test.env.three";
+        envVar3.setName(testEnvThreeKey);
+        envVar3.setValue(testEnvThreeValue);
+
+        ContainerEnvVar envVar4 = new ContainerEnvVar();
         String testEnvFourKey = "TEST_ENV_4";
         String testEnvFourValue = "test.env.four";
+        envVar4.setName(testEnvFourKey);
+        envVar4.setValue(testEnvFourValue);
 
-        Map<String, String> testEnvs = new HashMap<>();
-        testEnvs.put(testEnvOneKey, testEnvOneValue);
-        testEnvs.put(testEnvTwoKey, testEnvTwoValue);
-        testEnvs.put(testEnvThreeKey, testEnvThreeValue);
-        testEnvs.put(testEnvFourKey, testEnvFourValue);
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        testEnvs.add(envVar3);
+        testEnvs.add(envVar4);
         ContainerTemplate kafkaContainer = new ContainerTemplate();
         kafkaContainer.setEnv(testEnvs);
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -797,7 +797,22 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 |====
 |Property    |Description
 |env  1.2+<.<|Environment variables which should be applied to the container.
-|map
+|xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`] array
+|====
+
+[id='type-ContainerEnvVar-{context}']
+### `ContainerEnvVar` schema reference
+
+Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+
+
+[options="header"]
+|====
+|Property      |Description
+|name   1.2+<.<|The environment variable key.
+|string
+|value  1.2+<.<|The environment variable value.
+|string
 |====
 
 [id='type-PodDisruptionBudgetTemplate-{context}']

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -742,7 +742,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 [id='type-MetadataTemplate-{context}']
 ### `MetadataTemplate` schema reference
 
-Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+Used in: xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 
 
 [options="header"]
@@ -795,10 +795,8 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 
 [options="header"]
 |====
-|Property         |Description
-|metadata  1.2+<.<|Metadata which should be applied to the container.
-|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|env       1.2+<.<|Environment variables which should be applied to the container.
+|Property    |Description
+|env  1.2+<.<|Environment variables which should be applied to the container.
 |map
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -714,6 +714,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |externalBootstrapService  1.2+<.<|Template for Kafka external bootstrap `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|kafkaContainer            1.2+<.<|Template for the Kafka broker container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |perPodIngress             1.2+<.<|Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |perPodRoute               1.2+<.<|Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
@@ -740,7 +742,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 [id='type-MetadataTemplate-{context}']
 ### `MetadataTemplate` schema reference
 
-Used in: xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 
 
 [options="header"]
@@ -783,6 +785,21 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
+|====
+
+[id='type-ContainerTemplate-{context}']
+### `ContainerTemplate` schema reference
+
+Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
+
+
+[options="header"]
+|====
+|Property         |Description
+|metadata  1.2+<.<|Metadata which should be applied to the container.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|env       1.2+<.<|Environment variables which should be applied to the container.
+|map
 |====
 
 [id='type-PodDisruptionBudgetTemplate-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1090,6 +1090,18 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    kafkaContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                     perPodIngress:
                       type: object
                       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1089,7 +1089,14 @@ spec:
                       type: object
                       properties:
                         env:
-                          type: object
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                     perPodIngress:
                       type: object
                       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1088,13 +1088,6 @@ spec:
                     kafkaContainer:
                       type: object
                       properties:
-                        metadata:
-                          type: object
-                          properties:
-                            labels:
-                              type: object
-                            annotations:
-                              type: object
                         env:
                           type: object
                     perPodIngress:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1085,6 +1085,18 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    kafkaContainer:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        env:
+                          type: object
                     perPodIngress:
                       type: object
                       properties:

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
@@ -282,13 +283,21 @@ class KafkaST extends MessagingBaseST {
         kafkaConfig.put("transaction.state.log.replication.factor", "1");
         kafkaConfig.put("default.replication.factor", "1");
 
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
         String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
         String testEnvTwoKey = "TEST_ENV_2";
         String testEnvTwoValue = "test.env.two";
-        Map<String, String> testEnvs = new HashMap<String, String>();
-        testEnvs.put(testEnvOneKey, testEnvOneValue);
-        testEnvs.put(testEnvTwoKey, testEnvTwoValue);
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
         ContainerTemplate kafkaContainer = new ContainerTemplate();
         kafkaContainer.setEnv(testEnvs);
 
@@ -298,12 +307,20 @@ class KafkaST extends MessagingBaseST {
         zookeeperConfig.put("syncLimit", "2");
         zookeeperConfig.put("autopurge.purgeInterval", "1");
 
+        ContainerEnvVar updatedEnvVar2 = new ContainerEnvVar();
         String updatedTestEnvTwoValue = "updated.test.env.two";
+        updatedEnvVar2.setName(testEnvTwoKey);
+        updatedEnvVar2.setValue(updatedTestEnvTwoValue);
+
+        ContainerEnvVar envVar3 = new ContainerEnvVar();
         String testEnvThreeKey = "TEST_ENV_3";
         String testEnvThreeValue = "test.env.three";
-        Map<String, String> updatedTestEnvs = new HashMap<String, String>();
-        updatedTestEnvs.put(testEnvThreeKey, testEnvThreeValue);
-        updatedTestEnvs.put(testEnvTwoKey, updatedTestEnvTwoValue);
+        envVar3.setName(testEnvTwoKey);
+        envVar3.setValue(testEnvTwoValue);
+
+        List<ContainerEnvVar> updatedTestEnvs = new ArrayList<>();
+        updatedTestEnvs.add(updatedEnvVar2);
+        updatedTestEnvs.add(envVar3);
 
         int initialDelaySeconds = 30;
         int timeoutSeconds = 10;


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Allows users to set arbitrary environment variables in the `Kafka.spec.kafka.template.kafkaContainer.env` map that will be applied to the broker containers.
 
* Added Container template to CRD
* Added method to prevent overwriting stimzi env vars
* Added env vars checks to unit and system tests

### Checklist

- [x] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

