### PR TITLE
It should be possible to scale connect/s2i cluster to zero pods

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -46,7 +46,7 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
     private Map<String, Object> config = new HashMap<>(0);
 
     private Logging logging;
-    private int replicas;
+    private Integer replicas;
 
     private String version;
     private String image;
@@ -68,7 +68,7 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
 
     @Description("The number of pods in the Kafka Connect group.")
     @DefaultValue("3")
-    public int getReplicas() {
+    public Integer getReplicas() {
         return replicas;
     }
 
@@ -91,7 +91,7 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
         this.logging = logging;
     }
 
-    public void setReplicas(int replicas) {
+    public void setReplicas(Integer replicas) {
         this.replicas = replicas;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -142,7 +142,7 @@ public class KafkaConnectCluster extends AbstractModel {
     protected static <C extends KafkaConnectCluster> C fromSpec(KafkaConnectSpec spec,
                                                                 KafkaVersion.Lookup versions,
                                                                 C kafkaConnect) {
-        kafkaConnect.setReplicas(spec.getReplicas() > 0 ? spec.getReplicas() : DEFAULT_REPLICAS);
+        kafkaConnect.setReplicas(spec.getReplicas() != null && spec.getReplicas() >= 0 ? spec.getReplicas() : DEFAULT_REPLICAS);
         kafkaConnect.tracing = spec.getTracing();
 
         KafkaConnectConfiguration config = new KafkaConnectConfiguration(spec.getConfig().entrySet());


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
ssia

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

