### PR TITLE
Removed Strimzi version from kafka-agent artifact name

### DIFF
--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -O https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA
     && tar xvfz kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C $KAFKA_HOME --strip-components=1 \
     && rm -f kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz*
 
-COPY ./tmp/kafka-agent-${strimzi_version}.jar ${KAFKA_HOME}/libs/
+COPY ./tmp/kafka-agent.jar ${KAFKA_HOME}/libs/
 
 COPY kafka-thirdparty-libs/target/dependency/ ${KAFKA_HOME}/libs/
 

--- a/docker-images/kafka/Makefile
+++ b/docker-images/kafka/Makefile
@@ -7,7 +7,7 @@ clean:
 
 .kafka-agent.tmp: ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp
-	cp ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar tmp/
+	cp ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar tmp/kafka-agent.jar
 	mvn dependency:copy-dependencies $(MVN_ARGS) -f kafka-thirdparty-libs/pom.xml
 	touch .kafka-agent.tmp
 

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -23,7 +23,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 fi
 
 rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/kafka-agent-${STRIMZI_VERSION}.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
+export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/kafka-agent.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Because all the other artifacts (see operators) doesn't have the Strimzi version in their names, this PR removes the same from the kafka-agent name because it sounds to be useless.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

