### PR TITLE
Use apps/v1 instead of extensions/v1beta1

### DIFF
--- a/.travis/kube-registry.yaml
+++ b/.travis/kube-registry.yaml
@@ -64,7 +64,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-registry-proxy
@@ -74,6 +74,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     version: v0.4
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-registry
+      version: v0.4
   template:
     metadata:
       labels:

--- a/documentation/book/proc-deploying-cluster-operator-to-watch-multiple-namespaces.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-to-watch-multiple-namespaces.adoc
@@ -20,9 +20,10 @@ For example:
 +
 [source,yaml,subs="attributes"]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  # ...
   template:
     spec:
       serviceAccountName: strimzi-cluster-operator

--- a/documentation/book/proc-deploying-cluster-operator-to-watch-whole-cluster.adoc
+++ b/documentation/book/proc-deploying-cluster-operator-to-watch-whole-cluster.adoc
@@ -24,9 +24,10 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 +
 [source,yaml,subs="attributes"]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  # ...
   template:
     spec:
       # ...

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-cluster-operator
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+      strimzi.io/kind: cluster-operator
   template:
     metadata:
       labels:

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-cluster-operator
@@ -6,6 +6,10 @@ metadata:
     app: strimzi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+      strimzi.io/kind: cluster-operator
   template:
     metadata:
       labels:

--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-topic-operator
@@ -6,6 +6,9 @@ metadata:
     app: strimzi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-topic-operator
   template:
     metadata:
       labels:

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-user-operator
@@ -6,6 +6,9 @@ metadata:
     app: strimzi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-user-operator
   template:
     metadata:
       labels:

--- a/metrics/examples/grafana/grafana.yaml
+++ b/metrics/examples/grafana/grafana.yaml
@@ -1,7 +1,7 @@
 # This is not a recommended configuration, and further support should be available
 # from the Prometheus and Grafana communities.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
@@ -9,6 +9,9 @@ metadata:
     app: strimzi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: grafana
   template:
     metadata:
       labels:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kubernetes 1.16 drops support for `extensions/v1beta1`. We should update our Deployments to apps/v1 to make sure we are compatible.