### PR TITLE
Omit priority from CRD when it is 0 (the default)

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -243,7 +243,9 @@ public class CrdGenerator {
                 colNode.put("description", col.description());
                 colNode.put("JSONPath", col.jsonPath());
                 colNode.put("type", col.type());
-                colNode.put("priority", col.priority());
+                if (col.priority() != 0) {
+                    colNode.put("priority", col.priority());
+                }
                 if (!col.format().isEmpty()) {
                     colNode.put("format", col.format());
                 }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -23,7 +23,6 @@ spec:
     description: "The foo"
     JSONPath: "..."
     type: "integer"
-    priority: 0
   validation:
     openAPIV3Schema:
       properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -29,7 +29,6 @@ spec:
     description: "The foo"
     JSONPath: "..."
     type: "integer"
-    priority: 0
   validation:
     openAPIV3Schema:
       properties:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -32,12 +32,10 @@ spec:
     description: The desired number of Kafka replicas in the cluster
     JSONPath: .spec.kafka.replicas
     type: integer
-    priority: 0
   - name: Desired ZK replicas
     description: The desired number of Zookeeper replicas in the cluster
     JSONPath: .spec.zookeeper.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -32,7 +32,6 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -32,7 +32,6 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -32,12 +32,10 @@ spec:
     description: The desired number of partitions in the topic
     JSONPath: .spec.partitions
     type: integer
-    priority: 0
   - name: Replication factor
     description: The desired number of replicas of each partition
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -32,12 +32,10 @@ spec:
     description: How the user is authenticated
     JSONPath: .spec.authentication.type
     type: string
-    priority: 0
   - name: Authorization
     description: How the user is authorised
     JSONPath: .spec.authorization.type
     type: string
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -32,7 +32,6 @@ spec:
     description: The desired number of Kafka Mirror Maker replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   - name: Consumer Bootstrap Servers
     description: The boostrap servers for the consumer
     JSONPath: .spec.consumer.bootstrapServers

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -29,7 +29,6 @@ spec:
     description: The desired number of Kafka Bridge replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   - name: Bootstrap Servers
     description: The boostrap servers
     JSONPath: .spec.bootstrapServers

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -27,12 +27,10 @@ spec:
     description: The desired number of Kafka replicas in the cluster
     JSONPath: .spec.kafka.replicas
     type: integer
-    priority: 0
   - name: Desired ZK replicas
     description: The desired number of Zookeeper replicas in the cluster
     JSONPath: .spec.zookeeper.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -27,7 +27,6 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -27,7 +27,6 @@ spec:
     description: The desired number of Kafka Connect replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -27,12 +27,10 @@ spec:
     description: The desired number of partitions in the topic
     JSONPath: .spec.partitions
     type: integer
-    priority: 0
   - name: Replication factor
     description: The desired number of replicas of each partition
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -27,12 +27,10 @@ spec:
     description: How the user is authenticated
     JSONPath: .spec.authentication.type
     type: string
-    priority: 0
   - name: Authorization
     description: How the user is authorised
     JSONPath: .spec.authorization.type
     type: string
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -27,7 +27,6 @@ spec:
     description: The desired number of Kafka Mirror Maker replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   - name: Consumer Bootstrap Servers
     description: The boostrap servers for the consumer
     JSONPath: .spec.consumer.bootstrapServers

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -24,7 +24,6 @@ spec:
     description: The desired number of Kafka Bridge replicas
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   - name: Bootstrap Servers
     description: The boostrap servers
     JSONPath: .spec.bootstrapServers

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -27,12 +27,10 @@ spec:
     description: The desired number of partitions in the topic
     JSONPath: .spec.partitions
     type: integer
-    priority: 0
   - name: Replication factor
     description: The desired number of replicas of each partition
     JSONPath: .spec.replicas
     type: integer
-    priority: 0
   subresources:
     status: {}
   validation:

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -27,12 +27,10 @@ spec:
     description: How the user is authenticated
     JSONPath: .spec.authentication.type
     type: string
-    priority: 0
   - name: Authorization
     description: How the user is authorised
     JSONPath: .spec.authorization.type
     type: string
-    priority: 0
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This issue fixes #1909 by omitting the `priority` from the additional printer columns when it is 0. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

