### PR TITLE
Kafka connector operator

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -141,6 +141,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaUser=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}044-Crd-kafkauser.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}045-Crd-kafkamirrormaker.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaBridge=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}046-Crd-kafkabridge.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnector=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}047-Crd-kafkaconnector.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -167,6 +168,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaUser</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaBridge</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaConnector</argument>
                             </arguments>
                             <workingDirectory>${pom.basedir}${file.separator}..${file.separator}documentation</workingDirectory>
                         </configuration>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -22,6 +22,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.DoneableKafkaUser;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -29,6 +30,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.KafkaConnector;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,7 +52,8 @@ public class Crds {
         KafkaTopic.class,
         KafkaUser.class,
         KafkaMirrorMaker.class,
-        KafkaBridge.class
+        KafkaBridge.class,
+        KafkaConnector.class
     };
 
     private Crds() {
@@ -83,6 +86,8 @@ public class Crds {
             version = KafkaMirrorMaker.VERSIONS.get(0);
         } else if (cls.equals(KafkaBridge.class)) {
             version = KafkaBridge.VERSIONS.get(0);
+        } else if (cls.equals(KafkaConnector.class)) {
+            version = KafkaConnector.VERSIONS.get(0);
         } else {
             throw new RuntimeException();
         }
@@ -91,13 +96,7 @@ public class Crds {
     }
 
     private static CustomResourceDefinition crd(Class<? extends CustomResource> cls, String version) {
-        String scope;
-        String crdApiVersion;
-        String plural;
-        String singular;
-        String group;
-        String kind;
-        String listKind;
+        String scope, crdApiVersion, plural, singular, group, kind, listKind;
         CustomResourceSubresourceStatus status = null;
 
         if (cls.equals(Kafka.class)) {
@@ -183,6 +182,18 @@ public class Crds {
             if (!KafkaBridge.VERSIONS.contains(version)) {
                 throw new RuntimeException();
             }
+        } else if (cls.equals(KafkaConnector.class)) {
+            scope = KafkaConnector.SCOPE;
+            crdApiVersion = KafkaConnector.CRD_API_VERSION;
+            plural = KafkaConnector.RESOURCE_PLURAL;
+            singular = KafkaConnector.RESOURCE_SINGULAR;
+            group = KafkaConnector.RESOURCE_GROUP;
+            kind = KafkaConnector.RESOURCE_KIND;
+            listKind = KafkaConnector.RESOURCE_LIST_KIND;
+            status = new CustomResourceSubresourceStatus();
+            if (!KafkaConnector.VERSIONS.contains(version)) {
+                throw new RuntimeException();
+            }
         } else {
             throw new RuntimeException();
         }
@@ -228,6 +239,14 @@ public class Crds {
 
     public static MixedOperation<KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> kafkaConnectOperation(KubernetesClient client) {
         return client.customResources(kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class);
+    }
+
+    public static CustomResourceDefinition kafkaConnector() {
+        return crd(KafkaConnector.class);
+    }
+
+    public static MixedOperation<KafkaConnector, KafkaConnectorList, DoneableKafkaConnector, Resource<KafkaConnector, DoneableKafkaConnector>> kafkaConnectorOperation(KubernetesClient client) {
+        return client.customResources(kafkaConnector(), KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class);
     }
 
     public static CustomResourceDefinition kafkaConnectS2I() {

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaConnectorList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaConnectorList.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.strimzi.api.kafka.model.KafkaConnector;
+
+/**
+ * A {@code CustomResourceList<KafkaConnector>} required for using Fabric8 CRD support.
+ */
+public class KafkaConnectorList extends CustomResourceList<KafkaConnector> {
+    private static final long serialVersionUID = 1L;
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "replicas", "image",
+@JsonPropertyOrder({ "replicas", "config", "connectorSelector", "image",
         "livenessProbe", "readinessProbe", "jvmOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
 @EqualsAndHashCode(doNotUseGetters = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "replicas", "config", "connectorSelector", "image",
+@JsonPropertyOrder({ "replicas", "config", "image",
         "livenessProbe", "readinessProbe", "jvmOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
 @EqualsAndHashCode(doNotUseGetters = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
+import io.strimzi.crdgenerator.annotations.Crd;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableList;
+
+@Crd(
+        apiVersion = KafkaConnector.CRD_API_VERSION,
+        spec = @Crd.Spec(
+                names = @Crd.Spec.Names(
+                        kind = KafkaConnector.RESOURCE_KIND,
+                        plural = KafkaConnector.RESOURCE_PLURAL,
+                        shortNames = {KafkaConnector.SHORT_NAME}
+                ),
+                group = KafkaConnector.RESOURCE_GROUP,
+                scope = KafkaConnector.SCOPE,
+                version = KafkaConnector.V1ALPHA1,
+                versions = {
+                        @Crd.Spec.Version(
+                                name = KafkaConnector.V1ALPHA1,
+                                served = true,
+                                storage = true)
+                }
+        )
+)
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@EqualsAndHashCode
+@ToString
+public class KafkaConnector extends CustomResource implements UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+    public static final String V1ALPHA1 = "v1alpha1";
+    public static final List<String> VERSIONS = unmodifiableList(asList(V1ALPHA1));
+    public static final String SCOPE = "Namespaced";
+    public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
+    public static final String RESOURCE_PLURAL = "kafkaconnectors";
+    public static final String RESOURCE_SINGULAR = "kafkaconnector";
+    public static final String RESOURCE_GROUP = "kafka.strimzi.io";
+    public static final String RESOURCE_KIND = "KafkaConnector";
+    public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
+    public static final String SHORT_NAME = "kctr";
+
+    private KafkaConnectorSpec spec;
+    private KafkaConnectorStatus status;
+    private Map<String, Object> additionalProperties;
+    private ObjectMeta metadata;
+    private String apiVersion;
+
+    @Override
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    @Override
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @JsonProperty("kind")
+    @Override
+    public String getKind() {
+        return RESOURCE_KIND;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
+    public ObjectMeta getMetadata() {
+        return super.getMetadata();
+    }
+
+    @Override
+    public void setMetadata(ObjectMeta metadata) {
+        super.setMetadata(metadata);
+    }
+
+    @Description("The specification of the Kafka Connector.")
+    public KafkaConnectorSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(KafkaConnectorSpec spec) {
+        this.spec = spec;
+    }
+
+    @Description("The status of the Kafka Connector.")
+    public KafkaConnectorStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(KafkaConnectorStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}
+

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -42,7 +42,10 @@ import static java.util.Collections.unmodifiableList;
                                 name = KafkaConnector.V1ALPHA1,
                                 served = true,
                                 storage = true)
-                }
+                },
+                subresources = @Crd.Spec.Subresources(
+                        status = @Crd.Spec.Subresources.Status()
+                )
         )
 )
 @Buildable(
@@ -52,7 +55,7 @@ import static java.util.Collections.unmodifiableList;
         inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
 @ToString
 public class KafkaConnector extends CustomResource implements UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -58,7 +59,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
 @ToString
-public class KafkaConnector extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaConnector extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaConnectorStatus> {
     private static final long serialVersionUID = 1L;
     public static final String V1ALPHA1 = "v1alpha1";
     public static final List<String> VERSIONS = unmodifiableList(asList(V1ALPHA1));
@@ -113,6 +114,7 @@ public class KafkaConnector extends CustomResource implements UnknownPropertyPre
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka Connector.")
     public KafkaConnectorStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -24,7 +24,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"connectCluster", "class", "tasksMax", "config"})
+@JsonPropertyOrder({"class", "tasksMax", "config"})
 @EqualsAndHashCode
 public class KafkaConnectorSpec implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"connectCluster", "class", "tasksMax", "config"})
+@EqualsAndHashCode
+public class KafkaConnectorSpec implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+    private static final String FORBIDDEN_PARAMETERS = "connector.class, tasks.max";
+
+    private String className;
+    private Integer tasksMax;
+    private Map<String, Object> config = new HashMap<>(0);
+    private Map<String, Object> additionalProperties;
+
+    @Description("The Class for the Kafka Connector")
+    @JsonProperty("class")
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    @Description("The maximum number of tasks for the Kafka Connector")
+    @Minimum(1)
+    public Integer getTasksMax() {
+        return tasksMax;
+    }
+
+    public void setTasksMax(Integer tasksMax) {
+        this.tasksMax = tasksMax;
+    }
+
+    @Description("The Kafka Connector configuration. The following properties cannot be set: " + FORBIDDEN_PARAMETERS)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>();
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "type", "status", "lastTransitionTime", "reason", "message" })
 @EqualsAndHashCode
+@ToString
 public class Condition implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the Kafka Bridge resource
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class KafkaBridgeStatus extends Status {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the Kafka Connect S2I resource
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "url", "buildConfigName" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaConnectS2Istatus extends KafkaConnectStatus {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the Kafka Connect resource
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
@@ -6,15 +6,12 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.util.List;
-
 /**
- * Represents a status of the Kafka resource
+ * Represents a status of the Kafka Bridge resource
  */
 @Buildable(
         editableEnabled = false,
@@ -22,20 +19,10 @@ import java.util.List;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
-public class KafkaStatus extends Status {
+public class KafkaConnectorStatus extends Status {
     private static final long serialVersionUID = 1L;
 
-    private List<ListenerStatus> listeners;
-
-    @Description("Addresses of the internal and external listeners")
-    public List<ListenerStatus> getListeners() {
-        return listeners;
-    }
-
-    public void setListeners(List<ListenerStatus> listeners) {
-        this.listeners = listeners;
-    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
@@ -11,7 +11,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * Represents a status of the Kafka Bridge resource
+ * Represents a status of the KafkaConnector resource
  */
 @Buildable(
         editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the Kafka Mirror Maker resource
@@ -20,6 +21,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"conditions", "observedGeneration"})
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class KafkaMirrorMakerStatus extends Status {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the KafkaTopic resource
@@ -20,6 +21,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration" })
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaUserStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaUserStatus.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a status of the Kafka User resource
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "username", "secret" })
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class KafkaUserStatus extends Status {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "address", "host", "port" })
 @EqualsAndHashCode
+@ToString(callSuper = true)
 public class ListenerAddress implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Status implements UnknownPropertyPreserving, Serializable {
     private List<Condition> conditions;
     private long observedGeneration;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * The purpose of this test is to ensure:
+ *
+ * 1. we get a correct tree of POJOs when reading a JSON/YAML `Kafka` resource.
+ */
+public class KafkaConnectorTest extends AbstractCrdTest<KafkaConnector> {
+
+    public KafkaConnectorTest() {
+        super(KafkaConnector.class);
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorTest.java
@@ -7,7 +7,7 @@ package io.strimzi.api.kafka.model;
 /**
  * The purpose of this test is to ensure:
  *
- * 1. we get a correct tree of POJOs when reading a JSON/YAML `Kafka` resource.
+ * 1. we get a correct tree of POJOs when reading a JSON/YAML `KafkaConnector` resource.
  */
 public class KafkaConnectorTest extends AbstractCrdTest<KafkaConnector> {
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
@@ -5,6 +5,8 @@ metadata:
   name: "test-kafka-connect"
 spec:
   replicas: 6
+  config:
+    name: "bar"
   image: "foo"
   tolerations:
   - effect: "NoSchedule"
@@ -18,8 +20,6 @@ spec:
   logging:
     type: "inline"
     loggers: {}
-  config:
-    name: "bar"
   bootstrapServers: "kafka:9092"
   externalConfiguration:
     env:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-sink.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-sink.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnector
+metadata:
+  name: local-file-sink
+  labels:
+    connect-cluster: my-connect-cluster
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSinkConnector
+  tasksMax: 1
+  config:
+    file: "/tmp/test.sink.txt"
+    topics: "connect-test"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-sink.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-sink.yaml
@@ -9,4 +9,4 @@ spec:
   tasksMax: 1
   config:
     file: "/tmp/test.sink.txt"
-    topics: "connect-test"
+    topic: "connect-test"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-source.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector-with-filestream-source.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnector
+metadata:
+  name: local-file-source
+  labels:
+    connect-cluster: my-connect-cluster
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector
+  tasksMax: 3
+  config:
+    file: "/home/source/test.source.txt"
+    topic: "test.topic"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: "kafka.strimzi.io/v1alpha1"
+kind: "KafkaConnector"
+metadata:
+  labels:
+    strimzi.io/cluster: "my-connect-cluster"
+  name: "test-source"
+spec:
+  class: "org.apache.kafka.connect.file.FileStreamSourceConnector"
+  tasksMax: 2
+  config:
+    file: "/home/source/test.source.txt"
+    topic: "test.topic"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: "kafka.strimzi.io/v1alpha1"
+kind: "KafkaConnector"
+metadata:
+  name: "test-source"
+  labels:
+    strimzi.io/cluster: my-connect-cluster
+spec:
+  class: "org.apache.kafka.connect.file.FileStreamSourceConnector"
+  tasksMax: 2
+  config:
+    file: "/home/source/test.source.txt"
+    topic: "test.topic"

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -134,6 +134,47 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -6,16 +6,6 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.strimzi.api.kafka.KafkaConnectList;
-import io.strimzi.api.kafka.KafkaConnectS2IList;
-import io.strimzi.api.kafka.KafkaConnectorList;
-import io.strimzi.api.kafka.model.DoneableKafkaConnect;
-import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
-import io.strimzi.api.kafka.model.DoneableKafkaConnector;
-import io.strimzi.api.kafka.model.KafkaConnect;
-import io.strimzi.api.kafka.model.KafkaConnectS2I;
-import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaBridgeAssemblyOperator;
@@ -23,7 +13,6 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperato
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOperator;
 import io.strimzi.operator.common.AbstractOperator;
-import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -61,9 +50,6 @@ public class ClusterOperator extends AbstractVerticle {
     private final long reconciliationInterval;
 
     private final Map<String, Watch> watchByKind = new ConcurrentHashMap<>();
-    private final CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> connectorOperations;
-    private final CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperations;
-    private final CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2iOperations;
 
     private long reconcileTimer;
     private final KafkaAssemblyOperator kafkaAssemblyOperator;
@@ -79,10 +65,7 @@ public class ClusterOperator extends AbstractVerticle {
                            KafkaConnectAssemblyOperator kafkaConnectAssemblyOperator,
                            KafkaConnectS2IAssemblyOperator kafkaConnectS2IAssemblyOperator,
                            KafkaMirrorMakerAssemblyOperator kafkaMirrorMakerAssemblyOperator,
-                           KafkaBridgeAssemblyOperator kafkaBridgeAssemblyOperator,
-                           CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> connectorOperations,
-                           CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperations,
-                           CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2iOperations) {
+                           KafkaBridgeAssemblyOperator kafkaBridgeAssemblyOperator) {
         log.info("Creating ClusterOperator for namespace {}", namespace);
         this.namespace = namespace;
         this.reconciliationInterval = reconciliationInterval;
@@ -92,9 +75,6 @@ public class ClusterOperator extends AbstractVerticle {
         this.kafkaConnectS2IAssemblyOperator = kafkaConnectS2IAssemblyOperator;
         this.kafkaMirrorMakerAssemblyOperator = kafkaMirrorMakerAssemblyOperator;
         this.kafkaBridgeAssemblyOperator = kafkaBridgeAssemblyOperator;
-        this.connectorOperations = connectorOperations;
-        this.connectOperations = connectOperations;
-        this.connectS2iOperations = connectS2iOperations;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -6,22 +6,40 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaBridgeAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectS2IAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOperator;
+import io.strimzi.operator.common.AbstractOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
 
 /**
  * An "operator" for managing assemblies of various types <em>in a particular namespace</em>.
@@ -43,6 +61,9 @@ public class ClusterOperator extends AbstractVerticle {
     private final long reconciliationInterval;
 
     private final Map<String, Watch> watchByKind = new ConcurrentHashMap<>();
+    private final CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> connectorOperations;
+    private final CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperations;
+    private final CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2iOperations;
 
     private long reconcileTimer;
     private final KafkaAssemblyOperator kafkaAssemblyOperator;
@@ -58,7 +79,10 @@ public class ClusterOperator extends AbstractVerticle {
                            KafkaConnectAssemblyOperator kafkaConnectAssemblyOperator,
                            KafkaConnectS2IAssemblyOperator kafkaConnectS2IAssemblyOperator,
                            KafkaMirrorMakerAssemblyOperator kafkaMirrorMakerAssemblyOperator,
-                           KafkaBridgeAssemblyOperator kafkaBridgeAssemblyOperator) {
+                           KafkaBridgeAssemblyOperator kafkaBridgeAssemblyOperator,
+                           CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> connectorOperations,
+                           CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect> connectOperations,
+                           CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2iOperations) {
         log.info("Creating ClusterOperator for namespace {}", namespace);
         this.namespace = namespace;
         this.reconciliationInterval = reconciliationInterval;
@@ -68,6 +92,9 @@ public class ClusterOperator extends AbstractVerticle {
         this.kafkaConnectS2IAssemblyOperator = kafkaConnectS2IAssemblyOperator;
         this.kafkaMirrorMakerAssemblyOperator = kafkaMirrorMakerAssemblyOperator;
         this.kafkaBridgeAssemblyOperator = kafkaBridgeAssemblyOperator;
+        this.connectorOperations = connectorOperations;
+        this.connectOperations = connectOperations;
+        this.connectS2iOperations = connectS2iOperations;
     }
 
     @Override
@@ -77,40 +104,33 @@ public class ClusterOperator extends AbstractVerticle {
         // Configure the executor here, but it is used only in other places
         getVertx().createSharedWorkerExecutor("kubernetes-ops-pool", 10, TimeUnit.SECONDS.toNanos(120));
 
-        kafkaAssemblyOperator.createWatch(namespace, kafkaAssemblyOperator.recreateWatch(namespace))
-            .compose(w -> {
-                log.info("Started operator for {} kind", "Kafka");
-                watchByKind.put("Kafka", w);
-                return kafkaMirrorMakerAssemblyOperator.createWatch(namespace, kafkaMirrorMakerAssemblyOperator.recreateWatch(namespace));
-            }).compose(w -> {
-                log.info("Started operator for {} kind", "KafkaMirrorMaker");
-                watchByKind.put("KafkaMirrorMaker", w);
-                return kafkaConnectAssemblyOperator.createWatch(namespace, kafkaConnectAssemblyOperator.recreateWatch(namespace));
-            }).compose(w -> {
-                log.info("Started operator for {} kind", "KafkaConnect");
-                watchByKind.put("KafkaConnect", w);
-                if (kafkaConnectS2IAssemblyOperator != null) {
-                    // only on OS
-                    return kafkaConnectS2IAssemblyOperator.createWatch(namespace, kafkaConnectS2IAssemblyOperator.recreateWatch(namespace));
-                } else {
-                    return Future.succeededFuture(null);
-                }
-            }).compose(w -> {
-                if (w != null) {
-                    log.info("Started operator for {} kind", "KafkaConnectS2I");
-                    watchByKind.put("KafkaS2IConnect", w);
-                }
-                return kafkaBridgeAssemblyOperator.createWatch(namespace, kafkaBridgeAssemblyOperator.recreateWatch(namespace));
-            }).compose(w -> {
-                log.info("Started operator for {} kind", "KafkaBridge");
-                watchByKind.put("KafkaBridge", w);
-                log.info("Setting up periodic reconciliation for namespace {}", namespace);
-                this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
-                    log.info("Triggering periodic reconciliation for namespace {}...", namespace);
-                    reconcileAll("timer");
-                });
-                return startHealthServer().map((Void) null);
-            }).compose(start::complete, start);
+        List<Future> watchFutures = new ArrayList<>();
+        List<AbstractOperator<?, ?>> operators = new ArrayList<>(asList(
+                kafkaAssemblyOperator, kafkaMirrorMakerAssemblyOperator,
+                kafkaConnectAssemblyOperator, kafkaBridgeAssemblyOperator));
+        if (kafkaConnectS2IAssemblyOperator != null) {
+            operators.add(kafkaConnectS2IAssemblyOperator);
+        }
+        for (AbstractOperator<?, ?> operator : operators) {
+            watchFutures.add(operator.createWatch(namespace, operator.recreateWatch(namespace)).compose(w -> {
+                log.info("Opened watch for {} operator", operator.kind());
+                watchByKind.put(operator.kind(), w);
+                return Future.succeededFuture();
+            }));
+        }
+
+        watchFutures.add(AbstractConnectOperator.createConnectorWatch(kafkaConnectAssemblyOperator, kafkaConnectS2IAssemblyOperator, namespace));
+
+        CompositeFuture.join(watchFutures)
+                .compose(f -> {
+                    log.info("Setting up periodic reconciliation for namespace {}", namespace);
+                    this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
+                        log.info("Triggering periodic reconciliation for namespace {}...", namespace);
+                        reconcileAll("timer");
+                    });
+                    return startHealthServer().map((Void) null);
+                })
+                .compose(start::complete, start);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -118,10 +118,7 @@ public class Main {
                     kafkaConnectClusterOperations,
                     kafkaConnectS2IClusterOperations,
                     kafkaMirrorMakerAssemblyOperator,
-                    kafkaBridgeAssemblyOperator,
-                    resourceOperatorSupplier.kafkaConnectorOperator,
-                    resourceOperatorSupplier.connectOperator,
-                    resourceOperatorSupplier.connectS2IOperator);
+                    kafkaBridgeAssemblyOperator);
             vertx.deployVerticle(operator,
                 res -> {
                     if (res.succeeded()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.certs.CertManager;
@@ -91,20 +90,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         this.imagePullSecrets = config.getImagePullSecrets();
         this.versions = config.versions();
         this.operationTimeoutMs = config.getOperationTimeoutMs();
-    }
-
-    /**
-     * The name of the given {@code resource}, as read from its metadata.
-     * @param resource The resource
-     */
-    protected static String name(HasMetadata resource) {
-        if (resource != null) {
-            ObjectMeta metadata = resource.getMetadata();
-            if (metadata != null) {
-                return metadata.getName();
-            }
-        }
-        return null;
     }
 
     protected Future<Boolean> delete(Reconciliation reconciliation) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectorSpec;
+import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.model.ImagePullPolicy;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.NoSuchResourceException;
+import io.strimzi.operator.cluster.model.StatusDiff;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.AbstractOperator;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
+import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
+import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class AbstractConnectOperator<C extends KubernetesClient, T extends CustomResource,
+        L extends CustomResourceList<T>, D extends Doneable<T>, R extends Resource<T, D>>
+        extends AbstractOperator<T, CrdOperator<C, T, L, D>> {
+
+    private static final Logger log = LogManager.getLogger(AbstractConnectOperator.class.getName());
+
+    private final CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> connectorOperator;
+    private final Function<Vertx, KafkaConnectApi> connectClientProvider;
+    protected final ImagePullPolicy imagePullPolicy;
+    protected final ConfigMapOperator configMapOperations;
+    protected final ServiceOperator serviceOperations;
+    protected final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
+    protected final List<LocalObjectReference> imagePullSecrets;
+    protected final long operationTimeoutMs;
+    protected final PlatformFeaturesAvailability pfa;
+    protected final ServiceAccountOperator serviceAccountOperations;
+
+    public AbstractConnectOperator(Vertx vertx, PlatformFeaturesAvailability pfa, String kind,
+                                   CrdOperator<C, T, L, D> resourceOperator,
+                                   ResourceOperatorSupplier supplier, ClusterOperatorConfig config,
+                                   Function<Vertx, KafkaConnectApi> connectClientProvider) {
+        super(vertx, kind, resourceOperator);
+        this.connectorOperator = supplier.kafkaConnectorOperator;
+        this.connectClientProvider = connectClientProvider;
+        this.configMapOperations = supplier.configMapOperations;
+        this.serviceOperations = supplier.serviceOperations;
+        this.serviceAccountOperations = supplier.serviceAccountOperations;
+        this.podDisruptionBudgetOperator = supplier.podDisruptionBudgetOperator;
+        this.imagePullPolicy = config.getImagePullPolicy();
+        this.imagePullSecrets = config.getImagePullSecrets();
+        this.operationTimeoutMs = config.getOperationTimeoutMs();
+        this.pfa = pfa;
+    }
+
+    @Override
+    protected Future<Boolean> delete(Reconciliation reconciliation) {
+        // When deleting KafkaConnect we need to update the status of all selected KafkaConnector
+        return connectorOperator.listAsync(reconciliation.namespace(), Labels.forCluster(reconciliation.name())).compose(connectors -> {
+            List<Future> connectorFutures = new ArrayList<>();
+            for (KafkaConnector connector : connectors) {
+                connectorFutures.add(maybeUpdateConnectorStatus(reconciliation, connector,
+                        noConnectCluster(reconciliation.namespace(), reconciliation.name())));
+            }
+            return CompositeFuture.join(connectorFutures);
+        }).map(ignored -> Boolean.FALSE);
+    }
+
+    /**
+     * Create a watch on {@code KafkaConnector} in the given {@code namespace}.
+     * The watcher will:
+     * <ul>
+     * <li>{@link #reconcileConnectors(Reconciliation, CustomResource)} on the KafkaConnect or KafkaConnectS2I
+     * identified by {@code KafkaConnector.metadata.labels[strimzi.io/cluster]}.</li>
+     * <li>If there is a Connect and ConnectS2I cluster with the given name then the plain Connect one is used
+     * (and an error is logged about the ambiguity).</li>
+     * <li>The {@code KafkaConnector} status is updated with the result.</li>
+     * </ul>
+     * @param connectOperator The operator for {@code KafkaConnect}.
+     * @param connectS2IOperator The operator for {@code KafkaConnectS2I}.
+     * @param namespace The namespace.
+     * @return A future which completes when the watch has been set up.
+     */
+    public static Future<Void> createConnectorWatch(AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> connectOperator,
+            AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> connectS2IOperator,
+            String namespace) {
+        // TODO Only create a single watch
+        return Util.async(connectOperator.vertx, () -> {
+            connectOperator.connectorOperator.watch(namespace, new Watcher<KafkaConnector>() {
+                @Override
+                public void eventReceived(Action action, KafkaConnector kafkaConnector) {
+                    String connectName = kafkaConnector.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+                    Future<Void> f;
+                    if (connectName != null) {
+                        // Check whether a KafkaConnect/S2I exists
+                        CompositeFuture.join(connectOperator.resourceOperator.getAsync(namespace, connectName),
+                                             connectOperator.pfa.supportsS2I() ? connectS2IOperator.resourceOperator.getAsync(namespace, connectName) : Future.succeededFuture())
+                                .compose(cf -> {
+                                    KafkaConnect connect = cf.resultAt(0);
+                                    KafkaConnectS2I connectS2i = cf.resultAt(1);
+                                    if (connect == null && connectS2i == null) {
+                                        updateStatus(noConnectCluster(namespace, connectName), kafkaConnector, connectOperator.connectorOperator);
+                                        return Future.succeededFuture();
+                                    } else if (connect != null) {
+                                        // grab the lock and call reconcileConnectors()
+                                        // (i.e. short circuit doing a whole KafkaConnect reconciliation).
+                                        Reconciliation reconciliation = new Reconciliation("connector-watch", connectOperator.kind(),
+                                                kafkaConnector.getMetadata().getNamespace(), connectName);
+                                        if (connectS2i != null) {
+                                            log.warn("{}: There is both a KafkaConnect resource and a KafkaConnectS2I resource named {}. " +
+                                                            "The KafkaConnect takes precedence for the connector {}",
+                                                    reconciliation, connectName, connect.getMetadata().getName());
+                                        }
+                                        return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
+                                            () -> connectOperator.reconcileConnectors(reconciliation, connect));
+                                    } else {
+                                        // grab the lock and call reconcileConnectors()
+                                        // (i.e. short circuit doing a whole KafkaConnect reconciliation).
+                                        Reconciliation r = new Reconciliation("connector-watch", connectS2IOperator.kind(),
+                                                kafkaConnector.getMetadata().getNamespace(), connectName);
+                                        return connectS2IOperator.withLock(r, LOCK_TIMEOUT_MS,
+                                            () -> connectS2IOperator.reconcileConnectors(r, connectS2i));
+                                    }
+                                }
+                            );
+                    } else {
+                        updateStatus(new InvalidResourceException("Resource lacks label '"
+                                        + Labels.STRIMZI_CLUSTER_LABEL
+                                        + "': No connect cluster in which to create this connector."),
+                                kafkaConnector, connectOperator.connectorOperator);
+                    }
+                }
+
+                @Override
+                public void onClose(KubernetesClientException e) {
+                    if (e != null) {
+                        throw e;
+                    }
+                }
+            });
+            return null;
+        });
+    }
+
+    private static NoSuchResourceException noConnectCluster(String namespace, String connectName) {
+        return new NoSuchResourceException(
+                "KafkaConnect resource '" + connectName + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace " + namespace + ".");
+    }
+
+    /**
+     * Reconcile all the connectors selected by the given connect instance, updated each connectors status with the result.
+     * @param reconciliation The reconciliation
+     * @param connect The connector
+     * @return A future, failed if any of the connectors' statuses could not be updated.
+     */
+    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect) {
+        String connectName = connect.getMetadata().getName();
+        String namespace = connect.getMetadata().getNamespace();
+        String host = KafkaConnectResources.serviceName(connectName);
+        KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
+        boolean useResources = Annotations.booleanAnnotation(connect, "strimzi.io/use-connector-resources", false);
+        return CompositeFuture.join(apiClient.list(host, KafkaConnectCluster.REST_API_PORT),
+                connectorOperator.listAsync(namespace,
+                        Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build()))
+        ).compose(cf -> {
+            List<String> runningConnectors = cf.resultAt(0);
+            List<KafkaConnector> desired = cf.resultAt(1);
+            log.debug("{}: {}} cluster: required connectors: {}", reconciliation, kind(), desired);
+            Set<String> delete = new HashSet<>(runningConnectors);
+            delete.removeAll(desired.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));
+            log.debug("{}: {}} cluster: delete connectors: {}", reconciliation, kind(), delete);
+            Stream<Future<Void>> deletionFutures = delete.stream().map(connector -> {
+                log.debug("{}: {}} cluster: deleting connector: {}", reconciliation, kind(), connector);
+                return apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connector);
+            });
+            Stream<Future<Void>> createUpdateFutures = desired.stream()
+                    .map(connector -> {
+                        log.debug("{}: {}} cluster: creating/updating connector: {}", reconciliation, kind(), connector);
+                        if (connector.getSpec() == null) {
+                            return maybeUpdateConnectorStatus(reconciliation, connector,
+                                    new InvalidResourceException("spec property is required"));
+                        }
+                        if (!useResources) {
+                            return maybeUpdateConnectorStatus(reconciliation, connector,
+                                    new NoSuchResourceException("Not configured for connector management"));
+                        } else {
+                            return apiClient.createOrUpdatePutRequest(host, KafkaConnectCluster.REST_API_PORT,
+                                        connector.getMetadata().getName(), asJson(connector.getSpec()))
+                                    .compose(i -> maybeUpdateConnectorStatus(reconciliation, connector, null));
+                        }
+                    });
+            return CompositeFuture.join(Stream.concat(deletionFutures, createUpdateFutures).collect(Collectors.toList())).map((Void) null);
+        });
+    }
+
+    public static void updateStatus(Throwable error, KafkaConnector kafkaConnector2, CrdOperator<?, KafkaConnector, ?, ?> connectorOperations) {
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnector2, status, error);
+        StatusDiff diff = new StatusDiff(kafkaConnector2.getStatus(), status);
+        if (!diff.isEmpty()) {
+            KafkaConnector copy = new KafkaConnectorBuilder(kafkaConnector2).build();
+            copy.setStatus(status);
+            connectorOperations.updateStatusAsync(copy);
+        }
+    }
+
+    Future<Void> maybeUpdateConnectorStatus(Reconciliation reconciliation, KafkaConnector connector, Throwable error) {
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        if (error != null) {
+            log.warn("{}: Error reconciling connector {}", reconciliation, connector.getMetadata().getName(), error);
+        }
+        StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? Future.failedFuture(error) : Future.succeededFuture());
+        return maybeUpdateStatusCommon(connectorOperator, connector, reconciliation, KafkaConnector::getStatus, status,
+            (connector1, status1) -> {
+                return new KafkaConnectorBuilder(connector1).withStatus(status1).build();
+            });
+    }
+
+    private JsonObject asJson(KafkaConnectorSpec spec) {
+        JsonObject connectorConfigJson = new JsonObject();
+        if (spec.getConfig() != null) {
+            for (Map.Entry<String, Object> cf : spec.getConfig().entrySet()) {
+                String name = cf.getKey();
+                if ("connector.class".equals(name)
+                        || "tasks.max".equals(name)) {
+                    // TODO include resource namespace and name in this message
+                    log.warn("Configuration parameter {} in KafkaConnector.spec.config will be ignored and the value from KafkaConnector.spec will be used instead",
+                            name);
+                }
+                connectorConfigJson.put(name, cf.getValue());
+            }
+        }
+        return connectorConfigJson
+                .put("connector.class", spec.getClassName())
+                .put("tasks.max", spec.getTasksMax());
+    }
+
+    /**
+     * Updates the Status field of the KafkaConnect CR. It diffs the desired status against the current status and calls
+     * the update only when there is any difference in non-timestamp fields.
+     *
+     * @param kafkaConnectAssembly The CR of KafkaConnect
+     * @param reconciliation Reconciliation information
+     * @param desiredStatus The KafkaConnectStatus which should be set
+     *
+     * @return
+     */
+    protected <T extends CustomResource, S extends Status, L extends CustomResourceList<T>, D extends Doneable<T>> Future<Void>
+        maybeUpdateStatusCommon(CrdOperator<KubernetesClient, T, L, D> resourceOperator,
+                                T kafkaConnectAssembly,
+                                Reconciliation reconciliation,
+                                Function<T, S> fn,
+                                S desiredStatus,
+                                BiFunction<T, S, T> copyWithStatus) {
+        Future<Void> updateStatusFuture = Future.future();
+
+        resourceOperator.getAsync(kafkaConnectAssembly.getMetadata().getNamespace(), kafkaConnectAssembly.getMetadata().getName()).setHandler(getRes -> {
+            if (getRes.succeeded()) {
+                T connect = getRes.result();
+
+                if (connect != null) {
+                    if (StatusUtils.isResourceV1alpha1(connect)) {
+                        log.warn("{}: The resource needs to be upgraded from version {} to 'v1beta1' to use the status field", reconciliation, connect.getApiVersion());
+                        updateStatusFuture.complete();
+                    } else {
+                        S currentStatus = fn.apply(connect);
+
+                        StatusDiff ksDiff = new StatusDiff(currentStatus, desiredStatus);
+
+                        if (!ksDiff.isEmpty()) {
+                            T resourceWithNewStatus = copyWithStatus.apply(connect, desiredStatus);
+
+                            resourceOperator.updateStatusAsync(resourceWithNewStatus).setHandler(updateRes -> {
+                                if (updateRes.succeeded()) {
+                                    log.debug("{}: Completed status update", reconciliation);
+                                    updateStatusFuture.complete();
+                                } else {
+                                    log.error("{}: Failed to update status", reconciliation, updateRes.cause());
+                                    updateStatusFuture.fail(updateRes.cause());
+                                }
+                            });
+                        } else {
+                            log.debug("{}: Status did not change", reconciliation);
+                            updateStatusFuture.complete();
+                        }
+                    }
+                } else {
+                    log.error("{}: Current Kafka Connect resource not found", reconciliation);
+                    updateStatusFuture.fail("Current Kafka Connect resource not found");
+                }
+            } else {
+                log.error("{}: Failed to get the current Kafka Connect resource and its status", reconciliation, getRes.cause());
+                updateStatusFuture.fail(getRes.cause());
+            }
+        });
+
+        return updateStatusFuture;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface KafkaConnectApi {
+    Future<JsonObject> createOrUpdatePutRequest(String host, int port, String connectorName, JsonObject configJson);
+    Future<Void> delete(String host, int port, String connectorName);
+    Future<List<String>> list(String host, int port);
+}
+
+class ConnectRestException extends RuntimeException {
+    public ConnectRestException(String message) {
+        super(message);
+    }
+}
+
+@SuppressWarnings({"deprecation"})
+class KafkaConnectApiImpl implements KafkaConnectApi {
+    private static final Logger log = LogManager.getLogger(KafkaConnectApiImpl.class);
+    private final Vertx vertx;
+
+    public KafkaConnectApiImpl(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    @Override
+    public Future<JsonObject> createOrUpdatePutRequest(
+            String host, int port,
+            String connectorName,
+                                                       JsonObject configJson) {
+        Future<JsonObject> result = Future.future();
+        HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
+        Buffer data = configJson.toBuffer();
+        String path = "/connectors/" + connectorName + "/config";
+        vertx.createHttpClient(options)
+                .put(port, host, path, response -> {
+                    response.exceptionHandler(error -> {
+                        result.fail(error);
+                    });
+                    if (response.statusCode() == 200 || response.statusCode() == 201) {
+                        response.bodyHandler(buffer -> {
+                            result.complete(buffer.toJsonObject());
+                        });
+                    } else {
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        response.bodyHandler(buffer -> {
+                            JsonObject x = buffer.toJsonObject();
+                            result.fail(new ConnectRestException(x.getString("message")));
+                        });
+                    }
+                })
+                .exceptionHandler(error -> {
+                    result.fail(error);
+                })
+                .setFollowRedirects(true)
+                .putHeader("Accept", "application/json")
+                .putHeader("Content-Type", "application/json")
+                .putHeader("Content-Length", String.valueOf(data.length()))
+                .write(data)
+                .end();
+        return result;
+    }
+
+    @Override
+    public Future<Void> delete(String host, int port, String connectorName) {
+        Future<Void> result = Future.future();
+        HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
+        String path = "/connectors/" + connectorName;
+        vertx.createHttpClient(options)
+                .delete(port, host, path, response -> {
+                    if (response.statusCode() == 204) {
+                        result.complete();
+                    } else {
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        response.bodyHandler(buffer -> {
+                            JsonObject x = buffer.toJsonObject();
+                            result.fail(new ConnectRestException(x.getString("message")));
+                        });
+                    }
+                })
+                .setFollowRedirects(true)
+                .putHeader("Accept", "application/json")
+                .putHeader("Content-Type", "application/json")
+                //.write(configJson.toBuffer())
+                .end();
+        return result;
+    }
+
+    @Override
+    public Future<List<String>> list(String host, int port) {
+        Future<List<String>> result = Future.future();
+        HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
+        String path = "/connectors";
+        vertx.createHttpClient(options)
+                .get(port, host, path, response -> {
+                    response.exceptionHandler(error -> {
+                        result.fail(error);
+                    });
+                    if (response.statusCode() == 200 || response.statusCode() == 201) {
+                        response.bodyHandler(buffer -> {
+                            JsonArray objects = buffer.toJsonArray();
+                            List<String> list = new ArrayList<>(objects.size());
+                            for (Object o : objects) {
+                                if (o instanceof String) {
+                                    list.add((String) o);
+                                } else {
+                                    result.fail(o == null ? "null" : o.getClass().getName());
+                                }
+                            }
+                            result.complete(list);
+                        });
+                    } else {
+                        result.fail("Unexpected status code " + response.statusCode()
+                                + " for GET request to " + host + ":" + port + path);
+                    }
+                })
+                .exceptionHandler(error -> {
+                    result.fail(error);
+                })
+                .setFollowRedirects(true)
+                .putHeader("Accept", "application/json")
+                .end();
+        return result;
+
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -23,7 +23,6 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -85,7 +84,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             connect = KafkaConnectCluster.fromCrd(kafkaConnect, versions);
         } catch (Exception e) {
             StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, Future.failedFuture(e));
-            return this.maybeUpdateStatusCommon((CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect>) resourceOperator, kafkaConnect, reconciliation,
+            return this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation,
                     KafkaConnect::getStatus, kafkaConnectStatus,
                 (connect1, status) -> {
                     return new KafkaConnectBuilder(connect1).withStatus(status).build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -85,7 +85,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         } catch (Exception e) {
             StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, Future.failedFuture(e));
             return this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation,
-                    KafkaConnect::getStatus, kafkaConnectStatus,
+                    kafkaConnectStatus,
                 (connect1, status) -> {
                     return new KafkaConnectBuilder(connect1).withStatus(status).build();
                 });
@@ -115,7 +115,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
                     kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));
 
-                    this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation, KafkaConnect::getStatus, kafkaConnectStatus,
+                    this.maybeUpdateStatusCommon(resourceOperator, kafkaConnect, reconciliation, kafkaConnectStatus,
                         (connect1, status) -> new KafkaConnectBuilder(connect1).withStatus(status).build()).setHandler(statusResult -> {
                             // If both features succeeded, createOrUpdate succeeded as well
                             // If one or both of them failed, we prefer the reconciliation failure as the main error

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -8,17 +8,20 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.common.BackOff;
@@ -62,6 +65,7 @@ public class ResourceOperatorSupplier {
     public final CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2IOperator;
     public final CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker> mirrorMakerOperator;
     public final CrdOperator<KubernetesClient, KafkaBridge, KafkaBridgeList, DoneableKafkaBridge> kafkaBridgeOperator;
+    public final CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> kafkaConnectorOperator;
     public final NetworkPolicyOperator networkPolicyOperator;
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
     public final PodOperator podOperations;
@@ -106,6 +110,7 @@ public class ResourceOperatorSupplier {
                 pfa.hasBuilds() && pfa.hasApps() && pfa.hasImages() ? new CrdOperator<>(vertx, client.adapt(OpenShiftClient.class), KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class) : null,
                 new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class),
                 new CrdOperator<>(vertx, client, KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class),
+                new CrdOperator<>(vertx, client, KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class),
                 new StorageClassOperator(vertx, client, operationTimeoutMs));
     }
 
@@ -132,6 +137,7 @@ public class ResourceOperatorSupplier {
                                     CrdOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I> connectS2IOperator,
                                     CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker> mirrorMakerOperator,
                                     CrdOperator<KubernetesClient, KafkaBridge, KafkaBridgeList, DoneableKafkaBridge> kafkaBridgeOperator,
+                                    CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> kafkaConnectorOperator,
                                     StorageClassOperator storageClassOperator) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
@@ -157,5 +163,6 @@ public class ResourceOperatorSupplier {
         this.mirrorMakerOperator = mirrorMakerOperator;
         this.kafkaBridgeOperator = kafkaBridgeOperator;
         this.storageClassOperations = storageClassOperator;
+        this.kafkaConnectorOperator = kafkaConnectorOperator;
     }
 }

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -46,6 +46,8 @@ rules:
   - kafkaconnects/status
   - kafkaconnects2is
   - kafkaconnects2is/status
+  - kafkaconnectors
+  - kafkaconnectors/status
   - kafkamirrormakers
   - kafkamirrormakers/status
   - kafkabridges

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -183,7 +183,7 @@ public class ClusterOperatorTest {
         }
 
 
-        if (numWatchers.get() > (openShift ? 5 : 4) * namespaceList.size()) { // we do not have connectS2I on k8s
+        if (numWatchers.get() > (openShift ? 7 : 5) * namespaceList.size()) { // we do not have connectS2I on k8s
             context.failNow(new Throwable("Looks like there were more watchers than namespaces"));
         }
         context.completeNow();
@@ -262,7 +262,7 @@ public class ClusterOperatorTest {
             }
         }
 
-        if (numWatchers.get() > (openShift ? 5 : 4)) { // we do not have connectS2I on k8s
+        if (numWatchers.get() > (openShift ? 7 : 5)) { // we do not have connectS2I on k8s
             context.failNow(new Throwable("Looks like there were more watchers than should be"));
         }
         context.completeNow();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -620,7 +620,7 @@ public class ResourceUtils {
                 mock(NetworkPolicyOperator.class), mock(PodDisruptionBudgetOperator.class), mock(PodOperator.class),
                 mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
                 mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(CrdOperator.class), mock(CrdOperator.class),
+                mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
                 mock(StorageClassOperator.class));
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -134,7 +134,7 @@ public class CertificateRenewalTest {
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9), certManager, passwordGenerator,
                 new ResourceOperatorSupplier(null, null, null,
                         null, null, secretOps, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null, null, null),
+                        null, null, null, null, null, null, null, null, null, null, null, null, null),
                 ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -1,0 +1,726 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.operator.KubernetesVersion;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.mockkube.MockKube;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+
+import static io.strimzi.test.TestUtils.map;
+import static io.strimzi.test.TestUtils.set;
+import static io.strimzi.test.TestUtils.waitFor;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class ConnectorMockTest {
+
+    private static final Logger log = LogManager.getLogger(ConnectorMockTest.class);
+    private static final String NAMESPACE = "ns";
+
+    private Vertx vertx;
+    private KubernetesClient client;
+    private KafkaConnectApi api;
+    private HashMap<String, JsonObject> runningConnectors;
+    private KafkaConnectS2IAssemblyOperator kafkaConnectS2iOperator;
+    private KafkaConnectAssemblyOperator kafkaConnectOperator;
+
+    @Before
+    public void setup(TestContext testContext) {
+        vertx = Vertx.vertx();
+        client = new MockKube()
+                .withCustomResourceDefinition(Crds.kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class,
+                        KafkaConnect::getStatus, KafkaConnect::setStatus).end()
+                .withCustomResourceDefinition(Crds.kafkaConnectS2I(), KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class,
+                        KafkaConnectS2I::getStatus, KafkaConnectS2I::setStatus).end()
+                .withCustomResourceDefinition(Crds.kafkaConnector(), KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class,
+                        KafkaConnector::getStatus, KafkaConnector::setStatus).end()
+                .build();
+
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_11);
+        MockCertManager certManager = new MockCertManager();
+
+        api = mock(KafkaConnectApi.class);
+        runningConnectors = new HashMap<>();
+        when(api.list(any(), anyInt())).thenAnswer(i -> {
+            return Future.succeededFuture(new ArrayList<>(runningConnectors.keySet()));
+        });
+        when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
+            String connectorName = invocation.getArgument(2);
+            runningConnectors.put(connectorName, invocation.getArgument(3));
+            return Future.succeededFuture();
+        });
+        when(api.delete(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String connectorName = invocation.getArgument(2);
+            JsonObject remove = runningConnectors.remove(connectorName);
+            return remove != null ? Future.succeededFuture() : Future.failedFuture("No such connector " + connectorName);
+        });
+
+        ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client, pfa, 10_000);
+        ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
+            ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
+            ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(Long.MAX_VALUE)));
+        kafkaConnectOperator = new KafkaConnectAssemblyOperator(vertx,
+            pfa,
+            certManager,
+            ros,
+            config,
+            x -> api);
+        Async async2 = testContext.async();
+        kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.fail(e)).setHandler(asyncResultHandler(testContext, async2));
+        async2.await();
+        kafkaConnectS2iOperator = new KafkaConnectS2IAssemblyOperator(vertx,
+            pfa,
+            certManager,
+            ros,
+            config,
+            x -> api);
+        Async async1 = testContext.async();
+        kafkaConnectS2iOperator.createWatch(NAMESPACE, e -> testContext.fail(e)).setHandler(asyncResultHandler(testContext, async1));
+        async1.await();
+        Async async = testContext.async();
+        AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, kafkaConnectS2iOperator, NAMESPACE).setHandler(asyncResultHandler(testContext, async));
+        async.await();
+    }
+
+    @After
+    public void teardown() {
+        vertx.close();
+    }
+
+    public <T> Handler<AsyncResult<T>> asyncResultHandler(TestContext testContext, Async async) {
+        return ar -> {
+            if (ar.failed()) {
+                testContext.fail(ar.cause());
+            }
+            async.complete();
+        };
+    }
+
+    public Predicate<KafkaConnect> connectReady() {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition -> "Ready".equals(condition.getType()));
+        };
+    }
+
+    public Predicate<KafkaConnectS2I> connectS2IReady() {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition -> "Ready".equals(condition.getType()));
+        };
+    }
+
+    public Predicate<KafkaConnector> connectorReady() {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition -> "Ready".equals(condition.getType()));
+        };
+    }
+
+    public void waitForConnectReady(TestContext testContext, String connectName) {
+        Resource<KafkaConnect, DoneableKafkaConnect> resource = Crds.kafkaConnectOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectName);
+        try {
+            resource.waitUntilCondition(connectReady(), 5, TimeUnit.HOURS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectName + " never became ready: " + conditions);
+        }
+    }
+
+    public void waitForConnectUnready(TestContext testContext, String connectName, String reason, String message) {
+        Resource<KafkaConnect, DoneableKafkaConnect> resource = Crds.kafkaConnectOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectName);
+        try {
+            resource.waitUntilCondition(connectUnreadyWithReason(reason, message), 5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectName + " never became unready: " + conditions);
+        }
+    }
+
+    public void waitForConnectS2iReady(TestContext testContext, String connectName) {
+        Resource<KafkaConnectS2I, DoneableKafkaConnectS2I> resource = Crds.kafkaConnectS2iOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectName);
+        try {
+            resource.waitUntilCondition(connectS2IReady(), 5, TimeUnit.HOURS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectName + " never became ready: " + conditions);
+        }
+    }
+
+    public void waitForConnectS2iUnready(TestContext testContext, String connectName, String reason, String message) {
+        Resource<KafkaConnectS2I, DoneableKafkaConnectS2I> resource = Crds.kafkaConnectS2iOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectName);
+        try {
+            resource.waitUntilCondition(connectS2IUnreadyWithReason(reason, message), 5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectName + " never became unready: " + conditions);
+        }
+    }
+
+    public void waitForConnectorReady(TestContext testContext, String connectorName) {
+        Resource<KafkaConnector, DoneableKafkaConnector> resource = Crds.kafkaConnectorOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectorName);
+        try {
+            resource.waitUntilCondition(connectorReady(), 5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                    String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectorName + " never became ready: " + conditions);
+        }
+    }
+
+    public void waitForConnectorUnready(TestContext testContext, String connectorName, String reason, String message) {
+        Resource<KafkaConnector, DoneableKafkaConnector> resource = Crds.kafkaConnectorOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectorName);
+        try {
+            resource.waitUntilCondition(connectorUnreadyWithReason(reason, message), 5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (!(e instanceof TimeoutException)) {
+                throw new RuntimeException(e);
+            }
+            String conditions =
+                    resource.get().getStatus() == null ? "no status" :
+                            String.valueOf(resource.get().getStatus().getConditions());
+            testContext.fail(connectorName + " never became unready: " + conditions);
+        }
+    }
+
+    public Predicate<KafkaConnect> connectUnreadyWithReason(String reason, String message) {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition ->
+                        "NotReady".equals(condition.getType())
+                            && "True".equals(condition.getStatus())
+                            && reason.equals(condition.getReason())
+                            && Objects.equals(message, condition.getMessage())
+                    );
+        };
+    }
+
+    public Predicate<KafkaConnectS2I> connectS2IUnreadyWithReason(String reason, String message) {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition ->
+                            "NotReady".equals(condition.getType())
+                                    && "True".equals(condition.getStatus())
+                                    && reason.equals(condition.getReason())
+                                    && Objects.equals(message, condition.getMessage())
+                    );
+        };
+    }
+
+    public Predicate<KafkaConnector> connectorUnreadyWithReason(String reason, String message) {
+        return c -> {
+            log.debug(c);
+            return c.getStatus() != null && c.getStatus().getConditions().stream()
+                    .anyMatch(condition ->
+                            "NotReady".equals(condition.getType())
+                                    && "True".equals(condition.getStatus())
+                                    && reason.equals(condition.getReason())
+                                    && Objects.equals(message, condition.getMessage())
+                    );
+        };
+    }
+
+    @Test
+    public void testConnectWithoutSpec(TestContext testContext) {
+        String connectName = "cluster";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .endMetadata()
+                .done();
+        waitForConnectUnready(testContext, connectName, "InvalidResourceException", "spec property is required");
+        return;
+    }
+
+    @Test
+    public void testConnectorWithoutLabel(TestContext testContext) {
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectorName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorUnready(testContext, connectorName, "InvalidResourceException",
+                "Resource lacks label 'strimzi.io/cluster': No connect cluster in which to create this connector.");
+        return;
+    }
+
+    @Test
+    public void testConnectorButConnectDoesNotExist(TestContext testContext) {
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectorName)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, "cluster")
+                .endMetadata()
+                .done();
+        waitForConnectorUnready(testContext, connectorName, "NoSuchResourceException",
+                "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
+        return;
+    }
+
+    @Test
+    public void testConnectorWithoutSpec(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connectName);
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .done();
+        waitForConnectorUnready(testContext, connectorName, "InvalidResourceException", "spec property is required");
+        return;
+    }
+
+    @Test
+    public void testConnectorButConnectNotConfiguredForConnectors(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                //.addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connectName);
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec().endSpec()
+                .done();
+        assertNotNull(Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).get());
+        waitForConnectorUnready(testContext, connectorName, "NoSuchResourceException", "Not configured for connector management");
+    }
+
+    /** Create connect, create connector, delete connector, delete connect */
+    @Test
+    public void testConnectConnectorConnectorConnect(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+            .done();
+        waitForConnectReady(testContext, connectName);
+
+        // triggered twice (creation+status update)
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+            .done();
+        waitForConnectorReady(testContext, connectorName);
+
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), set(connectorName));
+        
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
+        //waitForConnectReady(testContext, connectName);
+        waitFor("delete call on connect REST api", 1_000, 30_000, () -> {
+            return runningConnectors.isEmpty();
+        });
+        verify(api).delete(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
+    }
+
+    /** Create connector, create connect, delete connector, delete connect */
+    @Test
+    public void testConnectorConnectConnectorConnect(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withName(connectorName)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorUnready(testContext, connectorName, "NoSuchResourceException",
+            "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
+
+        verify(api, never()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), emptySet());
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connectName);
+        // (connect crt, connector status, connect status)
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), set(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
+        //waitForConnectReady(testContext, connectName);
+        waitFor("delete call on connect REST api", 1_000, 30_000, () -> {
+            return runningConnectors.isEmpty();
+        });
+        verify(api).delete(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
+    }
+
+    /** Create connect, create connector, delete connect, delete connector */
+    @Test
+    public void testConnectConnectorConnectConnector(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connectName);
+
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withName(connectorName)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorReady(testContext, connectorName);
+
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), set(connectorName));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
+        waitForConnectorUnready(testContext, connectorName,
+                "NoSuchResourceException", "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
+        verify(api, never()).delete(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Create connector, create connect, delete connect, delete connector */
+    @Test
+    public void testConnectorConnectConnectConnector(TestContext testContext) {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorUnready(testContext, connectorName, "NoSuchResourceException",
+                "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
+
+        verify(api, never()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), emptySet());
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connectName);
+
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), set(connectorName));
+
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
+        waitForConnectorUnready(testContext, connectorName,
+                "NoSuchResourceException", "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
+        verify(api, never()).delete(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Change the cluster label from one cluster to another; check the connector is deleted from the old cluster */
+    @Test
+    public void testChangeLabel(TestContext testContext) {
+        String connect1Name = "cluster1";
+        String connect2Name = "cluster2";
+        String connectorName = "connector";
+
+        // Create two connect clusters
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connect1Name)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connect1Name);
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connect2Name)
+                    .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(testContext, connect2Name);
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connect1Name)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorReady(testContext, connectorName);
+
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connect2Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).patch(new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connect2Name)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec().build());
+        waitForConnectorReady(testContext, connectorName);
+
+        // Note: The connector does not get deleted immediately from cluster 1, only on the next timed reconciliation
+
+        verify(api, never()).delete(
+                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connect2Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        Async async = testContext.async();
+        kafkaConnectOperator.reconcile(new Reconciliation("test", "KafkaConnect", NAMESPACE, connect1Name)).setHandler(ar -> {
+            async.complete();
+        });
+        async.await();
+        verify(api, atLeastOnce()).delete(
+                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /*
+     * With and without openshift
+     *
+     */
+
+
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -325,8 +325,8 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(connectName)
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
                 .endMetadata()
                 .done();
         waitForConnectUnready(connectName, "InvalidResourceException", "spec property is required");
@@ -405,9 +405,9 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(connectName)
-                //.addToAnnotations("strimzi.io/use-connector-resources", "true")
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    //.addToAnnotations("strimzi.io/use-connector-resources", "true")
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -490,8 +490,9 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -564,8 +565,9 @@ public class ConnectorMockTest {
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -599,6 +601,7 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
                     .withName(connectorName)
+                    .withNamespace(NAMESPACE)
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -423,7 +423,8 @@ public class ConnectorMockTest {
                 .withNewSpec().endSpec()
                 .done();
         assertNotNull(Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).get());
-        waitForConnectorUnready(connectorName, "NoSuchResourceException", "Not configured for connector management");
+        waitForConnectorUnready(connectorName, "NoSuchResourceException",
+                "KafkaConnect cluster is not configured with annotation strimzi.io/use-connector-resources");
     }
 
     /** Create connect, create connector, delete connector, delete connect */

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -111,9 +111,9 @@ public class ConnectorMockTest {
 
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client, pfa, 10_000);
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
-            ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
-            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
-            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo",
+            ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo 2.3.1=foo",
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo 2.3.1=foo",
+            ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, "2.1.0=foo 2.1.1=foo 2.2.0=foo 2.2.1=foo 2.3.0=foo 2.3.1=foo",
             ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, Long.toString(Long.MAX_VALUE)));
         kafkaConnectOperator = new KafkaConnectAssemblyOperator(vertx,
             pfa,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.debezium.kafka.KafkaCluster;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.kafka.connect.cli.ConnectDistributed;
+import org.apache.kafka.connect.runtime.Connect;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(VertxUnitRunner.class)
+public class KafkaConnectApiTest {
+
+    private KafkaCluster cluster;
+    private Vertx vertx;
+    private Connect connect;
+    private static final int PORT = 18083;
+
+    @Before
+    public void before() throws IOException, InterruptedException {
+        vertx = Vertx.vertx();
+        cluster = new KafkaCluster();
+        cluster.addBrokers(3);
+        cluster.deleteDataPriorToStartup(true);
+        cluster.deleteDataUponShutdown(true);
+        cluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
+        //cluster.withKafkaConfiguration(kafkaClusterConfig());
+        cluster.startup();
+        cluster.createTopics(getClass().getSimpleName() + "-offsets", getClass().getSimpleName() + "-config", getClass().getSimpleName() + "-status");
+        // Somehow start connect distributed. Or can I just fire up the webserver hooked into some mock stuff?
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put("listeners", "http://localhost:" + PORT);
+        File tempDirectory = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+        workerProps.put("plugin.path", tempDirectory.toString());
+        workerProps.put("group.id", toString());
+        workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put("key.converter.schemas.enable", "false");
+        workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put("value.converter.schemas.enable", "false");
+        workerProps.put("offset.storage.topic", getClass().getSimpleName() + "-offsets");
+        workerProps.put("config.storage.topic", getClass().getSimpleName() + "-config");
+        workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
+        workerProps.put("bootstrap.servers", cluster.brokerList());
+        //DistributedConfig config = new DistributedConfig(workerProps);
+        //RestServer rest = new RestServer(config);
+        //rest.initializeServer();
+        CountDownLatch l = new CountDownLatch(1);
+        Thread thread = new Thread(() -> {
+            ConnectDistributed connectDistributed = new ConnectDistributed();
+            connect = connectDistributed.startConnect(workerProps);
+            l.countDown();
+            connect.awaitStop();
+        });
+        thread.setDaemon(false);
+        thread.start();
+        l.await();
+    }
+
+    @After
+    public void after() {
+        if (connect != null) {
+            connect.stop();
+            connect.awaitStop();
+        }
+        cluster.shutdown();
+    }
+
+    @Test
+    public void test(TestContext context) throws InterruptedException {
+        KafkaConnectApi client = new KafkaConnectApiImpl(vertx);
+        Async async = context.async();
+        client.list("localhost", PORT)
+            .compose(connectorNames -> {
+                assertEquals(emptyList(), connectorNames);
+                JsonObject o = new JsonObject()
+                    .put("connector.class", "FileStreamSource")
+                    .put("tasks.max", "1")
+                    .put("file", "/dev/null")
+                    .put("topic", "my-topic");
+                return client.createOrUpdatePutRequest("localhost", PORT, "test", o);
+            })
+            .compose(created -> {
+                JsonObject o = new JsonObject()
+                    .put("connector.class", "ThisConnectorDoesNotExist")
+                    .put("tasks.max", "1")
+                    .put("file", "/dev/null")
+                    .put("topic", "my-topic");
+                return client.createOrUpdatePutRequest("localhost", PORT, "broken", o)
+                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
+                    .recover(e -> {
+                        if (e instanceof ConnectRestException) {
+                            if (e.getMessage().contains("Failed to find any class that implements Connector and which name matches ThisConnectorDoesNotExist")) {
+                                return Future.succeededFuture();
+                            } else {
+                                return Future.failedFuture(e.getMessage());
+                            }
+                        } else {
+                            return Future.failedFuture(e);
+                        }
+                    });
+            }).compose(created -> {
+                JsonObject o = new JsonObject()
+                    .put("connector.class", "FileStreamSource")
+                    .put("tasks.max", "dog")
+                    .put("file", "/dev/null")
+                    .put("topic", "my-topic");
+                return client.createOrUpdatePutRequest("localhost", PORT, "broken2", o)
+                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
+                    .recover(e -> {
+                        if (e instanceof ConnectRestException) {
+                            if (e.getMessage().contains("Invalid value dog for configuration tasks.max: Not a number of type INT")) {
+                                return Future.succeededFuture();
+                            } else {
+                                return Future.failedFuture(e.getMessage());
+                            }
+                        } else {
+                            return Future.failedFuture(e);
+                        }
+                    });
+            }).compose(createResponse -> {
+                return client.list("localhost", PORT);
+            }).compose(connectorNames -> {
+                assertEquals(singletonList("test"), connectorNames);
+                return client.delete("localhost", PORT, "test");
+            }).compose(deleteResponse -> {
+                return client.list("localhost", PORT);
+            }).compose(connectorNames -> {
+                assertEquals(emptyList(), connectorNames);
+                return client.delete("localhost", PORT, "never-existed")
+                    .compose(ignored -> Future.failedFuture(new AssertionError("Should fail")))
+                    .recover(e -> {
+                        if (e instanceof ConnectRestException) {
+                            if (e.getMessage().contains("Connector never-existed not found")) {
+                                return Future.succeededFuture();
+                            } else {
+                                return Future.failedFuture(e.getMessage());
+                            }
+                        } else {
+                            return Future.failedFuture(e);
+                        }
+                    });
+            }).compose(ignored -> {
+                async.complete();
+                return Future.succeededFuture();
+            }).recover(e -> {
+                context.fail(e);
+                async.complete();
+                return Future.succeededFuture();
+            });
+        async.await();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
-import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -29,11 +28,8 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -42,25 +38,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -136,7 +126,6 @@ public class KafkaConnectAssemblyOperatorMockTest {
         return kco;
     }
 
-    /** Create a cluster from a Kafka Cluster CM */
     @Test
     public void testCreateUpdate(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         setConnectResource(new KafkaConnectBuilder()
@@ -161,141 +150,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
             updateAsync.countDown();
         });
         updateAsync.await(30, TimeUnit.SECONDS);
-    }
-
-    /*
-     * TODO Implement the KafkaConnect vs S2I preference
-     * TODO implement toggle in KafkaConnect.spec. (how do we change the default?)
-     * Create connect, create connector, delete connector, delete connect
-     * Create connect, create connector, delete connect, delete connector
-     * Create connector, create connect, delete connector, delete connect
-     * Create connector, create connect, delete connect, delete connector
-     * Create connect1, create connect2, create connector for 1, move to connector for 2, delete connector, delete connect
-     */
-
-    /** Create a cluster from a Kafka Cluster CM */
-    @Test
-    @Ignore
-    public void testCreateUpdateWithSelector(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
-        // KafkaConnector Config
-        String connectorAName = "my-connector-a";
-        String connectorBName = "my-connector-b";
-
-        Map<String, Object> kakfaConnectorConfig = new HashMap<>();
-        kakfaConnectorConfig.put("my.config", "true");
-
-        // Create a connect with a selector
-        KafkaConnect connectCluster = new KafkaConnectBuilder()
-                .withNewMetadata()
-                .withName(CLUSTER_NAME)
-                .withNamespace(NAMESPACE)
-                .withLabels(Labels.userLabels(TestUtils.map("foo", "bar")).toMap())
-                .endMetadata()
-                .withNewSpec()
-                .withReplicas(replicas)
-                .endSpec()
-                .build();
-        setConnectResource(connectCluster);
-        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        when(mockConnectApi.createOrUpdatePutRequest(anyString(), anyInt(), anyString(), any())).thenReturn(Future.succeededFuture());
-        when(mockConnectApi.delete(anyString(), anyInt(), any())).thenReturn(Future.succeededFuture());
-        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        KafkaConnectAssemblyOperator kco = createConnectCluster(context, mockConnectApi);
-        LOGGER.info("Reconciling again -> update");
-        Checkpoint updateCheckpoint = context.checkpoint();
-        CountDownLatch updateAsync = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            updateCheckpoint.flag();
-            updateAsync.countDown();
-        });
-
-        updateAsync.await(30, TimeUnit.SECONDS);
-
-        // Create connector A which matches the selector
-        KafkaConnector connectorA = Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).createNew()
-                .withNewMetadata()
-                    .withName(connectorAName)
-                    .withNamespace(NAMESPACE)
-                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME)
-                .endMetadata()
-                .withNewSpec()
-                    .withClassName("my.connector.ClassA")
-                    .withTasksMax(4)
-                    .withConfig(kakfaConnectorConfig)
-                .endSpec()
-            .done();
-
-        // Create a connector B which does not match the selector
-        KafkaConnector connectorB = Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).createNew()
-                .withNewMetadata()
-                    .withName(connectorBName)
-                    .withNamespace(NAMESPACE)
-                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME + "2")
-                .endMetadata()
-                .withNewSpec()
-                    .withClassName("my.connector.ClassB")
-                    .withTasksMax(4)
-                    .withConfig(any())
-                .endSpec()
-            .done();
-
-        Thread.sleep(3000); // TODO fix this
-
-        // Verify the REST API call, and that we've got a single watch
-        //mockKube.assertNumWatchers(KafkaConnect.class, 1);
-        //context.assertEquals(1, mockKube.watchers(KafkaConnector.class).size());
-        verify(mockConnectApi).createOrUpdatePutRequest(anyString(), anyInt(), eq(connectorAName), any(JsonObject.class));
-
-        // Change the connect cluster
-        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(connectorAName)));
-        Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).withName(connectorAName).patch(
-            new KafkaConnectorBuilder(connectorA)
-                .editMetadata()
-                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME + "2")
-                .endMetadata()
-            .build());
-        Checkpoint updateCheckpoint2 = context.checkpoint();
-        CountDownLatch updateAsync2 = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertTrue(ar.succeeded()));
-            updateCheckpoint2.flag();
-            updateAsync2.countDown();
-        });
-        updateAsync2.await(30, TimeUnit.SECONDS);
-
-        Thread.sleep(3000); // TODO fix this
-
-        // Verify we delete the connector which no longer matches
-        verify(mockConnectApi).delete(anyString(), anyInt(), eq(connectorAName));
-        // Verify we created the connector which does now match
-        verify(mockConnectApi).createOrUpdatePutRequest(anyString(), anyInt(), eq(connectorBName), any(JsonObject.class));
-
-
-        // Delete the connector
-        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(connectorBName)));
-        Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).withName(connectorBName).delete();
-
-        Thread.sleep(3000);
-
-        // Verify the connector was deleted
-        verify(mockConnectApi).delete(anyString(), anyInt(), eq(connectorBName));
-
-        Crds.kafkaConnectOperation(mockClient).inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
-        Checkpoint updateCheckpoint3 = context.checkpoint();
-        CountDownLatch updateAsync3 = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertTrue(ar.succeeded()));
-            updateCheckpoint3.flag();
-            updateAsync3.countDown();
-        });
-        updateAsync3.await(30, TimeUnit.SECONDS);
-        Thread.sleep(3000);
-
-        //context.async();
+        context.completeNow();
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -8,27 +8,32 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
-import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -37,14 +42,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectAssemblyOperatorMockTest {
@@ -61,40 +78,46 @@ public class KafkaConnectAssemblyOperatorMockTest {
     private KubernetesClient mockClient;
 
     private Vertx vertx;
-    private KafkaConnect cluster;
+    private MockKube mockKube;
 
     @BeforeEach
     public void before() {
         this.vertx = Vertx.vertx();
+    }
 
-        this.cluster = new KafkaConnectBuilder()
-                .withMetadata(new ObjectMetaBuilder()
-                    .withName(CLUSTER_NAME)
-                    .withNamespace(NAMESPACE)
-                    .withLabels(Labels.userLabels(TestUtils.map("foo", "bar")).toMap())
-                    .build())
-                .withNewSpec()
-                    .withReplicas(replicas)
-                .endSpec()
-            .build();
-        mockClient = new MockKube().withCustomResourceDefinition(Crds.kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class)
-                .withInitialInstances(Collections.singleton(cluster)).end().build();
+    private void setConnectResource(KafkaConnect connectResource) {
+        if (mockClient != null) {
+            mockClient.close();
+        }
+        mockKube = new MockKube();
+        mockClient = mockKube
+                .withCustomResourceDefinition(Crds.kafkaConnect(), KafkaConnect.class, KafkaConnectList.class, DoneableKafkaConnect.class, KafkaConnect::getStatus, KafkaConnect::setStatus)
+                    .withInitialInstances(Collections.singleton(connectResource))
+                .end()
+                .withCustomResourceDefinition(Crds.kafkaConnector(), KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class, KafkaConnector::getStatus, KafkaConnector::setStatus)
+                .end()
+                .build();
     }
 
     @AfterEach
     public void after() {
+        if (mockClient != null) {
+            mockClient.close();
+        }
         this.vertx.close();
     }
 
-    private KafkaConnectAssemblyOperator createConnectCluster(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+
+    private KafkaConnectAssemblyOperator createConnectCluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi)  throws InterruptedException, ExecutionException, TimeoutException {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, pfa,
-                new MockCertManager(),
-                new PasswordGenerator(10, "a", "a"),
-                supplier,
-                config);
+            supplier,
+            config,
+            foo -> {
+                return kafkaConnectApi;
+            });
 
         LOGGER.info("Reconciling initially -> create");
         CountDownLatch createAsync = new CountDownLatch(1);
@@ -116,13 +139,163 @@ public class KafkaConnectAssemblyOperatorMockTest {
     /** Create a cluster from a Kafka Cluster CM */
     @Test
     public void testCreateUpdate(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        KafkaConnectAssemblyOperator kco = createConnectCluster(context);
+        setConnectResource(new KafkaConnectBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName(CLUSTER_NAME)
+                        .withNamespace(NAMESPACE)
+                        .withLabels(Labels.userLabels(TestUtils.map("foo", "bar")).toMap())
+                        .build())
+                .withNewSpec()
+                .withReplicas(replicas)
+                .endSpec()
+            .build());
+        KafkaConnectApi mock = mock(KafkaConnectApi.class);
+        when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        KafkaConnectAssemblyOperator kco = createConnectCluster(context,
+                mock);
         LOGGER.info("Reconciling again -> update");
-        Checkpoint updateAsync = context.checkpoint();
+        CountDownLatch updateAsync = new CountDownLatch(1);
+        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.verify(() -> assertTrue(ar.succeeded()));
+            updateAsync.countDown();
+        });
+        updateAsync.await(30, TimeUnit.SECONDS);
+    }
+
+    /*
+     * TODO Implement the KafkaConnect vs S2I preference
+     * TODO implement toggle in KafkaConnect.spec. (how do we change the default?)
+     * Create connect, create connector, delete connector, delete connect
+     * Create connect, create connector, delete connect, delete connector
+     * Create connector, create connect, delete connector, delete connect
+     * Create connector, create connect, delete connect, delete connector
+     * Create connect1, create connect2, create connector for 1, move to connector for 2, delete connector, delete connect
+     */
+
+    /** Create a cluster from a Kafka Cluster CM */
+    @Test
+    @Ignore
+    public void testCreateUpdateWithSelector(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
+        // KafkaConnector Config
+        String connectorAName = "my-connector-a";
+        String connectorBName = "my-connector-b";
+
+        Map<String, Object> kakfaConnectorConfig = new HashMap<>();
+        kakfaConnectorConfig.put("my.config", "true");
+
+        // Create a connect with a selector
+        KafkaConnect connectCluster = new KafkaConnectBuilder()
+                .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+                .withLabels(Labels.userLabels(TestUtils.map("foo", "bar")).toMap())
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(replicas)
+                .endSpec()
+                .build();
+        setConnectResource(connectCluster);
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        when(mockConnectApi.createOrUpdatePutRequest(anyString(), anyInt(), anyString(), any())).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.delete(anyString(), anyInt(), any())).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        KafkaConnectAssemblyOperator kco = createConnectCluster(context, mockConnectApi);
+        LOGGER.info("Reconciling again -> update");
+        Checkpoint updateCheckpoint = context.checkpoint();
+        CountDownLatch updateAsync = new CountDownLatch(1);
         kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            updateAsync.flag();
+            updateCheckpoint.flag();
+            updateAsync.countDown();
         });
+
+        updateAsync.await(30, TimeUnit.SECONDS);
+
+        // Create connector A which matches the selector
+        KafkaConnector connectorA = Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorAName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withClassName("my.connector.ClassA")
+                    .withTasksMax(4)
+                    .withConfig(kakfaConnectorConfig)
+                .endSpec()
+            .done();
+
+        // Create a connector B which does not match the selector
+        KafkaConnector connectorB = Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                    .withName(connectorBName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME + "2")
+                .endMetadata()
+                .withNewSpec()
+                    .withClassName("my.connector.ClassB")
+                    .withTasksMax(4)
+                    .withConfig(any())
+                .endSpec()
+            .done();
+
+        Thread.sleep(3000); // TODO fix this
+
+        // Verify the REST API call, and that we've got a single watch
+        //mockKube.assertNumWatchers(KafkaConnect.class, 1);
+        //context.assertEquals(1, mockKube.watchers(KafkaConnector.class).size());
+        verify(mockConnectApi).createOrUpdatePutRequest(anyString(), anyInt(), eq(connectorAName), any(JsonObject.class));
+
+        // Change the connect cluster
+        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(connectorAName)));
+        Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).withName(connectorAName).patch(
+            new KafkaConnectorBuilder(connectorA)
+                .editMetadata()
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME + "2")
+                .endMetadata()
+            .build());
+        Checkpoint updateCheckpoint2 = context.checkpoint();
+        CountDownLatch updateAsync2 = new CountDownLatch(1);
+        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.verify(() -> assertTrue(ar.succeeded()));
+            updateCheckpoint2.flag();
+            updateAsync2.countDown();
+        });
+        updateAsync2.await(30, TimeUnit.SECONDS);
+
+        Thread.sleep(3000); // TODO fix this
+
+        // Verify we delete the connector which no longer matches
+        verify(mockConnectApi).delete(anyString(), anyInt(), eq(connectorAName));
+        // Verify we created the connector which does now match
+        verify(mockConnectApi).createOrUpdatePutRequest(anyString(), anyInt(), eq(connectorBName), any(JsonObject.class));
+
+
+        // Delete the connector
+        when(mockConnectApi.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(connectorBName)));
+        Crds.kafkaConnectorOperation(mockClient).inNamespace(NAMESPACE).withName(connectorBName).delete();
+
+        Thread.sleep(3000);
+
+        // Verify the connector was deleted
+        verify(mockConnectApi).delete(anyString(), anyInt(), eq(connectorBName));
+
+        Crds.kafkaConnectOperation(mockClient).inNamespace(NAMESPACE).withName(CLUSTER_NAME).delete();
+        Checkpoint updateCheckpoint3 = context.checkpoint();
+        CountDownLatch updateAsync3 = new CountDownLatch(1);
+        kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.verify(() -> assertTrue(ar.succeeded()));
+            updateCheckpoint3.flag();
+            updateAsync3.countDown();
+        });
+        updateAsync3.await(30, TimeUnit.SECONDS);
+        Thread.sleep(3000);
+
+        //context.async();
     }
+
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -149,7 +149,7 @@ public class KafkaUpdateTest {
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"),
                 new ResourceOperatorSupplier(null, null, null,
                         kso, null, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null, null, null, null),
+                        null, null, null, null, null, null, null, null, null, null, null, null, null, null),
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1227,7 +1227,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [id='type-Condition-{context}']
 ### `Condition` schema reference
 
-Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
+Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
 
 
 [options="header"]
@@ -1299,6 +1299,8 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |Property                      |Description
 |replicas               1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
+|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|map
 |image                  1.2+<.<|The docker image for the pods.
 |string
 |livenessProbe          1.2+<.<|Pod liveness checking.
@@ -1327,8 +1329,6 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
-|map
 |externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |resources              1.2+<.<|CPU and memory resources to reserve.
@@ -2212,5 +2212,50 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |integer
 |url                 1.2+<.<|The URL at which external client applications can access the Kafka Bridge.
 |string
+|====
+
+[id='type-KafkaConnector-{context}']
+### `KafkaConnector` schema reference
+
+
+[options="header"]
+|====
+|Property       |Description
+|spec    1.2+<.<|The specification of the Kafka Connector.
+|xref:type-KafkaConnectorSpec-{context}[`KafkaConnectorSpec`]
+|status  1.2+<.<|The status of the Kafka Connector.
+|xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`]
+|====
+
+[id='type-KafkaConnectorSpec-{context}']
+### `KafkaConnectorSpec` schema reference
+
+Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
+
+
+[options="header"]
+|====
+|Property         |Description
+|class     1.2+<.<|The Class for the Kafka Connector.
+|string
+|tasksMax  1.2+<.<|The maximum number of tasks for the Kafka Connector.
+|integer
+|config    1.2+<.<|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|map
+|====
+
+[id='type-KafkaConnectorStatus-{context}']
+### `KafkaConnectorStatus` schema reference
+
+Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
+
+
+[options="header"]
+|====
+|Property                   |Description
+|conditions          1.2+<.<|List of status conditions.
+|xref:type-Condition-{context}[`Condition`] array
+|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|integer
 |====
 

--- a/examples/connector/source-connector.yaml
+++ b/examples/connector/source-connector.yaml
@@ -3,6 +3,10 @@ kind: KafkaConnector
 metadata:
   name: my-source-connector
   labels:
+    # The strimzi.io/cluster label identifies the KafkaConnect instance
+    # in which to create this connector. That KafkaConnect instance
+    # must have the strimzi.io/use-connector-resources annotation
+    # set to true.
     strimzi.io/cluster: my-connect-cluster
 spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector

--- a/examples/connector/source-connector.yaml
+++ b/examples/connector/source-connector.yaml
@@ -3,7 +3,7 @@ kind: KafkaConnector
 metadata:
   name: my-source-connector
   labels:
-    connect-cluster: my-connect-cluster
+    strimzi.io/cluster: my-connect-cluster
 spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector
   tasksMax: 2

--- a/examples/connector/source-connector.yaml
+++ b/examples/connector/source-connector.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnector
+metadata:
+  name: my-source-connector
+  labels:
+    connect-cluster: my-connect-cluster
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector
+  tasksMax: 2
+  config:
+    file: "/opt/kafka/LICENSE"
+    topic: my-topic

--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -14,3 +14,8 @@ spec:
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1
+  connectorSelector:
+    # The connectorSelector identifies KafkaConnectors in the same namespace
+    # which should be created within this connect cluster
+    matchLabels:
+      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -2,8 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
-  annotations:
-    strimzi.io/use-connector-resources: true
+#    annotations:
+#      # use-connector-resources configures this KafkaConnect
+#      # to use KafkaConnector resources to avoid
+#      # needing to call the Connect REST API directly
+#      strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -2,11 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
-#    annotations:
-#      # use-connector-resources configures this KafkaConnect
-#      # to use KafkaConnector resources to avoid
-#      # needing to call the Connect REST API directly
-#      strimzi.io/use-connector-resources: true
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -2,6 +2,8 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1
@@ -14,8 +16,3 @@ spec:
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1
-  connectorSelector:
-    # The connectorSelector identifies KafkaConnectors in the same namespace
-    # which should be created within this connect cluster
-    matchLabels:
-      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -6,7 +6,7 @@ metadata:
 #  # use-connector-resources configures this KafkaConnect
 #  # to use KafkaConnector resources to avoid
 #  # needing to call the Connect REST API directly
-#    strimzi.io/use-connector-resources: true
+#    strimzi.io/use-connector-resources: "true"
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -10,3 +10,8 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
+  connectorSelector:
+    # The connectorSelector identifies KafkaConnectors in the same namespace
+    # which should be created within this connect cluster
+    matchLabels:
+      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -2,8 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
-  annotations:
-    strimzi.io/use-connector-resources: true
+#    annotations:
+#      # use-connector-resources configures this KafkaConnect
+#      # to use KafkaConnector resources to avoid
+#      # needing to call the Connect REST API directly
+#      strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -2,11 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
-#    annotations:
-#      # use-connector-resources configures this KafkaConnect
-#      # to use KafkaConnector resources to avoid
-#      # needing to call the Connect REST API directly
-#      strimzi.io/use-connector-resources: true
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -2,6 +2,8 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnectS2I
 metadata:
   name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1
@@ -10,8 +12,3 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
-  connectorSelector:
-    # The connectorSelector identifies KafkaConnectors in the same namespace
-    # which should be created within this connect cluster
-    matchLabels:
-      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -6,7 +6,7 @@ metadata:
 #  # use-connector-resources configures this KafkaConnect
 #  # to use KafkaConnector resources to avoid
 #  # needing to call the Connect REST API directly
-#    strimzi.io/use-connector-resources: true
+#    strimzi.io/use-connector-resources: "true"
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -14,4 +14,8 @@ spec:
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1
-
+  connectorSelector:
+    # The connectorSelector identifies KafkaConnectors in the same namespace
+    # which should be created within this connect cluster
+    matchLabels:
+      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -2,11 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-#    annotations:
-#      # use-connector-resources configures this KafkaConnect
-#      # to use KafkaConnector resources to avoid
-#      # needing to call the Connect REST API directly
-#      strimzi.io/use-connector-resources: true
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -2,8 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-  annotations:
-    strimzi.io/use-connector-resources: true
+#    annotations:
+#      # use-connector-resources configures this KafkaConnect
+#      # to use KafkaConnector resources to avoid
+#      # needing to call the Connect REST API directly
+#      strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -2,6 +2,8 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1
@@ -14,8 +16,3 @@ spec:
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1
-  connectorSelector:
-    # The connectorSelector identifies KafkaConnectors in the same namespace
-    # which should be created within this connect cluster
-    matchLabels:
-      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -6,7 +6,7 @@ metadata:
 #  # use-connector-resources configures this KafkaConnect
 #  # to use KafkaConnector resources to avoid
 #  # needing to call the Connect REST API directly
-#    strimzi.io/use-connector-resources: true
+#    strimzi.io/use-connector-resources: "true"
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -10,3 +10,8 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
+  connectorSelector:
+    # The connectorSelector identifies KafkaConnectors in the same namespace
+    # which should be created within this connect cluster
+    matchLabels:
+      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -2,6 +2,8 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1
@@ -10,8 +12,3 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
-  connectorSelector:
-    # The connectorSelector identifies KafkaConnectors in the same namespace
-    # which should be created within this connect cluster
-    matchLabels:
-      connect-cluster: my-connect-cluster

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -2,11 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-#    annotations:
-#      # The strimzi.io/use-connector-resources annotation configures
-#      # this KafkaConnect to use KafkaConnector resources to avoid
-#      # needing to call the Connect REST API directly
-#      strimzi.io/use-connector-resources: true
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -2,8 +2,11 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-  annotations:
-    strimzi.io/use-connector-resources: true
+#    annotations:
+#      # The strimzi.io/use-connector-resources annotation configures
+#      # this KafkaConnect to use KafkaConnector resources to avoid
+#      # needing to call the Connect REST API directly
+#      strimzi.io/use-connector-resources: true
 spec:
   version: 2.3.1
   replicas: 1

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -6,7 +6,7 @@ metadata:
 #  # use-connector-resources configures this KafkaConnect
 #  # to use KafkaConnector resources to avoid
 #  # needing to call the Connect REST API directly
-#    strimzi.io/use-connector-resources: true
+#    strimzi.io/use-connector-resources: "true"
 spec:
   version: 2.3.1
   replicas: 1

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -45,14 +45,22 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
+    # The cluster operator runs the KafkaAssemblyOperator, which needs to access Kafka resources
   - kafkas
   - kafkas/status
+    # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access KafkaConnect resources
   - kafkaconnects
   - kafkaconnects/status
+    # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access KafkaConnectS2I resources
   - kafkaconnects2is
   - kafkaconnects2is/status
+    # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access KafkaConnector resources
+  - kafkaconnectors
+  - kafkaconnectors/status
+    # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access KafkaMirrorMaker resources
   - kafkamirrormakers
   - kafkamirrormakers/status
+    # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access BridgeMaker resources
   - kafkabridges
   - kafkabridges/status
   verbs:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -42,6 +42,8 @@ spec:
           properties:
             replicas:
               type: integer
+            config:
+              type: object
             image:
               type: string
             livenessProbe:
@@ -759,8 +761,6 @@ spec:
               - type
             bootstrapServers:
               type: string
-            config:
-              type: object
             externalConfiguration:
               type: object
               properties:

--- a/install/Makefile
+++ b/install/Makefile
@@ -15,6 +15,7 @@ crd_install:
 	$(CP) ./cluster-operator/044-Crd-kafkauser.yaml ../helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
 	$(CP) ./cluster-operator/045-Crd-kafkamirrormaker.yaml ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
 	$(CP) ./cluster-operator/046-Crd-kafkabridge.yaml ../helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+	$(CP) ./cluster-operator/047-Crd-kafkaconnector.yaml ../helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.app "{{ template \"strimzi.name\" . }}" \; && cd $$oldpath
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.chart "{{ template \"strimzi.chart\" . }}" \; && cd $$oldpath
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml metadata.labels.component "kafkas.kafka.strimzi.io-crd"
@@ -24,6 +25,7 @@ crd_install:
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml metadata.labels.component "kafkausers.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml metadata.labels.component "kafkamirrormakers.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml metadata.labels.component "kafkabridges.kafka.strimzi.io-crd"
+	yq write -i ../helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml metadata.labels.component "kafkaconnectors.kafka.strimzi.io-crd"
 
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.release "{{ .Release.Name }}" \; && cd $$oldpath
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.heritage "{{ .Release.Service }}" \; && cd $$oldpath

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -46,6 +46,8 @@ rules:
   - kafkaconnects/status
   - kafkaconnects2is
   - kafkaconnects2is/status
+  - kafkaconnectors
+  - kafkaconnectors/status
   - kafkamirrormakers
   - kafkamirrormakers/status
   - kafkabridges

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -37,6 +37,8 @@ spec:
           properties:
             replicas:
               type: integer
+            config:
+              type: object
             image:
               type: string
             livenessProbe:
@@ -754,8 +756,6 @@ spec:
               - type
             bootstrapServers:
               type: string
-            config:
-              type: object
             externalConfiguration:
               type: object
               properties:

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnectors.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnector
+    listKind: KafkaConnectorList
+    singular: kafkaconnector
+    plural: kafkaconnectors
+    shortNames:
+    - kctr
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            class:
+              type: string
+            tasksMax:
+              type: integer
+              minimum: 1
+            config:
+              type: object
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -19,6 +19,8 @@ spec:
     plural: kafkaconnectors
     shortNames:
     - kctr
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -26,6 +26,15 @@
             <artifactId>kubernetes-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>${okio.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
@@ -79,6 +88,11 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
@@ -8,10 +8,37 @@ import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-class CustomResourceMockBuilder<T extends CustomResource, L extends KubernetesResource & KubernetesResourceList<T>, D extends Doneable<T>> extends MockBuilder<T, L, D, Resource<T, D>> {
-    public CustomResourceMockBuilder(MockKube.MockedCrd<T, L, D> mockedCrd) {
+import java.util.function.Function;
+
+class CustomResourceMockBuilder<T extends CustomResource, L extends KubernetesResource & KubernetesResourceList<T>, D extends Doneable<T>, S>
+        extends MockBuilder<T, L, D, Resource<T, D>> {
+
+    private static final Logger LOGGER = LogManager.getLogger(CustomResourceMockBuilder.class);
+
+    private final MockKube.MockedCrd<T, L, D, S> mockedCrd;
+
+    public CustomResourceMockBuilder(MockKube.MockedCrd<T, L, D, S> mockedCrd) {
         super(mockedCrd.getCrClass(), mockedCrd.getCrListClass(), mockedCrd.getCrDoneableClass(), castClass(Resource.class), mockedCrd.getInstances());
+        this.mockedCrd = mockedCrd;
+    }
+
+    @Override
+    public void updateStatus(String namespace, String name, T resource) {
+        checkDoesExist(name);
+        Function<T, S> getStatus = mockedCrd.getStatus();
+        if (getStatus != null) {
+            S status = getStatus.apply(copyResource(resource));
+            LOGGER.debug("Updating status on {} to {}", resourceTypeClass.getSimpleName(), status);
+            T t = incrementResourceVersion(copyResource(db.get(name)));
+            getStatus.apply(t);
+            mockedCrd.setStatus().accept(t, status);
+            db.put(name, t);
+            fireWatchers(name, t, Watcher.Action.MODIFIED, "updateStatus");
+        }
     }
 }

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -405,7 +405,7 @@ class MockBuilder<T extends HasMetadata,
     private T doCreate(String resourceName, T argument) {
         checkNotExists(resourceName);
         LOGGER.debug("create {} {} -> {}", resourceType, resourceName, argument);
-        db.put(resourceName, incrementResourceVersion(copyResource(argument)));
+        db.put(resourceName, incrementGeneration(incrementResourceVersion(copyResource(argument))));
         fireWatchers(resourceName, argument, Watcher.Action.ADDED, "create");
         return copyResource(argument);
     }
@@ -422,9 +422,10 @@ class MockBuilder<T extends HasMetadata,
     protected T incrementGeneration(T resource) {
         Long generation = resource.getMetadata().getGeneration();
         if (generation == null) {
-            generation = 0L;
+            resource.getMetadata().setGeneration(0L);
+        } else {
+            resource.getMetadata().setGeneration(generation + 1);
         }
-        resource.getMetadata().setGeneration(generation + 1);
         return resource;
     }
 

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/PredicatedWatcher.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/PredicatedWatcher.java
@@ -22,8 +22,10 @@ class PredicatedWatcher<CM extends HasMetadata> {
     private final String str;
     private final Watcher<CM> watcher;
     private final Predicate<CM> predicate;
+    private final String kind;
 
-    private PredicatedWatcher(String str, Predicate<CM> predicate, Watcher<CM> watcher) {
+    private PredicatedWatcher(String kind, String str, Predicate<CM> predicate, Watcher<CM> watcher) {
+        this.kind = kind;
         this.str = str;
         this.watcher = watcher;
         this.predicate = predicate;
@@ -37,20 +39,20 @@ class PredicatedWatcher<CM extends HasMetadata> {
         return predicate;
     }
 
-    static <CM extends HasMetadata> PredicatedWatcher<CM> watcher(Watcher<CM> watcher) {
-        return new PredicatedWatcher<>("watch on all", resource1 -> ((Predicate<CM>) resource -> true).test(resource1), watcher);
+    static <CM extends HasMetadata> PredicatedWatcher<CM> watcher(String kind, Watcher<CM> watcher) {
+        return new PredicatedWatcher<>(kind, "watch on all", resource1 -> ((Predicate<CM>) resource -> true).test(resource1), watcher);
     }
 
-    static <CM extends HasMetadata> PredicatedWatcher<CM> namedWatcher(String name, Watcher<CM> watcher) {
-        return new PredicatedWatcher<>("watch on named " + name, resource1 -> ((Predicate<CM>) resource -> name.equals(resource.getMetadata().getName())).test(resource1), watcher);
+    static <CM extends HasMetadata> PredicatedWatcher<CM> namedWatcher(String kind, String name, Watcher<CM> watcher) {
+        return new PredicatedWatcher<>(kind, "watch on named " + name, resource1 -> ((Predicate<CM>) resource -> name.equals(resource.getMetadata().getName())).test(resource1), watcher);
     }
 
-    static <CM extends HasMetadata> PredicatedWatcher<CM> predicatedWatcher(String desc, Predicate<CM> predicate, Watcher<CM> watcher) {
-        return new PredicatedWatcher<>(desc, resource -> predicate.test(resource), watcher);
+    static <CM extends HasMetadata> PredicatedWatcher<CM> predicatedWatcher(String kind, String desc, Predicate<CM> predicate, Watcher<CM> watcher) {
+        return new PredicatedWatcher<>(kind, desc, resource -> predicate.test(resource), watcher);
     }
 
     public String toString() {
-        return str;
+        return str + " for kind " + kind;
     }
 
     public void maybeFire(CM removed, Watcher.Action action) {

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
@@ -197,7 +197,7 @@ class StatefulSetMockBuilder extends MockBuilder<StatefulSet, StatefulSetList, D
             LOGGER.debug("delete {} {}", resourceType, resourceName);
             StatefulSet removed = db.remove(resourceName);
             if (removed != null) {
-                fireWatchers(resourceName, removed, Watcher.Action.DELETED);
+                fireWatchers(resourceName, removed, Watcher.Action.DELETED, "delete");
                 for (Map.Entry<String, Pod> pod : new HashMap<>(podDb).entrySet()) {
                     if (pod.getKey().matches(resourceName + "-[0-9]+")) {
                         mockPods.inNamespace(removed.getMetadata().getNamespace()).withName(pod.getKey()).delete();

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
@@ -156,6 +156,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         // Compare ignoring resource version
         RT resource = (RT) w.lastEvent().resource;
         resource.getMetadata().setResourceVersion(null);
+        resource.getMetadata().setGeneration(null);
         assertEquals(resource, pod);
         assertThat(mixedOp.apply(client).delete(pod), is(false));
 
@@ -193,6 +194,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         assertThat(items.size(), is(1));
         RT item = items.get(0);
         item.getMetadata().setResourceVersion(null);
+        item.getMetadata().setGeneration(null);
         assertThat(item, is(pod));
 
         // List with namespace
@@ -204,6 +206,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         assertThat(items.size(), is(1));
         RT actual = items.get(0);
         actual.getMetadata().setResourceVersion(null);
+        actual.getMetadata().setGeneration(null);
         assertThat(actual, is(pod));
 
         items = mixedOp.apply(client).withLabel("other-label").list().getItems();
@@ -213,6 +216,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         assertThat(items.size(), is(1));
         RT actual1 = items.get(0);
         actual1.getMetadata().setResourceVersion(null);
+        actual1.getMetadata().setGeneration(null);
         assertThat(actual1, is(pod));
 
         items = mixedOp.apply(client).withLabel("my-label", "bar").list().getItems();
@@ -222,6 +226,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         assertThat(items.size(), is(1));
         RT actual2 = items.get(0);
         actual2.getMetadata().setResourceVersion(null);
+        actual2.getMetadata().setGeneration(null);
         assertThat(actual2, is(pod));
 
         items = mixedOp.apply(client).withLabels(map("my-label", "foo", "my-other-label", "gee")).list().getItems();
@@ -230,6 +235,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         // Get
         RT gotResource = mixedOp.apply(client).withName(pod.getMetadata().getName()).get();
         gotResource.getMetadata().setResourceVersion(null);
+        gotResource.getMetadata().setGeneration(null);
         assertThat(gotResource, is(pod));
 
         // Get with namespace
@@ -241,6 +247,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         assertThat(w.lastEvent().action, is(Watcher.Action.DELETED));
         RT resource = (RT) w.lastEvent().resource;
         resource.getMetadata().setResourceVersion(null);
+        resource.getMetadata().setGeneration(null);
         assertThat(resource, is(pod));
 
         items = mixedOp.apply(client).list().getItems();

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -222,6 +222,10 @@ public class PlatformFeaturesAvailability {
         this.apps = apps;
     }
 
+    public boolean supportsS2I() {
+        return hasBuilds() && hasApps() && hasImages();
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/NoSuchResourceException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/NoSuchResourceException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+public class NoSuchResourceException extends RuntimeException {
+    public NoSuchResourceException() {
+    }
+
+    public NoSuchResourceException(String message) {
+        super(message);
+    }
+
+    public NoSuchResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoSuchResourceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -257,7 +257,7 @@ public abstract class AbstractOperator<
             Throwable cause = result.cause();
             if (cause instanceof InvalidConfigParameterException) {
                 log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
-            } else {
+            } else if (!(cause instanceof UnableToAcquireLockException)) {
                 log.warn("{}: Failed to reconcile", reconciliation, cause);
             }
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -183,7 +183,7 @@ public abstract class AbstractOperator<
                     handler.fail(ex);
                 }
             } else {
-                log.warn("{}: Failed to acquire lock {}.", reconciliation, lockName);
+                log.warn("{}: Failed to acquire lock {} within {}ms.", reconciliation, lockName, lockTimeoutMs);
                 handler.fail(new UnableToAcquireLockException());
             }
         });

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -16,10 +16,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 public class Util {
 
     private static final Logger LOGGER = LogManager.getLogger(Util.class);
+
+    public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
+        Future<T> result = Future.future();
+        vertx.executeBlocking(
+            future -> {
+                try {
+                    future.complete(supplier.get());
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            }, result
+        );
+        return result;
+    }
 
     /**
      * @param vertx The vertx instance.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
@@ -75,6 +76,8 @@ public class CrdOperator<C extends KubernetesClient,
             this.plural = KafkaMirrorMaker.RESOURCE_PLURAL;
         } else if (cls.equals(KafkaTopic.class)) {
             this.plural = KafkaTopic.RESOURCE_PLURAL;
+        } else if (cls.equals(KafkaConnector.class)) {
+            this.plural = KafkaConnector.RESOURCE_PLURAL;
         } else {
             this.plural = null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <fabric8.kubernetes-model.version>4.6.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.0</okhttp.version>
+        <okio.version>1.15.0</okio.version>
         <vertx.version>3.7.1</vertx.version>
         <vertx-juni5.version>3.8.1</vertx-juni5.version>
         <log4j.version>2.11.1</log4j.version>
@@ -330,6 +331,16 @@
                 <version>${vertx.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-web-common</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-web-client</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.strimzi</groupId>
                 <artifactId>certificate-manager</artifactId>
                 <version>${project.version}</version>
@@ -416,6 +427,16 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>connect-runtime</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-json</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-file</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
@@ -677,6 +698,7 @@
                                 <ignoredUnusedDeclaredDependency>org.glassfish:javax.json:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka_2.12:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredDependency>org.junit.platform</ignoredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.kafka:connect-file</ignoredUnusedDeclaredDependency>
                                 <ignoredDependency>org.junit.jupiter</ignoredDependency>
                                 <ignoredDependency>org.junit.platform</ignoredDependency>
                             </ignoredUnusedDeclaredDependencies>

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaBridgeList;
 import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaConnectS2IList;
+import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.KafkaMirrorMakerList;
 import io.strimzi.api.kafka.KafkaTopicList;
@@ -40,6 +41,7 @@ import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.DoneableKafkaBridge;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
 import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.DoneableKafkaUser;
@@ -47,6 +49,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaUser;
@@ -103,6 +106,12 @@ abstract class AbstractResources {
         return client()
                 .customResources(Crds.kafkaConnectS2I(),
                         KafkaConnectS2I.class, KafkaConnectS2IList.class, DoneableKafkaConnectS2I.class);
+    }
+
+    MixedOperation<KafkaConnector, KafkaConnectorList, DoneableKafkaConnector, Resource<KafkaConnector, DoneableKafkaConnector>> kafkaConnector() {
+        return client()
+                .customResources(Crds.kafkaConnector(),
+                        KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class);
     }
 
     MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker, Resource<KafkaMirrorMaker, DoneableKafkaMirrorMaker>> kafkaMirrorMaker() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -499,6 +499,13 @@ public class StUtils {
         LOGGER.info("Kafka Connect S2I {} is ready", name);
     }
 
+    public static void waitForConnectorReady(String name) {
+        LOGGER.info("Waiting for Kafka Connector {}", name);
+        TestUtils.waitFor("Test " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> Crds.kafkaConnectorOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals("Ready"));
+        LOGGER.info("Kafka Connector {} is ready", name);
+    }
+
     /**
      * Wait until the given DeploymentConfig has been deleted.
      * @param name The name of the DeploymentConfig.

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -143,9 +143,9 @@ class ConnectST extends AbstractST {
     }
 
     @Test
-    //@Tag(ACCEPTANCE)
-    //@Tag(TRAVIS)
-    //@Tag(NODEPORT_SUPPORTED)
+    @Tag(ACCEPTANCE)
+    @Tag(TRAVIS)
+    @Tag(NODEPORT_SUPPORTED)
     void testKafkaConnectAndConnectorFileSinkPlugin() throws Exception {
         testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3)
                 .editSpec()


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds initial support for a `KafkaConnector` CR and associated operator.

* An instance of the operator is deployed by the `KafkaConnectAssemblyOperator` for each `KafkaConnect` instance that has a `spec.connectorSelector`. That selector identifies the `KafkaConnectors` which should be created in the Kafka Connect cluster.
* The connector operator makes the HTTP REST calls to the connect REST API. 
* Currently the `KafkaConnector` does not support a `status` property, but there's no reason why that cannot be added.
* No ST are included in this PR.
* No docs are included in this PR. 

Fixes #1468

@pamelipluas @faustocv @gunnarmorling feel free to review.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

