### PR TITLE
Fix the way the Zookeeper image is read from the environment variable in CO

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.parseMap;
 import static java.util.Arrays.asList;
 
 public class ZookeeperCluster extends AbstractModel {
@@ -89,8 +88,6 @@ public class ZookeeperCluster extends AbstractModel {
     public static final String ENV_VAR_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
     public static final String ENV_VAR_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
     public static final String ENV_VAR_ZOOKEEPER_CONFIGURATION = "ZOOKEEPER_CONFIGURATION";
-
-    public static final Map<String, String> IMAGE_MAP = parseMap(System.getenv().get("STRIMZI_ZOOKEEPER_IMAGE_MAP"));
 
     // Templates
     protected List<ContainerEnvVar> templateZookeeperContainerEnvVars;
@@ -181,11 +178,9 @@ public class ZookeeperCluster extends AbstractModel {
         }
         zk.setReplicas(replicas);
 
-        String version = versions.defaultVersion().version();
-
         String image = zookeeperClusterSpec.getImage();
         if (image == null) {
-            image = IMAGE_MAP.get(version);
+            image = System.getenv().get("STRIMZI_DEFAULT_ZOOKEEPER_IMAGE");
         }
         if (image == null) {
             KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

ZookeeprCluster class seems to for some reason read the container image from the environment variable `STRIMZI_ZOOKEEPER_IMAGE_MAP` which is not used anywhere. This PR fixes it and uses the environment variable `STRIMZI_DEFAULT_ZOOKEEPER_IMAGE` used in our deployments. 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally