### PR TITLE
Add to helm chart the capability of watching all namespaces

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -2,9 +2,13 @@
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if $root.Values.watchAnyNamespace }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 metadata:
-  name: strimzi-cluster-operator
+  name: strimzi-cluster-operator-namespaced
   namespace: {{ . }}
   labels:
     app: {{ template "strimzi.name" $root }}

--- a/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -8,7 +8,11 @@ kind: ClusterRoleBinding
 kind: RoleBinding
 {{- end }}
 metadata:
+  {{- if $root.Values.watchAnyNamespace }}
   name: strimzi-cluster-operator-namespaced
+  {{- else }}
+  name: strimzi-cluster-operator
+  {{- end }}
   namespace: {{ . }}
   labels:
     app: {{ template "strimzi.name" $root }}

--- a/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -2,7 +2,11 @@
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if $root.Values.watchAnyNamespace }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 metadata:
   name: strimzi-cluster-operator-entity-operator-delegation
   namespace: {{ . }}

--- a/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -2,7 +2,11 @@
 {{- range append .Values.watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if $root.Values.watchAnyNamespace }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 metadata:
   name: strimzi-cluster-operator-topic-operator-delegation
   namespace: {{ . }}

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -29,6 +29,9 @@ spec:
             - /opt/strimzi/bin/cluster_operator_run.sh
           env:
             - name: STRIMZI_NAMESPACE
+              {{- if .Values.watchAnyNamespace }}
+              value: "*"
+              {{- else }}
               {{- if .Values.watchNamespaces -}}
               {{- $ns := .Values.watchNamespaces -}}
               {{- $ns := append $ns .Release.Namespace }}
@@ -37,6 +40,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+              {{- end }}
               {{- end }}
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: {{ .Values.fullReconciliationIntervalMs | quote }}

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -3,6 +3,7 @@
 # If you set `watchNamespaces` to the same value as ``.Release.Namespace` (e.g. `helm ... --namespace $NAMESPACE`), 
 # the chart will fail because duplicate RoleBindings will be attempted to be created in the same namespace
 watchNamespaces: []
+watchAnyNamespace: false
 
 image:
   repository: strimzi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Helm now is able to watch all namespaces, with the RBAC (RoleBindings to ClusterRoleBindings) also corrected.

Fixes #1661, #1454

