### PR TITLE
Push Quick Start guide to the website

### DIFF
--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -10,12 +10,16 @@ ssh-add github_deploy_key
 git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
 cp -v documentation/htmlnoheader/master.html /tmp/website/docs/master/master.html
 cp -v documentation/html/index.html /tmp/website/docs/master/full.html
+cp -v documentation/htmlnoheader/quickstart.html /tmp/website/docs/master/master.html
+cp -v documentation/html/quickstart.html /tmp/website/docs/master/full.html
 cp -v documentation/htmlnoheader/contributing.html /tmp/website/contributing/guide/contributing.html
 cp -v documentation/html/contributing.html /tmp/website/contributing/guide/full.html
 rm -rf /tmp/website/docs/master/images
+rm -rf /tmp/website/docs/quickstart/master/images
 rm -rf /tmp/website/contributing/guide/images
 rm -rf /tmp/website/contributing/guide/templates
 cp -vrL documentation/htmlnoheader/images /tmp/website/docs/master/images
+cp -vrL documentation/htmlnoheader/images /tmp/website/docs/quickstart/master/images
 cp -vrL documentation/htmlnoheader/images /tmp/website/contributing/guide/images
 cp -vrL documentation/contributing/templates /tmp/website/contributing/guide/templates
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ docu_html: docu_htmlclean docu_versions docu_check
 	mkdir -p documentation/html
 	$(CP) -vrL documentation/book/images documentation/html/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/book/master.adoc -o documentation/html/index.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/books/evaluating/master.adoc -o documentation/html/quickstart.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
 
 
@@ -95,6 +96,7 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_versions docu_check
 	mkdir -p documentation/htmlnoheader
 	$(CP) -vrL documentation/book/images documentation/htmlnoheader/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/book/master.adoc -o documentation/htmlnoheader/master.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/books/evaluating/master.adoc -o documentation/htmlnoheader/quickstart.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing.html
 
 docu_check:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Now with the new Quick Start guide merged, we should also add it to the make build and push it to the website from master as we do with other documentation books.

This should be merged only after strimzi/strimzi.github.io#98 is merged.