### PR TITLE
ST: do cluster operator setup correctly 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -668,7 +668,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
 
         applyRoleBindings(coNamespace, bindingsNamespaces);
         // 050-Deployment
-        testClassResources().clusterOperator(coNamespace, operationTimeout).done();
+        testClassResources().clusterOperator(coNamespace).done();
     }
 
     /**
@@ -953,6 +953,7 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
 
     @AfterEach
     void teardownEnvironmentMethod(ExtensionContext context) throws Exception {
+        assertNoCoErrorsLogged(0);
         if (Environment.SKIP_TEARDOWN == null) {
             if (context.getExecutionException().isPresent()) {
                 LOGGER.info("Test execution contains exception, going to recreate test environment");

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -792,7 +792,7 @@ public class Resources extends AbstractResources {
 
     DoneableKafkaTopic topic(KafkaTopic topic) {
         return new DoneableKafkaTopic(topic, kt -> {
-            KafkaTopic resource = kafkaTopic().inNamespace(topic.getMetadata().getNamespace()).create(kt);
+            KafkaTopic resource = kafkaTopic().inNamespace(topic.getMetadata().getNamespace()).createOrReplace(kt);
             LOGGER.info("Created KafkaTopic {}", resource.getMetadata().getName());
             return deleteLater(resource);
         });
@@ -848,14 +848,10 @@ public class Resources extends AbstractResources {
     }
 
     public DoneableDeployment clusterOperator(String namespace) {
-        return clusterOperator(namespace, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+        return createNewDeployment(defaultCLusterOperator(namespace).build());
     }
 
-    public DoneableDeployment clusterOperator(String namespace, long operationTimeout) {
-        return createNewDeployment(defaultCLusterOperator(namespace, operationTimeout).build());
-    }
-
-    private DeploymentBuilder defaultCLusterOperator(String namespace, long operationTimeout) {
+    private DeploymentBuilder defaultCLusterOperator(String namespace) {
 
         Deployment clusterOperator = getDeploymentFromYaml(STRIMZI_PATH_TO_CO_CONFIG);
 
@@ -876,9 +872,6 @@ public class Resources extends AbstractResources {
                     break;
                 case "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS":
                     envVar.setValue(Environment.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
-                    break;
-                case "STRIMZI_OPERATION_TIMEOUT_MS":
-                    envVar.setValue(Long.toString(operationTimeout));
                     break;
                 default:
                     if (envVar.getName().contains("KAFKA_BRIDGE_IMAGE")) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -223,7 +223,7 @@ class CustomResourceStatusST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        testClassResources().clusterOperator(NAMESPACE).done();
 
         deployTestSpecificResources();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -918,6 +918,7 @@ class KafkaST extends MessagingBaseST {
         //Waiting when EO pod will be recreated without UO
         StUtils.waitForPodDeletion(eoPodName);
         StUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1);
+        StUtils.waitUntilPodContainersCount(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 2);
 
         //Checking that UO was removed
         kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)).forEach(pod -> {
@@ -1955,6 +1956,7 @@ class KafkaST extends MessagingBaseST {
 
     @AfterEach
     void deleteTestResources() throws Exception {
+        kubeClient().getClient().persistentVolumeClaims().inNamespace(NAMESPACE).delete();
         deleteTestMethodResources();
         waitForDeletion(Constants.TIMEOUT_TEARDOWN);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -384,7 +384,7 @@ public class MirrorMakerST extends MessagingBaseST {
         consumerConfig.put("auto.offset.reset", "latest");
 
         Map<String, Object> updatedConsumerConfig = new HashMap<>();
-        consumerConfig.put("auto.offset.reset", "earliest");
+        updatedConsumerConfig.put("auto.offset.reset", "earliest");
 
         int initialDelaySeconds = 30;
         int timeoutSeconds = 10;
@@ -398,6 +398,12 @@ public class MirrorMakerST extends MessagingBaseST {
 
         testMethodResources().kafkaMirrorMaker(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME, "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, false)
                 .editSpec()
+                    .editProducer()
+                        .withConfig(producerConfig)
+                    .endProducer()
+                    .editConsumer()
+                        .withConfig(consumerConfig)
+                    .endConsumer()
                     .withNewTemplate()
                         .withNewMirrorMakerContainer()
                             .withEnv(StUtils.createContainerEnvVarsFromMap(envVarGeneral))

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -43,8 +43,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForDeploymentReady(entityOperatorDeploymentName, 1);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -62,8 +60,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForAllStatefulSetPodsReady(kafkaStatefulSetName, 3);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -81,8 +77,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForAllStatefulSetPodsReady(zookeeperStatefulSetName, 1);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -98,8 +92,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForServiceRecovery(kafkaServiceName, kafkaServiceUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -115,8 +107,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForServiceRecovery(zookeeperServiceName, zookeeperServiceUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -132,8 +122,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForServiceRecovery(kafkaHeadlessServiceName, kafkaHeadlessServiceUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -149,8 +137,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForServiceRecovery(zookeeperHeadlessServiceName, zookeeperHeadlessServiceUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -166,8 +152,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForConfigMapRecovery(kafkaMetricsConfigName, kafkaMetricsConfigUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -183,8 +167,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForConfigMapRecovery(zookeeperMetricsConfigName, zookeeperMetricsConfigUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -201,8 +183,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForDeploymentRecovery(kafkaBridgeDeploymentName, kafkaBridgeDeploymentUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -218,8 +198,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForServiceRecovery(kafkaBridgeServiceName, kafkaBridgeServiceUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @Test
@@ -235,8 +213,6 @@ class RecoveryST extends AbstractST {
         StUtils.waitForConfigMapRecovery(kafkaBridgeMetricsConfigName, kafkaBridgeMetricsConfigUid);
 
         TimeMeasuringSystem.stopOperation(getOperationID());
-        //Test that CO doesn't have any exceptions in log
-        assertNoCoErrorsLogged(TimeMeasuringSystem.getDurationInSecconds(testClass, testName, getOperationID()));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -143,7 +143,7 @@ class RollingUpdateST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+        testClassResources().clusterOperator(NAMESPACE).done();
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import static io.restassured.RestAssured.given;
 
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.TRACING;
 import static io.strimzi.test.TestUtils.getFileAsString;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.greaterThan;
 
 @Tag(TRACING)
+@Tag(REGRESSION)
 public class TracingST extends AbstractST {
 
     private static final String NAMESPACE = "tracing-cluster-test";

--- a/test/src/main/java/io/strimzi/test/BaseITST.java
+++ b/test/src/main/java/io/strimzi/test/BaseITST.java
@@ -96,7 +96,7 @@ public class BaseITST {
      * @return Kubernetes client
      */
     public static KubeClient kubeClient() {
-        return kubeCluster().client().namespace(namespace);
+        return kubeCluster(). client().namespace(namespace);
     }
 
     /**
@@ -157,7 +157,7 @@ public class BaseITST {
         bindingsNamespaces = namespaces;
         for (String namespace: namespaces) {
 
-            if (kubeClient().getNamespace(namespace) != null) {
+            if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {
                 LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
                 kubeClient().deleteNamespace(namespace);
                 cmdKubeClient().waitForResourceDeletion("Namespace", namespace);

--- a/test/src/main/java/io/strimzi/test/BaseITST.java
+++ b/test/src/main/java/io/strimzi/test/BaseITST.java
@@ -96,7 +96,7 @@ public class BaseITST {
      * @return Kubernetes client
      */
     public static KubeClient kubeClient() {
-        return kubeCluster(). client().namespace(namespace);
+        return kubeCluster().client().namespace(namespace);
     }
 
     /**

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -363,11 +363,11 @@ public class KubeClient {
     }
 
     public Service createService(Service service) {
-        return client.services().inNamespace(getNamespace()).create(service);
+        return client.services().inNamespace(getNamespace()).createOrReplace(service);
     }
 
     public Ingress createIngress(Ingress ingress) {
-        return client.extensions().ingresses().inNamespace(getNamespace()).create(ingress);
+        return client.extensions().ingresses().inNamespace(getNamespace()).createOrReplace(ingress);
     }
 
     public Boolean deleteIngress(Ingress ingress) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR contains following changes:
* Set `STRIMZI_OPERATION_TIMEOUT_MS` back to default value and whitelist timeout error message in matcher
* Improve matcher logic - matcher will now fail in case of any exception which will not be available in whitelist
* Assert CO logs for unexpected exceptions after each test
* Add option to skip setup phase if the resources are already ready with env var `SKIP_TEARDOWN`
* Fix for some potential flaky tests
### Checklist

- [x] Make sure all tests pass

