### PR TITLE
Fix repeted deletion of non-existent readines indicator file

### DIFF
--- a/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
+++ b/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
@@ -111,7 +111,7 @@ public class MirrorMakerAgent {
                     } else {
                         LOGGER.debug("Mirror Maker is not ready");
 
-                        if (!readinessFile.delete()) {
+                        if (readinessFile.exists() && !readinessFile.delete()) {
                             LOGGER.error("Could not delete readiness indicator file {}", readinessFile);
                         }
                     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a bug in the new Mirror Maker readiness probe. When the container is not ready, it should delete the readiness indicator file. But afterwards it tries to delete it again and again when it does not exist. That triggers following errors:

```
2019-08-28 05:49:24,979 ERROR Could not delete readiness indicator file /tmp/mirror-maker-ready (io.strimzi.mirrormaker.agent.MirrorMakerAgent) [ReadinessPoller]
2019-08-28 05:49:29,979 ERROR Could not delete readiness indicator file /tmp/mirror-maker-ready (io.strimzi.mirrormaker.agent.MirrorMakerAgent) [ReadinessPoller]
2019-08-28 05:49:34,979 ERROR Could not delete readiness indicator file /tmp/mirror-maker-ready (io.strimzi.mirrormaker.agent.MirrorMakerAgent) [ReadinessPoller]
2019-08-28 05:49:39,980 ERROR Could not delete readiness indicator file /tmp/mirror-maker-ready (io.strimzi.mirrormaker.agent.MirrorMakerAgent) [ReadinessPoller]
2019-08-28 05:49:44,980 ERROR Could not delete readiness indicator file /tmp/mirror-maker-ready (io.strimzi.mirrormaker.agent.MirrorMakerAgent) [ReadinessPoller]
```

This should at least partially resolve the issue #1933

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging