### PR TITLE
Fixed doc when bridge POST operation is done with empty body

### DIFF
--- a/documentation/book/con-requests-kafka-bridge.adoc
+++ b/documentation/book/con-requests-kafka-bridge.adoc
@@ -11,7 +11,7 @@ Specify data formats and HTTP headers to ensure valid requests are submitted to 
 
 API request and response bodies are always encoded as JSON.
 
-* When performing consumer operations, `POST` requests must provide the following `Content-Type` header if there is a non empty body:
+* When performing consumer operations, `POST` requests must provide the following `Content-Type` header if there is a non-empty body:
 +
 [source,http,subs=+quotes]
 ----

--- a/documentation/book/con-requests-kafka-bridge.adoc
+++ b/documentation/book/con-requests-kafka-bridge.adoc
@@ -11,7 +11,7 @@ Specify data formats and HTTP headers to ensure valid requests are submitted to 
 
 API request and response bodies are always encoded as JSON.
 
-* When performing consumer operations, `POST` requests must provide the following `Content-Type` header:
+* When performing consumer operations, `POST` requests must provide the following `Content-Type` header if there is a non empty body:
 +
 [source,http,subs=+quotes]
 ----
@@ -35,6 +35,9 @@ m¦Content-Type: application/vnd.kafka.binary.v2+json
 |===
 
 You set the embedded data format when creating a consumer using the `consumers/_groupid_` endpoint--for more information, see the next section.
+
+The `Content-Type` must not be set if the `POST` request has an empty body.
+It could be the case of the consumer creation operation when no configuration is provided in the body in order to create the consumer with the default values.
 
 == Embedded data format
 

--- a/documentation/book/con-requests-kafka-bridge.adoc
+++ b/documentation/book/con-requests-kafka-bridge.adoc
@@ -37,7 +37,7 @@ m¦Content-Type: application/vnd.kafka.binary.v2+json
 You set the embedded data format when creating a consumer using the `consumers/_groupid_` endpoint--for more information, see the next section.
 
 The `Content-Type` must not be set if the `POST` request has an empty body.
-It could be the case of the consumer creation operation when no configuration is provided in the body in order to create the consumer with the default values.
+An empty body can be used to create a consumer with the default values.
 
 == Embedded data format
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

This PR is related to this one on the bridge https://github.com/strimzi/strimzi-kafka-bridge/pull/355.
It'a about documenting that the OpenAPI validation fails if you are not sending a body (during a POST for creating a consumer) but a `Content-Type` header is provided.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

