### PR TITLE
Yet another set of minor Grafana dashboard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.0
 
 * Drop support for Kafka 2.1.0, 2.1.1, and 2.2.0
+* Improve Kafka Exporter Grafana dashboard
 
 ## 0.14.0
 

--- a/metrics/examples/grafana/strimzi-kafka-exporter.json
+++ b/metrics/examples/grafana/strimzi-kafka-exporter.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "description": "Kafka resource usage and throughput",
+  "description": "Kafka topics and consumer groups",
   "editable": true,
   "gnetId": 7589,
   "graphTooltip": 0,
@@ -126,7 +126,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -207,7 +207,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -288,7 +288,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -369,7 +369,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -450,7 +450,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -1150,7 +1150,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -1234,7 +1234,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -1318,7 +1318,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -1402,7 +1402,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Another set of fixes to the Grafana dashaboards:
* Fixed description of the Kafka Exporter dashboard
* Fixed the field showing just number or rate to show 0 instead of N/A when there is no traffic or no topics etc.
* Update the CHANGELOG.md since the improvements to the Exporter dashboard is IMHO worth it

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally