### PR TITLE
[Doc] Clarify what is needed to use custom Kafka Connect image

### DIFF
--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -29,7 +29,13 @@ USER {DockerImageUser}
 
 . Push your custom image to your container registry.
 
-. Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource to point to the new container image. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
+. Point to the new container image.
++
+You can either:
++
+* Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource.  
++
+If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
 +
 [source,yaml,subs=attributes+]
 ----
@@ -44,7 +50,7 @@ spec:
 +
 or
 +
-In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator.
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator.
 
 .Additional resources
 

--- a/documentation/book/proc-creating-new-image-from-base.adoc
+++ b/documentation/book/proc-creating-new-image-from-base.adoc
@@ -29,7 +29,7 @@ USER {DockerImageUser}
 
 . Push your custom image to your container registry.
 
-. Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource to point to the new container image. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable referred to in the next step. 
+. Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource to point to the new container image. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
 +
 [source,yaml,subs=attributes+]
 ----
@@ -41,8 +41,10 @@ spec:
   #...
   image: my-new-container-image 
 ----
-
-. In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image.
++
+or
++
+In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator.
 
 .Additional resources
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In the current documentation for building a custom image for Kafka Connect we have currently two separate steps:
* One sugests to change the `spec.image` property
* Second to change the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE ` env. var

This sugests that both need to be done, while in reality only one of these needs to be done. This PR should make it more clear that it is one or another