### PR TITLE
ST: fix for skipped tests

### DIFF
--- a/systemtest/scripts/results_info.sh
+++ b/systemtest/scripts/results_info.sh
@@ -29,7 +29,7 @@ TEST_ALL_FAILED_COUNT=$((TEST_ERRORS_COUNT + TEST_FAILURES_COUNT))
 
 SUMMARY="**TEST_PROFILE**: ${TEST_PROFILE}\n**TEST_CASE:** ${TEST_CASE}\n**TOTAL:** ${TEST_COUNT}\n**PASS:** $((TEST_COUNT - TEST_ALL_FAILED_COUNT - TEST_SKIPPED_COUNT))\n**FAIL:** ${TEST_ALL_FAILED_COUNT}\n**SKIP:** ${TEST_SKIPPED_COUNT}\n"
 
-FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs -0 sed -n "s#\(<testcase.*[^\/]>\)#\1#p" | awk -F '"' '{print "\\n- " $2 " in "  $4}')
+FAILED_TESTS=$(find "${RESULTS_PATH}" -name 'TEST*.xml' -type f -print0 | xargs -0 sed -n "s#\(<testcase.*time=\"[0-9]*,\{0,1\}[0-9]\{1,3\}\..*[^\/]>\)#\1#p" | awk -F '"' '{print "\\n- " $2 " in "  $4}')
 echo ${FAILED_TESTS}
 echo "Creating body ..."
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With previous changes for PR build, I forget to count in `skipped` tests. Currently, they are count as failed ones and they are printed into the comment. This PR fix it.

### Checklist

- [x] Make sure all tests pass

