### PR TITLE
Add Code of Conduct linking to CNCF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Strimzi Community Code of Conduct
+
+Strimzi project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
We should have a Code of Conduct. This PR adds a code of conduct which links to the CNCF Code of Conduct (which is available in multiple languages). This is a similar way it was done also in other CNCF Sandbox projects.