### PR TITLE
Fix pushing of docs to the website - use the right path

### DIFF
--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -10,8 +10,8 @@ ssh-add github_deploy_key
 git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
 cp -v documentation/htmlnoheader/master.html /tmp/website/docs/master/master.html
 cp -v documentation/html/index.html /tmp/website/docs/master/full.html
-cp -v documentation/htmlnoheader/quickstart.html /tmp/website/docs/master/master.html
-cp -v documentation/html/quickstart.html /tmp/website/docs/master/full.html
+cp -v documentation/htmlnoheader/quickstart.html /tmp/website/docs/quickstart/master/master.html
+cp -v documentation/html/quickstart.html /tmp/website/docs/quickstart/master/full.html
 cp -v documentation/htmlnoheader/contributing.html /tmp/website/contributing/guide/contributing.html
 cp -v documentation/html/contributing.html /tmp/website/contributing/guide/full.html
 rm -rf /tmp/website/docs/master/images


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like i screw up the PR #2053 and the quickstart overwrites the main docs by mistake 🙄 . Could you please approve the fix?