### PR TITLE
Add sign-off to derived resources advisory and to website push

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -37,7 +37,7 @@ if [ -n "$CHANGED_DERIVED" ] ; then
   echo "Run the following to add up-to-date resources:"
   echo "  mvn clean verify -DskipTests -DskipITs \\"
   echo "    && git add install/ helm-charts/ documentation/book/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles"
-  echo "    && git commit -m 'Update derived resources'"
+  echo "    && git commit -s -m 'Update derived resources'"
   exit 1
 fi
 

--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -30,7 +30,7 @@ git config user.name "Travis CI"
 git config user.email "ci@travis.tld"
 
 git add -A
-git commit -m "Update documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
+git commit -s -m "Update documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
 git push origin master
 
 popd


### PR DESCRIPTION
The PR #1963 added the `-s` for commit sign-off to the document check. But not to the check for derived resources. This PR adds it there. It also adds sign-off to the script which pushes updated documentation to the website.