### PR TITLE
Fine-grained tests for CA cert renewal; don't roll ZK for clients-ca

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -231,13 +231,7 @@ class SecurityST extends MessagingBaseST {
         // Check a new client (signed by new client key) can consume
         String bobUserName = "bob";
         testMethodResources().tlsUser(CLUSTER_NAME, bobUserName).done();
-        waitFor("", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_GET_SECRETS,
-            () -> {
-                return kubeClient().getSecret(bobUserName) != null;
-            },
-            () -> {
-                LOGGER.error("Couldn't find user secret {}", kubeClient().listSecrets());
-            });
+        StUtils.waitForSecretReady(bobUserName);
 
         waitForClusterAvailabilityTls(bobUserName, NAMESPACE, CLUSTER_NAME);
 

--- a/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
@@ -25,7 +25,7 @@ public class OpenShift implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            Exec.exec(OC, "cluster", "status");
+            Exec.exec(OC, "status");
             return true;
         } catch (KubeClusterException e) {
             if (e.result.exitStatus() == 1) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Test improvement
- Bugfix

### Description

The previous tests for CA cert replacement and key renewal tested both CAs (cluster and clients) at once, which meant we couldn't and didn't assert about expected rollings. This PR adds additional tests for just the cluster and just the clients cases and adds such assertions. 

This found that we were unnecessarily rolling ZK in the case of clients CA change. (ZK knows nothing about clients CA.) So I've also fixed the CO to not roll ZK in this case.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

