### PR TITLE
Added timestamps on minikube starting

### DIFF
--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -85,6 +85,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
 
     docker run -d -p 5000:5000 registry
 
+    date +%F_%T
     export KUBECONFIG=$HOME/.kube/config
     sudo -E minikube start --vm-driver=none --kubernetes-version=v1.15.0 \
       --insecure-registry=localhost:5000 --extra-config=apiserver.authorization-mode=RBAC
@@ -92,6 +93,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     sudo -E minikube addons enable default-storageclass
 
     wait_for_minikube
+    date +%F_%T
 
     if [ $? -ne 0 ]
     then


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Just adding timestamps to check the time needed to minikube for starting up.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

