### PR TITLE
Improve the S2I builds

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -161,10 +161,10 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         TagReference sourceTag = new TagReference();
         sourceTag.setName(sourceImageTag);
         sourceTag.setFrom(image);
+        sourceTag.setReferencePolicy(new TagReferencePolicyBuilder().withType("Local").build());
 
         if (insecureSourceRepository)   {
             sourceTag.setImportPolicy(new TagImportPolicyBuilder().withInsecure(true).build());
-            sourceTag.setReferencePolicy(new TagReferencePolicyBuilder().withType("Local").build());
         }
 
         ImageStream imageStream = new ImageStreamBuilder()
@@ -248,6 +248,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                         .endSourceStrategy()
                     .endStrategy()
                     .withTriggers(triggerConfigChange, triggerImageChange)
+                    .withSuccessfulBuildsHistoryLimit(5)
+                    .withFailedBuildsHistoryLimit(5)
                 .endSpec()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -241,6 +241,8 @@ public class KafkaConnectS2IClusterTest {
         assertEquals("ConfigChange", bc.getSpec().getTriggers().get(0).getType());
         assertEquals("ImageChange", bc.getSpec().getTriggers().get(1).getType());
         assertEquals(new ImageChangeTrigger(), bc.getSpec().getTriggers().get(1).getImageChange());
+        assertEquals(new Integer(5), bc.getSpec().getSuccessfulBuildsHistoryLimit());
+        assertEquals(new Integer(5), bc.getSpec().getFailedBuildsHistoryLimit());
         checkOwnerReference(kc.createOwnerReference(), bc);
     }
 
@@ -257,7 +259,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals("DockerImage", is.getSpec().getTags().get(0).getFrom().getKind());
         assertEquals(image, is.getSpec().getTags().get(0).getFrom().getName());
         assertNull(is.getSpec().getTags().get(0).getImportPolicy());
-        assertNull(is.getSpec().getTags().get(0).getReferencePolicy());
+        assertEquals("Local", is.getSpec().getTags().get(0).getReferencePolicy().getType());
         checkOwnerReference(kc.createOwnerReference(), is);
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Several improvements should be done to the KafkaConnectS2I BuildConfig and ImageStreams. In particular:
* Add a configuration for number of successful and failed builds to keep (for a start I suggest to hardcode 5 for both)

```yaml
successfulBuildsHistoryLimit: 5
failedBuildsHistoryLimit: 5
```

* Use the `Local` ReferencePolicy in the ImageStreamsTag regardless of the insecureRegistry setting.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally