### PR TITLE
Do not use the listener names from Kafka in docs, use the names from CRs

### DIFF
--- a/documentation/book/con-tls-connections.adoc
+++ b/documentation/book/con-tls-connections.adoc
@@ -16,7 +16,7 @@ This TLS encrypting `stunnel` proxy is instantiated from the `spec.zookeeper.stu
 
 == Kafka interbroker communication
 
-Communication between Kafka brokers is done through the `REPLICATION` listener on port 9091, which is encrypted by default.
+Communication between Kafka brokers is done through an internal listener on port 9091, which is encrypted by default and not accessible to {ProductName} users.
 
 Communication between Kafka brokers and Zookeeper nodes uses a TLS sidecar, as described above.
 
@@ -26,8 +26,8 @@ Like the Cluster Operator, the Topic and User Operators each use a TLS sidecar w
 
 == Kafka Client connections
 
-Encrypted communication between Kafka brokers and clients running within the same Kubernetes cluster is provided through the `CLIENTTLS` listener on port 9093.
+Encrypted communication between Kafka brokers and clients running within the same Kubernetes cluster is provided through the `tls` listener on port 9093.
 
-Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster is provided through the `EXTERNAL` listener on port 9094.
+Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster is provided through the `external` listener (the port of the external listener depends on its type).
 
-NOTE: You can use the `CLIENT` listener on port 9092 for unencrypted communication with brokers.
+NOTE: You can use the `plain` listener on port 9092 for unencrypted communication with brokers.

--- a/documentation/book/con-tls-connections.adoc
+++ b/documentation/book/con-tls-connections.adoc
@@ -16,7 +16,7 @@ This TLS encrypting `stunnel` proxy is instantiated from the `spec.zookeeper.stu
 
 == Kafka interbroker communication
 
-Communication between Kafka brokers is done through an internal listener on port 9091, which is encrypted by default and not accessible to {ProductName} users.
+Communication between Kafka brokers is done through an internal listener on port 9091, which is encrypted by default and not accessible to Kafka clients.
 
 Communication between Kafka brokers and Zookeeper nodes uses a TLS sidecar, as described above.
 
@@ -26,8 +26,8 @@ Like the Cluster Operator, the Topic and User Operators each use a TLS sidecar w
 
 == Kafka Client connections
 
-Encrypted communication between Kafka brokers and clients running within the same Kubernetes cluster is provided through the `tls` listener on port 9093.
+Encrypted communication between Kafka brokers and clients running within the same Kubernetes cluster can be provided by configuring the `spec.kafka.listeners.tls` listener, which listens on port 9093.
 
-Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster is provided through the `external` listener (the port of the `external` listener depends on its type).
+Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster can be provided by configuring the `spec.kafka.listeners.external` listener (the port of the `external` listener depends on its type).
 
-NOTE: You can use the `plain` listener on port 9092 for unencrypted communication with brokers.
+NOTE: Unencrypted client communication with brokers can be configured by `spec.kafka.listeners.plain`, which listens on port 9092.

--- a/documentation/book/con-tls-connections.adoc
+++ b/documentation/book/con-tls-connections.adoc
@@ -28,6 +28,6 @@ Like the Cluster Operator, the Topic and User Operators each use a TLS sidecar w
 
 Encrypted communication between Kafka brokers and clients running within the same Kubernetes cluster is provided through the `tls` listener on port 9093.
 
-Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster is provided through the `external` listener (the port of the external listener depends on its type).
+Encrypted communication between Kafka brokers and clients running outside the same Kubernetes cluster is provided through the `external` listener (the port of the `external` listener depends on its type).
 
 NOTE: You can use the `plain` listener on port 9092 for unencrypted communication with brokers.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

As described in #2028, the docs should not be using the listener names used in the Kafka configuration (e.g. EXTERNAL, CLIENT, CLIENTTLS or REPLICATION) but rather use the names we use in the KAfka custom resources (plain, tls, external).