### PR TITLE
Add possibility to specify loadBalancerIP address in load balancer type services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Add support for configuring Ingress class (#1716)
 * Add support for setting custom environment variables in the Kafka broker containers
 * Add liveness and readiness checks to Mirror Maker
-
+* Allow configuring loadBalancerIP for LoadBalancer type services
+git 
 ## 0.13.0
 
 * Allow users to manually configure ACL rules (for example, using `kafka-acls.sh`) for special Kafka users `*` and `ANONYMOUS` without them being deleted by the User Operator

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -26,6 +26,7 @@ public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBoots
     private static final long serialVersionUID = 1L;
 
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
+    private String loadBalancerIP;
 
     @Description("Annotations that will be added to the `Service` resource. " +
             "You can use this field to configure DNS providers such as External DNS.")
@@ -36,5 +37,17 @@ public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBoots
 
     public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
         this.dnsAnnotations = dnsAnnotations;
+    }
+
+    @Description("The LoadBalancer will be requested with the IP address specified in this field. " +
+            "This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. " +
+            "This field will be ignored if the cloud-provider does not support the feature.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getLoadBalancerIP() {
+        return loadBalancerIP;
+    }
+
+    public void setLoadBalancerIP(String loadBalancerIP) {
+        this.loadBalancerIP = loadBalancerIP;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -39,9 +39,9 @@ public class LoadBalancerListenerBootstrapOverride extends ExternalListenerBoots
         this.dnsAnnotations = dnsAnnotations;
     }
 
-    @Description("The LoadBalancer will be requested with the IP address specified in this field. " +
-            "This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. " +
-            "This field will be ignored if the cloud-provider does not support the feature.")
+    @Description("The loadbalancer is requested with the IP address specified in this field. " +
+            "This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. " +
+            "This field is ignored if the cloud provider does not support the feature.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String getLoadBalancerIP() {
         return loadBalancerIP;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -41,9 +41,9 @@ public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOv
         this.dnsAnnotations = dnsAnnotations;
     }
 
-    @Description("The LoadBalancer will be requested with the IP address specified in this field. " +
-            "This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. " +
-            "This field will be ignored if the cloud-provider does not support the feature.")
+    @Description("The loadbalancer is requested with the IP address specified in this field. " +
+            "This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. " +
+            "This field is ignored if the cloud provider does not support the feature.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String getLoadBalancerIP() {
         return loadBalancerIP;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -28,6 +28,7 @@ public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOv
     private static final long serialVersionUID = 1L;
 
     private Map<String, String> dnsAnnotations = new HashMap<>(0);
+    private String loadBalancerIP;
 
     @Description("Annotations that will be added to the `Service` resources for individual brokers. " +
             "You can use this field to configure DNS providers such as External DNS.")
@@ -38,5 +39,17 @@ public class LoadBalancerListenerBrokerOverride extends ExternalListenerBrokerOv
 
     public void setDnsAnnotations(Map<String, String> dnsAnnotations) {
         this.dnsAnnotations = dnsAnnotations;
+    }
+
+    @Description("The LoadBalancer will be requested with the IP address specified in this field. " +
+            "This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. " +
+            "This field will be ignored if the cloud-provider does not support the feature.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getLoadBalancerIP() {
+        return loadBalancerIP;
+    }
+
+    public void setLoadBalancerIP(String loadBalancerIP) {
+        this.loadBalancerIP = loadBalancerIP;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -755,6 +755,10 @@ public abstract class AbstractModel {
     }
 
     protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {
+        return createService(name, type, ports, labels, selector, annotations, null);
+    }
+
+    protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations, String loadBalancerIP) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(name)
@@ -767,6 +771,7 @@ public abstract class AbstractModel {
                     .withType(type)
                     .withSelector(selector)
                     .withPorts(ports)
+                    .withLoadBalancerIP(loadBalancerIP)
                 .endSpec()
                 .build();
         log.trace("Created service {}", service);

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -374,7 +374,7 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |string
 |dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
 |map
-|loadBalancerIP  1.2+<.<|The LoadBalancer will be requested with the IP address specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+|loadBalancerIP  1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.
 |string
 |====
 
@@ -395,7 +395,7 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |integer
 |dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
-|loadBalancerIP  1.2+<.<|The LoadBalancer will be requested with the IP address specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+|loadBalancerIP  1.2+<.<|The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -374,6 +374,8 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |string
 |dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resource. You can use this field to configure DNS providers such as External DNS.
 |map
+|loadBalancerIP  1.2+<.<|The LoadBalancer will be requested with the IP address specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+|string
 |====
 
 [id='type-LoadBalancerListenerBrokerOverride-{context}']
@@ -393,6 +395,8 @@ Used in: xref:type-LoadBalancerListenerOverride-{context}[`LoadBalancerListenerO
 |integer
 |dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
+|loadBalancerIP  1.2+<.<|The LoadBalancer will be requested with the IP address specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+|string
 |====
 
 [id='type-KafkaListenerExternalNodePort-{context}']

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -61,3 +61,31 @@ listeners:
           external-dns.alpha.kubernetes.io/ttl: "60"
 # ...
 ----
+
+= Customizing the load balancer IP addresses
+
+On `loadbalancer` listeners, you can use the `loadBalancerIP` property to request a specific IP address for the load balancer which will be created.
+This could be useful for example when you need to use a load balancer with a specific IP address.
+The `loadBalancerIP` field will be ignored if the cloud-provider does not support the feature.
+
+.Example of an external listener of type `loadbalancer` with specific load balancer IP address requests
+[source,yaml,subs="attributes+"]
+----
+# ...
+listeners:
+  external:
+    type: loadbalancer
+    authentication:
+      type: tls
+    overrides:
+      bootstrap:
+        loadBalancerIP: 172.29.3.10
+      brokers:
+      - broker: 0
+        loadBalancerIP: 172.29.3.1
+      - broker: 1
+        loadBalancerIP: 172.29.3.2
+      - broker: 2
+        loadBalancerIP: 172.29.3.3
+# ...
+----

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -62,13 +62,13 @@ listeners:
 # ...
 ----
 
-= Customizing the load balancer IP addresses
+= Customizing the loadbalancer IP addresses
 
-On `loadbalancer` listeners, you can use the `loadBalancerIP` property to request a specific IP address for the load balancer which will be created.
-This could be useful for example when you need to use a load balancer with a specific IP address.
-The `loadBalancerIP` field will be ignored if the cloud-provider does not support the feature.
+On `loadbalancer` listeners, you can use the `loadBalancerIP` property to request a specific IP address when creating a loadbalancer.
+Use this property when you need to use a loadbalancer with a specific IP address.
+The `loadBalancerIP` field is ignored if the cloud provider does not support the feature.
 
-.Example of an external listener of type `loadbalancer` with specific load balancer IP address requests
+.Example of an external listener of type `loadbalancer` with specific loadbalancer IP address requests
 [source,yaml,subs="attributes+"]
 ----
 # ...


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

This PR fixes the issue #1887. It adds the possibility to specify the `loadBalancerIP` address for load balancer services. When supported by the infrastructure this allows the user to fix / pre-select the IP address for the Kafka cluster. This PR also delivers the updated documentation.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

