### PR TITLE
[DOC] Added missing include statement to Kafka Bridge configuration assembly

### DIFF
--- a/documentation/book/assembly-deployment-configuration-kafka-bridge.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-bridge.adoc
@@ -29,6 +29,8 @@ include::assembly-kafka-bridge-authentication.adoc[leveloffset=+1]
 
 include::assembly-kafka-bridge-configuration.adoc[leveloffset=+1]
 
+include::assembly-resource-limits-and-requests.adoc[leveloffset=+1]
+
 include::assembly-logging.adoc[leveloffset=+1]
 
 include::assembly-jvm-options.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Included the "CPU and memory resources" assembly in the "Kafka Bridge configuration" assembly. The missing assembly was causing a docs build error in cross-references in the "JVM configuration" module.

I've run AsciiDoctor on this branch in `--safe` and `--verbose` mode and these build errors no longer occur.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

