### PR TITLE
Fix RBAC to allow watching clusterrolebindings to be able to synchronize their deletion

### DIFF
--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,6 +15,7 @@ rules:
   - delete
   - patch
   - update
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -20,6 +20,7 @@ rules:
     - delete
     - patch
     - update
+    - watch
 # Persistent Volumes can be resized only when it is supported in the storage class.
 # Therefore we need the ability to get the storage class details and we require this access right.
 - apiGroups:

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,6 +15,7 @@ rules:
   - delete
   - patch
   - update
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Deleting non-namespaced resources is now using watch to confirm the resource is really deleted. But we are missing the RBAC for watching ClusterRoleBindings and run into RBAC errors. This Pr adds the requited RBAC right.

This should be picked for the 0.14.0 branch.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally