### PR TITLE
Fix storage validation after the initial deployment

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -456,7 +456,22 @@ public abstract class AbstractModel {
         return storage;
     }
 
+    /**
+     * Set Storage
+     *
+     * @param storage   Persistent Storage configuration
+     */
     protected void setStorage(Storage storage) {
+        validatePersistentStorage(storage);
+        this.storage = storage;
+    }
+
+    /**
+     * Validates persistent storage
+     *
+     * @param storage   Persistent Storage configuration
+     */
+    protected static void validatePersistentStorage(Storage storage)   {
         if (storage instanceof PersistentClaimStorage) {
             PersistentClaimStorage persistentClaimStorage = (PersistentClaimStorage) storage;
             checkPersistentStorageSize(persistentClaimStorage);
@@ -474,11 +489,9 @@ public abstract class AbstractModel {
                 }
             }
         }
-
-        this.storage = storage;
     }
 
-    private void checkPersistentStorageSize(PersistentClaimStorage storage)   {
+    private static void checkPersistentStorageSize(PersistentClaimStorage storage)   {
         if (storage.getSize() == null || storage.getSize().isEmpty()) {
             throw new InvalidResourceException("The size is mandatory for a persistent-claim storage");
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -413,6 +413,8 @@ public class KafkaCluster extends AbstractModel {
 
         if (oldStorage != null) {
             Storage newStorage = kafkaClusterSpec.getStorage();
+            AbstractModel.validatePersistentStorage(newStorage);
+
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -209,6 +209,8 @@ public class ZookeeperCluster extends AbstractModel {
 
         if (oldStorage != null) {
             Storage newStorage = zookeeperClusterSpec.getStorage();
+            AbstractModel.validatePersistentStorage(newStorage);
+
             StorageDiff diff = new StorageDiff(oldStorage, newStorage);
 
             if (!diff.isEmpty()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2041,6 +2041,24 @@ public class KafkaClusterTest {
         KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
     }
 
+    @Test(expected = InvalidResourceException.class)
+    public void testStorageValidationAfterInitialDeployment() {
+        Storage oldStorage = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder().withSize("100Gi").build())
+                .build();
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                .editKafka()
+                .withStorage(new JbodStorageBuilder().withVolumes(Collections.EMPTY_LIST)
+                        .build())
+                .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage);
+    }
+
     @Test
     public void testGeneratePersistentVolumeClaimsEphemeral()    {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -28,7 +28,6 @@ import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
-import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.RackBuilder;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -28,6 +28,7 @@ import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.RackBuilder;
@@ -36,6 +37,7 @@ import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarBuilder;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
+import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -988,6 +990,23 @@ public class ZookeeperClusterTest {
                 .build();
         zc = ZookeeperCluster.fromCrd(ka, VERSIONS, ephemeral);
         assertEquals(ephemeral, zc.getStorage());
+    }
+
+    @Test(expected = InvalidResourceException.class)
+    public void testStorageValidationAfterInitialDeployment() {
+        Storage oldStorage = new PersistentClaimStorageBuilder()
+                .withSize("100Gi")
+                .build();
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                    .withStorage(new PersistentClaimStorageBuilder().build())
+                    .endZookeeper()
+                .endSpec()
+                .build();
+        ZookeeperCluster.fromCrd(kafkaAssembly, VERSIONS, oldStorage);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We do proper validation of the Storage when a new cluster is being created. But for existing clusters, we pass the new `Storage` object directy into the `StorageDiff` class without any validation and that can result in some NPEs. 

This PR adds the validation before we pass it into `StorageDiff`. That way, when the user changes the storage to invalid configuration `fromCrd` would throw a proper exception. When it is valid, it will pass it to `StorageDiff` (which might skip the new configuration because of invalid changes but that will currently continue into the reconciliation).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally