### PR TITLE
Document how to run multiple instances of Kafka Connect

### DIFF
--- a/documentation/book/assembly-kafka-connect-configuration.adoc
+++ b/documentation/book/assembly-kafka-connect-configuration.adoc
@@ -23,5 +23,5 @@ Configuration options that cannot be configured relate to:
 These options are automatically configured by {ProductName}.
 
 include::ref-kafka-connect-configuration.adoc[leveloffset=+1]
-
+include::con-kafka-connect-multiple-instances.adoc[leveloffset=+1]
 include::proc-configuring-kafka-connect.adoc[leveloffset=+1]

--- a/documentation/book/con-kafka-connect-multiple-instances.adoc
+++ b/documentation/book/con-kafka-connect-multiple-instances.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-connect-configuration.adoc
+
+[id='con-kafka-connect-multiple-instances-{context}']
+= Kafka Connect configuration for multiple instances
+
+If you are running multiple instances of Kafka Connect, pay attention to the default configuration of the following properties:
+
+[source,yaml,subs="attributes+"]
+----
+# ...
+  group.id: connect-cluster <1>
+  offset.storage.topic: connect-cluster-offsets <2>
+  config.storage.topic: connect-cluster-configs <3>
+  status.storage.topic: connect-cluster-status  <4>
+# ...
+----
+<1> Kafka Connect cluster group the instance belongs to.
+<2> Kafka topic that stores connector offsets.
+<3> Kafka topic that stores connector and task status configurations.
+<4> Kafka topic that stores connector and task status updates.
+
+NOTE: Values for the three topics must be the same for all Kafka Connect instances with the same `group.id`.
+
+Unless you change the default settings, each Kafka Connect instance connecting to the same Kafka cluster is deployed with the same values.
+What happens, in effect, is all instances are coupled to run in a cluster and use the same topics.
+
+If multiple Kafka Connect clusters try to use the same topics, Kafka Connect will not work as expected and generate errors.
+
+If you wish to run multiple Kafka Connect instances, change the values of these properties for each instance.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

### Type of change

- Documentation

### Description

New section for Kafka Connect to describe the implication of leaving default config properties when creating multiple Kafka instances. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

