### PR TITLE
[DOC] Add supporting docs for KafkaTopicStatus

### DIFF
--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -87,7 +87,7 @@ status:
 +
 The name is used by the xref:con-topic-operator-cluster-label-deploying[Topic Operator] and xref:con-user-operator-cluster-label-deploying-uo[User Operator] to identify the Kafka cluster when creating a topic or user.
 <3> The spec shows the number of partitions and replicas for the topic as well as the configuration parameters for the topic itself. In this example, the retention period for a message to remain in the topic and the segment file size for the log are specified.
-<4> Status conditions for the `KafkaTopic` resource. The `type` condition changed to `Ready` at the date and time described in the `lastTransitionTime`.
+<4> Status conditions for the `KafkaTopic` resource. The `type` condition changed to `Ready` at the `lastTransitionTime`.
 
 Custom resources can be applied to a cluster through the platform CLI. When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -31,8 +31,8 @@ spec: <2>
     - kt <3>
   additionalPrinterColumns: <4>
       # ...
-subresources: 
-  status: {} <5>
+  subresources: 
+    status: {} <5>
   validation: <6>
     openAPIV3Schema:
       properties:
@@ -52,7 +52,7 @@ subresources:
 <2> The specification for this CRD, including the group (domain) name, the plural name and the supported schema version, which are used in the URL to access the API of the topic. The other names are used to identify instance resources in the CLI. For example, `kubectl get kafkatopic my-topic` or `kubectl get kafkatopics`.
 <3> The shortname can be used in CLI commands. For example, `kubectl get kt` can be used as an abbreviation instead of `kubectl get kafkatopic`.
 <4> The information presented when using a `get` command on the custom resource.
-<5> The current status of the CRD.
+<5> The current status of the CRD as described in the xref:type-Kafka-reference[schema reference] for the resource.
 <6> openAPIV3Schema validation provides validation for the creation of topic custom resources. For example, a topic requires at least one partition and one replica.
 
 NOTE: You can identify the CRD YAML files supplied with the {ProductName} installation files, because the file names contain an index number followed by ‘Crd’.

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -60,7 +60,6 @@ NOTE: You can identify the CRD YAML files supplied with the {ProductName} instal
 Here is a corresponding example of a `KafkaTopic` custom resource.
 
 .Kafka topic custom resource
-//SHOULD WE ADD THE STATUS PROPERTY TO THIS EXAMPLE?
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -75,12 +74,20 @@ spec: <3>
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
+status: 
+  conditions: <4>
+    lastTransitionTime: "2019-08-20T11:37:00.706Z" 
+    status: "True"
+    type: Ready
+  observedGeneration: 1
+  / ...
 ----
 <1> The `kind` and `apiVersion` identify the CRD of which the custom resource is an instance.
 <2> A label, applicable only to `KafkaTopic` and `KafkaUser` resources, that defines the name of the Kafka cluster (which is same as the name of the `Kafka` resource) to which a topic or user belongs.
 +
 The name is used by the xref:con-topic-operator-cluster-label-deploying[Topic Operator] and xref:con-user-operator-cluster-label-deploying-uo[User Operator] to identify the Kafka cluster when creating a topic or user.
 <3> The spec shows the number of partitions and replicas for the topic as well as the configuration parameters for the topic itself. In this example, the retention period for a message to remain in the topic and the segment file size for the log are specified.
+<4> Status conditions for the `KafkaTopic` resource. The `type` condition changed to `Ready` at the date and time described in the `lastTransitionTime`.
 
 Custom resources can be applied to a cluster through the platform CLI. When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 

--- a/documentation/book/con-custom-resources-example.adoc
+++ b/documentation/book/con-custom-resources-example.adoc
@@ -31,7 +31,9 @@ spec: <2>
     - kt <3>
   additionalPrinterColumns: <4>
       # ...
-  validation: <5>
+subresources: 
+  status: {} <5>
+  validation: <6>
     openAPIV3Schema:
       properties:
         spec:
@@ -50,13 +52,15 @@ spec: <2>
 <2> The specification for this CRD, including the group (domain) name, the plural name and the supported schema version, which are used in the URL to access the API of the topic. The other names are used to identify instance resources in the CLI. For example, `kubectl get kafkatopic my-topic` or `kubectl get kafkatopics`.
 <3> The shortname can be used in CLI commands. For example, `kubectl get kt` can be used as an abbreviation instead of `kubectl get kafkatopic`.
 <4> The information presented when using a `get` command on the custom resource.
-<5> openAPIV3Schema validation provides validation for the creation of topic custom resources. For example, a topic requires at least one partition and one replica.
+<5> The current status of the CRD.
+<6> openAPIV3Schema validation provides validation for the creation of topic custom resources. For example, a topic requires at least one partition and one replica.
 
 NOTE: You can identify the CRD YAML files supplied with the {ProductName} installation files, because the file names contain an index number followed by ‘Crd’.
 
 Here is a corresponding example of a `KafkaTopic` custom resource.
 
 .Kafka topic custom resource
+//SHOULD WE ADD THE STATUS PROPERTY TO THIS EXAMPLE?
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -33,9 +33,13 @@ m¦KafkaMirrorMaker
 ¦xref:type-KafkaMirrorMakerStatus-reference[]
 ¦The Kafka MirrorMaker tool, if deployed.
 
+m¦KafkaTopic
+¦xref:type-KafkaTopicStatus-reference[]
+¦Kafka topics in your Kafka cluster.
+
 m¦KafkaUser
 ¦xref:type-KafkaUserStatus-reference[]
-¦Kafka users in your cluster.
+¦Kafka users in your Kafka cluster.
 
 m¦KafkaBridge
 ¦xref:type-KafkaBridgeStatus-reference[]
@@ -59,7 +63,7 @@ The `status` property also provides resource-specific information. For example:
 
 A resource's _current state_ is useful for tracking progress related to the resource achieving its _desired state_, as defined by the `spec` property. The status conditions provide the time and reason the state of the resource changed and details of events preventing or delaying the operator from realizing the resource's desired state.
 
-The _last observed generation_ is the generation of the resource that was most recently observed by the operator. If the value of `observedGeneration` is different from the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
+The _last observed generation_ is the generation of the resource that was last reconciled by the Cluster Operator. If the value of `observedGeneration` is different from the value of `metadata.generation`, the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
 
 {ProductName} creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.


### PR DESCRIPTION
### Type of change
- Documentation

### Description

Updated the existing conceptual information on custom resource status to include information on the `KafkaTopic` status. Updated the following modules:

- Strimzi custom resource example - added `subresources. status` to the existing example
- Strimzi custom resource status - added `KafkaTopicStatus` to the table at https://strimzi.io/docs/master/#con-custom-resources-status-str

The custom resource API documentation was updated in #1865 and is visible on the master docs build -- see [KafkaTopic schema reference](https://strimzi.io/docs/master/#type-KafkaTopicStatus-reference).

See also #1833 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

