### PR TITLE
Update Prometheus JMX Exporter to 0.12.0

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>0.11.0</version>
+            <version>0.12.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.logstash.log4j/jsonevent-layout -->
         <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

There seems to be a new version of the Prometheus JMX Exporter - 0.12.0. This PR updates to it.