### PR TITLE
Fix bugs in Kafka dashboard and improve tags

### DIFF
--- a/metrics/examples/grafana/strimzi-kafka-connect.json
+++ b/metrics/examples/grafana/strimzi-kafka-connect.json
@@ -667,6 +667,8 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
+    "Strimzi",
+    "Kafka",
     "Kafka Connect"
   ],
   "templating": {

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -2040,6 +2040,7 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
+    "Strimzi",
     "Kafka"
   ],
   "templating": {
@@ -2105,7 +2106,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": ".+",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,

--- a/metrics/examples/grafana/strimzi-zookeeper.json
+++ b/metrics/examples/grafana/strimzi-zookeeper.json
@@ -1246,6 +1246,8 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
+    "Strimzi",
+    "Kafka",
     "Zookeeper"
   ],
   "templating": {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Most of the metrics which are per topic have also its variant without the topic label which already contains already the sum for all labels. Right now we use for _All_ topics the regex `.*` which matches even missing topic label. That means that we basically show double the value for all of these metrics. This PR changes the _All_ value to `.+` to match only the metrics which have the topic labal and thus getting the right number. (It still sums over all topics instead of using the summed metric to allow filtering based on topic.)

This PR also improves the tags - to make sure that every dashabord has also _Kafka_ and _Strimzi_ labels. Thsi should be useful for anyone who has lot of dashboards installed.