### PR TITLE
Fix the name of the Kafka Exporter dashboard

### DIFF
--- a/metrics/examples/grafana/strimzi-kafka-exporter.json
+++ b/metrics/examples/grafana/strimzi-kafka-exporter.json
@@ -1273,7 +1273,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Strimzi - Kafka Exporter",
+  "title": "Strimzi Kafka Exporter",
   "uid": "jwPKIsniz",
   "version": 3
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It turns out that all the dashboards are named _Strimzi Kafka_, Strimzi Zookeeper_ etc. Only I named the Kafka Exporter dashabord _Strimzi - Kafka Exporter_. This PR changes it to _Strimzi Kafka Exporter_ to be in line with the others.