### PR TITLE
Make it possible to disable TLS hostname verification in Connect and Mirror Maker

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -50,6 +50,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, authorizer., super.user";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "zookeeper.connection.timeout.ms";
 
     protected Storage storage;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -40,6 +40,7 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
 
     private Map<String, Object> config = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -27,6 +27,7 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
 
     private Integer numStreams;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -26,6 +26,7 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     private Boolean abortOnSendFailure;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security., interceptor.classes";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
 
     @Description("Flag to set the Mirror Maker to exit on a failed send. Default value is `true`.")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -94,10 +94,27 @@ public abstract class AbstractConfiguration {
     }
 
     /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     * @param forbiddenOptions   List with configuration keys which are not allowed. All keys which start with one of
+     *                           these keys will be ignored.
+     * @param exceptions        Exceptions excluded from forbidden options checking
+     * @param defaults          Properties object with default options
+     */
+    public AbstractConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenOptions, List<String> exceptions, Map<String, String> defaults) {
+        options.addMapPairs(defaults);
+        options.addIterablePairs(jsonOptions);
+        filterForbidden(forbiddenOptions, exceptions);
+    }
+
+    /**
      * Filters forbidden values from the configuration.
      *
      * @param forbiddenOptions  List with configuration keys which are not allowed. All keys which start with one of
      *                          these keys will be ignored.
+     * @param exceptions        Exceptions excluded from forbidden options checking
      */
     private void filterForbidden(List<String> forbiddenOptions, List<String> exceptions)   {
         options.filter(k -> forbiddenOptions.stream().anyMatch(s -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -17,7 +17,6 @@ import static java.util.Collections.emptyList;
  * Class for handling Kafka configuration passed by the user
  */
 public class KafkaConfiguration extends AbstractConfiguration {
-
     public static final String INTERBROKER_PROTOCOL_VERSION = "inter.broker.protocol.version";
     public static final String LOG_MESSAGE_FORMAT_VERSION = "log.message.format.version";
 
@@ -26,18 +25,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList("zookeeper.connection.timeout.ms");
-    }
-
-    /**
-     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
-     * from the Assembly.
-     *
-     * @param configuration Configuration in String format. Should contain zero or more lines with with key=value
-     *                      pairs.
-     */
-    public KafkaConfiguration(String configuration) {
-        this(configuration, FORBIDDEN_OPTIONS);
+        EXCEPTIONS = asList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -18,10 +18,12 @@ import static java.util.Arrays.asList;
  */
 public class KafkaConnectConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
+        EXCEPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
         DEFAULTS = new HashMap<>();
         DEFAULTS.put("group.id", "connect-cluster");
@@ -33,23 +35,12 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
-     * from the Assembly.
-     *
-     * @param configuration Configuration in String format. Should contain zero or more lines with with key=value
-     *                      pairs.
-     */
-    public KafkaConnectConfiguration(String configuration) {
-        super(configuration, FORBIDDEN_OPTIONS, DEFAULTS);
-    }
-
-    /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
      * ConfigMap / CRD.
      *
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConnectConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka Mirror Maker consumer configuration passed by the user
  */
 public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration {
-
     private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES.split(", "));
-
+        EXCEPTIONS = asList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerConsumerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -17,13 +17,13 @@ import static java.util.Arrays.asList;
  * Class for handling Kafka Mirror Maker producer configuration passed by the user
  */
 public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration {
-
     private static final List<String> FORBIDDEN_OPTIONS;
+    private static final List<String> EXCEPTIONS;
     private static final Map<String, String> DEFAULTS;
 
     static {
         FORBIDDEN_OPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES.split(", "));
-
+        EXCEPTIONS = asList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
         DEFAULTS = new HashMap<>();
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerProducerConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_OPTIONS, DEFAULTS);
+        super(jsonOptions, FORBIDDEN_OPTIONS, EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -237,6 +237,48 @@ public class AbstractConfigurationTest {
         assertEquals("42", kc.asOrderedProperties().asMap().get("zookeeper.connection.timeout.ms"));
         assertNull(kc.asOrderedProperties().asMap().get("zookeeper.connection.timeout"));
     }
+
+    @Test
+    public void testKafkaConnectHostnameVerification() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("key.converter", "my.package.Converter"); // valid
+        conf.put("ssl.endpoint.identification.algorithm", ""); // valid
+        conf.put("ssl.keystore.location", "/tmp/my.keystore"); // invalid
+
+        KafkaConnectConfiguration configuration = new KafkaConnectConfiguration(conf.entrySet());
+
+        assertEquals("my.package.Converter", configuration.asOrderedProperties().asMap().get("key.converter"));
+        assertNull(configuration.asOrderedProperties().asMap().get("ssl.keystore.location"));
+        assertEquals("", configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"));
+    }
+
+    @Test
+    public void testKafkaMirrorMakerConsumerHostnameVerification() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("compression.type", "zstd"); // valid
+        conf.put("ssl.endpoint.identification.algorithm", ""); // valid
+        conf.put("ssl.keystore.location", "/tmp/my.keystore"); // invalid
+
+        KafkaMirrorMakerConsumerConfiguration configuration = new KafkaMirrorMakerConsumerConfiguration(conf.entrySet());
+
+        assertEquals("zstd", configuration.asOrderedProperties().asMap().get("compression.type"));
+        assertNull(configuration.asOrderedProperties().asMap().get("ssl.keystore.location"));
+        assertEquals("", configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"));
+    }
+
+    @Test
+    public void testKafkaMirrorMakerProducerHostnameVerification() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("compression.type", "zstd"); // valid
+        conf.put("ssl.endpoint.identification.algorithm", ""); // valid
+        conf.put("ssl.keystore.location", "/tmp/my.keystore"); // invalid
+
+        KafkaMirrorMakerProducerConfiguration configuration = new KafkaMirrorMakerProducerConfiguration(conf.entrySet());
+
+        assertEquals("zstd", configuration.asOrderedProperties().asMap().get("compression.type"));
+        assertNull(configuration.asOrderedProperties().asMap().get("ssl.keystore.location"));
+        assertEquals("", configuration.asOrderedProperties().asMap().get("ssl.endpoint.identification.algorithm"));
+    }
 }
 
 class TestConfiguration extends AbstractConfiguration {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, in Connect and Mirror Maker any configuration starting with `ssl.` is forbidden as it is configured through other means in the CRD. However, in might make sense to allow configuring `ssl.endpoint.identification.algorithm` to give users the option to disable it as requested in #1951. 

This PR does tht by using the existing mechanism of exceptions for fields matching the forbidden options which is already used for KAfka configuration.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging