### PR TITLE
Improve the Health-check documentation to cover the new options

### DIFF
--- a/documentation/book/ref-healthchecks.adoc
+++ b/documentation/book/ref-healthchecks.adoc
@@ -18,16 +18,15 @@ Liveness and readiness probes can be configured using the `livenessProbe` and `r
 * `KafkaConnectS2I.spec`
 * `KafkaBridge.spec`
 
-Both `livenessProbe` and `readinessProbe` support two additional options:
+Both `livenessProbe` and `readinessProbe` support following options:
 
 * `initialDelaySeconds`
 * `timeoutSeconds`
+* `periodSeconds`
+* `successThreshold`
+* `failureThreshold`
 
-The `initialDelaySeconds` property defines the initial delay before the probe is tried for the first time.
-Default is 15 seconds.
-
-The `timeoutSeconds` property defines timeout of the probe.
-Default is 5 seconds.
+For more information about the `livenessProbe` and `readinessProbe` options, see xref:type-Probe-reference[].
 
 .An example of liveness and readiness probe configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/book/ref-healthchecks.adoc
+++ b/documentation/book/ref-healthchecks.adoc
@@ -18,7 +18,7 @@ Liveness and readiness probes can be configured using the `livenessProbe` and `r
 * `KafkaConnectS2I.spec`
 * `KafkaBridge.spec`
 
-Both `livenessProbe` and `readinessProbe` support following options:
+Both `livenessProbe` and `readinessProbe` support the following options:
 
 * `initialDelaySeconds`
 * `timeoutSeconds`


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In the past we added some more options to the readiness and liveness probe configuration but we didn't document them. This Pr adds the new options and links to the API reference for their detailed description.