### PR TITLE
Clarify relationship between jwksRefreshSeconds and jwksExpirySeconds

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -101,6 +101,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     }
 
     @Description("Configures how often are the JWKS certificates considered valid. " +
+            "The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. " +
             "Defaults to 360 seconds.")
     @Minimum(1)
     @DefaultValue("360")

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -88,6 +88,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     }
 
     @Description("Configures how often are the JWKS certificates refreshed. " +
+            "The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. " +
             "Defaults to 300 seconds.")
     @Minimum(1)
     @DefaultValue("300")

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -255,7 +255,7 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |string
 |jwksEndpointUri                 1.2+<.<|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
 |string
-|jwksExpirySeconds               1.2+<.<|Configures how often are the JWKS certificates considered valid. Defaults to 360 seconds.
+|jwksExpirySeconds               1.2+<.<|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
 |integer
 |jwksRefreshSeconds              1.2+<.<|Configures how often are the JWKS certificates refreshed. Defaults to 300 seconds.
 |integer

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -257,7 +257,7 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |string
 |jwksExpirySeconds               1.2+<.<|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
 |integer
-|jwksRefreshSeconds              1.2+<.<|Configures how often are the JWKS certificates refreshed. Defaults to 300 seconds.
+|jwksRefreshSeconds              1.2+<.<|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
 |integer
 |tlsTrustedCertificates          1.2+<.<|Trusted certificates for TLS connection to the OAuth server.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

The Oauth callback library requires the `jwksRefreshSeconds` to be at least 60 seconds longer then `jwksExpirySeconds`. We should clarify this in the API docs.

We should validate this in the `fromCrd` method, but we should leave that after 0.14.0 - I opened issue #2019 to cover it.