### PR TITLE
Fix issues in Kafka Bridge with readiness probe and configurable port numbers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -153,7 +153,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         }
 
         if (kafkaBridge.getSpec().getReadinessProbe() != null) {
-            kafkaBridgeCluster.setLivenessProbe(kafkaBridge.getSpec().getReadinessProbe());
+            kafkaBridgeCluster.setReadinessProbe(kafkaBridge.getSpec().getReadinessProbe());
         }
 
         Map<String, Object> metrics = spec.getMetrics();
@@ -203,11 +203,14 @@ public class KafkaBridgeCluster extends AbstractModel {
     
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(3);
+
         int port = DEFAULT_REST_API_PORT;
         if (http != null) {
             port = http.getPort();
         }
+
         ports.add(createServicePort(REST_API_PORT_NAME, port, port, "TCP"));
+
         if (isMetricsEnabled()) {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
@@ -217,7 +220,14 @@ public class KafkaBridgeCluster extends AbstractModel {
 
     protected List<ContainerPort> getContainerPortList() {
         List<ContainerPort> portList = new ArrayList<>(3);
-        portList.add(createContainerPort(REST_API_PORT_NAME, DEFAULT_REST_API_PORT, "TCP"));
+
+        int port = DEFAULT_REST_API_PORT;
+        if (http != null) {
+            port = http.getPort();
+        }
+
+        portList.add(createContainerPort(REST_API_PORT_NAME, port, "TCP"));
+
         if (isMetricsEnabled) {
             portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka Bridge deployment has some issues with handling of readiness probe and port configurations:
* When user configures custom port for the HTTP interface instead of the default 8080, the port is not properly configured. As a result the bridge is not accessible and probes are failing because they are connecting to wrong port
* Because of a wrong setter the Readiness Probe configuration is ignored.

This PR fixes the issue and adds tests.

This change should be included in 0.14.0.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally