### PR TITLE
Use Prometheus annotations on services only when metrics are enabled

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1101,12 +1101,17 @@ public abstract class AbstractModel {
      * @return Map with Prometheus annotations using the default port (9404) and path (/metrics)
      */
     protected Map<String, String> getPrometheusAnnotations()    {
-        Map<String, String> annotations = new HashMap<String, String>(3);
-        annotations.put("prometheus.io/port", String.valueOf(METRICS_PORT));
-        annotations.put("prometheus.io/scrape", "true");
-        annotations.put("prometheus.io/path", "/metrics");
+        if (isMetricsEnabled) {
+            Map<String, String> annotations = new HashMap<String, String>(3);
 
-        return annotations;
+            annotations.put("prometheus.io/port", String.valueOf(METRICS_PORT));
+            annotations.put("prometheus.io/scrape", "true");
+            annotations.put("prometheus.io/path", "/metrics");
+
+            return annotations;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -81,6 +81,9 @@ public class KafkaExporter extends AbstractModel {
 
         this.saramaLoggingEnabled = false;
         this.mountPath = "/var/lib/kafka";
+
+        // Kafka Exporter is all about metrics - they are always enabled
+        this.isMetricsEnabled = true;
     }
 
     public static KafkaExporter fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -186,7 +186,36 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
         assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
+        assertEquals(AbstractModel.METRICS_PORT_NAME, svc.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(KafkaCluster.METRICS_PORT), svc.getSpec().getPorts().get(1).getPort());
+        assertEquals("TCP", svc.getSpec().getPorts().get(1).getProtocol());
         assertEquals(kc.getPrometheusAnnotations(), svc.getMetadata().getAnnotations());
+
+        checkOwnerReference(kc.createOwnerReference(), svc);
+    }
+
+    @Test
+    public void testGenerateServiceWithoutMetrics()   {
+        KafkaConnectS2I resource = new KafkaConnectS2IBuilder(this.resource)
+                .editSpec()
+                    .withMetrics(null)
+                .endSpec()
+                .build();
+        KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromCrd(resource, VERSIONS);
+        Service svc = kc.generateService();
+
+        assertEquals("ClusterIP", svc.getSpec().getType());
+        assertEquals(expectedLabels(kc.getServiceName()), svc.getMetadata().getLabels());
+        assertEquals(expectedSelectorLabels(), svc.getSpec().getSelector());
+        assertEquals(1, svc.getSpec().getPorts().size());
+        assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
+        assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
+
+        assertFalse(svc.getMetadata().getAnnotations().containsKey("prometheus.io/port"));
+        assertFalse(svc.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"));
+        assertFalse(svc.getMetadata().getAnnotations().containsKey("prometheus.io/path"));
+
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Prometheus annotations should be used only in the cases when the metrics are enabled. But currently we set them all the time. And when the annotations are there but the port 9404 is not open, it basically tells proetheus to scrape there and causes errors.

This should close issue #2048.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging