### PR TITLE
Use one common base image

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -15,7 +15,7 @@ RELEASE_VERSION    ?= $(shell cat $(TOPDIR)/release.version)
 
 all: docker_build docker_push
 
-docker_build:
+docker_build_default:
 	# Build Docker image ...
 	docker build $(DOCKER_BUILD_ARGS) --build-arg strimzi_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
@@ -24,10 +24,13 @@ docker_build:
 	# Also tag with $(BUILD_TAG)
 	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
 
-docker_tag:
+docker_tag_default:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
 	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
-docker_push: docker_tag
+docker_push_default: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
 	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+
+docker_%: docker_%_default
+	@  true

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -6,4 +6,4 @@ RUN yum -y update \
     && yum -y clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+ARG JAVA_VERSION=1.8.0
+
+RUN yum -y update \
+    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
+    && yum -y clean all
+
+# Set JAVA_HOME env var
+ENV JAVA_HOME /usr/lib/jvm/java

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -4,6 +4,3 @@ ARG JAVA_VERSION=1.8.0
 RUN yum -y update \
     && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
     && yum -y clean all
-
-# Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre

--- a/docker-images/base/Makefile
+++ b/docker-images/base/Makefile
@@ -1,0 +1,9 @@
+PROJECT_NAME=base
+
+include ../../Makefile.os
+include ../../Makefile.docker
+
+docker_push:
+	# Do nothing
+
+.PHONY: build clean release

--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+base_images="base"
 java_images="operator"
 kafka_images="kafka test-client"
 
@@ -34,6 +35,11 @@ function build {
     local targets="$@"
     local tag="${DOCKER_TAG:-latest}"
     local java_version=${JAVA_VERSION:-1.8.0}
+
+    # Base images
+    for image in $base_images; do
+        DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg JAVA_VERSION=${java_version} $(alternate_base $image)" make -C "$image" "$targets"
+    done
 
     # Images not depending on Kafka version
     for image in $java_images; do

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -1,36 +1,25 @@
-FROM centos:7
+FROM strimzi/base:latest
 
-ARG JAVA_VERSION
 ARG KAFKA_SHA512
 ARG KAFKA_VERSION
 ARG THIRD_PARTY_LIBS
 ARG strimzi_version
 
-RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless gettext nmap-ncat openssl \
-    && yum clean all -y
-
-# set Kafka home folder
-ENV KAFKA_HOME=/opt/kafka
-
-ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
+RUN yum -y install gettext nmap-ncat stunnel net-tools bind-utils && yum clean all -y
 
 # Add kafka user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage
 RUN useradd -r -m -u 1001 -g 0 kafka
 
-# Set Scala and Kafka version
+#####
+# Add Kafka
+#####
+ENV KAFKA_HOME=/opt/kafka
 ENV KAFKA_VERSION=${KAFKA_VERSION}
 ENV STRIMZI_VERSION=${strimzi_version}
 ENV SCALA_VERSION=2.12
-
-ENV KAFKA_EXPORTER_VERSION=1.2.0
-ENV KAFKA_EXPORTER_CHECKSUM="7afa40365ddf0cb0a88457684bd64d565e250c7e5a4536ba7f9d37d02d2808c3b07766f94e0b1338beb296573ade29db630948c931be44bde416c0410b5d783b  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
-
-# Set Kafka (SHA512) and Prometheus JMX exporter (SHA1) checksums
 ENV KAFKA_CHECKSUM="${KAFKA_SHA512}  kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 
-# Downloading/extracting Apache Kafka
 RUN curl -O https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz \
     && echo $KAFKA_CHECKSUM > kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz.sha512 \
     && sha512sum --check kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz.sha512 \
@@ -38,7 +27,15 @@ RUN curl -O https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA
     && tar xvfz kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C $KAFKA_HOME --strip-components=1 \
     && rm -f kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz*
 
-# Downloading/extracting Kafka Exporter
+COPY ./scripts/ $KAFKA_HOME
+
+#####
+# Add Kafka Exporter
+#####
+ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
+ENV KAFKA_EXPORTER_VERSION=1.2.0
+ENV KAFKA_EXPORTER_CHECKSUM="7afa40365ddf0cb0a88457684bd64d565e250c7e5a4536ba7f9d37d02d2808c3b07766f94e0b1338beb296573ade29db630948c931be44bde416c0410b5d783b  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
+
 RUN curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz \
     && echo $KAFKA_EXPORTER_CHECKSUM > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512 \
     && sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512 \
@@ -46,33 +43,32 @@ RUN curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KA
     && tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1 \
     && rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz*
 
+COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
+
+#####
+# Add Strimzi agents
+#####
 COPY ./tmp/kafka-agent.jar ${KAFKA_HOME}/libs/
 COPY ./tmp/mirror-maker-agent.jar ${KAFKA_HOME}/libs/
 COPY ./tmp/tracing-agent.jar ${KAFKA_HOME}/libs/
 
+#####
+# Add 3dr party libs
+#####
 COPY kafka-thirdparty-libs/${THIRD_PARTY_LIBS}/target/dependency/ ${KAFKA_HOME}/libs/
 
-RUN yum -y install stunnel net-tools bind-utils && yum clean all -y
-
-# set Stunnel home folder
+#####
+# Add Stunnel
+#####
 ENV STUNNEL_HOME=/opt/stunnel
-
 RUN mkdir $STUNNEL_HOME && mkdir -p -m g+rw /usr/local/var/run/
-
-# copy scripts for Stunnel
 COPY ./stunnel-scripts/ $STUNNEL_HOME
 
-# copy scripts for starting Kafka
-COPY ./scripts/ $KAFKA_HOME
-
-# Set S2I folder
+#####
+# Add Kafka Connect S2I feature
+#####
 ENV S2I_HOME=/opt/kafka/s2i
-
-# Copy S2I scripts
 COPY ./s2i-scripts $S2I_HOME
-
-# Copy Kafka Exporter scripts
-COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 
 WORKDIR $KAFKA_HOME
 

--- a/docker-images/kafka/Makefile
+++ b/docker-images/kafka/Makefile
@@ -26,7 +26,8 @@ clean:
 	mvn dependency:copy-dependencies $(MVN_ARGS) -f kafka-thirdparty-libs/$(THIRD_PARTY_LIBS)/pom.xml
 	touch .thirdparty-libs-$(THIRD_PARTY_LIBS).tmp
 
-docker_build: .kafka-agent.tmp .tracing-agent.tmp .mirror-maker-agent.tmp .thirdparty-libs-$(THIRD_PARTY_LIBS).tmp
+docker_build: .kafka-agent.tmp .tracing-agent.tmp .mirror-maker-agent.tmp .thirdparty-libs-$(THIRD_PARTY_LIBS).tmp docker_build_default
+	# Pull dependencies first
 
 include ../../Makefile.docker
 

--- a/docker-images/operator/Dockerfile
+++ b/docker-images/operator/Dockerfile
@@ -1,12 +1,4 @@
-FROM centos:7
-ARG JAVA_VERSION=1.8.0
-
-RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
-    && yum -y clean all
-
-# Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+FROM strimzi/base:latest
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/docker-images/operator/Makefile
+++ b/docker-images/operator/Makefile
@@ -6,7 +6,7 @@ cluster_operator_dist := ../../cluster-operator/target/cluster-operator-$(jar_ve
 kafka_init_dist := ../../kafka-init/target/kafka-init-$(jar_version)-dist.zip
 
 clean: 
-	rm -f .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp
+	rm -rf .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp ./tmp
 
 # We unzip each of the -dist.zip files into tmp which is then
 # COPYed in the Dockerfile, so can delete tmp on exit
@@ -32,7 +32,8 @@ clean:
 	unzip -qo $(cluster_operator_dist) -d tmp
 	touch .cluster-operator.tmp
 
-docker_build: .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp
+docker_build: .topic-operator.tmp .user-operator.tmp .kafka-init.tmp .cluster-operator.tmp docker_build_default
+	# Pull dependencies first
 
 include ../../Makefile.docker
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Sometime we run into issues with the length of the builds on TravisCI. From my observations one of the things which makes a difference is the Docker image builds. Currently, all our Docker images do `yum -y update`. That sometimes takes a long time and pulls a lot of packages. However we do this again and again for every image.

This PR adds new base image to the `docker_images` structure. This base image does the `yum update` and is used as a basis for the other images. This image is not pushed anywhere, it is used only locally to safe the time.