### PR TITLE
ST: fix some flaky tests and get component names in tests properly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -530,6 +530,7 @@ public class Resources extends AbstractResources {
                 .withNewTls()
                 .withTrustedCertificates(new CertSecretSourceBuilder().withNewSecretName(kafkaClusterName + "-cluster-ca-cert").withCertificate("ca.crt").build())
                 .endTls()
+                .withInsecureSourceRepository(true)
             .endSpec();
     }
 
@@ -564,12 +565,12 @@ public class Resources extends AbstractResources {
             .withNewSpec()
                 .withVersion(KAFKA_VERSION)
                 .withNewConsumer()
-                    .withBootstrapServers(tlsListener ? sourceBootstrapServer + "-kafka-bootstrap:9093" : sourceBootstrapServer + "-kafka-bootstrap:9092")
+                    .withBootstrapServers(tlsListener ? KafkaResources.tlsBootstrapAddress(sourceBootstrapServer) : KafkaResources.plainBootstrapAddress(sourceBootstrapServer))
                     .withGroupId(groupId)
                     .addToConfig(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                 .endConsumer()
                 .withNewProducer()
-                    .withBootstrapServers(tlsListener ? targetBootstrapServer + "-kafka-bootstrap:9093" : targetBootstrapServer + "-kafka-bootstrap:9092")
+                .withBootstrapServers(tlsListener ? KafkaResources.tlsBootstrapAddress(targetBootstrapServer) : KafkaResources.plainBootstrapAddress(targetBootstrapServer))
                     .addToConfig(ProducerConfig.ACKS_CONFIG, "all")
                 .endProducer()
                 .withResources(new ResourceRequirementsBuilder()

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -77,19 +77,4 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void teardownAdditionalResources() {
         secondNamespaceResources.deleteResources();
     }
-
-//    @BeforeEach
-//    void createSecondNamespaceResources() {
-//        setNamespace(SECOND_NAMESPACE);
-//        secondNamespaceResources = new Resources(kubeClient(SECOND_NAMESPACE));
-//        setNamespace(CO_NAMESPACE);
-//    }
-
-    @Override
-    protected void tearDownEnvironmentAfterEach() throws Exception {
-//        setNamespace(SECOND_NAMESPACE);
-//        secondNamespaceResources.deleteResources();
-//        waitForDeletion(Constants.TIMEOUT_TEARDOWN);
-//        setNamespace(CO_NAMESPACE);
-    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest;
 
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.AfterAll;
 
 import java.io.File;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractNamespaceST extends AbstractST {
 
@@ -29,8 +32,13 @@ public abstract class AbstractNamespaceST extends AbstractST {
     void checkKafkaInDiffNamespaceThanCO(String clusterName, String namespace) {
         String previousNamespace = setNamespace(namespace);
         LOGGER.info("Check if Kafka Cluster {} in namespace {}", KafkaResources.kafkaStatefulSetName(clusterName), namespace);
-        // Jen assert
-        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
+
+        Condition kafkaCondition = secondNamespaceResources.kafka().inNamespace(namespace).withName(clusterName).get()
+                .getStatus().getConditions().get(0);
+        LOGGER.info("Kafka condition status: {}", kafkaCondition.getStatus());
+        LOGGER.info("Kafka condition type: {}", kafkaCondition.getType());
+
+        assertEquals("Ready", kafkaCondition.getType());
         setNamespace(previousNamespace);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -4,11 +4,12 @@
  */
 package io.strimzi.systemtest;
 
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
 
 import java.io.File;
 import java.util.List;
@@ -25,32 +26,20 @@ public abstract class AbstractNamespaceST extends AbstractST {
 
     static Resources secondNamespaceResources;
 
-    void checkKafkaInDiffNamespaceThanCO() {
-        String kafkaName = kafkaClusterName(CLUSTER_NAME + "-second");
-        String previousNamespace = setNamespace(SECOND_NAMESPACE);
-        secondNamespaceResources.kafkaEphemeral(CLUSTER_NAME + "-second", 3)
-                .editSpec()
-                    .editKafka()
-                        .editListeners()
-                            .withNewKafkaListenerExternalNodePort()
-                            .endKafkaListenerExternalNodePort()
-                        .endListeners()
-                    .endKafka()
-                .endSpec()
-                .done();
-
-        LOGGER.info("Waiting for creation {} in namespace {}", kafkaName, SECOND_NAMESPACE);
-        StUtils.waitForAllStatefulSetPodsReady(kafkaName, 3);
+    void checkKafkaInDiffNamespaceThanCO(String clusterName, String namespace) {
+        String previousNamespace = setNamespace(namespace);
+        LOGGER.info("Check if Kafka Cluster {} in namespace {}", KafkaResources.kafkaStatefulSetName(clusterName), namespace);
+        // Jen assert
+        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), 3);
         setNamespace(previousNamespace);
     }
 
-    void checkMirrorMakerForKafkaInDifNamespaceThanCO() {
-        String kafkaName = CLUSTER_NAME + "-target";
-        String kafkaSourceName = kafkaClusterName(CLUSTER_NAME);
-        String kafkaTargetName = kafkaClusterName(kafkaName);
+    void checkMirrorMakerForKafkaInDifNamespaceThanCO(String sourceClusterName) {
+        String kafkaSourceName = sourceClusterName;
+        String kafkaTargetName = CLUSTER_NAME + "-target";
 
         String previousNamespace = setNamespace(SECOND_NAMESPACE);
-        secondNamespaceResources.kafkaEphemeral(kafkaName, 3).done();
+        secondNamespaceResources.kafkaEphemeral(kafkaTargetName, 1, 1).done();
         secondNamespaceResources.kafkaMirrorMaker(CLUSTER_NAME, kafkaSourceName, kafkaTargetName, "my-group", 1, false).done();
 
         LOGGER.info("Waiting for creation {} in namespace {}", CLUSTER_NAME + "-mirror-maker", SECOND_NAMESPACE);
@@ -58,12 +47,12 @@ public abstract class AbstractNamespaceST extends AbstractST {
         setNamespace(previousNamespace);
     }
 
-    void deployNewTopic(String topicNamespace, String clusterNamespace, String topic) {
+    void deployNewTopic(String topicNamespace, String kafkaClusterNamespace, String topic) {
         LOGGER.info("Creating topic {} in namespace {}", topic, topicNamespace);
         setNamespace(topicNamespace);
         cmdKubeClient().create(new File(TOPIC_EXAMPLES_DIR));
         TestUtils.waitFor("wait for 'my-topic' to be created in Kafka", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_TOPIC_CREATION, () -> {
-            setNamespace(clusterNamespace);
+            setNamespace(kafkaClusterNamespace);
             List<String> topics2 = listTopicsUsingPodCLI(CLUSTER_NAME, 0);
             return topics2.contains(topic);
         });
@@ -76,18 +65,23 @@ public abstract class AbstractNamespaceST extends AbstractST {
         setNamespace(CO_NAMESPACE);
     }
 
-    @BeforeEach
-    void createSecondNamespaceResources() {
-        setNamespace(SECOND_NAMESPACE);
-        secondNamespaceResources = new Resources(kubeClient(SECOND_NAMESPACE));
-        setNamespace(CO_NAMESPACE);
+    @AfterAll
+    void teardownAdditionalResources() {
+        secondNamespaceResources.deleteResources();
     }
+
+//    @BeforeEach
+//    void createSecondNamespaceResources() {
+//        setNamespace(SECOND_NAMESPACE);
+//        secondNamespaceResources = new Resources(kubeClient(SECOND_NAMESPACE));
+//        setNamespace(CO_NAMESPACE);
+//    }
 
     @Override
     protected void tearDownEnvironmentAfterEach() throws Exception {
-        setNamespace(SECOND_NAMESPACE);
-        secondNamespaceResources.deleteResources();
-        waitForDeletion(Constants.TIMEOUT_TEARDOWN);
-        setNamespace(CO_NAMESPACE);
+//        setNamespace(SECOND_NAMESPACE);
+//        secondNamespaceResources.deleteResources();
+//        waitForDeletion(Constants.TIMEOUT_TEARDOWN);
+//        setNamespace(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -67,7 +67,7 @@ class ConnectST extends AbstractST {
         testMethodResources().kafkaConnect(CLUSTER_NAME, 1).done();
         LOGGER.info("Looks like the connect cluster my-cluster deployed OK");
 
-        String podName = StUtils.getPodNameByPrefix(kafkaConnectName(CLUSTER_NAME));
+        String podName = StUtils.getPodNameByPrefix(KafkaConnectResources.deploymentName(CLUSTER_NAME));
         String kafkaPodJson = TestUtils.toJsonString(kubeClient().getPod(podName));
 
         assertThat(kafkaPodJson, hasJsonPath(globalVariableJsonPathBuilder("KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
@@ -163,10 +163,10 @@ class ConnectST extends AbstractST {
                 .endSpec()
                 .done();
 
-        String podName = StUtils.getPodNameByPrefix(kafkaConnectName(CLUSTER_NAME));
-        assertResources(NAMESPACE, podName, kafkaConnectName(CLUSTER_NAME),
+        String podName = StUtils.getPodNameByPrefix(KafkaConnectResources.deploymentName(CLUSTER_NAME));
+        assertResources(NAMESPACE, podName, KafkaConnectResources.deploymentName(CLUSTER_NAME),
                 "400M", "2", "300M", "1");
-        assertExpectedJavaOpts(podName, kafkaConnectName(CLUSTER_NAME),
+        assertExpectedJavaOpts(podName, KafkaConnectResources.deploymentName(CLUSTER_NAME),
                 "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
     }
 
@@ -184,7 +184,7 @@ class ConnectST extends AbstractST {
 
         LOGGER.info("Scaling up to {}", scaleTo);
         replaceKafkaConnectResource(CLUSTER_NAME, c -> c.getSpec().setReplicas(initialReplicas + 1));
-        StUtils.waitForDeploymentReady(kafkaConnectName(CLUSTER_NAME), initialReplicas + 1);
+        StUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(CLUSTER_NAME), initialReplicas + 1);
         connectPods = kubeClient().listPodNames("strimzi.io/kind", "KafkaConnect");
         assertEquals(scaleTo, connectPods.size());
         for (String pod : connectPods) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest;
 
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.utils.StUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,8 +30,8 @@ class HelmChartST extends AbstractST {
     void testDeployKafkaClusterViaHelmChart() {
         testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3).done();
         testMethodResources().topic(CLUSTER_NAME, TOPIC_NAME).done();
-        StUtils.waitForAllStatefulSetPodsReady(zookeeperClusterName(CLUSTER_NAME), 3);
-        StUtils.waitForAllStatefulSetPodsReady(kafkaClusterName(CLUSTER_NAME), 3);
+        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 3);
+        StUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -8,6 +8,9 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorJvmOptions;
 import io.strimzi.api.kafka.model.JvmOptions;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.timemeasuring.Operation;
 import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
@@ -142,34 +145,34 @@ class LogSettingST extends AbstractST {
     @Test
     @Order(7)
     void testGcLoggingNonSetEnabled() {
-        assertTrue(checkGcLoggingStatefulSets(kafkaClusterName(GC_LOGGING_SET_NAME)), "Kafka GC logging is enabled");
-        assertTrue(checkGcLoggingStatefulSets(zookeeperClusterName(GC_LOGGING_SET_NAME)), "Zookeeper GC logging is enabled");
+        assertTrue(checkGcLoggingStatefulSets(KafkaResources.kafkaStatefulSetName(GC_LOGGING_SET_NAME)), "Kafka GC logging is enabled");
+        assertTrue(checkGcLoggingStatefulSets(KafkaResources.zookeeperStatefulSetName(GC_LOGGING_SET_NAME)), "Zookeeper GC logging is enabled");
 
-        assertTrue(checkGcLoggingDeployments(entityOperatorDeploymentName(GC_LOGGING_SET_NAME), "topic-operator"), "TO GC logging is enabled");
-        assertTrue(checkGcLoggingDeployments(entityOperatorDeploymentName(GC_LOGGING_SET_NAME), "user-operator"), "UO GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(GC_LOGGING_SET_NAME), "topic-operator"), "TO GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(GC_LOGGING_SET_NAME), "user-operator"), "UO GC logging is enabled");
     }
 
     @Test
     @Order(8)
     void testGcLoggingSetEnabled() {
-        assertTrue(checkGcLoggingStatefulSets(kafkaClusterName(CLUSTER_NAME)), "Kafka GC logging is enabled");
-        assertTrue(checkGcLoggingStatefulSets(zookeeperClusterName(CLUSTER_NAME)), "Zookeeper GC logging is enabled");
+        assertTrue(checkGcLoggingStatefulSets(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)), "Kafka GC logging is enabled");
+        assertTrue(checkGcLoggingStatefulSets(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)), "Zookeeper GC logging is enabled");
 
-        assertTrue(checkGcLoggingDeployments(entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator"), "TO GC logging is enabled");
-        assertTrue(checkGcLoggingDeployments(entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), "UO GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator"), "TO GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), "UO GC logging is enabled");
 
-        assertTrue(checkGcLoggingDeployments(kafkaConnectName(CLUSTER_NAME)), "Connect GC logging is enabled");
-        assertTrue(checkGcLoggingDeployments(kafkaMirrorMakerName(CLUSTER_NAME)), "Mirror-maker GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaConnectResources.deploymentName(CLUSTER_NAME)), "Connect GC logging is enabled");
+        assertTrue(checkGcLoggingDeployments(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME)), "Mirror-maker GC logging is enabled");
     }
 
     @Test
     @Order(9)
     void testGcLoggingSetDisabled() {
-        String connectName = kafkaConnectName(CLUSTER_NAME);
-        String mmName = kafkaMirrorMakerName(CLUSTER_NAME);
-        String eoName = entityOperatorDeploymentName(CLUSTER_NAME);
-        String kafkaName = kafkaClusterName(CLUSTER_NAME);
-        String zkName = zookeeperClusterName(CLUSTER_NAME);
+        String connectName = KafkaConnectResources.deploymentName(CLUSTER_NAME);
+        String mmName = KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME);
+        String eoName = KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME);
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        String zkName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
         Map<String, String> connectPods = StUtils.depSnapshot(connectName);
         Map<String, String> mmPods = StUtils.depSnapshot(mmName);
         Map<String, String> eoPods = StUtils.depSnapshot(eoName);
@@ -198,14 +201,14 @@ class LogSettingST extends AbstractST {
         StUtils.waitTillDepHasRolled(connectName, 1, connectPods);
         StUtils.waitTillDepHasRolled(mmName, 1, mmPods);
 
-        assertFalse(checkGcLoggingStatefulSets(kafkaClusterName(CLUSTER_NAME)), "Kafka GC logging is disabled");
-        assertFalse(checkGcLoggingStatefulSets(zookeeperClusterName(CLUSTER_NAME)), "Zookeeper GC logging is disabled");
+        assertFalse(checkGcLoggingStatefulSets(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)), "Kafka GC logging is disabled");
+        assertFalse(checkGcLoggingStatefulSets(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)), "Zookeeper GC logging is disabled");
 
-        assertFalse(checkGcLoggingDeployments(entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator"), "TO GC logging is disabled");
-        assertFalse(checkGcLoggingDeployments(entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), "UO GC logging is disabled");
+        assertFalse(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "topic-operator"), "TO GC logging is disabled");
+        assertFalse(checkGcLoggingDeployments(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), "user-operator"), "UO GC logging is disabled");
 
-        assertFalse(checkGcLoggingDeployments(kafkaConnectName(CLUSTER_NAME)), "Connect GC logging is disabled");
-        assertFalse(checkGcLoggingDeployments(kafkaMirrorMakerName(CLUSTER_NAME)), "Mirror-maker GC logging is disabled");
+        assertFalse(checkGcLoggingDeployments(KafkaConnectResources.deploymentName(CLUSTER_NAME)), "Connect GC logging is disabled");
+        assertFalse(checkGcLoggingDeployments(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME)), "Mirror-maker GC logging is disabled");
     }
 
     private boolean checkLoggersLevel(Map<String, String> loggers, int since, String configMapName) {
@@ -217,7 +220,7 @@ class LogSettingST extends AbstractST {
             result = configMap.contains(loggerConfig);
 
             if (result) {
-                String log = cmdKubeClient().searchInLog(STATEFUL_SET, kafkaClusterName(CLUSTER_NAME), since, ERROR);
+                String log = cmdKubeClient().searchInLog(STATEFUL_SET, KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), since, ERROR);
                 result = log.isEmpty();
             }
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -90,10 +90,10 @@ public class MirrorMakerST extends MessagingBaseST {
         verifyLabelsForConfigMaps(kafkaClusterSourceName, null, kafkaClusterTargetName);
         verifyLabelsForServiceAccounts(kafkaClusterSourceName, null);
 
-        String podName = kubeClient().listPods().stream().filter(n -> n.getMetadata().getName().startsWith(kafkaMirrorMakerName(CLUSTER_NAME))).findFirst().get().getMetadata().getName();
+        String podName = kubeClient().listPods().stream().filter(n -> n.getMetadata().getName().startsWith(KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME))).findFirst().get().getMetadata().getName();
         assertResources(NAMESPACE, podName, CLUSTER_NAME.concat("-mirror-maker"),
                 "400M", "2", "300M", "1");
-        assertExpectedJavaOpts(podName, kafkaMirrorMakerName(CLUSTER_NAME),
+        assertExpectedJavaOpts(podName, KafkaMirrorMakerResources.deploymentName(CLUSTER_NAME),
                 "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
 
         TimeMeasuringSystem.stopOperation(getOperationID());

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -34,7 +34,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running testRecoveryFromEntityOperatorDeletion with cluster {}", CLUSTER_NAME);
-        String entityOperatorDeploymentName = entityOperatorDeploymentName(CLUSTER_NAME);
+        String entityOperatorDeploymentName = KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME);
         String entityOperatorDeploymentUid = kubeClient().getDeploymentUid(entityOperatorDeploymentName);
         kubeClient().deleteDeployment(entityOperatorDeploymentName);
 
@@ -53,7 +53,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaStatefulSet with cluster {}", CLUSTER_NAME);
-        String kafkaStatefulSetName = kafkaClusterName(CLUSTER_NAME);
+        String kafkaStatefulSetName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
         String kafkaStatefulSetUid = kubeClient().getStatefulSetUid(kafkaStatefulSetName);
         kubeClient().deleteStatefulSet(kafkaStatefulSetName);
 
@@ -72,7 +72,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running deleteZookeeperStatefulSet with cluster {}", CLUSTER_NAME);
-        String zookeeperStatefulSetName = zookeeperClusterName(CLUSTER_NAME);
+        String zookeeperStatefulSetName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
         String zookeeperStatefulSetUid = kubeClient().getStatefulSetUid(zookeeperStatefulSetName);
         kubeClient().deleteStatefulSet(zookeeperStatefulSetName);
 
@@ -90,7 +90,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaService with cluster {}", CLUSTER_NAME);
-        String kafkaServiceName = kafkaServiceName(CLUSTER_NAME);
+        String kafkaServiceName = KafkaResources.bootstrapServiceName(CLUSTER_NAME);
         String kafkaServiceUid = kubeClient().getServiceUid(kafkaServiceName);
         kubeClient().deleteService(kafkaServiceName);
 
@@ -124,7 +124,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaHeadlessService with cluster {}", CLUSTER_NAME);
-        String kafkaHeadlessServiceName = kafkaHeadlessServiceName(CLUSTER_NAME);
+        String kafkaHeadlessServiceName = KafkaResources.brokersServiceName(CLUSTER_NAME);
         String kafkaHeadlessServiceUid = kubeClient().getServiceUid(kafkaHeadlessServiceName);
         kubeClient().deleteService(kafkaHeadlessServiceName);
 
@@ -158,7 +158,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaMetricsConfig with cluster {}", CLUSTER_NAME);
-        String kafkaMetricsConfigName = kafkaMetricsConfigName(CLUSTER_NAME);
+        String kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(CLUSTER_NAME);
         String kafkaMetricsConfigUid = kubeClient().getConfigMapUid(kafkaMetricsConfigName);
         kubeClient().deleteConfigMap(kafkaMetricsConfigName);
 
@@ -175,7 +175,7 @@ class RecoveryST extends AbstractST {
         setOperationID(startTimeMeasuring(Operation.CLUSTER_RECOVERY));
         LOGGER.info("Running deleteZookeeperMetricsConfig with cluster {}", CLUSTER_NAME);
         // kafka cluster already deployed
-        String zookeeperMetricsConfigName = zookeeperMetricsConfigName(CLUSTER_NAME);
+        String zookeeperMetricsConfigName = KafkaResources.zookeeperMetricsAndLogConfigMapName(CLUSTER_NAME);
         String zookeeperMetricsConfigUid = kubeClient().getConfigMapUid(zookeeperMetricsConfigName);
         kubeClient().deleteConfigMap(zookeeperMetricsConfigName);
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Refactoring

### Description

Some of the tests were using method form `AbstractST` which were kinda useless, cause same methods are already in `<COMPONENT>Resources.java` classes. This PR removes these methods and instead of them use the ocrrect ones.

It also contains fix for `ConnectS2I` tests, which CR didn't have `InsecureRegistry` setting, which cause failures on some environments.

`AllNamespaceST` and `MultipleNamespaceST` was refactored and should be stable now.

### Checklist

- [x] Make sure all tests pass


