### PR TITLE
[DOC] Fix typo in Certificates and Secrets

### DIFF
--- a/documentation/book/ref-certificates-and-secrets.adoc
+++ b/documentation/book/ref-certificates-and-secrets.adoc
@@ -5,11 +5,10 @@
 [id='certificates-and-secrets-{context}']
 = Certificates and `Secrets`
 
-{ProductName} stores CA, component and Kafka client private keys and certificates in `Secrets`.
+{ProductName} stores Certificate Authority (CA), component, and Kafka client private keys and certificates in `Secrets`.
 All keys are 2048 bits in size.
 
-CA certificate validity periods, expressed as a number of days after certificate generation, can be configured in `Kafka.spec.clusterCa.validityDays`
-and `Kafka.spec.clusterCa.validityDays`.
+CA certificate validity periods are expressed as a number of days after certificate generation. You can configure the validity period of cluster CA certificates in `Kafka.spec.clusterCa.validityDays` and client CA certificates in `Kafka.spec.clientsCa.validityDays`.
 
 == Cluster CA `Secrets`
 


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Corrected a typo in the Certificates and Secrets module. Previously, the text was as follows:

> CA certificate validity periods, expressed as a number of days after certificate generation, can be configured in Kafka.spec.clusterCa.validityDays and Kafka.spec.clusterCa.validityDays.

Split this into two sentences and corrected the typo (Kafka.spec.clusterCa.validityDays > Kafka.spec.clientsCa.validityDays).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

