### PR TITLE
Fix Travis builds running on forks

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -46,10 +46,10 @@ if [ "$PULL_REQUEST" != "false" ] ; then
     make docu_html
     make docu_htmlnoheader
     echo "Building Pull Request - nothing to push"
-elif [ "${TRAVIS_SECURE_ENV_VARS}" = "false" ]; then
+elif [ -z "$DOCKER_PASS" ]; then
     make docu_html
     make docu_htmlnoheader
-    echo "Probably building in fork because no secrets are present. Will not attempt to push anything."
+    echo "Probably building in fork because some secrets are present. Will not attempt to push anything."
 elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "master" ]; then
     make docu_html
     make docu_htmlnoheader

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -46,10 +46,10 @@ if [ "$PULL_REQUEST" != "false" ] ; then
     make docu_html
     make docu_htmlnoheader
     echo "Building Pull Request - nothing to push"
-elif [ -z "$DOCKER_PASS" ]; then
+elif [ "${TRAVIS_REPO_SLUG}" != "strimzi/strimzi-kafka-operator" ]; then
     make docu_html
     make docu_htmlnoheader
-    echo "Probably building in fork because some secrets are present. Will not attempt to push anything."
+    echo "Building in a fork and not in a Strimzi repository. Will not attempt to push anything."
 elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "master" ]; then
     make docu_html
     make docu_htmlnoheader

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -46,12 +46,16 @@ if [ "$PULL_REQUEST" != "false" ] ; then
     make docu_html
     make docu_htmlnoheader
     echo "Building Pull Request - nothing to push"
+elif [ "${TRAVIS_SECURE_ENV_VARS}" = "false" ]; then
+    make docu_html
+    make docu_htmlnoheader
+    echo "Probably building in fork because no secrets are present. Will not attempt to push anything."
 elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "master" ]; then
     make docu_html
     make docu_htmlnoheader
     echo "Not in master branch and not in release tag - nothing to push"
 else
-    if [ "${MAIN_BUILD}" = "TRUE" ] ; then
+    if [ "${MAIN_BUILD}" = "TRUE" ]; then
         echo "Login into Docker Hub ..."
         docker login -u $DOCKER_USER -p $DOCKER_PASS
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -55,7 +55,7 @@ elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "master" ]; then
     make docu_htmlnoheader
     echo "Not in master branch and not in release tag - nothing to push"
 else
-    if [ "${MAIN_BUILD}" = "TRUE" ]; then
+    if [ "${MAIN_BUILD}" = "TRUE" ] ; then
         echo "Login into Docker Hub ..."
         docker login -u $DOCKER_USER -p $DOCKER_PASS
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When users have their own Travis running on their own forks, it might sometimes run into timeout error when try to build master but not having the secrets for logging to Travis etc. (this tries specifically if you use master branch in the fork). This PR tries to detect such situations and not try to login or push anything. That should allow users to use their own Travis to build branches without running into this kind of error.