### PR TITLE
Add environment variable setting to all container templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.14.0
 
 * Add support for configuring Ingress class (#1716)
-* Add support for setting custom environment variables in the Kafka broker containers
+* Add support for setting custom environment variables in all containers
 * Add liveness and readiness checks to Mirror Maker
 * Allow configuring loadBalancerIP for LoadBalancer type services
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -32,6 +32,9 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
 
     private ResourceTemplate deployment;
     private PodTemplate pod;
+    private ContainerTemplate topicOperatorContainer;
+    private ContainerTemplate userOperatorContainer;
+    private ContainerTemplate tlsSidecarContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Entity Operator `Deployment`.")
@@ -52,6 +55,36 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
 
     public void setPod(PodTemplate pod) {
         this.pod = pod;
+    }
+
+    @Description("Template for the Entity Topic Operator container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getTopicOperatorContainer() {
+        return topicOperatorContainer;
+    }
+
+    public void setTopicOperatorContainer(ContainerTemplate topicOperatorContainer) {
+        this.topicOperatorContainer = topicOperatorContainer;
+    }
+
+    @Description("Template for the Entity User Operator container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getUserOperatorContainer() {
+        return userOperatorContainer;
+    }
+
+    public void setUserOperatorContainer(ContainerTemplate userOperatorContainer) {
+        this.userOperatorContainer = userOperatorContainer;
+    }
+
+    @Description("Template for the Entity Operator TLS sidecar container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getTlsSidecarContainer() {
+        return tlsSidecarContainer;
+    }
+
+    public void setTlsSidecarContainer(ContainerTemplate tlsSidecarContainer) {
+        this.tlsSidecarContainer = tlsSidecarContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -34,6 +34,7 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
     private PodTemplate pod;
     private ResourceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
+    private ContainerTemplate bridgeContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Bridge `Deployment`.")
@@ -74,6 +75,16 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
         this.podDisruptionBudget = podDisruptionBudget;
+    }
+
+    @Description("Template for the Kafka Bridge container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getBridgeContainer() {
+        return bridgeContainer;
+    }
+
+    public void setBridgeContainer(ContainerTemplate bridgeContainer) {
+        this.bridgeContainer = bridgeContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -42,6 +42,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private ResourceTemplate perPodIngress;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate kafkaContainer;
+    private ContainerTemplate tlsSidecarContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka `StatefulSet`.")
@@ -162,6 +163,16 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setKafkaContainer(ContainerTemplate kafkaContainer) {
         this.kafkaContainer = kafkaContainer;
+    }
+
+    @Description("Template for the Kafka broker TLS sidecar container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getTlsSidecarContainer() {
+        return tlsSidecarContainer;
+    }
+
+    public void setTlsSidecarContainer(ContainerTemplate tlsSidecarContainer) {
+        this.tlsSidecarContainer = tlsSidecarContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -43,6 +43,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate kafkaContainer;
     private ContainerTemplate tlsSidecarContainer;
+    private ContainerTemplate initContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka `StatefulSet`.")
@@ -173,6 +174,16 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setTlsSidecarContainer(ContainerTemplate tlsSidecarContainer) {
         this.tlsSidecarContainer = tlsSidecarContainer;
+    }
+
+    @Description("Template for the Kafka init container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getInitContainer() {
+        return initContainer;
+    }
+
+    public void setInitContainer(ContainerTemplate initContainer) {
+        this.initContainer = initContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -34,6 +34,7 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     private PodTemplate pod;
     private ResourceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
+    private ContainerTemplate connectContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Connect `Deployment`.")
@@ -74,6 +75,16 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
 
     public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
         this.podDisruptionBudget = podDisruptionBudget;
+    }
+
+    @Description("Template for the Kafka Connect container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getConnectContainer() {
+        return connectContainer;
+    }
+
+    public void setConnectContainer(ContainerTemplate connectContainer) {
+        this.connectContainer = connectContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
@@ -33,6 +33,7 @@ public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPr
     private ResourceTemplate deployment;
     private PodTemplate pod;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
+    private ContainerTemplate mirrorMakerContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Mirror Maker `Deployment`.")
@@ -63,6 +64,16 @@ public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPr
 
     public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
         this.podDisruptionBudget = podDisruptionBudget;
+    }
+
+    @Description("Template for Kafka Mirror Maker `Deployment`.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getMirrorMakerContainer() {
+        return mirrorMakerContainer;
+    }
+
+    public void setMirrorMakerContainer(ContainerTemplate mirrorMakerContainer) {
+        this.mirrorMakerContainer = mirrorMakerContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
@@ -66,7 +66,7 @@ public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPr
         this.podDisruptionBudget = podDisruptionBudget;
     }
 
-    @Description("Template for Kafka Mirror Maker `Deployment`.")
+    @Description("Template for Kafka Mirror Maker container")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ContainerTemplate getMirrorMakerContainer() {
         return mirrorMakerContainer;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -35,6 +35,8 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
     private ResourceTemplate clientService;
     private ResourceTemplate nodesService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
+    private ContainerTemplate zookeeperContainer;
+    private ContainerTemplate tlsSidecarContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Zookeeper `StatefulSet`.")
@@ -85,6 +87,26 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
 
     public void setPodDisruptionBudget(PodDisruptionBudgetTemplate podDisruptionBudget) {
         this.podDisruptionBudget = podDisruptionBudget;
+    }
+
+    @Description("Template for the Zookeeper container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getZookeeperContainer() {
+        return zookeeperContainer;
+    }
+
+    public void setZookeeperContainer(ContainerTemplate zookeeperContainer) {
+        this.zookeeperContainer = zookeeperContainer;
+    }
+
+    @Description("Template for the Kafka broker TLS sidevar container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getTlsSidecarContainer() {
+        return tlsSidecarContainer;
+    }
+
+    public void setTlsSidecarContainer(ContainerTemplate tlsSidecarContainer) {
+        this.tlsSidecarContainer = tlsSidecarContainer;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -99,7 +99,7 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
         this.zookeeperContainer = zookeeperContainer;
     }
 
-    @Description("Template for the Kafka broker TLS sidevar container")
+    @Description("Template for the Kafka broker TLS sidecar container")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ContainerTemplate getTlsSidecarContainer() {
         return tlsSidecarContainer;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1202,19 +1202,21 @@ public abstract class AbstractModel {
      **/
     protected void addContainerEnvsToExistingEnvs(List<EnvVar> existingEnvs, List<ContainerEnvVar> containerEnvs) {
 
-        // Create set of env var names to test if any user defined template env vars will conflict with those set above
-        Set<String> predefinedEnvs = new HashSet<String>();
-        for (EnvVar envVar : existingEnvs) {
-            predefinedEnvs.add(envVar.getName());
-        }
+        if (containerEnvs != null) {
+            // Create set of env var names to test if any user defined template env vars will conflict with those set above
+            Set<String> predefinedEnvs = new HashSet<String>();
+            for (EnvVar envVar : existingEnvs) {
+                predefinedEnvs.add(envVar.getName());
+            }
 
-        // Set custom env vars from the user defined template
-        for (ContainerEnvVar containerEnvVar : containerEnvs) {
-            if (predefinedEnvs.contains(containerEnvVar.getName())) {
-                log.warn("User defined container template environment variable " + containerEnvVar.getName() +
-                        " is already in use and will be ignored");
-            } else {
-                existingEnvs.add(buildEnvVar(containerEnvVar.getName(), containerEnvVar.getValue()));
+            // Set custom env vars from the user defined template
+            for (ContainerEnvVar containerEnvVar : containerEnvs) {
+                if (predefinedEnvs.contains(containerEnvVar.getName())) {
+                    log.warn("User defined container template environment variable " + containerEnvVar.getName() +
+                            " is already in use and will be ignored");
+                } else {
+                    existingEnvs.add(buildEnvVar(containerEnvVar.getName(), containerEnvVar.getValue()));
+                }
             }
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1189,7 +1189,6 @@ public abstract class AbstractModel {
             .build();
     }
 
-
     /**
      * Adds the supplied list of container environment variables {@see io.strimzi.api.kafka.model.ContainerEnvVar} to the
      * supplied list of fabric8 environment variables {@see io.fabric8.kubernetes.api.model.EnvVar}, checking first if the

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetUpdateStrategyBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
@@ -70,9 +71,11 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1184,5 +1187,36 @@ public abstract class AbstractModel {
                     .withLabels(labels.toMap())
                 .endMetadata()
             .build();
+    }
+
+
+    /**
+     * Adds the supplied list of container environment variables {@see io.strimzi.api.kafka.model.ContainerEnvVar} to the
+     * supplied list of fabric8 environment variables {@see io.fabric8.kubernetes.api.model.EnvVar}, checking first if the
+     * environment variable key has already been set in the existing list and then converts them. If a key is already in
+     * use then the container environment variable will not be added to the environment variable list and a warning will
+     * be logged.
+     *
+     * @param existingEnvs The list of fabric8 environment variable object that will be modified.
+     * @param containerEnvs The list of container environment variable objects to be converted and added to the existing
+     *                      environment variable list
+     **/
+    protected void addContainerEnvsToExistingEnvs(List<EnvVar> existingEnvs, List<ContainerEnvVar> containerEnvs) {
+
+        // Create set of env var names to test if any user defined template env vars will conflict with those set above
+        Set<String> predefinedEnvs = new HashSet<String>();
+        for (EnvVar envVar : existingEnvs) {
+            predefinedEnvs.add(envVar.getName());
+        }
+
+        // Set custom env vars from the user defined template
+        for (ContainerEnvVar containerEnvVar : containerEnvs) {
+            if (predefinedEnvs.contains(containerEnvVar.getName())) {
+                log.warn("User defined container template environment variable " + containerEnvVar.getName() +
+                        " is already in use and will be ignored");
+            } else {
+                existingEnvs.add(buildEnvVar(containerEnvVar.getName(), containerEnvVar.getValue()));
+            }
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -285,13 +285,10 @@ public class EntityOperator extends AbstractModel {
 
     protected List<EnvVar> getTlsSidecarEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONNECT, zookeeperConnect));
 
-        if (templateTlsSidecarContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
@@ -64,6 +65,7 @@ public class EntityTopicOperator extends AbstractModel {
     private int zookeeperSessionTimeoutMs;
     private String resourceLabels;
     private int topicMetadataMaxAttempts;
+    protected List<ContainerEnvVar> templateContainerEnvVars;
 
     /**
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
@@ -256,6 +258,11 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
+
+        if (templateContainerEnvVars != null) {
+            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
+        }
+
         return varList;
     }
 
@@ -294,5 +301,9 @@ public class EntityTopicOperator extends AbstractModel {
                 .build();
 
         return rb;
+    }
+
+    public void setContainerEnvVars(List<ContainerEnvVar> envVars) {
+        templateContainerEnvVars = envVars;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -259,9 +259,7 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        if (templateContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -257,9 +257,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        if (templateContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.CertificateAuthority;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
@@ -63,6 +64,7 @@ public class EntityUserOperator extends AbstractModel {
     private long zookeeperSessionTimeoutMs;
     private int clientsCaValidityDays;
     private int clientsCaRenewalDays;
+    protected List<ContainerEnvVar> templateContainerEnvVars;
 
     /**
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
@@ -254,6 +256,11 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
+
+        if (templateContainerEnvVars != null) {
+            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
+        }
+
         return varList;
     }
 
@@ -290,5 +297,9 @@ public class EntityUserOperator extends AbstractModel {
                 .build();
 
         return rb;
+    }
+
+    public void setContainerEnvVars(List<ContainerEnvVar> envVars) {
+        templateContainerEnvVars = envVars;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -406,9 +406,7 @@ public class KafkaBridgeCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_SASL_MECHANISM, saslMechanism));
         }
 
-        if (templateContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1227,9 +1227,7 @@ public class KafkaCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_EXTERNAL_ADVERTISED_ADDRESSES, String.join(" ", externalAddresses)));
         }
 
-        if (templateInitContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateInitContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateInitContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -750,23 +750,23 @@ public class KafkaCluster extends AbstractModel {
 
             Route route = new RouteBuilder()
                     .withNewMetadata()
-                    .withName(perPodServiceName)
-                    .withLabels(getLabelsWithName(perPodServiceName, templatePerPodRouteLabels))
-                    .withAnnotations(mergeLabelsOrAnnotations(null, templatePerPodRouteAnnotations))
-                    .withNamespace(namespace)
-                    .withOwnerReferences(createOwnerReference())
+                        .withName(perPodServiceName)
+                        .withLabels(getLabelsWithName(perPodServiceName, templatePerPodRouteLabels))
+                        .withAnnotations(mergeLabelsOrAnnotations(null, templatePerPodRouteAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
-                    .withNewTo()
-                    .withKind("Service")
-                    .withName(perPodServiceName)
-                    .endTo()
-                    .withNewPort()
-                    .withNewTargetPort(EXTERNAL_PORT)
-                    .endPort()
-                    .withNewTls()
-                    .withTermination("passthrough")
-                    .endTls()
+                        .withNewTo()
+                            .withKind("Service")
+                            .withName(perPodServiceName)
+                        .endTo()
+                        .withNewPort()
+                            .withNewTargetPort(EXTERNAL_PORT)
+                        .endPort()
+                        .withNewTls()
+                            .withTermination("passthrough")
+                        .endTls()
                     .endSpec()
                     .build();
 
@@ -799,23 +799,23 @@ public class KafkaCluster extends AbstractModel {
         if (isExposedWithRoute()) {
             Route route = new RouteBuilder()
                     .withNewMetadata()
-                    .withName(serviceName)
-                    .withLabels(getLabelsWithName(serviceName, templateExternalBootstrapRouteLabels))
-                    .withAnnotations(mergeLabelsOrAnnotations(null, templateExternalBootstrapRouteAnnotations))
-                    .withNamespace(namespace)
-                    .withOwnerReferences(createOwnerReference())
+                        .withName(serviceName)
+                        .withLabels(getLabelsWithName(serviceName, templateExternalBootstrapRouteLabels))
+                        .withAnnotations(mergeLabelsOrAnnotations(null, templateExternalBootstrapRouteAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
-                    .withNewTo()
-                    .withKind("Service")
-                    .withName(externalBootstrapServiceName(cluster))
-                    .endTo()
-                    .withNewPort()
-                    .withNewTargetPort(EXTERNAL_PORT)
-                    .endPort()
-                    .withNewTls()
-                    .withTermination("passthrough")
-                    .endTls()
+                        .withNewTo()
+                            .withKind("Service")
+                            .withName(externalBootstrapServiceName(cluster))
+                        .endTo()
+                        .withNewPort()
+                            .withNewTargetPort(EXTERNAL_PORT)
+                        .endPort()
+                        .withNewTls()
+                            .withTermination("passthrough")
+                        .endTls()
                     .endSpec()
                     .build();
 
@@ -862,15 +862,15 @@ public class KafkaCluster extends AbstractModel {
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
                     .withNewBackend()
-                    .withNewServicePort(EXTERNAL_PORT)
-                    .withServiceName(perPodServiceName)
+                        .withNewServicePort(EXTERNAL_PORT)
+                        .withServiceName(perPodServiceName)
                     .endBackend()
                     .build();
 
             IngressRule rule = new IngressRuleBuilder()
                     .withHost(host)
                     .withNewHttp()
-                    .withPaths(path)
+                        .withPaths(path)
                     .endHttp()
                     .build();
 
@@ -880,15 +880,15 @@ public class KafkaCluster extends AbstractModel {
 
             Ingress ingress = new IngressBuilder()
                     .withNewMetadata()
-                    .withName(perPodServiceName)
-                    .withLabels(getLabelsWithName(perPodServiceName, templatePerPodIngressLabels))
-                    .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templatePerPodIngressAnnotations, dnsAnnotations))
-                    .withNamespace(namespace)
-                    .withOwnerReferences(createOwnerReference())
+                        .withName(perPodServiceName)
+                        .withLabels(getLabelsWithName(perPodServiceName, templatePerPodIngressLabels))
+                        .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templatePerPodIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
-                    .withRules(rule)
-                    .withTls(tls)
+                        .withRules(rule)
+                        .withTls(tls)
                     .endSpec()
                     .build();
 
@@ -919,15 +919,15 @@ public class KafkaCluster extends AbstractModel {
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
                     .withNewBackend()
-                    .withNewServicePort(EXTERNAL_PORT)
-                    .withServiceName(externalBootstrapServiceName(cluster))
+                        .withNewServicePort(EXTERNAL_PORT)
+                        .withServiceName(externalBootstrapServiceName(cluster))
                     .endBackend()
                     .build();
 
             IngressRule rule = new IngressRuleBuilder()
                     .withHost(host)
                     .withNewHttp()
-                    .withPaths(path)
+                        .withPaths(path)
                     .endHttp()
                     .build();
 
@@ -937,15 +937,15 @@ public class KafkaCluster extends AbstractModel {
 
             Ingress ingress = new IngressBuilder()
                     .withNewMetadata()
-                    .withName(serviceName)
-                    .withLabels(getLabelsWithName(serviceName, templateExternalBootstrapIngressLabels))
-                    .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
-                    .withNamespace(namespace)
-                    .withOwnerReferences(createOwnerReference())
+                        .withName(serviceName)
+                        .withLabels(getLabelsWithName(serviceName, templateExternalBootstrapIngressLabels))
+                        .withAnnotations(mergeLabelsOrAnnotations(generateInternalIngressAnnotations(listener), templateExternalBootstrapIngressAnnotations, dnsAnnotations))
+                        .withNamespace(namespace)
+                        .withOwnerReferences(createOwnerReference())
                     .endMetadata()
                     .withNewSpec()
-                    .withRules(rule)
-                    .withTls(tls)
+                        .withRules(rule)
+                        .withTls(tls)
                     .endSpec()
                     .build();
 
@@ -1199,16 +1199,16 @@ public class KafkaCluster extends AbstractModel {
             // If there's a rack config, we need to add a podAntiAffinity to spread the brokers among the racks
             builder = builder
                     .editOrNewPodAntiAffinity()
-                    .addNewPreferredDuringSchedulingIgnoredDuringExecution()
-                    .withWeight(100)
-                    .withNewPodAffinityTerm()
-                    .withTopologyKey(rack.getTopologyKey())
-                    .withNewLabelSelector()
-                    .addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, cluster)
-                    .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, name)
-                    .endLabelSelector()
-                    .endPodAffinityTerm()
-                    .endPreferredDuringSchedulingIgnoredDuringExecution()
+                        .addNewPreferredDuringSchedulingIgnoredDuringExecution()
+                            .withWeight(100)
+                            .withNewPodAffinityTerm()
+                                .withTopologyKey(rack.getTopologyKey())
+                                .withNewLabelSelector()
+                                    .addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, cluster)
+                                    .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, name)
+                                .endLabelSelector()
+                            .endPodAffinityTerm()
+                        .endPreferredDuringSchedulingIgnoredDuringExecution()
                     .endPodAntiAffinity();
         }
         return builder.build();
@@ -1275,12 +1275,12 @@ public class KafkaCluster extends AbstractModel {
                 .withPorts(getContainerPortList())
                 .withLivenessProbe(ModelUtils.newProbeBuilder(livenessProbeOptions)
                         .withNewExec()
-                        .withCommand("/opt/kafka/kafka_liveness.sh")
+                            .withCommand("/opt/kafka/kafka_liveness.sh")
                         .endExec().build())
                 .withReadinessProbe(ModelUtils.newProbeBuilder(readinessProbeOptions)
                         .withNewExec()
-                        // The kafka-agent will create /var/opt/kafka/kafka-ready in the container
-                        .withCommand("test", "-f", "/var/opt/kafka/kafka-ready")
+                            // The kafka-agent will create /var/opt/kafka/kafka-ready in the container
+                            .withCommand("test", "-f", "/var/opt/kafka/kafka-ready")
                         .endExec().build())
                 .withResources(getResources())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, getImage()))
@@ -1376,9 +1376,7 @@ public class KafkaCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_LOG_DIRS, logDirs));
 
         // Add user defined environment variables to the Kafka broker containers
-        if (templateKafkaContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateKafkaContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateKafkaContainerEnvVars);
 
         return varList;
     }
@@ -1388,9 +1386,7 @@ public class KafkaCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
 
-        if (templateTlsSidecarContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 
         return varList;
     }
@@ -1460,9 +1456,9 @@ public class KafkaCluster extends AbstractModel {
 
             return new ClusterRoleBindingBuilder()
                     .withNewMetadata()
-                    .withName(initContainerClusterRoleBindingName(namespace, cluster))
-                    .withOwnerReferences(createOwnerReference())
-                    .withLabels(labels.toMap())
+                        .withName(initContainerClusterRoleBindingName(namespace, cluster))
+                        .withOwnerReferences(createOwnerReference())
+                        .withLabels(labels.toMap())
                     .endMetadata()
                     .withSubjects(ks)
                     .withRoleRef(roleRef)
@@ -1564,14 +1560,14 @@ public class KafkaCluster extends AbstractModel {
 
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
                 .withNewMetadata()
-                .withName(policyName(cluster))
-                .withNamespace(namespace)
-                .withLabels(labels.toMap())
-                .withOwnerReferences(createOwnerReference())
+                    .withName(policyName(cluster))
+                    .withNamespace(namespace)
+                    .withLabels(labels.toMap())
+                    .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withNewSpec()
-                .withPodSelector(labelSelector)
-                .withIngress(rules)
+                    .withPodSelector(labelSelector)
+                    .withIngress(rules)
                 .endSpec()
                 .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationPlain;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationScramSha512;
@@ -89,6 +90,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected String bootstrapServers;
     protected List<ExternalConfigurationEnv> externalEnvs = Collections.emptyList();
     protected List<ExternalConfigurationVolumeSource> externalVolumes = Collections.emptyList();
+    protected List<ContainerEnvVar> templateContainerEnvVars;
 
     private KafkaConnectTls tls;
     private CertAndKeySecretSource tlsAuthCertAndKey;
@@ -213,6 +215,10 @@ public class KafkaConnectCluster extends AbstractModel {
             if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
                 kafkaConnect.templateServiceLabels = template.getApiService().getMetadata().getLabels();
                 kafkaConnect.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
+            }
+
+            if (template.getConnectContainer() != null && template.getConnectContainer().getEnv() != null) {
+                kafkaConnect.templateContainerEnvVars = template.getConnectContainer().getEnv();
             }
 
             ModelUtils.parsePodDisruptionBudgetTemplate(kafkaConnect, template.getPodDisruptionBudget());
@@ -498,6 +504,10 @@ public class KafkaConnectCluster extends AbstractModel {
         }
 
         varList.addAll(getExternalConfigurationEnvVars());
+
+        if (templateContainerEnvVars != null) {
+            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
+        }
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -505,9 +505,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
         varList.addAll(getExternalConfigurationEnvVars());
 
-        if (templateContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -443,9 +443,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_READINESS_PERIOD,
                 String.valueOf(readinessProbeOptions.getPeriodSeconds() != null ? readinessProbeOptions.getPeriodSeconds() : DEFAULT_HEALTHCHECK_PERIOD)));
 
-        if (templateContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationPlain;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationScramSha512;
@@ -100,6 +101,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     private String consumerSaslMechanism;
     private String consumerUsername;
     private PasswordSecretSource consumerPasswordSecret;
+    protected List<ContainerEnvVar> templateContainerEnvVars;
 
     /**
      * Constructor
@@ -211,6 +213,10 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 if (template.getDeployment() != null && template.getDeployment().getMetadata() != null) {
                     kafkaMirrorMakerCluster.templateDeploymentLabels = template.getDeployment().getMetadata().getLabels();
                     kafkaMirrorMakerCluster.templateDeploymentAnnotations = template.getDeployment().getMetadata().getAnnotations();
+                }
+
+                if (template.getMirrorMakerContainer() != null && template.getMirrorMakerContainer().getEnv() != null) {
+                    kafkaMirrorMakerCluster.templateContainerEnvVars = template.getMirrorMakerContainer().getEnv();
                 }
 
                 ModelUtils.parsePodTemplate(kafkaMirrorMakerCluster, template.getPod());
@@ -436,6 +442,10 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 String.valueOf(livenessProbeOptions.getPeriodSeconds() != null ? livenessProbeOptions.getPeriodSeconds() : DEFAULT_HEALTHCHECK_PERIOD)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_READINESS_PERIOD,
                 String.valueOf(readinessProbeOptions.getPeriodSeconds() != null ? readinessProbeOptions.getPeriodSeconds() : DEFAULT_HEALTHCHECK_PERIOD)));
+
+        if (templateContainerEnvVars != null) {
+            addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
+        }
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -528,9 +528,7 @@ public class ZookeeperCluster extends AbstractModel {
         jvmPerformanceOptions(varList);
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));
 
-        if (templateZookeeperContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateZookeeperContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateZookeeperContainerEnvVars);
 
         return varList;
     }
@@ -540,9 +538,7 @@ public class ZookeeperCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas)));
         varList.add(ModelUtils.tlsSidecarLogEnvVar(tlsSidecar));
 
-        if (templateTlsSidecarContainerEnvVars != null) {
-            addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
-        }
+        addContainerEnvsToExistingEnvs(varList, templateTlsSidecarContainerEnvVars);
 
         return varList;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -19,11 +19,13 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.KafkaBridgeAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaBridgeHttpConfig;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
+import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -596,5 +598,114 @@ public class KafkaBridgeClusterTest {
         Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
         assertEquals(limits, cont.getResources().getLimits());
         assertEquals(requests, cont.getResources().getRequests());
+    }
+
+    @Test
+    public void testKafkaBridgeContainerEnvVars() {
+
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = "TEST_ENV_1";
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        ContainerTemplate kafkaBridgeContainer = new ContainerTemplate();
+        kafkaBridgeContainer.setEnv(testEnvs);
+
+        KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
+                .editSpec()
+                .withNewTemplate()
+                .withBridgeContainer(kafkaBridgeContainer)
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaBridgeCluster kb = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kb.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+
+            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
+                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
+                    keyCount++;
+                }
+            }
+
+        }
+
+        assertEquals("Failed to set all Kafka Mirror Maker container template environment variables", testEnvs.size(), keyCount);
+    }
+
+    @Test
+    public void testKafkaBridgeContainerEnvVarsConflict() {
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_BOOTSTRAP_SERVERS;
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        ContainerEnvVar envVar3 = new ContainerEnvVar();
+        String testEnvThreeKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG;
+        String testEnvThreeValue = "test.env.three";
+        envVar3.setName(testEnvThreeKey);
+        envVar3.setValue(testEnvThreeValue);
+
+        ContainerEnvVar envVar4 = new ContainerEnvVar();
+        String testEnvFourKey = "TEST_ENV_4";
+        String testEnvFourValue = "test.env.four";
+        envVar4.setName(testEnvFourKey);
+        envVar4.setValue(testEnvFourValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        testEnvs.add(envVar3);
+        testEnvs.add(envVar4);
+        ContainerTemplate kafkaBridgeContainer = new ContainerTemplate();
+        kafkaBridgeContainer.setEnv(testEnvs);
+
+        KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
+                .editSpec()
+                .withNewTemplate()
+                .withBridgeContainer(kafkaBridgeContainer)
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaBridgeCluster kb = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kb.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
+                keyCount++;
+            } else if (envVar.getName().equals(testEnvOneKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
+            } else if (envVar.getName().equals(testEnvThreeKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
+            }
+        }
+
+        assertEquals("Failed to set Kafka Mirror Maker container template environment variables", 2, keyCount);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -629,23 +629,14 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaBridgeCluster kb = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaBridgeCluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kb.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all Kafka Mirror Maker container template environment variables", testEnvs.size(), keyCount);
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 
     @Test
@@ -657,28 +648,14 @@ public class KafkaBridgeClusterTest {
         envVar1.setValue(testEnvOneValue);
 
         ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG;
         String testEnvTwoValue = "test.env.two";
         envVar2.setName(testEnvTwoKey);
         envVar2.setValue(testEnvTwoValue);
 
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG;
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
-
-        ContainerEnvVar envVar4 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_4";
-        String testEnvFourValue = "test.env.four";
-        envVar4.setName(testEnvFourKey);
-        envVar4.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
         testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
-        testEnvs.add(envVar4);
         ContainerTemplate kafkaBridgeContainer = new ContainerTemplate();
         kafkaBridgeContainer.setEnv(testEnvs);
 
@@ -690,22 +667,13 @@ public class KafkaBridgeClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaBridgeCluster kb = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaBridgeCluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kb.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            } else if (envVar.getName().equals(testEnvThreeKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
-            }
-        }
-
-        assertEquals("Failed to set Kafka Mirror Maker container template environment variables", 2, keyCount);
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2309,19 +2309,13 @@ public class KafkaClusterTest {
 
         List<EnvVar> kafkaEnvVars = kc.getEnvVars();
 
-        int keyCount = 0;
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : kafkaEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all Kafka broker container template environment variables", testEnvs.size(), keyCount);
     }
 
     @Test
@@ -2333,28 +2327,14 @@ public class KafkaClusterTest {
         envVar1.setValue(testEnvOneValue);
 
         ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoKey = KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION;
         String testEnvTwoValue = "test.env.two";
         envVar2.setName(testEnvTwoKey);
         envVar2.setValue(testEnvTwoValue);
 
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION;
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
-
-        ContainerEnvVar envVar4 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_4";
-        String testEnvFourValue = "test.env.four";
-        envVar4.setName(testEnvFourKey);
-        envVar4.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
         testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
-        testEnvs.add(envVar4);
         ContainerTemplate kafkaContainer = new ContainerTemplate();
         kafkaContainer.setEnv(testEnvs);
 
@@ -2373,20 +2353,13 @@ public class KafkaClusterTest {
 
         List<EnvVar> kafkaEnvVars = kc.getEnvVars();
 
-        int keyCount = 0;
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : kafkaEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            } else if (envVar.getName().equals(testEnvThreeKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
-            }
-
-        }
-
-        assertEquals("Failed to set Kafka broker container template environment variables", 2, keyCount);
     }
 
     @Test
@@ -2425,19 +2398,13 @@ public class KafkaClusterTest {
 
         List<EnvVar> kafkaEnvVars = kc.getTlsSidevarEnvVars();
 
-        int keyCount = 0;
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : kafkaEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all TLS sidecar container template environment variables", testEnvs.size(), keyCount);
     }
 
     @Test
@@ -2448,22 +2415,8 @@ public class KafkaClusterTest {
         envVar1.setName(testEnvOneKey);
         envVar1.setValue(testEnvOneValue);
 
-        ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
-        String testEnvTwoValue = "test.env.two";
-        envVar2.setName(testEnvTwoKey);
-        envVar2.setValue(testEnvTwoValue);
-
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_3";
-        String testEnvFourValue = "test.env.three";
-        envVar3.setName(testEnvFourKey);
-        envVar3.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
-        testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
         ContainerTemplate tlsContainer = new ContainerTemplate();
         tlsContainer.setEnv(testEnvs);
 
@@ -2482,16 +2435,9 @@ public class KafkaClusterTest {
 
         List<EnvVar> kafkaEnvVars = kc.getTlsSidevarEnvVars();
 
-        int keyCount = 0;
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
 
-        for (EnvVar envVar : kafkaEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            }
-        }
-
-        assertEquals("Failed to set TLS sidecar container template environment variables", 2, keyCount);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -30,6 +30,7 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageChangeTrigger;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationScramSha512Builder;
 import io.strimzi.api.kafka.model.KafkaConnectAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
@@ -39,6 +40,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnv;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvBuilder;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSourceBuilder;
+import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -943,5 +945,114 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xmx1024m"));
         assertTrue(cont.getEnv().stream().filter(env -> "KAFKA_HEAP_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-Xms512m"));
+    }
+
+    @Test
+    public void testKafkaConnectContainerEnvVars() {
+
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = "TEST_ENV_1";
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        ContainerTemplate kafkaConnectContainer = new ContainerTemplate();
+        kafkaConnectContainer.setEnv(testEnvs);
+
+        KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
+                .editSpec()
+                .withNewTemplate()
+                .withConnectContainer(kafkaConnectContainer)
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaConnectS2ICluster kcc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kcc.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+
+            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
+                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
+                    keyCount++;
+                }
+            }
+
+        }
+
+        assertEquals("Failed to set all Kafka Connect container template environment variables", testEnvs.size(), keyCount);
+    }
+
+    @Test
+    public void testKafkaContainerEnvVarsConflict() {
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION;
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        ContainerEnvVar envVar3 = new ContainerEnvVar();
+        String testEnvThreeKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS;
+        String testEnvThreeValue = "test.env.three";
+        envVar3.setName(testEnvThreeKey);
+        envVar3.setValue(testEnvThreeValue);
+
+        ContainerEnvVar envVar4 = new ContainerEnvVar();
+        String testEnvFourKey = "TEST_ENV_4";
+        String testEnvFourValue = "test.env.four";
+        envVar4.setName(testEnvFourKey);
+        envVar4.setValue(testEnvFourValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        testEnvs.add(envVar3);
+        testEnvs.add(envVar4);
+        ContainerTemplate kafkaConnectContainer = new ContainerTemplate();
+        kafkaConnectContainer.setEnv(testEnvs);
+
+        KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
+                .editSpec()
+                .withNewTemplate()
+                .withConnectContainer(kafkaConnectContainer)
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaConnectS2ICluster kcc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kcc.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
+                keyCount++;
+            } else if (envVar.getName().equals(testEnvOneKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
+            } else if (envVar.getName().equals(testEnvThreeKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
+            }
+        }
+
+        assertEquals("Failed to set Kafka connect container template environment variables", 2, keyCount);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -976,23 +976,14 @@ public class KafkaConnectS2IClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaConnectS2ICluster kcc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kcc.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all Kafka Connect container template environment variables", testEnvs.size(), keyCount);
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 
     @Test
@@ -1004,28 +995,14 @@ public class KafkaConnectS2IClusterTest {
         envVar1.setValue(testEnvOneValue);
 
         ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS;
         String testEnvTwoValue = "test.env.two";
         envVar2.setName(testEnvTwoKey);
         envVar2.setValue(testEnvTwoValue);
 
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS;
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
-
-        ContainerEnvVar envVar4 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_4";
-        String testEnvFourValue = "test.env.four";
-        envVar4.setName(testEnvFourKey);
-        envVar4.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
         testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
-        testEnvs.add(envVar4);
         ContainerTemplate kafkaConnectContainer = new ContainerTemplate();
         kafkaConnectContainer.setEnv(testEnvs);
 
@@ -1037,22 +1014,13 @@ public class KafkaConnectS2IClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaConnectS2ICluster kcc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kcc.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            } else if (envVar.getName().equals(testEnvThreeKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
-            }
-        }
-
-        assertEquals("Failed to set Kafka connect container template environment variables", 2, keyCount);
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -838,23 +838,14 @@ public class KafkaMirrorMakerClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kmm.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all Kafka Mirror Maker container template environment variables", testEnvs.size(), keyCount);
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 
     @Test
@@ -866,28 +857,14 @@ public class KafkaMirrorMakerClusterTest {
         envVar1.setValue(testEnvOneValue);
 
         ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoKey = KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_WHITELIST;
         String testEnvTwoValue = "test.env.two";
         envVar2.setName(testEnvTwoKey);
         envVar2.setValue(testEnvTwoValue);
 
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_WHITELIST;
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
-
-        ContainerEnvVar envVar4 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_4";
-        String testEnvFourValue = "test.env.four";
-        envVar4.setName(testEnvFourKey);
-        envVar4.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
         testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
-        testEnvs.add(envVar4);
         ContainerTemplate kafkaMMContainer = new ContainerTemplate();
         kafkaMMContainer.setEnv(testEnvs);
 
@@ -899,22 +876,13 @@ public class KafkaMirrorMakerClusterTest {
                 .endSpec()
                 .build();
 
-        KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
+        List<EnvVar> kafkaEnvVars = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS).getEnvVars();
 
-        List<EnvVar> kafkaEnvVars = kmm.getEnvVars();
-
-        int keyCount = 0;
-
-        for (EnvVar envVar : kafkaEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            } else if (envVar.getName().equals(testEnvThreeKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
-            }
-        }
-
-        assertEquals("Failed to set Kafka Mirror Maker container template environment variables", 2, keyCount);
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvTwoKey,
+                kafkaEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
@@ -27,6 +28,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
+import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -804,5 +806,115 @@ public class KafkaMirrorMakerClusterTest {
 
         assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_READINESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("61"));
         assertTrue(cont.getEnv().stream().filter(env -> "STRIMZI_LIVENESS_PERIOD".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("60"));
+    }
+
+
+    @Test
+    public void testKafkaMMContainerEnvVars() {
+
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = "TEST_ENV_1";
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        ContainerTemplate kafkaMMContainer = new ContainerTemplate();
+        kafkaMMContainer.setEnv(testEnvs);
+
+        KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
+                .editSpec()
+                    .withNewTemplate()
+                        .withMirrorMakerContainer(kafkaMMContainer)
+                    .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kmm.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+
+            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
+                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
+                    keyCount++;
+                }
+            }
+
+        }
+
+        assertEquals("Failed to set all Kafka Mirror Maker container template environment variables", testEnvs.size(), keyCount);
+    }
+
+    @Test
+    public void testKafkaMMContainerEnvVarsConflict() {
+        ContainerEnvVar envVar1 = new ContainerEnvVar();
+        String testEnvOneKey = KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_BOOTSTRAP_SERVERS_CONSUMER;
+        String testEnvOneValue = "test.env.one";
+        envVar1.setName(testEnvOneKey);
+        envVar1.setValue(testEnvOneValue);
+
+        ContainerEnvVar envVar2 = new ContainerEnvVar();
+        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoValue = "test.env.two";
+        envVar2.setName(testEnvTwoKey);
+        envVar2.setValue(testEnvTwoValue);
+
+        ContainerEnvVar envVar3 = new ContainerEnvVar();
+        String testEnvThreeKey = KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_WHITELIST;
+        String testEnvThreeValue = "test.env.three";
+        envVar3.setName(testEnvThreeKey);
+        envVar3.setValue(testEnvThreeValue);
+
+        ContainerEnvVar envVar4 = new ContainerEnvVar();
+        String testEnvFourKey = "TEST_ENV_4";
+        String testEnvFourValue = "test.env.four";
+        envVar4.setName(testEnvFourKey);
+        envVar4.setValue(testEnvFourValue);
+
+        List<ContainerEnvVar> testEnvs = new ArrayList<>();
+        testEnvs.add(envVar1);
+        testEnvs.add(envVar2);
+        testEnvs.add(envVar3);
+        testEnvs.add(envVar4);
+        ContainerTemplate kafkaMMContainer = new ContainerTemplate();
+        kafkaMMContainer.setEnv(testEnvs);
+
+        KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
+                .editSpec()
+                .withNewTemplate()
+                .withMirrorMakerContainer(kafkaMMContainer)
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(resource, VERSIONS);
+
+        List<EnvVar> kafkaEnvVars = kmm.getEnvVars();
+
+        int keyCount = 0;
+
+        for (EnvVar envVar : kafkaEnvVars) {
+            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
+                keyCount++;
+            } else if (envVar.getName().equals(testEnvOneKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
+            } else if (envVar.getName().equals(testEnvThreeKey)) {
+                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
+            }
+        }
+
+        assertEquals("Failed to set Kafka Mirror Maker container template environment variables", 2, keyCount);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -964,19 +964,13 @@ public class ZookeeperClusterTest {
 
         List<EnvVar> zkEnvVars = zc.getEnvVars();
 
-        int keyCount = 0;
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                zkEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                zkEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : zkEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all Zookeeper container template environment variables", testEnvs.size(), keyCount);
     }
 
     @Test
@@ -988,28 +982,14 @@ public class ZookeeperClusterTest {
         envVar1.setValue(testEnvOneValue);
 
         ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
+        String testEnvTwoKey = ZookeeperCluster.ENV_VAR_ZOOKEEPER_METRICS_ENABLED;
         String testEnvTwoValue = "test.env.two";
         envVar2.setName(testEnvTwoKey);
         envVar2.setValue(testEnvTwoValue);
 
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = ZookeeperCluster.ENV_VAR_ZOOKEEPER_METRICS_ENABLED;
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
-
-        ContainerEnvVar envVar4 = new ContainerEnvVar();
-        String testEnvFourKey = "TEST_ENV_4";
-        String testEnvFourValue = "test.env.four";
-        envVar4.setName(testEnvFourKey);
-        envVar4.setValue(testEnvFourValue);
-
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
         testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
-        testEnvs.add(envVar4);
         ContainerTemplate zookeeperContainer = new ContainerTemplate();
         zookeeperContainer.setEnv(testEnvs);
 
@@ -1028,19 +1008,13 @@ public class ZookeeperClusterTest {
 
         List<EnvVar> zkEnvVars = zc.getEnvVars();
 
-        int keyCount = 0;
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                zkEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvTwoKey,
+                zkEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : zkEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvFourKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvOneValue));
-            } else if (envVar.getName().equals(testEnvThreeKey)) {
-                assertFalse("Failed to prevent overwriting existing environment variables", envVar.getValue().equals(testEnvThreeValue));
-            }
-        }
-
-        assertEquals("Failed to set Zookeeper container template environment variables", 2, keyCount);
     }
 
     @Test
@@ -1079,45 +1053,27 @@ public class ZookeeperClusterTest {
 
         List<EnvVar> zkEnvVars = zc.getTlsSidevarEnvVars();
 
-        int keyCount = 0;
+        assertTrue("Failed to correctly set container environment variable: " + testEnvOneKey,
+                zkEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
+        assertTrue("Failed to correctly set container environment variable: " + testEnvTwoKey,
+                zkEnvVars.stream().filter(env -> testEnvTwoKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvTwoValue));
 
-        for (EnvVar envVar : zkEnvVars) {
-
-            if (envVar.getName().equals(testEnvOneKey) || envVar.getName().equals(testEnvTwoKey)) {
-                if (envVar.getValue().equals(testEnvOneValue) || envVar.getValue().equals(testEnvTwoValue)) {
-                    keyCount++;
-                }
-            }
-
-        }
-
-        assertEquals("Failed to set all TLS sidecar container template environment variables", testEnvs.size(), keyCount);
     }
 
     @Test
     public void testTlsSidecarContainerEnvVarsConflict() {
+
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = ZookeeperCluster.ENV_VAR_ZOOKEEPER_NODE_COUNT;
         String testEnvOneValue = "test.env.one";
         envVar1.setName(testEnvOneKey);
         envVar1.setValue(testEnvOneValue);
 
-        ContainerEnvVar envVar2 = new ContainerEnvVar();
-        String testEnvTwoKey = "TEST_ENV_2";
-        String testEnvTwoValue = "test.env.two";
-        envVar2.setName(testEnvTwoKey);
-        envVar2.setValue(testEnvTwoValue);
-
-        ContainerEnvVar envVar3 = new ContainerEnvVar();
-        String testEnvThreeKey = "TEST_ENV_3";
-        String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvThreeKey);
-        envVar3.setValue(testEnvThreeValue);
 
         List<ContainerEnvVar> testEnvs = new ArrayList<>();
         testEnvs.add(envVar1);
-        testEnvs.add(envVar2);
-        testEnvs.add(envVar3);
         ContainerTemplate tlsContainer = new ContainerTemplate();
         tlsContainer.setEnv(testEnvs);
 
@@ -1136,16 +1092,9 @@ public class ZookeeperClusterTest {
 
         List<EnvVar> zkEnvVars = zc.getTlsSidevarEnvVars();
 
-        int keyCount = 0;
+        assertFalse("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
+                zkEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse("").equals(testEnvOneValue));
 
-        for (EnvVar envVar : zkEnvVars) {
-            if (envVar.getName().equals(testEnvTwoKey) || envVar.getName().equals(testEnvThreeKey)) {
-                keyCount++;
-            } else if (envVar.getName().equals(testEnvOneKey)) {
-                assertFalse(envVar.getValue().equals(testEnvOneValue));
-            }
-        }
-
-        assertEquals("Failed to ignore TLS sidecar container template environment variables which conflict with those already in use", 2, keyCount);
     }
 }

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -728,6 +728,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |podDisruptionBudget       1.2+<.<|Template for Kafka `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
+|tlsSidecarContainer       1.2+<.<|Template for the Kafka broker TLS sidecar container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
 [id='type-ResourceTemplate-{context}']
@@ -794,7 +796,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 [id='type-ContainerTemplate-{context}']
 ### `ContainerTemplate` schema reference
 
-Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
+Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 
 
 [options="header"]
@@ -896,6 +898,10 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |podDisruptionBudget  1.2+<.<|Template for Zookeeper `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
+|tlsSidecarContainer  1.2+<.<|Template for the Kafka broker TLS sidevar container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|zookeeperContainer   1.2+<.<|Template for the Zookeeper container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
 [id='type-TopicOperatorSpec-{context}']
@@ -1043,11 +1049,17 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 
 [options="header"]
 |====
-|Property           |Description
-|deployment  1.2+<.<|Template for Entity Operator `Deployment`.
+|Property                       |Description
+|deployment              1.2+<.<|Template for Entity Operator `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod         1.2+<.<|Template for Entity Operator `Pods`.
+|pod                     1.2+<.<|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
+|tlsSidecarContainer     1.2+<.<|Template for the Entity Operator TLS sidecar container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|topicOperatorContainer  1.2+<.<|Template for the Entity Topic Operator container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|userOperatorContainer   1.2+<.<|Template for the Entity User Operator container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
 [id='type-CertificateAuthority-{context}']
@@ -1215,6 +1227,8 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<|Template for Kafka Connect API `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|connectContainer     1.2+<.<|Template for the Kafka Connect container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |podDisruptionBudget  1.2+<.<|Template for Kafka Connect `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====
@@ -1916,12 +1930,14 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 
 [options="header"]
 |====
-|Property                    |Description
-|deployment           1.2+<.<|Template for Kafka Mirror Maker `Deployment`.
+|Property                     |Description
+|deployment            1.2+<.<|Template for Kafka Mirror Maker `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                  1.2+<.<|Template for Kafka Mirror Maker `Pods`.
+|pod                   1.2+<.<|Template for Kafka Mirror Maker `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|podDisruptionBudget  1.2+<.<|Template for Kafka Mirror Maker `PodDisruptionBudget`.
+|mirrorMakerContainer  1.2+<.<|Template for Kafka Mirror Maker `Deployment`.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|podDisruptionBudget   1.2+<.<|Template for Kafka Mirror Maker `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====
 
@@ -2116,6 +2132,8 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<|Template for Kafka Bridge API `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|bridgeContainer      1.2+<.<|Template for the Kafka Bridge container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |podDisruptionBudget  1.2+<.<|Template for Kafka Bridge `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |====

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -718,6 +718,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |externalBootstrapService  1.2+<.<|Template for Kafka external bootstrap `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|initContainer             1.2+<.<|Template for the Kafka init container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |kafkaContainer            1.2+<.<|Template for the Kafka broker container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |perPodIngress             1.2+<.<|Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -900,7 +900,7 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |podDisruptionBudget  1.2+<.<|Template for Zookeeper `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
-|tlsSidecarContainer  1.2+<.<|Template for the Kafka broker TLS sidevar container.
+|tlsSidecarContainer  1.2+<.<|Template for the Kafka broker TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |zookeeperContainer   1.2+<.<|Template for the Zookeeper container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
@@ -1937,7 +1937,7 @@ Used in: xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |pod                   1.2+<.<|Template for Kafka Mirror Maker `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|mirrorMakerContainer  1.2+<.<|Template for Kafka Mirror Maker `Deployment`.
+|mirrorMakerContainer  1.2+<.<|Template for Kafka Mirror Maker container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |podDisruptionBudget   1.2+<.<|Template for Kafka Mirror Maker `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]

--- a/documentation/book/con-customizing-containers.adoc
+++ b/documentation/book/con-customizing-containers.adoc
@@ -5,8 +5,8 @@
 [id='con-customizing-containers-{context}']
 = Customizing containers with environment variables
 
-You can set custom environment variables for the various containers by using the relevant `template` container property. 
-The table below lists the various containers belonging to the different elements of {ProductName} and the relevant configuration path (under the top level `spec` for the custom resource) for each.
+You can set custom environment variables for a container by using the relevant `template` container property. 
+The following table lists the {ProductName} containers and the relevant template configuration property (defined under `spec`) for each custom resource.
 
 .Table Container environment variable properties
 |===
@@ -53,7 +53,7 @@ The table below lists the various containers belonging to the different elements
 |`template.bridgeContainer.env`
 |===
 
-The environment variables are defined under the `env` field as a list of objects with `name` and `value` fields. 
+The environment variables are defined under the `env` property as a list of objects with `name` and `value` fields. 
 The following example shows two custom environment variables set for the Kafka broker containers:
 
 [source,yaml,subs=attributes+]

--- a/documentation/book/con-customizing-containers.adoc
+++ b/documentation/book/con-customizing-containers.adoc
@@ -20,6 +20,10 @@ The following table lists the {ProductName} containers and the relevant template
 |Kafka Broker TLS Sidecar
 |`kafka.template.tlsSidecarContainer.env`
 
+|Kafka 
+|Kafka Initialization
+|`kafka.template.initContainer.env`
+
 |Kafka
 |Zookeeper Node
 |`zookeeper.template.zookeeperContainer.env`

--- a/documentation/book/con-customizing-containers.adoc
+++ b/documentation/book/con-customizing-containers.adoc
@@ -5,14 +5,61 @@
 [id='con-customizing-containers-{context}']
 = Customizing containers with environment variables
 
-You can set custom environment variables for Kafka broker containers by using the `kafkaContainer` template property in `Kafka.spec.kafka`.
-These environment variables are defined under the `env` field as a list of objects with `name` and `value` fields.
+You can set custom environment variables for the various containers by using the relevant `template` container property. 
+The table below lists the various containers belonging to the different elements of {ProductName} and the relevant configuration path (under the top level `spec` for the custom resource) for each.
 
-The following example shows two custom environment variables set for a Kafka broker:
+.Table Container environment variable properties
+|===
+|{ProductName} Element |Container |Configuration property
+
+|Kafka 
+|Kafka Broker 
+|`kafka.template.kafkaContainer.env`
+
+|Kafka 
+|Kafka Broker TLS Sidecar
+|`kafka.template.tlsSidecarContainer.env`
+
+|Kafka
+|Zookeeper Node
+|`zookeeper.template.zookeeperContainer.env`
+
+|Kafka
+|Zookeeper TLS Sidecar
+|`zookeeper.template.tlsSidecarContainer.env`
+
+|Kafka
+|Topic Operator
+|`entityOperator.template.topicOperatorContainer.env`
+
+|Kafka
+|User Operator
+|`entityOperator.template.userOperatorContainer.env`
+
+|Kafka
+|Entity Operator TLS Sidecar
+|`entityOperator.template.tlsSidecarContainer.env`
+
+|KafkaConnect
+|Connect and ConnectS2I
+|`template.connectContainer.env`
+
+|KafkaMirrorMaker
+|Mirror Maker 
+|`template.mirrorMakerContainer.env`
+
+|KafkaBridge
+|Bridge
+|`template.bridgeContainer.env`
+|===
+
+The environment variables are defined under the `env` field as a list of objects with `name` and `value` fields. 
+The following example shows two custom environment variables set for the Kafka broker containers:
 
 [source,yaml,subs=attributes+]
 ----
 # ...
+kind: Kafka
 spec:
     kafka:
         template:

--- a/documentation/book/con-customizing-template-properties.adoc
+++ b/documentation/book/con-customizing-template-properties.adoc
@@ -50,6 +50,7 @@ When defined in a Kafka cluster, the `template` object can have the following fi
 `perPodRoute`:: Configures the per-Pod routes used by clients connecting to the Kafka broker from outside OpenShift to access individual brokers using OpenShift `Routes`.
 `podDisruptionBudget`:: Configures the Pod Disruption Budget for Kafka broker `StatefulSet`.
 `kafkaContainer`:: Configures the container used to run the Kafka broker, including custom environment variables. 
+`tlsSidecarContainer`:: Configures the TLS sidecar container, including custom environment variables. 
 
 .Supported resources in Zookeeper cluster
 
@@ -60,6 +61,8 @@ When defined in a Zookeeper cluster, the `template` object can have the followin
 `clientsService`:: Configures the service used by clients to access Zookeeper.
 `nodesService`:: Configures the headless service.
 `podDisruptionBudget`:: Configures the Pod Disruption Budget for Zookeeper `StatefulSet`.
+`zookeeperContainer`:: Configures the container used to run the Zookeeper Node, including custom environment variables. 
+`tlsSidecarContainer`:: Configures the TLS sidecar container, including custom environment variables. 
 
 .Supported resources in Entity Operator
 
@@ -67,6 +70,9 @@ When defined in an Entity Operator , the template object can have the following 
 
 `deployment`:: Configures the Deployment used by the Entity Operator.
 `pod`:: Configures the Entity Operator `Pod` created by the `Deployment`.
+`topicOperatorContainer`:: Configures the container used to run the topic operator, including custom environment variables. 
+`userOperatorContainer`:: Configures the container used to run the topic operator, including custom environment variables. 
+`tlsSidecarContainer`:: Configures the TLS sidecar container, including custom environment variables. 
 
 .Supported resources in Kafka Connect and Kafka Connect with Source2Image support
 
@@ -76,6 +82,7 @@ When used with Kafka Connect and Kafka Connect with Source2Image support , the t
 `pod`:: Configures the Kafka Connect `Pods` created by the `Deployment`.
 `apiService`:: Configures the service used by the Kafka Connect REST API.
 `podDisruptionBudget`:: Configures the Pod Disruption Budget for Kafka Connect `Deployment`.
+`connectContainer`:: Configures the container used to run Kafka Connect, including custom environment variables. 
 
 .Supported resource in Kafka Mirror Maker
 
@@ -84,3 +91,4 @@ When used with Kafka Mirror Maker , the template object can have the following f
 `deployment`:: Configures the Kafka Mirror Maker `Deployment`.
 `pod`:: Configures the Kafka Mirror Maker `Pods` created by the `Deployment`.
 `podDisruptionBudget`:: Configures the Pod Disruption Budget for Kafka Mirror Maker `Deployment`.
+`mirrorMakerContainer`:: Configures the container used to run Kafka Mirror Maker, including custom environment variables. 

--- a/documentation/book/con-customizing-template-properties.adoc
+++ b/documentation/book/con-customizing-template-properties.adoc
@@ -51,6 +51,7 @@ When defined in a Kafka cluster, the `template` object can have the following fi
 `podDisruptionBudget`:: Configures the Pod Disruption Budget for Kafka broker `StatefulSet`.
 `kafkaContainer`:: Configures the container used to run the Kafka broker, including custom environment variables. 
 `tlsSidecarContainer`:: Configures the TLS sidecar container, including custom environment variables. 
+`initContainer`:: Configures the container used to initialize the brokers.
 
 .Supported resources in Zookeeper cluster
 

--- a/documentation/book/con-customizing-template-properties.adoc
+++ b/documentation/book/con-customizing-template-properties.adoc
@@ -70,8 +70,8 @@ When defined in an Entity Operator , the template object can have the following 
 
 `deployment`:: Configures the Deployment used by the Entity Operator.
 `pod`:: Configures the Entity Operator `Pod` created by the `Deployment`.
-`topicOperatorContainer`:: Configures the container used to run the topic operator, including custom environment variables. 
-`userOperatorContainer`:: Configures the container used to run the topic operator, including custom environment variables. 
+`topicOperatorContainer`:: Configures the container used to run the Topic Operator, including custom environment variables. 
+`userOperatorContainer`:: Configures the container used to run the User Operator, including custom environment variables. 
 `tlsSidecarContainer`:: Configures the TLS sidecar container, including custom environment variables. 
 
 .Supported resources in Kafka Connect and Kafka Connect with Source2Image support

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1145,6 +1145,18 @@ spec:
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                 version:
                   type: string
               required:
@@ -1859,6 +1871,30 @@ spec:
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    zookeeperContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
               required:
               - replicas
               - storage
@@ -2906,6 +2942,42 @@ spec:
                                 type: string
                               tolerationSeconds:
                                 type: integer
+                              value:
+                                type: string
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    topicOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    userOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
                               value:
                                 type: string
             clusterCa:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1090,6 +1090,18 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    initContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                     kafkaContainer:
                       type: object
                       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -630,6 +630,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -615,6 +615,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -740,6 +740,18 @@ spec:
                             type: integer
                           value:
                             type: string
+                mirrorMakerContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -486,6 +486,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                bridgeContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1140,6 +1140,18 @@ spec:
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                 version:
                   type: string
               required:
@@ -1854,6 +1866,30 @@ spec:
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    zookeeperContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
               required:
               - replicas
               - storage
@@ -2901,6 +2937,42 @@ spec:
                                 type: string
                               tolerationSeconds:
                                 type: integer
+                              value:
+                                type: string
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    topicOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    userOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
                               value:
                                 type: string
             clusterCa:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1085,6 +1085,18 @@ spec:
                               type: object
                             annotations:
                               type: object
+                    initContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
                     kafkaContainer:
                       type: object
                       properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -625,6 +625,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -610,6 +610,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -735,6 +735,18 @@ spec:
                             type: integer
                           value:
                             type: string
+                mirrorMakerContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -481,6 +481,18 @@ spec:
                           type: object
                         annotations:
                           type: object
+                bridgeContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
                 podDisruptionBudget:
                   type: object
                   properties:

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -971,4 +971,29 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
             teardownEnvForOperator();
         }
     }
+
+    /**
+     * Verifies container configuration by environment key
+     * @param podNamePrefix Name of pod where container is located
+     * @param containerName The container where verifying is expected
+     * @param configKey Expected configuration key
+     * @param config Expected configuration
+     */
+    void checkContainerConfiguration(String podNamePrefix, String containerName, String configKey, String config) {
+        LOGGER.info("Getting pods by prefix in name {}", podNamePrefix);
+        List<Pod> pods = kubeClient().listPodsByPrefixInName(podNamePrefix);
+
+        if (pods.size() != 0) {
+            LOGGER.info("Testing configuration for container {}", containerName);
+            pods.forEach(pod -> {
+                pod.getSpec().getContainers().stream().filter(c -> c.getName().equals(containerName))
+                        .forEach(container -> {
+                            container.getEnv().stream().filter(envVar -> envVar.getName().equals(configKey))
+                                    .forEach(envVar -> assertEquals(config, envVar.getValue()));
+                        });
+            });
+        } else {
+            fail("Pod with prefix " + podNamePrefix + " in name, not found");
+        }
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -282,11 +282,13 @@ class KafkaST extends MessagingBaseST {
     @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:JavaNCSS"})
     void testCustomAndUpdatedValues() {
 
+        // Kafka Broker config
         Map<String, Object> kafkaConfig = new HashMap<>();
         kafkaConfig.put("offsets.topic.replication.factor", "1");
         kafkaConfig.put("transaction.state.log.replication.factor", "1");
         kafkaConfig.put("default.replication.factor", "1");
 
+        // Kafka broker container env vars
         ContainerEnvVar envVar1 = new ContainerEnvVar();
         String testEnvOneKey = "TEST_ENV_1";
         String testEnvOneValue = "test.env.one";
@@ -305,12 +307,37 @@ class KafkaST extends MessagingBaseST {
         ContainerTemplate kafkaContainer = new ContainerTemplate();
         kafkaContainer.setEnv(testEnvs);
 
+        // TLS Sidecar container env vars
+        ContainerEnvVar tlsEnvVar1 = new ContainerEnvVar();
+        String testTlsEnvOneKey = "TEST_ENV_1";
+        String testTlsEnvOneValue = "test.env.one";
+        tlsEnvVar1.setName(testTlsEnvOneKey);
+        tlsEnvVar1.setValue(testTlsEnvOneValue);
+
+        ContainerEnvVar tlsEnvVar2 = new ContainerEnvVar();
+        String testTlsEnvTwoKey = "TEST_ENV_2";
+        String testTlsEnvTwoValue = "test.env.two";
+        tlsEnvVar2.setName(testTlsEnvTwoKey);
+        tlsEnvVar2.setValue(testTlsEnvTwoValue);
+
+        List<ContainerEnvVar> tlsTestEnvs = new ArrayList<>();
+        tlsTestEnvs.add(tlsEnvVar1);
+        tlsTestEnvs.add(tlsEnvVar2);
+        ContainerTemplate tlsSidecarContainer = new ContainerTemplate();
+        tlsSidecarContainer.setEnv(tlsTestEnvs);
+
+        // Zookeeper Config
         Map<String, Object> zookeeperConfig = new HashMap<>();
         zookeeperConfig.put("tickTime", "2000");
         zookeeperConfig.put("initLimit", "5");
         zookeeperConfig.put("syncLimit", "2");
         zookeeperConfig.put("autopurge.purgeInterval", "1");
 
+        // Zookeeper Env Vars
+        ContainerTemplate zookeeperContainer = new ContainerTemplate();
+        zookeeperContainer.setEnv(testEnvs);
+
+        // Updated broker env vars
         ContainerEnvVar updatedEnvVar2 = new ContainerEnvVar();
         String updatedTestEnvTwoValue = "updated.test.env.two";
         updatedEnvVar2.setName(testEnvTwoKey);
@@ -319,12 +346,28 @@ class KafkaST extends MessagingBaseST {
         ContainerEnvVar envVar3 = new ContainerEnvVar();
         String testEnvThreeKey = "TEST_ENV_3";
         String testEnvThreeValue = "test.env.three";
-        envVar3.setName(testEnvTwoKey);
-        envVar3.setValue(testEnvTwoValue);
+        envVar3.setName(testEnvThreeKey);
+        envVar3.setValue(testEnvThreeValue);
 
         List<ContainerEnvVar> updatedTestEnvs = new ArrayList<>();
         updatedTestEnvs.add(updatedEnvVar2);
         updatedTestEnvs.add(envVar3);
+
+        // Updated TLS Sidecar env vars
+        ContainerEnvVar updatedTlsEnvVar2 = new ContainerEnvVar();
+        String updatedTlsTestEnvTwoValue = "updated.test.env.two";
+        updatedEnvVar2.setName(testTlsEnvTwoKey);
+        updatedEnvVar2.setValue(updatedTlsTestEnvTwoValue);
+
+        ContainerEnvVar tlsEnvVar3 = new ContainerEnvVar();
+        String testTlsEnvThreeKey = "TEST_ENV_3";
+        String testTlsEnvThreeValue = "test.env.three";
+        tlsEnvVar3.setName(testTlsEnvThreeKey);
+        tlsEnvVar3.setValue(testTlsEnvThreeValue);
+
+        List<ContainerEnvVar> updatedTlsTestEnvs = new ArrayList<>();
+        updatedTlsTestEnvs.add(updatedTlsEnvVar2);
+        updatedTlsTestEnvs.add(tlsEnvVar3);
 
         int initialDelaySeconds = 30;
         int timeoutSeconds = 10;
@@ -366,6 +409,7 @@ class KafkaST extends MessagingBaseST {
                     .withConfig(kafkaConfig)
                     .withNewTemplate()
                         .withKafkaContainer(kafkaContainer)
+                        .withTlsSidecarContainer(tlsSidecarContainer)
                     .endTemplate()
                 .endKafka()
                 .editZookeeper()
@@ -385,7 +429,7 @@ class KafkaST extends MessagingBaseST {
                             .withFailureThreshold(failureThreshold)
                         .endLivenessProbe()
                     .endTlsSidecar()
-                .withReplicas(2)
+                    .withReplicas(2)
                     .withNewReadinessProbe()
                        .withInitialDelaySeconds(initialDelaySeconds)
                         .withTimeoutSeconds(timeoutSeconds)
@@ -395,6 +439,10 @@ class KafkaST extends MessagingBaseST {
                         .withTimeoutSeconds(timeoutSeconds)
                     .endLivenessProbe()
                     .withConfig(zookeeperConfig)
+                    .withNewTemplate()
+                        .withZookeeperContainer(zookeeperContainer)
+                        .withTlsSidecarContainer(tlsSidecarContainer)
+                    .endTemplate()
                 .endZookeeper()
                 .editEntityOperator()
                     .editUserOperator()
@@ -462,14 +510,20 @@ class KafkaST extends MessagingBaseST {
         checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "kafka", testEnvTwoKey, testEnvTwoValue);
         checkReadinessLivenessProbe(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", initialDelaySeconds, timeoutSeconds,
                 periodSeconds, successThreshold, failureThreshold);
+        checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvOneKey, testTlsEnvOneValue);
+        checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvTwoKey, testTlsEnvTwoValue);
 
         LOGGER.info("Testing Zookeepers");
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", initialDelaySeconds, timeoutSeconds,
                 periodSeconds, successThreshold, failureThreshold);
         checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", "ZOOKEEPER_CONFIGURATION",
                 "autopurge.purgeInterval=1\ntickTime=2000\ninitLimit=5\nsyncLimit=2\n");
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", testEnvOneKey, testEnvOneValue);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", testEnvTwoKey, testEnvTwoValue);
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", initialDelaySeconds, timeoutSeconds,
                 periodSeconds, successThreshold, failureThreshold);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvOneKey, testTlsEnvOneValue);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvTwoKey, testTlsEnvTwoValue);
 
         LOGGER.info("Checking configuration of TO and UO");
         checkReadinessLivenessProbe(entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator", initialDelaySeconds, timeoutSeconds,
@@ -500,6 +554,7 @@ class KafkaST extends MessagingBaseST {
             kafkaClusterSpec.getTlsSidecar().getLivenessProbe().setFailureThreshold(updatedFailureThreshold);
             kafkaClusterSpec.getTlsSidecar().getReadinessProbe().setFailureThreshold(updatedFailureThreshold);
             kafkaClusterSpec.getTemplate().getKafkaContainer().setEnv(updatedTestEnvs);
+            kafkaClusterSpec.getTemplate().getTlsSidecarContainer().setEnv(updatedTlsTestEnvs);
             ZookeeperClusterSpec zookeeperClusterSpec = k.getSpec().getZookeeper();
             zookeeperClusterSpec.getLivenessProbe().setInitialDelaySeconds(updatedInitialDelaySeconds);
             zookeeperClusterSpec.getReadinessProbe().setInitialDelaySeconds(updatedInitialDelaySeconds);
@@ -518,6 +573,8 @@ class KafkaST extends MessagingBaseST {
             zookeeperClusterSpec.getTlsSidecar().getReadinessProbe().setPeriodSeconds(updatedPeriodSeconds);
             zookeeperClusterSpec.getTlsSidecar().getLivenessProbe().setFailureThreshold(updatedFailureThreshold);
             zookeeperClusterSpec.getTlsSidecar().getReadinessProbe().setFailureThreshold(updatedFailureThreshold);
+            zookeeperClusterSpec.getTemplate().getZookeeperContainer().setEnv(updatedTestEnvs);
+            zookeeperClusterSpec.getTemplate().getTlsSidecarContainer().setEnv(updatedTlsTestEnvs);
             // Configuring TO and UO to use new values for InitialDelaySeconds and TimeoutSeconds
             EntityOperatorSpec entityOperatorSpec = k.getSpec().getEntityOperator();
             entityOperatorSpec.getTopicOperator().getLivenessProbe().setInitialDelaySeconds(updatedInitialDelaySeconds);
@@ -559,14 +616,20 @@ class KafkaST extends MessagingBaseST {
         checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "kafka", testEnvThreeKey, testEnvThreeValue);
         checkReadinessLivenessProbe(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", updatedInitialDelaySeconds, updatedTimeoutSeconds,
                 updatedPeriodSeconds, successThreshold, updatedFailureThreshold);
+        checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvTwoKey, updatedTlsTestEnvTwoValue);
+        checkContainerConfiguration(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvThreeKey, testTlsEnvThreeValue);
 
         LOGGER.info("Testing Zookeepers");
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", updatedInitialDelaySeconds, updatedTimeoutSeconds,
                 updatedPeriodSeconds, successThreshold, updatedFailureThreshold);
         checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", "ZOOKEEPER_CONFIGURATION",
                 "autopurge.purgeInterval=1\ntickTime=2100\ninitLimit=6\nsyncLimit=3\n");
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", testEnvTwoKey, updatedTestEnvTwoValue);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", testEnvThreeKey, testEnvThreeValue);
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", updatedInitialDelaySeconds, updatedTimeoutSeconds,
                 updatedPeriodSeconds, successThreshold, updatedFailureThreshold);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvTwoKey, updatedTlsTestEnvTwoValue);
+        checkContainerConfiguration(zookeeperStatefulSetName(CLUSTER_NAME), "tls-sidecar", testTlsEnvThreeKey, testTlsEnvThreeValue);
 
         LOGGER.info("Getting entity operator to check configuration of TO and UO");
         checkReadinessLivenessProbe(entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator", updatedInitialDelaySeconds, updatedTimeoutSeconds,
@@ -604,32 +667,6 @@ class KafkaST extends MessagingBaseST {
                         assertEquals(successThreshold, container.getReadinessProbe().getSuccessThreshold());
                         assertEquals(failureThreshold, container.getLivenessProbe().getFailureThreshold());
                         assertEquals(failureThreshold, container.getReadinessProbe().getFailureThreshold());
-                    });
-            });
-        } else {
-            fail("Pod with prefix " + podNamePrefix + " in name, not found");
-        }
-    }
-
-    /**
-     * Verifies container configuration by environment key
-     * @param podNamePrefix Name of pod where container is located
-     * @param containerName The container where verifying is expected
-     * @param configKey Expected configuration key
-     * @param config Expected configuration
-     */
-    void checkContainerConfiguration(String podNamePrefix, String containerName, String configKey, String config) {
-        LOGGER.info("Getting pods by prefix in name {}", podNamePrefix);
-        List<Pod> pods = kubeClient().listPodsByPrefixInName(podNamePrefix);
-
-        if (pods.size() != 0) {
-            LOGGER.info("Testing configuration for container {}", containerName);
-            pods.forEach(pod -> {
-                pod.getSpec().getContainers().stream().filter(c -> c.getName().equals(containerName))
-                    .forEach(container -> {
-                        container.getEnv().stream().filter(
-                            envVar -> envVar.getName().equals(configKey))
-                                .forEach(envVar -> assertEquals(config, envVar.getValue()));
                     });
             });
         } else {


### PR DESCRIPTION
### Type of change

- Enhancement
- Documentation

### Description

Adds environment variable settings to all container templates:

* Kafka Broker TLS sidecar
* Zookeeper node
* Zookeeper tls sidecar
* Entity Operators and TLS Sidecar
* Kafka Connect and ConnectS2I
* Kafka Mirror Maker
* Kafka Bridge
* Updated documentation with examples and config path table

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

