### PR TITLE
Use GitHub Actions to automatically label PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+documentation:
+  - documentation/**/*
+
+System tests:
+  - systemtest/**/*
+  - test/**/*
+
+cluster operator:
+  - cluster-operator/**/*
+
+topic operator:
+  - topic-operator/**/*
+
+user operator:
+  - user-operator/**/*
+
+docker images:
+  - docker-images/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Labeler
+on: [pull_request]
+jobs:
+  Label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign labels based on changed files
+        uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Assign labels based on size
+        uses: pascalgn/size-label-action@v0.0.6
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR tests how GitHub actions can be used to trigger automatic labeling of PRs based on their size and based on the files they changed.