### PR TITLE
Fix problem with erroneous topic creations resulting in ready status

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -88,9 +89,17 @@ public class K8sImpl implements K8s {
         vertx.executeBlocking(future -> {
             try {
                 // Delete the resource by the topic name, because neither ZK nor Kafka know the resource name
-                operation().inNamespace(namespace).withName(resourceName.toString()).delete();
-                LOGGER.debug("KafkaTopic {} deleted", resourceName.toString());
-                future.complete();
+                if (!Boolean.TRUE.equals(operation().inNamespace(namespace).withName(resourceName.toString()).delete())) {
+                    LOGGER.warn("KafkaTopic {} could not be deleted, since it doesn't seem to exist", resourceName.toString());
+                    future.complete();
+                } else {
+                    Util.waitFor(vertx, "sync resource deletion " + resourceName, 1000, Long.MAX_VALUE, () -> {
+                        KafkaTopic kafkaTopic = operation().inNamespace(namespace).withName(resourceName.toString()).get();
+                        boolean notExists = kafkaTopic == null;
+                        LOGGER.debug("KafkaTopic {} deleted {}", resourceName.toString(), notExists);
+                        return notExists;
+                    }).setHandler(future);
+                }
             } catch (Exception e) {
                 future.fail(e);
             }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -36,8 +36,8 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
             LogContext logContext = LogContext.kubeWatch(action, kafkaTopic).withKubeTopic(kafkaTopic);
             String name = metadata.getName();
             String kind = kafkaTopic.getKind();
-            if (action == Action.ADDED && !initReconcileFuture.isComplete()) {
-                LOGGER.debug("Ignoring initial added event for {} {} during initial reconcile", kind, name);
+            if (!initReconcileFuture.isComplete()) {
+                LOGGER.debug("Ignoring initial event for {} {} during initial reconcile", kind, name);
                 return;
             }
             LOGGER.info("{}: event {} on resource {} generation={}, labels={}", logContext, action, name,

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -433,23 +433,26 @@ class TopicOperator {
                 return waiters + 1;
             }
         });
-        vertx.sharedData().getLockWithTimeout(lockName, timeoutMs, ar -> {
-            if (ar.succeeded()) {
+        vertx.sharedData().getLockWithTimeout(lockName, timeoutMs, lockResult -> {
+            if (lockResult.succeeded()) {
                 LOGGER.debug("{}: Lock acquired", logContext);
                 LOGGER.debug("{}: Executing action {} on topic {}", logContext, action, lockName);
-                action.execute().setHandler(ar2 -> {
+                action.execute().setHandler(actionResult -> {
                     LOGGER.debug("{}: Executing handler for action {} on topic {}", logContext, action, lockName);
-                    action.result = ar2;
+                    action.result = actionResult;
                     // Update status with lock held so that event is ignored via statusUpdateGeneration
-                    action.updateStatus(logContext).setHandler(ar3 -> {
-                        if (ar3.failed()) {
+                    action.updateStatus(logContext).setHandler(statusResult -> {
+                        if (statusResult.failed()) {
                             LOGGER.error("{}: Error updating KafkaTopic.status for action {}", logContext, action,
-                                    ar3.cause());
+                                    statusResult.cause());
                         }
                         try {
-                            result.handle(ar2);
+                            if (actionResult.failed() && statusResult.failed()) {
+                                actionResult.cause().addSuppressed(statusResult.cause());
+                            }
+                            result.handle(actionResult.failed() ? actionResult : statusResult);
                         } finally {
-                            ar.result().release();
+                            lockResult.result().release();
                             LOGGER.debug("{}: Lock released", logContext);
                             inflight.compute(key, decrement);
                         }
@@ -915,7 +918,7 @@ class TopicOperator {
                     LOGGER.debug("{}: No KafkaTopic to set status", logContext);
                     statusFuture = Future.succeededFuture();
                 }
-                return result.failed() ? Future.failedFuture(result.cause()) : statusFuture;
+                return statusFuture;
             } catch (Throwable t) {
                 LOGGER.error("{}", logContext, t);
                 return Future.failedFuture(t);
@@ -933,7 +936,7 @@ class TopicOperator {
                             .compose(mt ->  {
                                 final Topic k8sTopic;
                                 if (mt != null) {
-                                    observedTopicFuture(mt);
+
                                     Long generation = statusUpdateGeneration.get(mt.getMetadata().getName());
                                     LOGGER.debug("{}: last updated generation={}", logContext, generation);
                                     if (mt.getMetadata() != null
@@ -954,7 +957,7 @@ class TopicOperator {
                                     } else {
                                         LOGGER.debug("{}: modifiedTopic.getMetadata().getGeneration()=null", logContext);
                                     }
-
+                                    observedTopicFuture(mt);
                                     try {
                                         k8sTopic = TopicSerialization.fromTopicResource(mt);
                                     } catch (InvalidTopicException e) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -102,7 +102,7 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
         waitForTopicInKafka(context, topicName, true);
 
         // Delete the k8 KafkaTopic and wait for that to be deleted
-        deleteInKube(topicResource.getMetadata().getName());
+        deleteInKube(context, topicResource.getMetadata().getName());
 
         // trigger an immediate reconcile where, with with delete.topic.enable=false, the K8s KafkaTopic should be recreated
         Future<?> result = session.topicOperator.reconcileAllTopics("periodic");


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Fix problem with erroneous topic creations resulting in ready status.
The problem was that although the initial CREATED even set a NotReady status
the following one (which caused by the setStatus triggering an even) was "successful" (i.e. detected as a no op), which then overwrote the published status.
By moving observedTopicFuture(mt) after the noop detection we don't attempt to update status in the no op case.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

