### PR TITLE
ST: add test for loadBalancerIP override

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -159,6 +159,16 @@ public class KafkaResources {
     }
 
     /**
+     * Returns the name of the {@code Service} for a specific Kafka {@code Pod} of a {@code Kafka} cluster of the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @param podNum The number of the Kafka pod corresponding to the service
+     * @return The name of the corresponding Kafka {@code Service}.
+     */
+    public static String brokerSpecificService(String clusterName, int podNum) {
+        return clusterName + "-kafka-" + podNum;
+    }
+
+    /**
      * Returns the name of the Kafka metrics and log {@code ConfigMap} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The name of the corresponding Kafka metrics and log {@code ConfigMap}.

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -226,5 +226,12 @@
                 <groups>scalability &amp; !flaky</groups>
             </properties>
         </profile>
+        <profile>
+            <id>specific</id>
+            <properties>
+                <skippTests>false</skippTests>
+                <groups>specific</groups>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -8,7 +8,6 @@ import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -300,12 +299,6 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
      */
     static String globalVariableJsonPathBuilder(String envVar) {
         return "$.spec.containers[*].env[?(@.name=='" + envVar + "')].value";
-    }
-
-    List<Event> getEvents(String resourceUid) {
-        return kubeClient().listEvents().stream()
-                .filter(event -> event.getInvolvedObject().getUid().equals(resourceUid))
-                .collect(Collectors.toList());
     }
 
     public void sendMessages(String podName, String clusterName, String containerName, String topic, int messagesCount) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -91,4 +91,8 @@ public interface Constants {
      * Tag for scalability tests
      */
     String SCALABILITY = "scalability";
+    /**
+     * Tag for tests, which are working only on specific environment and we usually don't want to execute them on all environments.
+     */
+    String SPECIFIC = "specific";
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -168,7 +168,7 @@ class ConnectST extends AbstractST {
         for (String pod : connectPods) {
             StUtils.waitForPod(pod);
             String uid = kubeClient().getPodUid(pod);
-            List<Event> events = getEvents(uid);
+            List<Event> events = kubeClient().listEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
         }
@@ -182,7 +182,7 @@ class ConnectST extends AbstractST {
         assertEquals(initialReplicas, connectPods.size());
         for (String pod : connectPods) {
             String uid = kubeClient().getPodUid(pod);
-            List<Event> events = getEvents(uid);
+            List<Event> events = kubeClient().listEvents(uid);
             assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
             assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.specific;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverride;
+import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverrideBuilder;
+import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverride;
+import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverrideBuilder;
+import io.strimzi.systemtest.MessagingBaseST;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.strimzi.systemtest.Constants.SPECIFIC;
+import static io.strimzi.systemtest.k8s.Events.Created;
+import static io.strimzi.systemtest.k8s.Events.Pulled;
+import static io.strimzi.systemtest.k8s.Events.Scheduled;
+import static io.strimzi.systemtest.k8s.Events.Started;
+import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(SPECIFIC)
+public class SpecificST extends MessagingBaseST {
+
+    private static final Logger LOGGER = LogManager.getLogger(SpecificST.class);
+    public static final String NAMESPACE = "specific-cluster-test";
+
+    @Test
+    void testRackAware() throws Exception {
+        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 1, 1)
+            .editSpec()
+                .editKafka()
+                .withNewRack()
+                    .withTopologyKey("rack-key")
+                .endRack()
+                .editListeners()
+                    .withNewKafkaListenerExternalLoadBalancer()
+                        .withTls(false)
+                    .endKafkaListenerExternalLoadBalancer()
+                .endListeners()
+                .endKafka()
+            .endSpec().done();
+
+        String rackId = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", "cat /opt/kafka/init/rack.id").out();
+        assertEquals("zone", rackId.trim());
+
+        String brokerRack = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack").out();
+        assertTrue(brokerRack.contains("broker.rack=zone"));
+
+        String uid = kubeClient().getPodUid(KafkaResources.kafkaPodName(CLUSTER_NAME, 0));
+        List<Event> events = kubeClient().listEvents(uid);
+        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
+        waitForClusterAvailability(NAMESPACE);
+    }
+
+
+    @Test
+    void testLoadBalancerIpOverride() throws Exception {
+        String bootstrapOverrideIP = "10.0.0.1";
+        String brokerOverrideIP = "10.0.0.2";
+
+        LoadBalancerListenerBootstrapOverride bootstrapOverride = new LoadBalancerListenerBootstrapOverrideBuilder()
+                .withLoadBalancerIP(bootstrapOverrideIP)
+                .build();
+
+        LoadBalancerListenerBrokerOverride brokerOverride0 = new LoadBalancerListenerBrokerOverrideBuilder()
+                .withBroker(0)
+                .withLoadBalancerIP(brokerOverrideIP)
+                .build();
+
+        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3, 1)
+            .editSpec()
+                .editKafka()
+                    .editListeners()
+                        .withNewKafkaListenerExternalLoadBalancer()
+                            .withTls(false)
+                        .withNewOverrides()
+                            .withBootstrap(bootstrapOverride)
+                            .withBrokers(brokerOverride0)
+                        .endOverrides()
+                        .endKafkaListenerExternalLoadBalancer()
+                    .endListeners()
+                .endKafka()
+            .endSpec()
+            .done();
+
+        assertThat("Kafka External bootstrap doesn't contain correct loadBalancer address", kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getSpec().getLoadBalancerIP(), is(bootstrapOverrideIP));
+        assertThat("Kafka Broker-0 service doesn't contain correct loadBalancer address", kubeClient().getService(KafkaResources.brokerSpecificService(CLUSTER_NAME, 0)).getSpec().getLoadBalancerIP(), is(brokerOverrideIP));
+
+        waitForClusterAvailability(NAMESPACE);
+    }
+
+    @BeforeEach
+    void createTestResources() {
+        createTestMethodResources();
+    }
+
+    @AfterEach
+    void deleteTestResources() {
+        deleteTestMethodResources();
+    }
+
+    @BeforeAll
+    void setupEnvironment() {
+        LOGGER.info("Creating resources before the test class");
+        prepareEnvForOperator(NAMESPACE);
+
+        createTestClassResources();
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        testClassResources().clusterOperator(NAMESPACE).done();
+    }
+}

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -421,6 +421,12 @@ public class KubeClient {
                 .collect(Collectors.toList());
     }
 
+    public List<Event> listEvents(String resourceUid) {
+        return listEvents().stream()
+                .filter(event -> event.getInvolvedObject().getUid().equals(resourceUid))
+                .collect(Collectors.toList());
+    }
+
     public RoleBinding createOrReplaceRoleBinding(RoleBinding roleBinding) {
         return client.rbac().roleBindings().inNamespace(getNamespace()).createOrReplace(roleBinding);
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add new system test for specify `loadBalancerIP` value. Also introduce new tag - `specific` which contains tests suited only for specific base environment like `minikube`, `oc cluster up` or `minishift`. This tests needs manual changes in default cluster configuration and this option will allows us exclude them in default pipelines.

### Checklist

- [x] Make sure all tests pass

