### PR TITLE
Kafka pods self-restarting fix

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -92,6 +92,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1344,7 +1345,7 @@ public class KafkaCluster extends AbstractModel {
         // Add user defined environment variables to the Kafka broker containers
         if (templateKafkaContainerEnvVars != null) {
             // Create set of env var names to test if any user defined template env vars will conflict with those set above
-            Set<String> predefinedEnvs = new HashSet<String>();
+            Set<String> predefinedEnvs = new LinkedHashSet<>();
             for (EnvVar envVar : varList) {
                 predefinedEnvs.add(envVar.getName());
             }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix


### Description
The `HashSet` implementation does not preserve insert order and thus the `StatefullDiff` was returning false positives. And kafka pods were rolling update over and over again,

### Checklist


- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

