### PR TITLE
Prometheus configuration

### DIFF
--- a/documentation/book/con-metrics-prometheus-resources.adoc
+++ b/documentation/book/con-metrics-prometheus-resources.adoc
@@ -15,3 +15,4 @@ When you apply the Prometheus configuration, the following resources are created
 * A `Prometheus` to manage the configuration of the Prometheus pod.
 * A `PrometheusRule` to manage alerting rules for the Prometheus pod.
 * A `Secret` to manage additional Prometheus settings.
+* A `Service` to allow applications running in the cluster to connect to Prometheus (for example, Grafana using Prometheus as datasource).

--- a/metrics/examples/prometheus/install/prometheus.yaml
+++ b/metrics/examples/prometheus/install/prometheus.yaml
@@ -50,6 +50,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
+  labels:
+    app: strimzi
 spec:
   replicas: 1
   serviceAccountName: prometheus-server
@@ -72,3 +74,19 @@ spec:
   additionalScrapeConfigs:
     name: additional-scrape-configs
     key: prometheus-additional.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app: strimzi
+spec:
+  ports:
+    - name: prometheus
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    prometheus: prometheus
+  type: ClusterIP


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
https://github.com/strimzi/strimzi-kafka-operator/issues/1877
Currently, we are deploying the Prometheus servers without any 'service umbrella'. Fixed.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

