### PR TITLE
Make it clear which loggers are Kafka and which are Zookeeper

### DIFF
--- a/documentation/book/ref-loggers-Kafka.adoc
+++ b/documentation/book/ref-loggers-Kafka.adoc
@@ -3,7 +3,7 @@
 // assembly-deployment-configuration-kafka.adoc
 
 [id='ref-loggers-Kafka-{context}']
-= Kafka loggers
+= Kafka and Zookeeper loggers
 
 Kafka has its own configurable loggers:
 
@@ -21,5 +21,6 @@ Kafka has its own configurable loggers:
 * `log4j.logger.state.change.logger`
 * `log4j.logger.kafka.authorizer.logger`
 
-* Zookeeper
-** `zookeeper.root.logger`
+Zookeeper has its own logger as well:
+
+* `zookeeper.root.logger`


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Currently, the Zookeeper logger is mixed into the list of Kafka loggers which is confusing. This PR makes it clear these are two separate lists. This is related to the issue #1918 - but it doesn't solve all the docs issues related to that.

### Checklist

- [x] Update documentation