### PR TITLE
Try to push without rebuilding the universe

### DIFF
--- a/.travis/push-to-nexus.sh
+++ b/.travis/push-to-nexus.sh
@@ -3,7 +3,7 @@
 openssl aes-256-cbc -K $encrypted_cdaf52794220_key -iv $encrypted_cdaf52794220_iv -in .travis/signing.gpg.enc -out signing.gpg -d
 gpg --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh clean package gpg:sign deploy
+GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh gpg:sign deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/.travis/push-to-nexus.sh
+++ b/.travis/push-to-nexus.sh
@@ -3,7 +3,7 @@
 openssl aes-256-cbc -K $encrypted_cdaf52794220_key -iv $encrypted_cdaf52794220_iv -in .travis/signing.gpg.enc -out signing.gpg -d
 gpg --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh gpg:sign deploy
+GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh package gpg:sign deploy
 
 rm -rf signing.gpg
 gpg --delete-keys


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We do not need to clean everything and rebuild it again before pushing to OSSRH. That should save us some time on compiling etc. in the master and tag builds.