### PR TITLE
Mask passwords in startup scripts

### DIFF
--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -16,7 +16,7 @@ mkdir -p /tmp/kafka
 
 # Generate and print the config file
 echo "Starting Kafka Connect with configuration:"
-./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
+./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Disable Kafka's GC logging (which logs to a file)...

--- a/docker-images/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka/scripts/kafka_connect_run.sh
@@ -16,7 +16,7 @@ mkdir -p /tmp/kafka
 
 # Generate and print the config file
 echo "Starting Kafka Connect with configuration:"
-./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Disable Kafka's GC logging (which logs to a file)...

--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -31,12 +31,12 @@ mkdir -p /tmp/kafka
 
 # Generate and print the consumer config file
 echo "Kafka Mirror Maker consumer configuration:"
-./kafka_mirror_maker_consumer_config_generator.sh | tee /tmp/strimzi-consumer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+./kafka_mirror_maker_consumer_config_generator.sh | tee /tmp/strimzi-consumer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Generate and print the producer config file
 echo "Kafka Mirror Maker producer configuration:"
-./kafka_mirror_maker_producer_config_generator.sh | tee /tmp/strimzi-producer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+./kafka_mirror_maker_producer_config_generator.sh | tee /tmp/strimzi-producer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Disable Kafka's GC logging (which logs to a file)...

--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -31,12 +31,12 @@ mkdir -p /tmp/kafka
 
 # Generate and print the consumer config file
 echo "Kafka Mirror Maker consumer configuration:"
-./kafka_mirror_maker_consumer_config_generator.sh | tee /tmp/strimzi-consumer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
+./kafka_mirror_maker_consumer_config_generator.sh | tee /tmp/strimzi-consumer.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Generate and print the producer config file
 echo "Kafka Mirror Maker producer configuration:"
-./kafka_mirror_maker_producer_config_generator.sh | tee /tmp/strimzi-producer.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
+./kafka_mirror_maker_producer_config_generator.sh | tee /tmp/strimzi-producer.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Disable Kafka's GC logging (which logs to a file)...

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -49,7 +49,7 @@ mkdir -p /tmp/kafka
 
 # Generate and print the config file
 echo "Starting Kafka with configuration:"
-./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
+./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -49,7 +49,7 @@ mkdir -p /tmp/kafka
 
 # Generate and print the config file
 echo "Starting Kafka with configuration:"
-./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set +x
 
 # Parameters:
 # $1: Path to the new truststore


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We should make sure that passwords are not printed in the startup scripts. The JKS store passwords are only temporary passwords for JKS stores stored inside in the container (so who can access the JKS store can anyway get the password from the actual file), but we should still mask it.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally