### PR TITLE
Fix build warnings

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -128,6 +128,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.surefire.version>2.22.1</maven.surefire.version>
         <maven.failsafe.version>2.22.1</maven.failsafe.version>
         <maven.assembly.version>3.1.0</maven.assembly.version>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.version}</version>
                     <executions>
                         <execution>
                             <id>default-compile</id>


### PR DESCRIPTION
### Type of change

- Build improvement

### Description

The maven build was warning about undefined compiler plugin version.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

