### PR TITLE
Alter Topic Operator to respect delete.topic.enable=false broker config

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -567,14 +567,13 @@ class TopicOperator {
     private Future<Void> handleTopicDeletionDisabled(Throwable thrown) {
 
         if (thrown instanceof org.apache.kafka.common.errors.TopicDeletionDisabledException) {
-            LOGGER.warn("Topic deletion is disabled. Kafka topic will persist and K8s resource will be recreated in next reconciliation.");
+            LOGGER.warn("Topic deletion is disabled. Kafka broker topic will persist and KafkaTopic resource will be recreated in the next reconciliation.");
         } else {
-            LOGGER.error("Topic deletion failed with (" + thrown.getClass() + ") error: " + thrown.getMessage());
+            LOGGER.error("Topic deletion failed with ({}) error: {}", thrown.getClass(), thrown.getMessage());
             return Future.failedFuture(thrown);
         }
 
         return Future.succeededFuture();
-
     }
 
     private Future<Void> update2Way(Reconciliation reconciliation, LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -536,8 +536,9 @@ class TopicOperator {
                     reconciliationResultHandler = deleteFromTopicStore(logContext, involvedObject, privateTopic.getTopicName());
                 } else {
                     // it was deleted in k8s so delete in kafka and privateState
+                    // If delete.topic.enable=false then the resulting exception will be ignored and only the privateState topic will be deleted
                     LOGGER.debug("{}: KafkaTopic deleted in k8s => delete topic from kafka and from topicStore", logContext);
-                    reconciliationResultHandler = deleteKafkaTopic(logContext, kafkaTopic.getTopicName())
+                    reconciliationResultHandler = deleteKafkaTopic(logContext, kafkaTopic.getTopicName()).recover(this::handleTopicDeletionDisabled)
                         .compose(ignored -> deleteFromTopicStore(logContext, involvedObject, privateTopic.getTopicName()));
                 }
             } else if (kafkaTopic == null) {
@@ -553,6 +554,27 @@ class TopicOperator {
             }
         }
         return reconciliationResultHandler;
+    }
+
+    /**
+     * Function for handling the exceptions thrown by attempting to delete a topic. If the  delete.topic.enable config
+     * is set to false on the broker the exception is ignored an a blank future returned. For any other form of exception
+     * a failed future is returned using that exception as the cause.
+     *
+     * @param thrown The exception encountered when attempting to delete the kafka topic.
+     * @return Either an succeeded future in the case that topic deletion is disabled or a failed future in all other cases.
+     */
+    private Future<Void> handleTopicDeletionDisabled(Throwable thrown) {
+
+        if (thrown instanceof org.apache.kafka.common.errors.TopicDeletionDisabledException) {
+            LOGGER.warn("Topic deletion is disabled. Kafka topic will persist and K8s resource will be recreated in next reconciliation.");
+        } else {
+            LOGGER.error("Topic deletion failed with (" + thrown.getClass() + ") error: " + thrown.getMessage());
+            return Future.failedFuture(thrown);
+        }
+
+        return Future.succeededFuture();
+
     }
 
     private Future<Void> update2Way(Reconciliation reconciliation, LogContext logContext, HasMetadata involvedObject, Topic k8sTopic, Topic kafkaTopic) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.kafka.ZookeeperServer;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaTopicList;
+import io.strimzi.api.kafka.model.DoneableKafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.operator.common.Util;
+import io.strimzi.test.BaseITST;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeCluster;
+import io.strimzi.test.k8s.NoClusterException;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.CreatePartitionsResult;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+public class TopicOperatorBaseIT extends BaseITST {
+
+    private static final Logger LOGGER = LogManager.getLogger(TopicOperatorBaseIT.class);
+
+    protected static String oldNamespace;
+
+    protected final Labels labels = Labels.fromString(
+            "strimzi.io/kind=topic");
+
+    public static final String NAMESPACE = "topic-operator-it";
+
+    protected final Vertx vertx = Vertx.vertx();
+    protected KafkaCluster kafkaCluster;
+    protected volatile AdminClient adminClient;
+    protected KubernetesClient kubeClient;
+    protected Thread kafkaHook = new Thread() {
+        @Override
+        public void run() {
+            if (kafkaCluster != null) {
+                kafkaCluster.shutdown();
+            }
+        }
+    };
+    protected final long timeout = 30_000L;
+
+    protected volatile String deploymentId;
+    protected Set<String> preExistingEvents;
+
+    protected Session session;
+
+    @BeforeClass
+    public static void setupKubeCluster() throws IOException {
+        try {
+            KubeCluster.bootstrap();
+        } catch (NoClusterException e) {
+            Assume.assumeTrue(e.getMessage(), false);
+        }
+        cmdKubeClient()
+                .createNamespace(NAMESPACE);
+        oldNamespace = setNamespace(NAMESPACE);
+        LOGGER.info("#### Creating " + "../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
+        LOGGER.info(new String(Files.readAllBytes(new File("../install/topic-operator/02-Role-strimzi-topic-operator.yaml").toPath())));
+        cmdKubeClient().create("../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
+        LOGGER.info("#### Creating " + TestUtils.CRD_TOPIC);
+        LOGGER.info(new String(Files.readAllBytes(new File(TestUtils.CRD_TOPIC).toPath())));
+        cmdKubeClient().create(TestUtils.CRD_TOPIC);
+        LOGGER.info("#### Creating " + "src/test/resources/TopicOperatorIT-rbac.yaml");
+        LOGGER.info(new String(Files.readAllBytes(new File("src/test/resources/TopicOperatorIT-rbac.yaml").toPath())));
+
+        cmdKubeClient().create("src/test/resources/TopicOperatorIT-rbac.yaml");
+    }
+
+    @AfterClass
+    public static void teardownKubeCluster() {
+        if (oldNamespace != null) {
+            cmdKubeClient()
+                    .delete("src/test/resources/TopicOperatorIT-rbac.yaml")
+                    .delete(TestUtils.CRD_TOPIC)
+                    .delete("../install/topic-operator/02-Role-strimzi-topic-operator.yaml")
+                    .deleteNamespace(NAMESPACE);
+            cmdKubeClient().namespace(oldNamespace);
+        }
+    }
+
+    protected void startTopicOperator(TestContext context) {
+
+        LOGGER.info("Starting Topic Operator");
+        Map<String, String> m = new HashMap();
+        m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
+        m.put(Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
+        m.put(Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
+        m.put(Config.NAMESPACE.key, NAMESPACE);
+        m.put(Config.TC_RESOURCE_LABELS, "strimzi.io/kind=topic");
+        session = new Session(kubeClient, new Config(m));
+
+        Async async = context.async();
+        vertx.deployVerticle(session, ar -> {
+            if (ar.succeeded()) {
+                deploymentId = ar.result();
+                async.complete();
+            } else {
+                ar.cause().printStackTrace();
+                context.fail("Failed to deploy session");
+            }
+        });
+        async.await();
+        LOGGER.info("Started Topic Operator");
+    }
+
+    protected static int zkPort(KafkaCluster cluster) {
+        // TODO Method was added in DBZ-540, so no need for reflection once
+        // dependency gets upgraded
+        try {
+            Field zkServerField = KafkaCluster.class.getDeclaredField("zkServer");
+            zkServerField.setAccessible(true);
+            return ((ZookeeperServer) zkServerField.get(cluster)).getPort();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void stopTopicOperator(TestContext context) {
+        LOGGER.info("Stopping Topic Operator");
+        Async async = context.async();
+        if (deploymentId != null) {
+            vertx.undeploy(deploymentId, ar -> {
+                deploymentId = null;
+                if (ar.failed()) {
+                    LOGGER.error("Error undeploying session", ar.cause());
+                    context.fail("Error undeploying session");
+                }
+                async.complete();
+            });
+        }
+        async.await();
+        LOGGER.info("Stopped Topic Operator");
+    }
+
+    protected KafkaTopic createKafkaTopicResource(TestContext context, KafkaTopic topicResource) {
+        String topicName = new TopicName(topicResource).toString();
+        // Create a Topic Resource
+        operation().inNamespace(NAMESPACE).create(topicResource);
+
+        // Wait for the topic to be created
+        waitForTopicInKafka(context, topicName);
+        assertStatusReady(context, topicResource.getMetadata().getName());
+        return topicResource;
+    }
+
+    protected void assertStatusReady(TestContext testContext, String topicName) {
+        waitFor(testContext, () -> {
+            KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
+            if (kafkaTopic != null) {
+                if (kafkaTopic.getStatus() != null
+                        && kafkaTopic.getStatus().getConditions() != null) {
+                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
+                    testContext.assertTrue(conditions.size() > 0);
+                    if (conditions.stream().anyMatch(condition ->
+                            "Ready".equals(condition.getType()) &&
+                                    "True".equals(condition.getStatus()))) {
+                        return true;
+                    } else {
+                        LOGGER.info(conditions);
+                    }
+                }
+            } else {
+                LOGGER.info("{} does not exist", topicName);
+            }
+            return false;
+        }, 60000, "status ready");
+    }
+
+    protected KafkaTopic createKafkaTopicResource(TestContext context, String topicName) {
+        Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
+        KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
+        return createKafkaTopicResource(context, topicResource);
+    }
+
+    protected String createTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
+        LOGGER.info("Creating topic {}", topicName);
+        // Create a topic
+        String resourceName = new TopicName(topicName).asKubeName().toString();
+        CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicName, 1, (short) 1)));
+        crt.all().get();
+
+        // Wait for the resource to be created
+        waitForTopicInKube(context, resourceName);
+
+        LOGGER.info("topic {} has been created", resourceName);
+        return resourceName;
+    }
+
+    protected void waitForTopicInKube(TestContext context, String resourceName) {
+        waitForTopicInKube(context, resourceName, true);
+    }
+
+    protected void waitForTopicInKube(TestContext context, String resourceName, boolean exist) {
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
+            return topic != null == exist;
+        }, timeout, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
+    }
+
+    protected void alterTopicConfigInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        String key = "compression.type";
+        final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
+        awaitTopicConfigInKube(context, resourceName, key, changedValue);
+    }
+
+    protected void awaitTopicConfigInKube(TestContext context, String resourceName, String key, String expectedValue) {
+
+        // Wait for the resource to be modified
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {}, waiting for config change", resourceName);
+            String gotValue = TopicSerialization.fromTopicResource(topic).getConfig().get(key);
+            LOGGER.info("Expecting value {}, got value {}", expectedValue, gotValue);
+            return expectedValue.equals(gotValue);
+        }, timeout, "Expected the config of topic " + resourceName + " to have " + key + "=" + expectedValue + " in Kube by now");
+    }
+
+    protected String alterTopicConfigInKafka(String topicName, String key, Function<String, String> mutator) throws InterruptedException, ExecutionException {
+        // Get the topic config
+        ConfigResource configResource = topicConfigResource(topicName);
+        org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
+
+        Map<String, ConfigEntry> m = new HashMap<>();
+        for (ConfigEntry entry: config.entries()) {
+            m.put(entry.name(), entry);
+        }
+        final String changedValue = mutator.apply(m.get(key).value());
+        m.put(key, new ConfigEntry(key, changedValue));
+        LOGGER.info("Changing topic config {} to {}", key, changedValue);
+
+        // Update the topic config
+        AlterConfigsResult cgf = adminClient.alterConfigs(singletonMap(configResource,
+                new org.apache.kafka.clients.admin.Config(m.values())));
+        cgf.all().get();
+        return changedValue;
+    }
+
+    protected void alterTopicNumPartitions(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        int changedValue = 2;
+
+        NewPartitions newPartitions = NewPartitions.increaseTo(changedValue);
+        Map<String, NewPartitions> map = new HashMap<>(1);
+        map.put(topicName, newPartitions);
+
+        CreatePartitionsResult createPartitionsResult = adminClient.createPartitions(map);
+        createPartitionsResult.all().get();
+
+        // Wait for the resource to be modified
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {}, waiting for partitions change", resourceName);
+            int gotValue = TopicSerialization.fromTopicResource(topic).getNumPartitions();
+            LOGGER.info("Expected value {}, got value {}", changedValue, gotValue);
+            return changedValue == gotValue;
+        }, timeout, "Expected the topic " + topicName + "to have " + changedValue + " partitions by now");
+    }
+
+    protected org.apache.kafka.clients.admin.Config getTopicConfig(ConfigResource configResource) {
+        try {
+            return adminClient.describeConfigs(singletonList(configResource)).values().get(configResource).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected ConfigResource topicConfigResource(String topicName) {
+        return new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+    }
+
+    protected void createAndAlterTopicConfig(TestContext context, String topicName) throws InterruptedException, ExecutionException {
+        String resourceName = createTopic(context, topicName);
+        alterTopicConfigInKafkaAndAwaitReconciliation(context, topicName, resourceName);
+    }
+
+    protected void deleteTopicInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        deleteTopicInKafka(topicName, resourceName);
+
+        // Wait for the resource to be deleted
+        waitFor(context, () -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {}, got {}, waiting for deletion", resourceName, topic);
+            return topic == null;
+        }, timeout, "Expected the topic " + topicName + " to have been deleted by now");
+    }
+
+    protected void deleteTopicInKafka(String topicName, String resourceName) throws InterruptedException, ExecutionException {
+        LOGGER.info("Deleting topic {} (KafkaTopic {})", topicName, resourceName);
+        // Now we can delete the topic
+        DeleteTopicsResult dlt = adminClient.deleteTopics(singletonList(topicName));
+        dlt.all().get();
+        LOGGER.info("Deleted topic {}", topicName);
+    }
+
+    protected void createAndDeleteTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
+        String resourceName = createTopic(context, topicName);
+        deleteTopicInKafkaAndAwaitReconciliation(context, topicName, resourceName);
+    }
+
+    protected void createAndAlterNumPartitions(TestContext context, String topicName) throws InterruptedException, ExecutionException {
+        String resourceName = createTopic(context, topicName);
+        alterTopicNumPartitions(context, topicName, resourceName);
+    }
+
+    protected void waitFor(TestContext context, BooleanSupplier ready, long timeout, String message) {
+        Async async = context.async();
+        Util.waitFor(vertx, message, 3_000, timeout, ready).setHandler(ar -> {
+            if (ar.failed()) {
+                context.fail(ar.cause());
+            }
+            async.complete();
+        });
+        async.awaitSuccess();
+    }
+
+    protected void waitForEvent(TestContext context, KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) {
+        waitFor(context, () -> {
+            List<Event> items = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().getItems();
+            List<Event> filtered = items.stream().
+                    filter(evt -> !preExistingEvents.contains(evt.getMetadata().getUid())
+                            && "KafkaTopic".equals(evt.getInvolvedObject().getKind())
+                            && kafkaTopic.getMetadata().getName().equals(evt.getInvolvedObject().getName())).
+                    collect(Collectors.toList());
+            LOGGER.debug("Waiting for events: {}", filtered.stream().map(evt -> evt.getMessage()).collect(Collectors.toList()));
+            return filtered.stream().anyMatch(event ->
+                    Objects.equals(expectedMessage, event.getMessage()) &&
+                            Objects.equals(expectedType.name, event.getType()) &&
+                            event.getInvolvedObject() != null &&
+                            event.getLastTimestamp() != null &&
+                            Objects.equals("KafkaTopic", event.getInvolvedObject().getKind()) &&
+                            Objects.equals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName()));
+        }, timeout, "Expected an error event");
+    }
+
+    protected MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
+        return kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
+    }
+
+    protected void waitForTopicInKafka(TestContext context, String topicName) {
+        waitForTopicInKafka(context, topicName, true);
+    }
+
+    protected void waitForTopicInKafka(TestContext context, String topicName, boolean exist) {
+        waitFor(context, () -> {
+            try {
+                adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
+                return exist;
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException
+                        || e.getCause() instanceof InvalidTopicException) {
+                    return !exist;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, timeout, "Expected topic '" + topicName + "' to " + (exist ? "exist" : "not exist") + " in Kafka by now");
+    }
+
+    protected void deleteInKubeAndAwaitReconciliation(TestContext context, String topicName, KafkaTopic topicResource) {
+        deleteInKube(topicResource.getMetadata().getName());
+
+        // Wait for the topic to be deleted
+        waitFor(context, () -> {
+            try {
+                adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
+                return false;
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException
+                        || e.getCause() instanceof InvalidTopicException) {
+                    return true;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, timeout, "Expected topic to be deleted by now");
+    }
+
+    protected void deleteInKube(String resourceName) {
+        // can now delete the topicResource
+        operation().inNamespace(NAMESPACE).withName(resourceName).delete();
+    }
+
+    protected void awaitTopicConfigInKafka(TestContext context, String topicName, String key, String expectedValue) {
+        // Wait for that to be reflected in the kafka topic
+        waitFor(context, () -> {
+            ConfigResource configResource = topicConfigResource(topicName);
+            org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
+            String retention = config.get("retention.ms").value();
+            LOGGER.debug("retention of {}, waiting for 12341234", retention);
+            return expectedValue.equals(retention);
+        },  timeout, "Expected the topic " + topicName + " to have retention.ms=" + expectedValue + " in Kafka");
+    }
+
+    protected String alterTopicConfigInKube(String resourceName, String key, Function<String, String> mutator) {
+        // now change the topic resource
+        Object retention = operation().inNamespace(NAMESPACE).withName(resourceName).get().getSpec().getConfig().getOrDefault(key, "12341233");
+        String currentValue = retention instanceof Integer ? retention.toString() : (String) retention;
+        String newValue = mutator.apply(currentValue);
+        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(resourceName).get())
+                .editOrNewSpec().addToConfig(key, newValue).endSpec().build();
+        operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
+        return newValue;
+    }
+}
+

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -82,18 +82,18 @@ public class TopicOperatorIT extends BaseITST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);
 
-    private static String oldNamespace;
+    protected static String oldNamespace;
 
-    private final Labels labels = Labels.fromString(
+    protected final Labels labels = Labels.fromString(
             "strimzi.io/kind=topic");
 
     public static final String NAMESPACE = "topic-operator-it";
 
-    private final Vertx vertx = Vertx.vertx();
-    private KafkaCluster kafkaCluster;
-    private volatile AdminClient adminClient;
-    private KubernetesClient kubeClient;
-    private Thread kafkaHook = new Thread() {
+    protected final Vertx vertx = Vertx.vertx();
+    protected KafkaCluster kafkaCluster;
+    protected volatile AdminClient adminClient;
+    protected KubernetesClient kubeClient;
+    protected Thread kafkaHook = new Thread() {
         @Override
         public void run() {
             if (kafkaCluster != null) {
@@ -101,12 +101,12 @@ public class TopicOperatorIT extends BaseITST {
             }
         }
     };
-    private final long timeout = 30_000L;
+    protected final long timeout = 30_000L;
 
-    private volatile String deploymentId;
-    private Set<String> preExistingEvents;
+    protected volatile String deploymentId;
+    protected Set<String> preExistingEvents;
 
-    private Session session;
+    protected Session session;
 
     @BeforeClass
     public static void setupKubeCluster() throws IOException {
@@ -208,7 +208,7 @@ public class TopicOperatorIT extends BaseITST {
         LOGGER.info("Started Topic Operator");
     }
 
-    private static int zkPort(KafkaCluster cluster) {
+    protected static int zkPort(KafkaCluster cluster) {
         // TODO Method was added in DBZ-540, so no need for reflection once
         // dependency gets upgraded
         try {
@@ -295,7 +295,7 @@ public class TopicOperatorIT extends BaseITST {
         }, 60000, "status ready");
     }
 
-    private KafkaTopic createKafkaTopicResource(TestContext context, String topicName) {
+    protected KafkaTopic createKafkaTopicResource(TestContext context, String topicName) {
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
         KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
         return createKafkaTopicResource(context, topicResource);
@@ -319,7 +319,7 @@ public class TopicOperatorIT extends BaseITST {
         waitForTopicInKube(context, resourceName, true);
     }
 
-    private void waitForTopicInKube(TestContext context, String resourceName, boolean exist) {
+    protected void waitForTopicInKube(TestContext context, String resourceName, boolean exist) {
         waitFor(context, () -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
@@ -572,7 +572,7 @@ public class TopicOperatorIT extends BaseITST {
         }, timeout, "Expected topic to be deleted by now");
     }
 
-    private void deleteInKube(String resourceName) {
+    protected void deleteInKube(String resourceName) {
         // can now delete the topicResource
         operation().inNamespace(NAMESPACE).withName(resourceName).delete();
     }
@@ -663,7 +663,7 @@ public class TopicOperatorIT extends BaseITST {
                 TopicOperator.EventType.WARNING);
     }
 
-    private MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
+    protected MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
         return kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -5,142 +5,49 @@
 package io.strimzi.operator.topic;
 
 import io.debezium.kafka.KafkaCluster;
-import io.debezium.kafka.ZookeeperServer;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
-import io.strimzi.api.kafka.KafkaTopicList;
-import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.operator.common.Util;
 import io.strimzi.test.BaseITST;
-import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeCluster;
-import io.strimzi.test.k8s.NoClusterException;
-import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.AlterConfigsResult;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
-import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
-import org.apache.kafka.common.errors.InvalidTopicException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
-public class TopicOperatorIT extends BaseITST {
+public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);
-
-    protected static String oldNamespace;
-
-    protected final Labels labels = Labels.fromString(
-            "strimzi.io/kind=topic");
-
-    public static final String NAMESPACE = "topic-operator-it";
-
-    protected final Vertx vertx = Vertx.vertx();
-    protected KafkaCluster kafkaCluster;
-    protected volatile AdminClient adminClient;
-    protected KubernetesClient kubeClient;
-    protected Thread kafkaHook = new Thread() {
-        @Override
-        public void run() {
-            if (kafkaCluster != null) {
-                kafkaCluster.shutdown();
-            }
-        }
-    };
-    protected final long timeout = 30_000L;
-
-    protected volatile String deploymentId;
-    protected Set<String> preExistingEvents;
-
-    protected Session session;
-
-    @BeforeClass
-    public static void setupKubeCluster() throws IOException {
-        try {
-            KubeCluster.bootstrap();
-        } catch (NoClusterException e) {
-            Assume.assumeTrue(e.getMessage(), false);
-        }
-        cmdKubeClient()
-                .createNamespace(NAMESPACE);
-        oldNamespace = setNamespace(NAMESPACE);
-        LOGGER.info("#### Creating " + "../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
-        LOGGER.info(new String(Files.readAllBytes(new File("../install/topic-operator/02-Role-strimzi-topic-operator.yaml").toPath())));
-        cmdKubeClient().create("../install/topic-operator/02-Role-strimzi-topic-operator.yaml");
-        LOGGER.info("#### Creating " + TestUtils.CRD_TOPIC);
-        LOGGER.info(new String(Files.readAllBytes(new File(TestUtils.CRD_TOPIC).toPath())));
-        cmdKubeClient().create(TestUtils.CRD_TOPIC);
-        LOGGER.info("#### Creating " + "src/test/resources/TopicOperatorIT-rbac.yaml");
-        LOGGER.info(new String(Files.readAllBytes(new File("src/test/resources/TopicOperatorIT-rbac.yaml").toPath())));
-
-        cmdKubeClient().create("src/test/resources/TopicOperatorIT-rbac.yaml");
-    }
-
-    @AfterClass
-    public static void teardownKubeCluster() {
-        if (oldNamespace != null) {
-            cmdKubeClient()
-                    .delete("src/test/resources/TopicOperatorIT-rbac.yaml")
-                    .delete(TestUtils.CRD_TOPIC)
-                    .delete("../install/topic-operator/02-Role-strimzi-topic-operator.yaml")
-                    .deleteNamespace(NAMESPACE);
-            cmdKubeClient().namespace(oldNamespace);
-        }
-    }
 
     @Before
     public void setup(TestContext context) throws Exception {
@@ -184,42 +91,6 @@ public class TopicOperatorIT extends BaseITST {
         LOGGER.info("Finished setting up test");
     }
 
-    void startTopicOperator(TestContext context) {
-        LOGGER.info("Starting Topic Operator");
-        Map<String, String> m = new HashMap();
-        m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
-        m.put(Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
-        m.put(Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
-        m.put(Config.NAMESPACE.key, NAMESPACE);
-        m.put(Config.TC_RESOURCE_LABELS, "strimzi.io/kind=topic");
-        session = new Session(kubeClient, new Config(m));
-
-        Async async = context.async();
-        vertx.deployVerticle(session, ar -> {
-            if (ar.succeeded()) {
-                deploymentId = ar.result();
-                async.complete();
-            } else {
-                ar.cause().printStackTrace();
-                context.fail("Failed to deploy session");
-            }
-        });
-        async.await();
-        LOGGER.info("Started Topic Operator");
-    }
-
-    protected static int zkPort(KafkaCluster cluster) {
-        // TODO Method was added in DBZ-540, so no need for reflection once
-        // dependency gets upgraded
-        try {
-            Field zkServerField = KafkaCluster.class.getDeclaredField("zkServer");
-            zkServerField.setAccessible(true);
-            return ((ZookeeperServer) zkServerField.get(cluster)).getPort();
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @After
     public void teardown(TestContext context) {
         LOGGER.info("Tearing down test");
@@ -242,228 +113,6 @@ public class TopicOperatorIT extends BaseITST {
         Runtime.getRuntime().removeShutdownHook(kafkaHook);
         LOGGER.info("Finished tearing down test");
     }
-
-    void stopTopicOperator(TestContext context) {
-        LOGGER.info("Stopping Topic Operator");
-        Async async = context.async();
-        if (deploymentId != null) {
-            vertx.undeploy(deploymentId, ar -> {
-                deploymentId = null;
-                if (ar.failed()) {
-                    LOGGER.error("Error undeploying session", ar.cause());
-                    context.fail("Error undeploying session");
-                }
-                async.complete();
-            });
-        }
-        async.await();
-        LOGGER.info("Stopped Topic Operator");
-    }
-
-
-    private KafkaTopic createKafkaTopicResource(TestContext context, KafkaTopic topicResource) {
-        String topicName = new TopicName(topicResource).toString();
-        // Create a Topic Resource
-        operation().inNamespace(NAMESPACE).create(topicResource);
-
-        // Wait for the topic to be created
-        waitForTopicInKafka(context, topicName);
-        assertStatusReady(context, topicResource.getMetadata().getName());
-        return topicResource;
-    }
-
-    private void assertStatusReady(TestContext testContext, String topicName) {
-        waitFor(testContext, () -> {
-            KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
-            if (kafkaTopic != null) {
-                if (kafkaTopic.getStatus() != null
-                        && kafkaTopic.getStatus().getConditions() != null) {
-                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
-                    testContext.assertTrue(conditions.size() > 0);
-                    if (conditions.stream().anyMatch(condition ->
-                            "Ready".equals(condition.getType()) &&
-                                    "True".equals(condition.getStatus()))) {
-                        return true;
-                    } else {
-                        LOGGER.info(conditions);
-                    }
-                }
-            } else {
-                LOGGER.info("{} does not exist", topicName);
-            }
-            return false;
-        }, 60000, "status ready");
-    }
-
-    protected KafkaTopic createKafkaTopicResource(TestContext context, String topicName) {
-        Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
-        KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
-        return createKafkaTopicResource(context, topicResource);
-    }
-
-    private String createTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
-        LOGGER.info("Creating topic {}", topicName);
-        // Create a topic
-        String resourceName = new TopicName(topicName).asKubeName().toString();
-        CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicName, 1, (short) 1)));
-        crt.all().get();
-
-        // Wait for the resource to be created
-        waitForTopicInKube(context, resourceName);
-
-        LOGGER.info("topic {} has been created", resourceName);
-        return resourceName;
-    }
-
-    private void waitForTopicInKube(TestContext context, String resourceName) {
-        waitForTopicInKube(context, resourceName, true);
-    }
-
-    protected void waitForTopicInKube(TestContext context, String resourceName, boolean exist) {
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
-            return topic != null == exist;
-        }, timeout, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
-    }
-
-    private void alterTopicConfigInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
-        String key = "compression.type";
-        final String changedValue = alterTopicConfigInKafka(topicName, key,
-            value -> "snappy".equals(value) ? "lz4" : "snappy");
-        awaitTopicConfigInKube(context, resourceName, key, changedValue);
-    }
-
-    private void awaitTopicConfigInKube(TestContext context, String resourceName, String key, String expectedValue) {
-
-        // Wait for the resource to be modified
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {}, waiting for config change", resourceName);
-            String gotValue = TopicSerialization.fromTopicResource(topic).getConfig().get(key);
-            LOGGER.info("Expecting value {}, got value {}", expectedValue, gotValue);
-            return expectedValue.equals(gotValue);
-        }, timeout, "Expected the config of topic " + resourceName + " to have " + key + "=" + expectedValue + " in Kube by now");
-    }
-
-    private String alterTopicConfigInKafka(String topicName, String key, Function<String, String> mutator) throws InterruptedException, ExecutionException {
-        // Get the topic config
-        ConfigResource configResource = topicConfigResource(topicName);
-        org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
-
-        Map<String, ConfigEntry> m = new HashMap<>();
-        for (ConfigEntry entry: config.entries()) {
-            m.put(entry.name(), entry);
-        }
-        final String changedValue = mutator.apply(m.get(key).value());
-        m.put(key, new ConfigEntry(key, changedValue));
-        LOGGER.info("Changing topic config {} to {}", key, changedValue);
-
-        // Update the topic config
-        AlterConfigsResult cgf = adminClient.alterConfigs(singletonMap(configResource,
-                new org.apache.kafka.clients.admin.Config(m.values())));
-        cgf.all().get();
-        return changedValue;
-    }
-
-    private void alterTopicNumPartitions(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
-        int changedValue = 2;
-
-        NewPartitions newPartitions = NewPartitions.increaseTo(changedValue);
-        Map<String, NewPartitions> map = new HashMap<>(1);
-        map.put(topicName, newPartitions);
-
-        CreatePartitionsResult createPartitionsResult = adminClient.createPartitions(map);
-        createPartitionsResult.all().get();
-
-        // Wait for the resource to be modified
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {}, waiting for partitions change", resourceName);
-            int gotValue = TopicSerialization.fromTopicResource(topic).getNumPartitions();
-            LOGGER.info("Expected value {}, got value {}", changedValue, gotValue);
-            return changedValue == gotValue;
-        }, timeout, "Expected the topic " + topicName + "to have " + changedValue + " partitions by now");
-    }
-
-    private org.apache.kafka.clients.admin.Config getTopicConfig(ConfigResource configResource) {
-        try {
-            return adminClient.describeConfigs(singletonList(configResource)).values().get(configResource).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private ConfigResource topicConfigResource(String topicName) {
-        return new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-    }
-
-    private void createAndAlterTopicConfig(TestContext context, String topicName) throws InterruptedException, ExecutionException {
-        String resourceName = createTopic(context, topicName);
-        alterTopicConfigInKafkaAndAwaitReconciliation(context, topicName, resourceName);
-    }
-
-    private void deleteTopicInKafkaAndAwaitReconciliation(TestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException {
-        deleteTopicInKafka(topicName, resourceName);
-
-        // Wait for the resource to be deleted
-        waitFor(context, () -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {}, got {}, waiting for deletion", resourceName, topic);
-            return topic == null;
-        }, timeout, "Expected the topic " + topicName + " to have been deleted by now");
-    }
-
-    private void deleteTopicInKafka(String topicName, String resourceName) throws InterruptedException, ExecutionException {
-        LOGGER.info("Deleting topic {} (KafkaTopic {})", topicName, resourceName);
-        // Now we can delete the topic
-        DeleteTopicsResult dlt = adminClient.deleteTopics(singletonList(topicName));
-        dlt.all().get();
-        LOGGER.info("Deleted topic {}", topicName);
-    }
-
-    private void createAndDeleteTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
-        String resourceName = createTopic(context, topicName);
-        deleteTopicInKafkaAndAwaitReconciliation(context, topicName, resourceName);
-    }
-
-    private void createAndAlterNumPartitions(TestContext context, String topicName) throws InterruptedException, ExecutionException {
-        String resourceName = createTopic(context, topicName);
-        alterTopicNumPartitions(context, topicName, resourceName);
-    }
-
-    private void waitFor(TestContext context, BooleanSupplier ready, long timeout, String message) {
-        Async async = context.async();
-        Util.waitFor(vertx, message, 3_000, timeout, ready).setHandler(ar -> {
-            if (ar.failed()) {
-                context.fail(ar.cause());
-            }
-            async.complete();
-        });
-        async.awaitSuccess();
-    }
-
-    private void waitForEvent(TestContext context, KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) {
-        waitFor(context, () -> {
-            List<Event> items = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().getItems();
-            List<Event> filtered = items.stream().
-                    filter(evt -> !preExistingEvents.contains(evt.getMetadata().getUid())
-                    && "KafkaTopic".equals(evt.getInvolvedObject().getKind())
-                    && kafkaTopic.getMetadata().getName().equals(evt.getInvolvedObject().getName())).
-                    collect(Collectors.toList());
-            LOGGER.debug("Waiting for events: {}", filtered.stream().map(evt -> evt.getMessage()).collect(Collectors.toList()));
-            return filtered.stream().anyMatch(event ->
-                    Objects.equals(expectedMessage, event.getMessage()) &&
-                    Objects.equals(expectedType.name, event.getType()) &&
-                    event.getInvolvedObject() != null &&
-                    event.getLastTimestamp() != null &&
-                    Objects.equals("KafkaTopic", event.getInvolvedObject().getKind()) &&
-                    Objects.equals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName()));
-        }, timeout, "Expected an error event");
-    }
-
 
     @Test
     public void testTopicAdded(TestContext context) throws Exception {
@@ -551,33 +200,6 @@ public class TopicOperatorIT extends BaseITST {
 
     }
 
-    void deleteInKubeAndAwaitReconciliation(TestContext context, String topicName, KafkaTopic topicResource) {
-        deleteInKube(topicResource.getMetadata().getName());
-
-        // Wait for the topic to be deleted
-        waitFor(context, () -> {
-            try {
-                adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
-                return false;
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException
-                        || e.getCause() instanceof InvalidTopicException) {
-                    return true;
-                } else {
-                    throw new RuntimeException(e);
-                }
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }, timeout, "Expected topic to be deleted by now");
-    }
-
-    protected void deleteInKube(String resourceName) {
-        // can now delete the topicResource
-        operation().inNamespace(NAMESPACE).withName(resourceName).delete();
-    }
-
-
     @Test
     public void testKafkaTopicModifiedRetentionChanged(TestContext context) throws Exception {
         // create the topic
@@ -586,28 +208,6 @@ public class TopicOperatorIT extends BaseITST {
         String expectedValue = alterTopicConfigInKube(topicResource.getMetadata().getName(),
                 "retention.ms", currentValue -> Integer.toString(Integer.parseInt(currentValue) + 1));
         awaitTopicConfigInKafka(context, topicName, "retention.ms", expectedValue);
-    }
-
-    void awaitTopicConfigInKafka(TestContext context, String topicName, String key, String expectedValue) {
-        // Wait for that to be reflected in the kafka topic
-        waitFor(context, () -> {
-            ConfigResource configResource = topicConfigResource(topicName);
-            org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
-            String retention = config.get("retention.ms").value();
-            LOGGER.debug("retention of {}, waiting for 12341234", retention);
-            return expectedValue.equals(retention);
-        },  timeout, "Expected the topic " + topicName + " to have retention.ms=" + expectedValue + " in Kafka");
-    }
-
-    String alterTopicConfigInKube(String resourceName, String key, Function<String, String> mutator) {
-        // now change the topic resource
-        Object retention = operation().inNamespace(NAMESPACE).withName(resourceName).get().getSpec().getConfig().getOrDefault(key, "12341233");
-        String currentValue = retention instanceof Integer ? retention.toString() : (String) retention;
-        String newValue = mutator.apply(currentValue);
-        KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(resourceName).get())
-            .editOrNewSpec().addToConfig(key, newValue).endSpec().build();
-        operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
-        return newValue;
     }
 
     @Test
@@ -663,9 +263,6 @@ public class TopicOperatorIT extends BaseITST {
                 TopicOperator.EventType.WARNING);
     }
 
-    protected MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
-        return kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
-    }
 
     @Test
     public void testReconcile(TestContext context) {
@@ -699,31 +296,8 @@ public class TopicOperatorIT extends BaseITST {
         assertStatusReady(context, topicName);
     }
 
-    void waitForTopicInKafka(TestContext context, String topicName) {
-        waitForTopicInKafka(context, topicName, true);
-    }
-
-    void waitForTopicInKafka(TestContext context, String topicName, boolean exist) {
-        waitFor(context, () -> {
-            try {
-                adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
-                return exist;
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException
-                        || e.getCause() instanceof InvalidTopicException) {
-                    return !exist;
-                } else {
-                    throw new RuntimeException(e);
-                }
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }, timeout, "Expected topic '" + topicName + "' to " + (exist ? "exist" : "not exist") + " in Kafka by now");
-    }
-
     // TODO: What happens if we create and then change labels to the resource predicate isn't matched any more
     //       What then happens if we change labels back?
-
 
     @Test
     public void testKafkaTopicWithOwnerRef(TestContext context) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 @RunWith(VertxUnitRunner.class)
-public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorIT {
+public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorTopicDeletionDisabledIT.class);
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic;
+
+import io.debezium.kafka.KafkaCluster;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.test.BaseITST;
+import io.vertx.core.Future;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Files;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+@RunWith(VertxUnitRunner.class)
+public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorIT {
+
+    private static final Logger LOGGER = LogManager.getLogger(TopicOperatorTopicDeletionDisabledIT.class);
+
+    @Before
+    public void setup(TestContext context) throws Exception {
+        LOGGER.info("Setting up test");
+        kubeCluster().before();
+        Runtime.getRuntime().addShutdownHook(kafkaHook);
+        int counts = 3;
+        do {
+            try {
+                kafkaCluster = new KafkaCluster();
+                kafkaCluster.addBrokers(1);
+                Properties props = new Properties();
+                props.setProperty("delete.topic.enable", "false");
+                kafkaCluster.withKafkaConfiguration(props);
+                kafkaCluster.deleteDataPriorToStartup(true);
+                kafkaCluster.deleteDataUponShutdown(true);
+                kafkaCluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
+                kafkaCluster.startup();
+                break;
+            } catch (kafka.zookeeper.ZooKeeperClientTimeoutException e) {
+                if (counts == 0) {
+                    throw e;
+                }
+                counts--;
+            }
+        } while (true);
+
+        Properties p = new Properties();
+        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.brokerList());
+        adminClient = AdminClient.create(p);
+
+        kubeClient = BaseITST.kubeClient().getClient();
+        Crds.registerCustomKinds();
+        LOGGER.info("Using namespace {}", NAMESPACE);
+        startTopicOperator(context);
+
+        // We can't delete events, so record the events which exist at the start of the test
+        // and then waitForEvents() can ignore those
+        preExistingEvents = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().
+                getItems().stream().
+                map(evt -> evt.getMetadata().getUid()).
+                collect(Collectors.toSet());
+
+        LOGGER.info("Finished setting up test");
+    }
+
+    @After
+    public void teardown(TestContext context) {
+        LOGGER.info("Tearing down test");
+
+        if (kubeClient != null) {
+            operation().inNamespace(NAMESPACE).delete();
+        }
+
+        stopTopicOperator(context);
+
+        adminClient.close();
+        if (kafkaCluster != null) {
+            kafkaCluster.shutdown();
+        }
+        Runtime.getRuntime().removeShutdownHook(kafkaHook);
+        LOGGER.info("Finished tearing down test");
+    }
+
+    @Test
+    public void testKafkaTopicDeletionDisabled(TestContext context) {
+        // create the Topic Resource
+        String topicName = "test-topic-deletion-disabled";
+        // The creation method will wait for the topic to be ready in K8s
+        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        // Wait for the topic to be ready on the Kafka Broker
+        waitForTopicInKafka(context, topicName, true);
+
+        // Delete the k8 KafkaTopic and wait for that to be deleted
+        deleteInKube(topicResource.getMetadata().getName());
+
+        // trigger an immediate reconcile where, with with delete.topic.enable=false, the K8s KafkaTopic should be recreated
+        Future<?> result = session.topicOperator.reconcileAllTopics("periodic");
+        do {
+            if (result.isComplete()) {
+                break;
+            }
+        } while (true);
+
+        // Wait for the KafkaTopic to be recreated
+        waitForTopicInKube(context, topicName, true);
+    }
+}
+


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

* Added exception recovery for disabled topic deletion exception
* Added unit tests for topic deletion disabled exception

### Checklist

- [x] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Update CHANGELOG.md

