### PR TITLE
Fix watched namespace in Prometheus configuration

### DIFF
--- a/metrics/examples/prometheus/install/strimzi-service-monitor.yaml
+++ b/metrics/examples/prometheus/install/strimzi-service-monitor.yaml
@@ -8,6 +8,9 @@ spec:
   selector:
     matchLabels:
       strimzi.io/kind: Kafka
+  namespaceSelector:
+    matchNames:
+      - myproject
   endpoints:
   #### job_name: kubernetes-cadvisor
   # configured in additional secret
@@ -19,8 +22,6 @@ spec:
     scrapeTimeout: 10s
     path: /metrics
     scheme: http
-    namespaceSelector:
-      any: true
     relabelings:
     - sourceLabels: [__meta_kubernetes_endpoints_name]
       separator: ;
@@ -69,8 +70,6 @@ spec:
     scrapeTimeout: 10s
     path: /metrics
     scheme: http
-    namespaceSelector:
-      any: true
     relabelings:
     - sourceLabels: [__meta_kubernetes_endpoints_name]
       separator: ;


### PR DESCRIPTION
### Type of change
- Bugfix


### Description
https://github.com/strimzi/strimzi-kafka-operator/issues/1957

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

