### PR TITLE
Add bind-utils to kafka docker image

### DIFF
--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -39,6 +39,9 @@ COPY kafka-thirdparty-libs/target/dependency/ ${KAFKA_HOME}/libs/
 
 RUN yum -y install stunnel net-tools && yum clean all -y
 
+# for nslookup
+RUN yum -y install bind-utils && yum clean all -y
+
 # set Stunnel home folder
 ENV STUNNEL_HOME=/opt/stunnel
 

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -37,10 +37,7 @@ COPY ./tmp/mirror-maker-agent.jar ${KAFKA_HOME}/libs/
 
 COPY kafka-thirdparty-libs/target/dependency/ ${KAFKA_HOME}/libs/
 
-RUN yum -y install stunnel net-tools && yum clean all -y
-
-# for nslookup
-RUN yum -y install bind-utils && yum clean all -y
+RUN yum -y install stunnel net-tools bind-utils && yum clean all -y
 
 # set Stunnel home folder
 ENV STUNNEL_HOME=/opt/stunnel


### PR DESCRIPTION
- Helps with debugging services in kubernetes

### Type of change

- Enhancement


### Description
Add bind-utils to kafka image. Please check #1926

