### PR TITLE
ST: fix testEntityOperatorWithoutUserAndTopicOperators

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 public interface Constants {
     long TIMEOUT_FOR_DEPLOYMENT_CONFIG_READINESS = Duration.ofMinutes(7).toMillis();
     long TIMEOUT_FOR_RESOURCE_CREATION = Duration.ofMinutes(5).toMillis();
+    long TIMEOUT_FOR_SECRET_CREATION = Duration.ofMinutes(2).toMillis();
     long TIMEOUT_FOR_RESOURCE_READINESS = Duration.ofMinutes(7).toMillis();
     long TIMEOUT_FOR_MIRROR_JOIN_TO_GROUP = Duration.ofMinutes(2).toMillis();
     long TIMEOUT_FOR_TOPIC_CREATION = Duration.ofMinutes(1).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -511,7 +511,7 @@ public class Resources extends AbstractResources {
         StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(name), kafka.getSpec().getKafka().getReplicas());
         LOGGER.info("Kafka pods are ready");
         // EO should not be deployed if it does not contain UO and TO
-        if (kafka.getSpec().getEntityOperator() != null) {
+        if (kafka.getSpec().getEntityOperator().getTopicOperator() != null || kafka.getSpec().getEntityOperator().getUserOperator() != null) {
             LOGGER.info("Waiting for Entity Operator pods");
             StUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(name));
             LOGGER.info("Entity Operator pods are ready");

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -453,9 +453,10 @@ public class StUtils {
     }
 
     public static void waitForSecretReady(String secretName) {
-        LOGGER.info("Waiting for secret {}", secretName);
-        TestUtils.waitFor("Expected secret " + secretName + " exists", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        LOGGER.info("Waiting for Kafka user secret {}", secretName);
+        TestUtils.waitFor("Expected secret " + secretName + " exists", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_SECRET_CREATION,
             () -> kubeClient().getSecret(secretName) != null);
+        LOGGER.info("Kafka user secret {} created", secretName);
     }
 
     public static void waitForKafkaUserDeletion(String userName) {
@@ -463,6 +464,7 @@ public class StUtils {
         TestUtils.waitFor("Waits for Kafka user deletion " + userName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(userName).get() == null
         );
+        LOGGER.info("Kafka user {} deleted", userName);
     }
 
     public static void waitForKafkaUserCreationError(String userName, String eoPodName) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix for test `testEntityOperatorWithoutUserAndTopicOperators` and minor fix for recreate env in `UserST`.

### Checklist

- [x] Make sure all tests pass


