### PR TITLE
Add headless Kafka service to the broker certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -149,8 +149,12 @@ public class ClusterCa extends Ca {
             sbjAltNames.put("DNS.2", String.format("%s.%s", KafkaCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.3", String.format("%s.%s.svc", KafkaCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", KafkaCluster.serviceName(cluster), namespace, ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN));
-            sbjAltNames.put("DNS.5", KafkaCluster.podDnsName(namespace, cluster, i));
-            int nextDnsId = 6;
+            sbjAltNames.put("DNS.5", KafkaCluster.headlessServiceName(cluster));
+            sbjAltNames.put("DNS.6", String.format("%s.%s", KafkaCluster.headlessServiceName(cluster), namespace));
+            sbjAltNames.put("DNS.7", String.format("%s.%s.svc", KafkaCluster.headlessServiceName(cluster), namespace));
+            sbjAltNames.put("DNS.8", String.format("%s.%s.svc.%s", KafkaCluster.headlessServiceName(cluster), namespace, ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN));
+            sbjAltNames.put("DNS.9", KafkaCluster.podDnsName(namespace, cluster, i));
+            int nextDnsId = 10;
             int nextIpId = 1;
 
             if (externalBootstrapAddresses != null)   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1052,7 +1052,11 @@ public class KafkaClusterTest {
                 asList(2, "foo-kafka-bootstrap"),
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),
-                asList(2, "foo-kafka-bootstrap.test.svc.cluster.local")),
+                asList(2, "foo-kafka-bootstrap.test.svc.cluster.local"),
+                asList(2, "foo-kafka-brokers"),
+                asList(2, "foo-kafka-brokers.test"),
+                asList(2, "foo-kafka-brokers.test.svc"),
+                asList(2, "foo-kafka-brokers.test.svc.cluster.local")),
                 new HashSet<Object>(cert.getSubjectAlternativeNames()));
 
     }
@@ -1078,6 +1082,10 @@ public class KafkaClusterTest {
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),
                 asList(2, "foo-kafka-bootstrap.test.svc.cluster.local"),
+                asList(2, "foo-kafka-brokers"),
+                asList(2, "foo-kafka-brokers.test"),
+                asList(2, "foo-kafka-brokers.test.svc"),
+                asList(2, "foo-kafka-brokers.test.svc.cluster.local"),
                 asList(7, "123.10.125.140"),
                 asList(7, "123.10.125.130")),
                 new HashSet<Object>(cert.getSubjectAlternativeNames()));
@@ -1104,6 +1112,10 @@ public class KafkaClusterTest {
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),
                 asList(2, "foo-kafka-bootstrap.test.svc.cluster.local"),
+                asList(2, "foo-kafka-brokers"),
+                asList(2, "foo-kafka-brokers.test"),
+                asList(2, "foo-kafka-brokers.test.svc"),
+                asList(2, "foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "my-broker-0"),
                 asList(2, "my-bootstrap"),
                 asList(7, "123.10.125.140"),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The issue #2027 raised the issue that our certificates do not have the headless service in the alternative subject names. While we do not expect the headless service to be used, it might still make sense to add them so that anyone who uses them (and maybe has a reason) can use hostname verification.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally