### PR TITLE
Fix SASL bug caused by empty callback configuration

### DIFF
--- a/docker-images/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_connect_config_generator.sh
@@ -73,21 +73,21 @@ if [ -n "$KAFKA_CONNECT_SASL_MECHANISM" ]; then
 
         SASL_MECHANISM="OAUTHBEARER"
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_CONNECT_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
-        OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS="sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS_PRODUCER="producer.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS_CONSUMER="consumer.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 sasl.mechanism=${SASL_MECHANISM}
 sasl.jaas.config=${JAAS_CONFIG}
-sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
-
+${OAUTH_CALLBACK_CLASS}
 producer.sasl.mechanism=${SASL_MECHANISM}
 producer.sasl.jaas.config=${JAAS_CONFIG}
-producer.sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
-
+${OAUTH_CALLBACK_CLASS_PRODUCER}
 consumer.sasl.mechanism=${SASL_MECHANISM}
 consumer.sasl.jaas.config=${JAAS_CONFIG}
-consumer.sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
+${OAUTH_CALLBACK_CLASS_CONSUMER}
 
 EOF
 )

--- a/docker-images/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_connect_config_generator.sh
@@ -74,8 +74,8 @@ if [ -n "$KAFKA_CONNECT_SASL_MECHANISM" ]; then
         SASL_MECHANISM="OAUTHBEARER"
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_CONNECT_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
         OAUTH_CALLBACK_CLASS="sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
-        OAUTH_CALLBACK_CLASS_PRODUCER="producer.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
-        OAUTH_CALLBACK_CLASS_CONSUMER="consumer.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS_PRODUCER="producer.${OAUTH_CALLBACK_CLASS}"
+        OAUTH_CALLBACK_CLASS_CONSUMER="consumer.${OAUTH_CALLBACK_CLASS}"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF

--- a/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
@@ -59,13 +59,13 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" ]; then
 
         SASL_MECHANISM="OAUTHBEARER"
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_MIRRORMAKER_OAUTH_CONFIG_CONSUMER} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
-        OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS="sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 sasl.mechanism=${SASL_MECHANISM}
 sasl.jaas.config=${JAAS_CONFIG}
-sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
+${OAUTH_CALLBACK_CLASS}
 EOF
 )
 fi

--- a/docker-images/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
@@ -59,13 +59,13 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" ]; then
 
         SASL_MECHANISM="OAUTHBEARER"
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_MIRRORMAKER_OAUTH_CONFIG_PRODUCER} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
-        OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS="sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 sasl.mechanism=${SASL_MECHANISM}
 sasl.jaas.config=${JAAS_CONFIG}
-sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
+${OAUTH_CALLBACK_CLASS}
 EOF
 )
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The OAuth implementation seems to have broken the SASL SCRAM and PLAIN authentication in our images. In the SASL configuration, the empty value

```
consumer.sasl.login.callback.handler.class=
```

Is not interpreted as not set / null but as a class name and cause the pod to fail during startup. This PR changes the way this confgiuration options is generated to make sure it is used only with OAUTH.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally