### PR TITLE
Add Liveness and Readiness probes to Mirror Maker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for configuring Ingress class (#1716)
 * Add support for setting custom environment variables in the Kafka broker containers
+* Add liveness and readiness checks to Mirror Maker
 
 ## 0.13.0
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)
 endif
 
-SUBDIRS=kafka-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init test-client docker-images helm-charts install examples metrics
+SUBDIRS=kafka-agent mirror-maker-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common cluster-operator topic-operator user-operator kafka-init test-client docker-images helm-charts install examples metrics
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -46,6 +46,8 @@ public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializ
     private KafkaMirrorMakerConsumerSpec consumer;
     private KafkaMirrorMakerProducerSpec producer;
     private ResourceRequirements resources;
+    private Probe livenessProbe;
+    private Probe readinessProbe;
     private Affinity affinity;
     private List<Toleration> tolerations;
     private JvmOptions jvmOptions;
@@ -184,6 +186,26 @@ public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializ
 
     public void setResources(ResourceRequirements resources) {
         this.resources = resources;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
     }
 
     @Description("Template for Kafka Mirror Maker resources. " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -387,7 +387,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                         .endExec().build())
                 .withReadinessProbe(ModelUtils.newProbeBuilder(readinessProbeOptions)
                         .withNewExec()
-                        // The kafka-agent will create /var/opt/kafka/kafka-ready in the container
+                        // The mirror-maker-agent will create /tmp/mirror-maker-ready in the container
                         .withCommand("test", "-f", "/tmp/mirror-maker-ready")
                         .endExec().build())
                 .withVolumeMounts(getVolumeMounts())
@@ -427,10 +427,10 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         jvmPerformanceOptions(varList);
 
         /** consumer */
-        setConsumerEnvVars(varList);
+        addConsumerEnvVars(varList);
 
         /** producer */
-        setProducerEnvVars(varList);
+        addProducerEnvVars(varList);
 
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_LIVENESS_PERIOD,
                 String.valueOf(livenessProbeOptions.getPeriodSeconds() != null ? livenessProbeOptions.getPeriodSeconds() : DEFAULT_HEALTHCHECK_PERIOD)));
@@ -445,7 +445,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
      *
      * @param varList   List with environment variables
      */
-    private void setConsumerEnvVars(List<EnvVar> varList) {
+    private void addConsumerEnvVars(List<EnvVar> varList) {
         if (consumer.getTls() != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_CONSUMER, "true"));
 
@@ -481,7 +481,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
      *
      * @param varList   List with environment variables
      */
-    private void setProducerEnvVars(List<EnvVar> varList) {
+    private void addProducerEnvVars(List<EnvVar> varList) {
         if (producer.getTls() != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_PRODUCER, "true"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -145,6 +145,9 @@ public class KafkaMirrorMakerClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_ABORT_ON_SEND_FAILURE).withValue(Boolean.toString(abortOnSendFailure)).build());
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED).withValue(KafkaMirrorMakerCluster.DEFAULT_KAFKA_GC_LOG_ENABLED).build());
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_HEAP_OPTS).withValue(kafkaHeapOpts).build());
+        expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_STRIMZI_LIVENESS_PERIOD).withValue("10").build());
+        expected.add(new EnvVarBuilder().withName(KafkaMirrorMakerCluster.ENV_VAR_STRIMZI_READINESS_PERIOD).withValue("10").build());
+
         return expected;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -736,5 +737,69 @@ public class KafkaMirrorMakerClusterTest {
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"));
+    }
+
+    @Test
+    public void testDefaultProbes() {
+        KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(this.resource, VERSIONS);
+
+        Deployment dep = mmc.generateDeployment(Collections.EMPTY_MAP, true, null, null);
+        Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Probe livenessProbe = cont.getLivenessProbe();
+        Probe readinessProbe = cont.getReadinessProbe();
+
+        assertEquals("/opt/kafka/kafka_mirror_maker_liveness.sh", livenessProbe.getExec().getCommand().get(0));
+        assertEquals(new Integer(60), livenessProbe.getInitialDelaySeconds());
+        assertEquals(new Integer(5), livenessProbe.getTimeoutSeconds());
+
+        assertEquals(3, readinessProbe.getExec().getCommand().size());
+        assertEquals("test", readinessProbe.getExec().getCommand().get(0));
+        assertEquals("-f", readinessProbe.getExec().getCommand().get(1));
+        assertEquals("/tmp/mirror-maker-ready", readinessProbe.getExec().getCommand().get(2));
+        assertEquals(new Integer(60), readinessProbe.getInitialDelaySeconds());
+        assertEquals(new Integer(5), readinessProbe.getTimeoutSeconds());
+
+        assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_READINESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("10"));
+        assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_LIVENESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("10"));
+    }
+
+    @Test
+    public void testConfiguredProbes() {
+        KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
+                .editSpec()
+                    .withNewLivenessProbe()
+                        .withInitialDelaySeconds(120)
+                        .withTimeoutSeconds(10)
+                        .withPeriodSeconds(60)
+                    .endLivenessProbe()
+                    .withNewReadinessProbe()
+                        .withInitialDelaySeconds(121)
+                        .withTimeoutSeconds(11)
+                        .withPeriodSeconds(61)
+                    .endReadinessProbe()
+                .endSpec()
+                .build();
+        KafkaMirrorMakerCluster mmc = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
+
+        Deployment dep = mmc.generateDeployment(Collections.EMPTY_MAP, true, null, null);
+        Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Probe livenessProbe = cont.getLivenessProbe();
+        Probe readinessProbe = cont.getReadinessProbe();
+
+        assertEquals("/opt/kafka/kafka_mirror_maker_liveness.sh", livenessProbe.getExec().getCommand().get(0));
+        assertEquals(new Integer(120), livenessProbe.getInitialDelaySeconds());
+        assertEquals(new Integer(10), livenessProbe.getTimeoutSeconds());
+        assertEquals(new Integer(60), livenessProbe.getPeriodSeconds());
+
+        assertEquals(3, readinessProbe.getExec().getCommand().size());
+        assertEquals("test", readinessProbe.getExec().getCommand().get(0));
+        assertEquals("-f", readinessProbe.getExec().getCommand().get(1));
+        assertEquals("/tmp/mirror-maker-ready", readinessProbe.getExec().getCommand().get(2));
+        assertEquals(new Integer(121), readinessProbe.getInitialDelaySeconds());
+        assertEquals(new Integer(11), readinessProbe.getTimeoutSeconds());
+        assertEquals(new Integer(61), readinessProbe.getPeriodSeconds());
+
+        assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_READINESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("61"));
+        assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_LIVENESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("60"));
     }
 }

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -33,6 +33,7 @@ RUN curl -O https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA
     && rm -f kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz*
 
 COPY ./tmp/kafka-agent.jar ${KAFKA_HOME}/libs/
+COPY ./tmp/mirror-maker-agent.jar ${KAFKA_HOME}/libs/
 
 COPY kafka-thirdparty-libs/target/dependency/ ${KAFKA_HOME}/libs/
 

--- a/docker-images/kafka/Makefile
+++ b/docker-images/kafka/Makefile
@@ -8,6 +8,7 @@ clean:
 .kafka-agent.tmp: ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar
 	test -d tmp || mkdir tmp
 	cp ../../kafka-agent/target/kafka-agent-$(RELEASE_VERSION).jar tmp/kafka-agent.jar
+	cp ../../mirror-maker-agent/target/mirror-maker-agent-$(RELEASE_VERSION).jar tmp/mirror-maker-agent.jar
 	mvn dependency:copy-dependencies $(MVN_ARGS) -f kafka-thirdparty-libs/pom.xml
 	touch .kafka-agent.tmp
 

--- a/docker-images/kafka/scripts/kafka_mirror_maker_liveness.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_liveness.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [ -f /tmp/mirror-maker-alive ] ; then
+  rm /tmp/mirror-maker-alive 2&> /dev/null
+  exit 0
+else
+  exit 1
+fi

--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -47,9 +47,13 @@ fi
 # directory avoids trying to create it (and logging a permission denied error)
 export LOG_DIR="$KAFKA_HOME"
 
+# Enabling the Mirror Maker agent which monitors readiness / liveness
+rm /tmp/mirror-maker-ready /tmp/mirror-maker-alive 2> /dev/null
+export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/mirror-maker-agent.jar=/tmp/mirror-maker-ready:/tmp/mirror-maker-alive:${STRIMZI_READINESS_PERIOD:-10}:${STRIMZI_LIVENESS_PERIOD:-10}"
+
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
+  export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -584,7 +584,7 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 [id='type-Probe-{context}']
 ### `Probe` schema reference
 
-Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-EntityTopicOperatorSpec-{context}[`EntityTopicOperatorSpec`], xref:type-EntityUserOperatorSpec-{context}[`EntityUserOperatorSpec`], xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`], xref:type-TlsSidecar-{context}[`TlsSidecar`], xref:type-TopicOperatorSpec-{context}[`TopicOperatorSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 [options="header"]
@@ -1736,36 +1736,40 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 
 [options="header"]
 |====
-|Property            |Description
-|replicas     1.2+<.<|The number of pods in the `Deployment`.
+|Property               |Description
+|replicas        1.2+<.<|The number of pods in the `Deployment`.
 |integer
-|image        1.2+<.<|The docker image for the pods.
+|image           1.2+<.<|The docker image for the pods.
 |string
-|whitelist    1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B can be achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. Multiple regular expressions separated by commas can be specified as well.
+|whitelist       1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B can be achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. Multiple regular expressions separated by commas can be specified as well.
 |string
-|consumer     1.2+<.<|Configuration of source cluster.
+|consumer        1.2+<.<|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]
-|producer     1.2+<.<|Configuration of target cluster.
+|producer        1.2+<.<|Configuration of target cluster.
 |xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
-|resources    1.2+<.<|Resource constraints (limits and requests).
+|resources       1.2+<.<|Resource constraints (limits and requests).
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|affinity     1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity        1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|tolerations  1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations     1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations.See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|jvmOptions   1.2+<.<|JVM Options for pods.
+|jvmOptions      1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging      1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging         1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics      1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
+|metrics         1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
 |map
-|template     1.2+<.<|Template for Kafka Mirror Maker resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
+|template        1.2+<.<|Template for Kafka Mirror Maker resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
 |xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
-|version      1.2+<.<|The Kafka Mirror Maker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|livenessProbe   1.2+<.<|Pod liveness checking.
+|xref:type-Probe-{context}[`Probe`]
+|readinessProbe  1.2+<.<|Pod readiness checking.
+|xref:type-Probe-{context}[`Probe`]
+|version         1.2+<.<|The Kafka Mirror Maker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
 

--- a/documentation/book/assembly-deployment-configuration-kafka-mirror-maker.adoc
+++ b/documentation/book/assembly-deployment-configuration-kafka-mirror-maker.adoc
@@ -43,6 +43,8 @@ include::assembly-resource-limits-and-requests.adoc[leveloffset=+1]
 
 include::assembly-logging.adoc[leveloffset=+1]
 
+include::assembly-healthchecks.adoc[leveloffset=+1]
+
 include::assembly-metrics.adoc[leveloffset=+1]
 
 include::assembly-jvm-options.adoc[leveloffset=+1]

--- a/documentation/book/ref-healthchecks.adoc
+++ b/documentation/book/ref-healthchecks.adoc
@@ -16,6 +16,7 @@ Liveness and readiness probes can be configured using the `livenessProbe` and `r
 * `Kafka.spec.entityOperator.userOperator`
 * `KafkaConnect.spec`
 * `KafkaConnectS2I.spec`
+* `KafkaMirrorMaker.spec`
 * `KafkaBridge.spec`
 
 Both `livenessProbe` and `readinessProbe` support two additional options:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -753,6 +753,36 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                periodSeconds:
+                  type: integer
+                successThreshold:
+                  type: integer
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                periodSeconds:
+                  type: integer
+                successThreshold:
+                  type: integer
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
             version:
               type: string
           required:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -748,6 +748,36 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                periodSeconds:
+                  type: integer
+                successThreshold:
+                  type: integer
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                periodSeconds:
+                  type: integer
+                successThreshold:
+                  type: integer
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
             version:
               type: string
           required:

--- a/mirror-maker-agent/Makefile
+++ b/mirror-maker-agent/Makefile
@@ -1,0 +1,11 @@
+PROJECT_NAME=mirror-maker-agent
+
+docker_build: java_install
+docker_push:
+docker_tag:
+all: docker_build docker_push
+clean: java_clean
+
+include ../Makefile.maven
+
+.PHONY: build clean release

--- a/mirror-maker-agent/pom.xml
+++ b/mirror-maker-agent/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>strimzi</artifactId>
+        <groupId>io.strimzi</groupId>
+        <version>0.14.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mirror-maker-agent</artifactId>
+
+    <dependencies>
+        <!-- Note these dependencies are aligned with those in Kafka.
+        The scope is provided because the agent's classloader is the system class loader,
+        which is the class loader which loads the class containing the application main method.
+        So these classes will already be available to that classloader (because they're on the classpath).
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Premain-Class>io.strimzi.mirrormaker.agent.MirrorMakerAgent</Premain-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
+++ b/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.mirrormaker.agent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.JMException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+
+/**
+ * A Java agent which helps with the Readiness and Liveness check in Kafka Mirror Maker.
+ *
+ * Liveness:
+ *   In every loop it touches a liveness file if it doesn't exist. The file is expected to tbe deleted by the Kubernetes
+ *   liveness probe. So it should be periodically deleted and recreated.
+ *
+ * Readiness:
+ *   Readiness checks the number of connections to the source and target Kafka clusters. If at least one connection
+ *   exists to each of the clusters, the readiness file will be created. If not it will be deleted.
+ */
+public class MirrorMakerAgent {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MirrorMakerAgent.class);
+
+    private final File livenessFile;
+    private final File readinessFile;
+    private final long readinessSleepInterval;
+    private final long livenessSleepInterval;
+
+    public MirrorMakerAgent(File readinessFile, File livenessFile, long readinessSleepInterval, long livenessSleepInterval) {
+        this.readinessFile = readinessFile;
+        this.livenessFile = livenessFile;
+        this.readinessSleepInterval = readinessSleepInterval;
+        this.livenessSleepInterval = livenessSleepInterval;
+    }
+
+    /**
+     * Starts two poller threads - one for readiness and one for liveness.
+     */
+    private void run() {
+        LOGGER.info("Starting readiness poller");
+        Thread readinessThread = new Thread(readinessPoller(), "ReadinessPoller");
+        readinessThread.setDaemon(true);
+        readinessThread.start();
+
+        LOGGER.info("Starting liveness poller");
+        Thread livenessThread = new Thread(livenessPoller(), "LivenessPoller");
+        livenessThread.setDaemon(true);
+        livenessThread.start();
+    }
+
+    /**
+     * Creates the poller thread for the liveness check
+     *
+     * @return Runable for liveness check
+     */
+    private Runnable livenessPoller() {
+        return new Runnable() {
+            int i = 0;
+
+            @Override
+            public void run() {
+                while (true) {
+                    if (!livenessFile.exists()) {
+                        try {
+                            LOGGER.debug("Mirror Maker is alive");
+                            touch(livenessFile);
+                        } catch (IOException e) {
+                            LOGGER.error("Could not write liveness file {}", livenessFile, e);
+                        }
+                    }
+
+                    try {
+                        Thread.sleep(livenessSleepInterval);
+                    } catch (InterruptedException e) {
+                        // In theory this should never normally happen
+                        LOGGER.warn("Unexpectedly interrupted");
+                        break;
+                    }
+                }
+                LOGGER.debug("Exiting thread");
+            }
+        };
+    }
+
+    /**
+     * Creates the poller thread for the readiness check
+     *
+     * @return Runable for readiness check
+     */
+    private Runnable readinessPoller() {
+        return new Runnable() {
+            private MBeanServerConnection beanConn;
+
+            @Override
+            public void run() {
+                beanConn = ManagementFactory.getPlatformMBeanServer();
+
+                while (true) {
+                    if (handleProducerConnected() && handleConsumerConnected()) {
+                        try {
+                            LOGGER.debug("Mirror Maker is ready");
+                            touch(readinessFile);
+                        } catch (IOException e) {
+                            LOGGER.error("Could not write readiness file {}", readinessFile, e);
+                        }
+                    } else {
+                        LOGGER.debug("Mirror Maker is not ready");
+                        readinessFile.delete();
+                    }
+
+                    try {
+                        Thread.sleep(readinessSleepInterval);
+                    } catch (InterruptedException e) {
+                        // In theory this should never normally happen
+                        LOGGER.warn("Unexpectedly interrupted");
+                        break;
+                    }
+                }
+                LOGGER.debug("Exiting thread");
+            }
+
+            /**
+             * Gets the producer connections from JMX and counts them.
+             *
+             * @return True if at least one producer connections exists. False otherwise.
+             */
+            boolean handleProducerConnected() {
+                LOGGER.debug("Polling for producer connections");
+                Double connectionCount = 0.0D;
+
+                try {
+                    Set<ObjectName> mbeans = beanConn.queryNames(new ObjectName("kafka.producer:type=producer-metrics,client-id=*"), null);
+
+                    for (ObjectName oName : mbeans) {
+                        MBeanInfo info = beanConn.getMBeanInfo(oName);
+                        Double attr = (Double) beanConn.getAttribute(oName, "connection-count");
+                        connectionCount += attr;
+                        LOGGER.trace("Found connection metric with name {} and value: {}", oName, attr);
+                    }
+                }   catch (IOException | JMException e) {
+                    LOGGER.error("Failed to query JMX metrics", e);
+                }   finally {
+                    LOGGER.trace("Total producer connections {}", connectionCount);
+                    return connectionCount > 0;
+                }
+            }
+
+            /**
+             * Gets the consumer connections from JMX and counts them.
+             *
+             * @return True if at least one consumer connections exists. False otherwise.
+             */
+            boolean handleConsumerConnected() {
+                LOGGER.debug("Polling for consumer connections");
+                Double connectionCount = 0.0D;
+
+                try {
+                    Set<ObjectName> mbeans = beanConn.queryNames(new ObjectName("kafka.consumer:type=consumer-metrics,client-id=*"), null);
+
+                    for (ObjectName oName : mbeans) {
+                        MBeanInfo info = beanConn.getMBeanInfo(oName);
+                        Double attr = (Double) beanConn.getAttribute(oName, "connection-count");
+                        connectionCount += attr;
+                        LOGGER.trace("Found connection metric with name {} and value: {}", oName, attr);
+                    }
+                }   catch (IOException | JMException e) {
+                    LOGGER.error("Failed to query JMX metrics", e);
+                }   finally {
+                    LOGGER.trace("Total consumer connections {}", connectionCount);
+                    return connectionCount > 0;
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates the file which indicates readiness or liveness.
+     *
+     * @param file  File which should be created
+     *
+     * @throws IOException
+     */
+    private void touch(File file) throws IOException {
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(file);
+            file.deleteOnExit();
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+
+    /**
+     * Agent entry point
+     *
+     * @param agentArgs The agent arguments
+     */
+    public static void premain(String agentArgs) {
+        String[] args = agentArgs.split(":");
+
+        if (args.length != 4) {
+            LOGGER.error("Unexpected number of arguments ({}): {}", args.length, agentArgs);
+            System.exit(1);
+        } else {
+            File mirrorMakerReadyFile = new File(args[0]);
+            File livenessFile = new File(args[1]);
+
+            if (mirrorMakerReadyFile.exists() && !mirrorMakerReadyFile.delete()) {
+                LOGGER.error("Mirror Maker readiness file already exists and could not be deleted: {}", mirrorMakerReadyFile);
+                System.exit(1);
+            } else if (livenessFile.exists() && !livenessFile.delete()) {
+                LOGGER.error("Liveness file already exists and could not be deleted: {}", livenessFile);
+                System.exit(1);
+            } else {
+                long readinessSleepInterval = Long.parseLong(args[2]) / 2L * 1000L;
+                long livenessSleepInterval = Long.parseLong(args[3]) / 2L * 1000L;
+
+                new MirrorMakerAgent(mirrorMakerReadyFile, livenessFile, readinessSleepInterval, livenessSleepInterval).run();
+            }
+        }
+    }
+}

--- a/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
+++ b/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
@@ -110,7 +110,10 @@ public class MirrorMakerAgent {
                         }
                     } else {
                         LOGGER.debug("Mirror Maker is not ready");
-                        readinessFile.delete();
+
+                        if (!readinessFile.delete()) {
+                            LOGGER.error("Could not delete readiness indicator file {}", readinessFile);
+                        }
                     }
 
                     try {

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
 
     <modules>
         <module>kafka-agent</module>
+        <module>mirror-maker-agent</module>
         <module>test</module>
         <module>test-client</module>
         <module>crd-annotations</module>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This Pr adds liveness and readiness probes for Mirror Maker ... which we surprisingly didn't had yet :-/.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

