### PR TITLE
Add Kafka Exporter to network policies for 9091 port

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1624,9 +1624,16 @@ public class KafkaCluster extends AbstractModel {
         labelSelector2.setMatchLabels(expressions2);
         entityOperatorPeer.setPodSelector(labelSelector2);
 
+        NetworkPolicyPeer kafkaExporterPeer = new NetworkPolicyPeer();
+        LabelSelector labelSelector3 = new LabelSelector();
+        Map<String, String> expressions3 = new HashMap<>();
+        expressions3.put(Labels.STRIMZI_NAME_LABEL, KafkaExporter.kafkaExporterName(cluster));
+        labelSelector3.setMatchLabels(expressions3);
+        kafkaExporterPeer.setPodSelector(labelSelector3);
+
         NetworkPolicyIngressRule replicationRule = new NetworkPolicyIngressRuleBuilder()
                 .withPorts(replicationPort)
-                .withFrom(kafkaClusterPeer, entityOperatorPeer)
+                .withFrom(kafkaClusterPeer, entityOperatorPeer, kafkaExporterPeer)
                 .build();
 
         rules.add(replicationRule);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1306,7 +1306,7 @@ public class KafkaClusterTest {
         // Check Network Policies
         NetworkPolicy np = k.generateNetworkPolicy();
 
-        List<NetworkPolicyIngressRule>  rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.CLIENT_PORT))).collect(Collectors.toList());
+        List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.CLIENT_PORT))).collect(Collectors.toList());
         assertEquals(1, rules.size());
         assertEquals(peer1, rules.get(0).getFrom().get(0));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kafka exporter needs to be added to network policies for port 9091 so that it can connect to KAfka Cluster on Kubernetes clusters with network policies.

This should be cherry-picked into 0.14.0 release branch.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally