### PR TITLE
Default to the default pull policy in the installation files

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -28,7 +28,9 @@ spec:
       containers:
         - name: strimzi-cluster-operator
           image: {{ default .Values.image.repository .Values.imageRepositoryOverride }}/{{ .Values.image.name }}:{{ default .Values.image.tag .Values.imageTagOverride }}
+          {{- if .Values.image.imagePullPolicy }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
+          {{- end }}
           args:
             - /opt/strimzi/bin/cluster_operator_run.sh
           env:

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -9,7 +9,6 @@ image:
   repository: strimzi
   name: operator
   tag: latest
-  imagePullPolicy: IfNotPresent
 logLevel: INFO
 fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -20,7 +20,6 @@ spec:
       containers:
       - name: strimzi-cluster-operator
         image: strimzi/operator:latest
-        imagePullPolicy: IfNotPresent
         args:
         - /opt/strimzi/bin/cluster_operator_run.sh
         env:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently our CO deployment is using the `IfNotPresent` image pull policy which does not work well with master builds. By removing it, we get more desired behaviour, where the `:latest` images get always pulled while the other images will use `IfNotPresent` policy.