### PR TITLE
Use https in all Strimzi links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,6 @@ If you want to get in touch with us first before contributing, you can use:
 [hacking-guide]: https://github.com/strimzi/strimzi-kafka-operator/blob/master/HACKING.md
 [dev-quick-start]: https://github.com/strimzi/strimzi-kafka-operator/blob/master/DEV_QUICK_START.md
 [release-list]: https://github.com/strimzi/strimzi-kafka-operator/blob/master/RELEASE.md
-[doc-contrib-guide]: http://strimzi.io/contributing/guide/
+[doc-contrib-guide]: https://strimzi.io/contributing/guide/
 [mailinglist]: https://www.redhat.com/mailman/listinfo/strimzi 
 [slack]: https://join.slack.com/t/strimzi/shared_invite/enQtMzU2Mjk3NTgxMzE5LTYyMTUwMGNlMDQwMzBhOGI4YmY4MjhiMDgyNjA5OTk2MTFiYjc4M2Q3NGU1YTFjOWRiMzM2NGMwNDUwMjBlNDY

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Strimzi](./documentation/logo/strimzi.png)](http://strimzi.io/)
+[![Strimzi](./documentation/logo/strimzi.png)](https://strimzi.io/)
 
 # Run Apache Kafka on Kubernetes and OpenShift
 
@@ -13,7 +13,7 @@ See our [website][strimzi] for more details about the project.
 
 ## Quickstart
 
-To get up and running quickly, check our Quickstart guides for [OKD (OpenShift Origin)](http://strimzi.io/quickstarts/okd/) and [Minikube](http://strimzi.io/quickstarts/minikube/). 
+To get up and running quickly, check our Quickstart guides for [OKD (OpenShift Origin)](https://strimzi.io/quickstarts/okd/) and [Minikube](https://strimzi.io/quickstarts/minikube/). 
 
 ## Documentation
 
@@ -41,7 +41,7 @@ label.
 The [Hacking guide](https://github.com/strimzi/strimzi-kafka-operator/blob/master/HACKING.md) describes how to build Strimzi and how to 
 test your changes before submitting a patch or opening a PR.
 
-The [Documentation Contributor Guide](http://strimzi.io/contributing/guide/) describes how to contribute to Strimzi documentation.
+The [Documentation Contributor Guide](https://strimzi.io/contributing/guide/) describes how to contribute to Strimzi documentation.
 
 If you want to get in touch with us first before contributing, you can use:
 
@@ -51,7 +51,7 @@ If you want to get in touch with us first before contributing, you can use:
 ## License
 Strimzi is licensed under the [Apache License](./LICENSE), Version 2.0
 
-[strimzi]: http://strimzi.io "Strimzi"
+[strimzi]: https://strimzi.io "Strimzi"
 [kafka]: https://kafka.apache.org "Apache Kafka"
 [k8s]: https://kubernetes.io/ "Kubernetes"
 [os]: https://www.openshift.com/ "OpenShift"

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -121,7 +121,7 @@
 // Helm Chart - deploy cluster operator
 :ChartName: strimzi-kafka-operator
 :ChartReleaseCoordinate: strimzi/strimzi-kafka-operator
-:ChartRepositoryUrl: http://strimzi.io/charts/
+:ChartRepositoryUrl: https://strimzi.io/charts/
 
 //Latest Strimzi version
 :ProductVersion: 0.12.x

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -7,10 +7,10 @@ metadata:
     description: >-
       This template installes Apache Kafka Connect in distributed mode together with build pipeline
       for new Kafka Connect images with additional plugins. For more information about using this
-      template see http://strimzi.io
+      template see https://strimzi.io
     tags: "messaging"
     iconClass: "fa fa-exchange"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 message: "Kafka Connect S2I cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-connect-api:8083' to access Kafka Connect REST API."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -6,10 +6,10 @@ metadata:
     openshift.io/display-name: "Apache Kafka Connect"
     description: >-
       This template installs Apache Kafka Connect in distributed mode. For more information
-      about using this template see http://strimzi.io
+      about using this template see https://strimzi.io
     tags: "messaging"
     iconClass: "fa fa-exchange"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 message: "Kafka Connect cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-connect-api:8083' to access Kafka Connect REST API."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -6,14 +6,14 @@ metadata:
     openshift.io/display-name: "Apache Kafka (Ephemeral storage)"
     description: >-
       This template installs Apache Zookeeper and Apache Kafka clusters. For more information
-      about using this template see http://strimzi.io
+      about using this template see https://strimzi.io
 
 
       WARNING: Any data stored will be lost upon pod destruction. Only use this
       template for testing."
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-kafka-bootstrap:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name

--- a/examples/templates/cluster-operator/mirror-maker-template.yaml
+++ b/examples/templates/cluster-operator/mirror-maker-template.yaml
@@ -6,10 +6,10 @@ metadata:
     openshift.io/display-name: "Apache Kafka MirrorMaker"
     description: >-
       This template installs Kafka MirrorMaker to mirror Kafka clusters. 
-      For more information about using this template see http://strimzi.io
+      For more information about using this template see https://strimzi.io
     tags: "messaging,datastore"
     iconClass: "fa fa-cubes"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 message: "Kafka MirrorMaker is being deployed"
 parameters:
 - description: Bootstrap server of the source cluster to be mirrored

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -6,10 +6,10 @@ metadata:
     openshift.io/display-name: "Apache Kafka (Persistent storage)"
     description: >-
       This template installs Apache Zookeeper and Apache Kafka clusters. For more information
-      about using this template see http://strimzi.io
+      about using this template see https://strimzi.io
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}-kafka-bootstrap:9092' as bootstrap server in your application."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name

--- a/examples/templates/topic-operator/topic-template.yaml
+++ b/examples/templates/topic-operator/topic-template.yaml
@@ -8,10 +8,10 @@ metadata:
       This template creates a "Topic ConfigMap". Used in conjunction with
       the Strimzi topic operator this will create a corresponding
       topic in a Strimzi Kafka cluster.
-      For more information about using this template see http://strimzi.io
+      For more information about using this template see https://strimzi.io
     tags: "messaging"
     iconClass: "fa fa-exchange"
-    template.openshift.io/documentation-url: "http://strimzi.io"
+    template.openshift.io/documentation-url: "https://strimzi.io"
 parameters:
 - name: CLUSTER_NAME
   displayName: Name of the Kafka cluster

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -6,7 +6,7 @@ entries:
     created: 2019-07-29T18:12:49.026595+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 19b2654650bff0bf2b449820ce5104bf6cce3a4f72babea32e5217c6fa751601
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -31,7 +31,7 @@ entries:
     created: 2019-07-18T10:00:58.022983+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 2d9941e9f73e0e57ed521ddffbd1eb1a5edb39d891cdf7756ecd73e761075b55
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -56,7 +56,7 @@ entries:
     created: 2019-06-24T11:35:41.042200072+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: a9e82303e02d412e4e1b5e13d2b9b2d5c6290d6411f3aa78cd7647cd617dfd89
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -81,7 +81,7 @@ entries:
     created: 2019-06-14T16:28:55.590731075+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: 42f957fc2d2df0943e75cf274baba3c839e65e4aafb70e0593e77d69be715098
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -106,7 +106,7 @@ entries:
     created: 2019-05-15T17:15:58.840777+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 58bb338054aff06dc0ebbdd13f544ec7802bb4dac8a23c32b7533bfa78c4209d
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -131,7 +131,7 @@ entries:
     created: 2019-04-29T21:15:08.617707+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 03086beb8771c0fe95fd6ef8003ea68dd79f81e66937456c3957d2dd79aa15b8
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -156,7 +156,7 @@ entries:
     created: 2019-04-27T14:46:09.201004+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 2c8ae7ee38f49cb57ed501a89128d503bb28e034855b2d9cc6f504bd9f65c35d
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -181,7 +181,7 @@ entries:
     created: 2019-03-05T00:09:37.350407+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: eb5d8fb9f8861a98c22ded2a7143597d49d2276ea55225af2564c365ad2f356d
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -206,7 +206,7 @@ entries:
     created: 2019-03-05T00:09:37.352282+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: 8d429c9b44b2fffe14ff5f00e462934fbdaa83374d7b7221b186c4e24690ef8a
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -231,7 +231,7 @@ entries:
     created: 2019-02-21T11:16:28.462123+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: d172fa9e91e254e4ba2057ec70a8c047402513f585e07edce59a96fb6d59dd90
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -256,7 +256,7 @@ entries:
     created: 2018-12-13T19:20:03.332037+01:00
     description: 'Strimzi: Kafka as a Service'
     digest: d915c029ee9692a1eab7d51d71c415db1a533756eb3bf1a997e5769f127601e0
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -281,7 +281,7 @@ entries:
     created: 2018-10-26T10:31:11.712551341+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 2e21d3a86d3fd6f36b259f19086b93c478da1b9e0f9dccbfaa379d87091ce457
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -306,7 +306,7 @@ entries:
     created: 2018-10-26T10:31:11.711883438+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 67d28bf30bad5fbae8a63c4e1bc2065c2b9fd4a88e9dec78e82ddb57d9c49a79
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -331,7 +331,7 @@ entries:
     created: 2018-10-12T14:28:03.648679252+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 331b9bab35aea7413716e8b79e773f653909afc53209f25ff0033fc6a8dbc06a
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -356,7 +356,7 @@ entries:
     created: 2018-09-18T22:22:50.0474295+02:00
     description: 'Strimzi: Kafka as a Service'
     digest: 0ae660efb5f445a98649d4a6768d09defe8fabebf0ca807fac9075376f460944
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka
@@ -381,7 +381,7 @@ entries:
     created: 2018-08-23T14:25:34.526805221-04:00
     description: 'Strimzi: Kafka as a Service'
     digest: 684868a46604411a151d90579f15e065320ba636c2afd25702b508fe11b30c64
-    home: http://strimzi.io/
+    home: https://strimzi.io/
     icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
     keywords:
     - kafka

--- a/helm-charts/strimzi-kafka-operator/Chart.yaml
+++ b/helm-charts/strimzi-kafka-operator/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 - messaging
 - datastore
 - topic
-home: http://strimzi.io/
+home: https://strimzi.io/
 sources:
 - https://github.com/strimzi/strimzi-kafka-operator
 maintainers:

--- a/helm-charts/strimzi-kafka-operator/README.md
+++ b/helm-charts/strimzi-kafka-operator/README.md
@@ -20,7 +20,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 Add the Strimzi Helm Chart repository:
 
 ```bash
-$ helm repo add strimzi http://strimzi.io/charts/
+$ helm repo add strimzi https://strimzi.io/charts/
 ```
 
 To install the chart with the release name `my-release`:

--- a/helm-charts/strimzi-kafka-operator/templates/NOTES.txt
+++ b/helm-charts/strimzi-kafka-operator/templates/NOTES.txt
@@ -2,4 +2,4 @@ Thank you for installing {{ .Chart.Name }}-{{ .Chart.Version }}
 
 To create a Kafka cluster refer to the following documentation.
 
-http://strimzi.io/docs/{{ .Chart.Version }}/#kafka-cluster-str
+https://strimzi.io/docs/{{ .Chart.Version }}/#kafka-cluster-str

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>Strimzi - Apache Kafka on Kubernetes and OpenShift</name>
     <description>Strimzi uses the Kubernetes operator pattern to provide a way to run an Apache Kafka cluster on
         Kubernetes or OpenShift in various deployment configurations. </description>
-    <url>http://strimzi.io/</url>
+    <url>https://strimzi.io/</url>
 
     <scm>
         <connection>scm:git:git://github.com/strimzi/strimzi-kafka-operator.git</connection>


### PR DESCRIPTION
When linking to Strimzi, we should use HTTPS protocol in all places. This PR implements this change.