### PR TITLE
Ignore some IT on Travis

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -5,8 +5,6 @@
 package io.strimzi.api.kafka.model;
 
 import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.VersionInfo;
 import io.strimzi.test.BaseITST;
 import io.strimzi.test.TestUtils;
 import org.junit.Assume;
@@ -16,10 +14,8 @@ import static org.junit.Assert.assertNotNull;
 
 public abstract class AbstractCrdIT extends BaseITST {
 
-    protected void assumeKube1_11Plus() {
-        VersionInfo version = new DefaultKubernetesClient().getVersion();
-        Assume.assumeTrue("1".equals(version.getMajor())
-                && Integer.parseInt(version.getMinor().split("\\D")[0]) >= 11);
+    protected void assumeNotTravis() {
+        Assume.assumeTrue(System.getenv("TRAVIS") == null);
     }
 
     protected <T extends CustomResource> void createDelete(Class<T> resourceClass, String resource) {

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -24,7 +24,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaMirrorMakerV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(KafkaBridge.class, "KafkaBridgeV1alpha1.yaml");
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -23,7 +23,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaConnectV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(KafkaConnect.class, "KafkaConnectV1alpha1.yaml");
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -23,7 +23,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(Kafka.class, "KafkaV1alpha1.yaml");
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -24,7 +24,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaMirrorMakerV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(KafkaMirrorMaker.class, "KafkaMirrorMakerV1alpha1.yaml");
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -24,7 +24,7 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaTopicV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(KafkaTopic.class, "KafkaTopicV1alpha1.yaml");
     }
     @Test

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -23,7 +23,7 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaUserV1alpha1() {
-        assumeKube1_11Plus();
+        assumeNotTravis();
         createDelete(KafkaUser.class, "KafkaUserV1alpha1.yaml");
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR prevents travis from running some ITs which it previously didn't run because travis was using an old version of Kubernetes 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

