### PR TITLE
1505 ephemeral storage size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Drop support for Kafka 2.1.0, 2.1.1, and 2.2.0
 * Improve Kafka Exporter Grafana dashboard
+* Add sizeLimit option to ephemeral storage (#1505)
 
 ## 0.14.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.storage;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -26,6 +27,8 @@ public class EphemeralStorage extends SingleVolumeStorage {
 
     private Integer id;
 
+    private String sizeLimit;
+
     @Description("Must be `" + TYPE_EPHEMERAL + "`")
     @Override
     public String getType() {
@@ -43,5 +46,15 @@ public class EphemeralStorage extends SingleVolumeStorage {
     @Override
     public void setId(Integer id) {
         super.setId(id);
+    }
+
+    @Pattern("^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$")
+    @Description("When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (i.e 1Gi).")
+    public String getSizeLimit() {
+        return sizeLimit;
+    }
+
+    public void setSizeLimit(String sizeLimit) {
+        this.sizeLimit = sizeLimit;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
@@ -49,7 +49,7 @@ public class EphemeralStorage extends SingleVolumeStorage {
     }
 
     @Pattern("^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$")
-    @Description("When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (i.e 1Gi).")
+    @Description("When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).")
     public String getSizeLimit() {
         return sizeLimit;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -12,6 +12,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
@@ -647,13 +649,21 @@ public abstract class AbstractModel {
         return pvc;
     }
 
-    protected Volume createEmptyDirVolume(String name) {
-        Volume volume = new VolumeBuilder()
-                .withName(name)
-                .withNewEmptyDir()
-                .endEmptyDir()
+    protected Volume createEmptyDirVolume(String name, String sizeLimit) {
+        EmptyDirVolumeSource emptyDirVolumeSource;
+        if (sizeLimit == null || sizeLimit.isEmpty()) {
+            emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder()
                 .build();
-        log.trace("Created emptyDir Volume named '{}'", name);
+        } else {
+            emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder()
+                .withNewSizeLimit(sizeLimit)
+                .build();
+        }
+        Volume volume = new VolumeBuilder()
+            .withName(name)
+            .withEmptyDir(emptyDirVolumeSource)
+            .build();
+        log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", name, sizeLimit);
         return volume;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -12,8 +12,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
-import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
-import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
@@ -650,18 +648,11 @@ public abstract class AbstractModel {
     }
 
     protected Volume createEmptyDirVolume(String name, String sizeLimit) {
-        EmptyDirVolumeSource emptyDirVolumeSource;
-        if (sizeLimit == null || sizeLimit.isEmpty()) {
-            emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder()
-                .build();
-        } else {
-            emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder()
-                .withNewSizeLimit(sizeLimit)
-                .build();
-        }
         Volume volume = new VolumeBuilder()
             .withName(name)
-            .withEmptyDir(emptyDirVolumeSource)
+                .withNewEmptyDir()
+                    .withNewSizeLimit(sizeLimit == null || sizeLimit.isEmpty() ? null : sizeLimit)
+                .endEmptyDir()
             .build();
         log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", name, sizeLimit);
         return volume;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1149,7 +1149,8 @@ public class KafkaCluster extends AbstractModel {
             String mountPath = this.mountPath + "/" + name;
 
             if (storage instanceof EphemeralStorage) {
-                dataVolumes.add(createEmptyDirVolume(name));
+                String sizeLimit = ((EphemeralStorage) storage).getSizeLimit();
+                dataVolumes.add(createEmptyDirVolume(name, sizeLimit));
             } else if (storage instanceof PersistentClaimStorage) {
                 dataPvcs.add(createPersistentVolumeClaimTemplate(name, (PersistentClaimStorage) storage));
             }
@@ -1194,7 +1195,7 @@ public class KafkaCluster extends AbstractModel {
         volumeList.addAll(dataVolumes);
 
         if (rack != null || isExposedWithNodePort()) {
-            volumeList.add(createEmptyDirVolume(INIT_VOLUME_NAME));
+            volumeList.add(createEmptyDirVolume(INIT_VOLUME_NAME, null));
         }
         volumeList.add(createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         volumeList.add(createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster), isOpenShift));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -571,7 +571,8 @@ public class ZookeeperCluster extends AbstractModel {
     private List<Volume> getVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
         if (storage instanceof EphemeralStorage) {
-            volumeList.add(createEmptyDirVolume(VOLUME_NAME));
+            String sizeLimit = ((EphemeralStorage) storage).getSizeLimit();
+            volumeList.add(createEmptyDirVolume(VOLUME_NAME, sizeLimit));
         }
         volumeList.add(createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigName));
         volumeList.add(createSecretVolume(TLS_SIDECAR_NODES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -246,7 +246,7 @@ public class AbstractModelTest {
             }
         };
         Volume volume = am.createEmptyDirVolume("bar", null);
-        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit().getAmount());
     }
 
     @Test
@@ -263,6 +263,6 @@ public class AbstractModelTest {
             }
         };
         Volume volume = am.createEmptyDirVolume("bar", "");
-        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit().getAmount());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -212,5 +213,56 @@ public class AbstractModelTest {
         Assert.assertEquals(ImagePullPolicy.NEVER.toString(), am.determineImagePullPolicy(ImagePullPolicy.NEVER, "docker.io/repo/image:tag"));
         Assert.assertEquals(ImagePullPolicy.ALWAYS.toString(), am.determineImagePullPolicy(null, "docker.io/repo/image:latest"));
         Assert.assertEquals(ImagePullPolicy.IFNOTPRESENT.toString(), am.determineImagePullPolicy(null, "docker.io/repo/image:not-so-latest"));
+    }
+
+    @Test
+    public void testCreateEmptyDirVolumeWithSizeLimit() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) {
+            @Override
+            protected String getDefaultLogConfigFileName() {
+                return "";
+            }
+
+            @Override
+            protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
+                return emptyList();
+            }
+        };
+        Volume volume = am.createEmptyDirVolume("bar", "1Gi");
+        Assert.assertEquals("1Gi", volume.getEmptyDir().getSizeLimit().getAmount());
+    }
+
+    @Test
+    public void testCreateEmptyDirVolumeWithNullSizeLimit() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) {
+            @Override
+            protected String getDefaultLogConfigFileName() {
+                return "";
+            }
+
+            @Override
+            protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
+                return emptyList();
+            }
+        };
+        Volume volume = am.createEmptyDirVolume("bar", null);
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
+    }
+
+    @Test
+    public void testCreateEmptyDirVolumeWithEmptySizeLimit() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) {
+            @Override
+            protected String getDefaultLogConfigFileName() {
+                return "";
+            }
+
+            @Override
+            protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
+                return emptyList();
+            }
+        };
+        Volume volume = am.createEmptyDirVolume("bar", "");
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -280,9 +280,9 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
-                .editKafka()
-                .withNewEphemeralStorage().withNewSizeLimit(sizeLimit).endEphemeralStorage()
-                .endKafka()
+                    .editKafka()
+                        .withNewEphemeralStorage().withNewSizeLimit(sizeLimit).endEphemeralStorage()
+                    .endKafka()
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
@@ -295,14 +295,14 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
-                .editKafka()
-                .withNewEphemeralStorage().endEphemeralStorage()
-                .endKafka()
+                    .editKafka()
+                        .withNewEphemeralStorage().endEphemeralStorage()
+                    .endKafka()
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
         StatefulSet ss = kc.generateStatefulSet(false, null, null);
-        assertEquals(null, ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit());
+        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -968,15 +968,15 @@ public class ZookeeperClusterTest {
     public void testGenerateSTSWithPersistentVolumeEphemeral()    {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
                 .editSpec()
-                .editZookeeper()
-                .withNewEphemeralStorage().endEphemeralStorage()
-                .endZookeeper()
+                    .editZookeeper()
+                        .withNewEphemeralStorage().endEphemeralStorage()
+                    .endZookeeper()
                 .endSpec()
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
 
         StatefulSet ss = zc.generateStatefulSet(false, null, null);
-        assertEquals(null, ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit());
+        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount());
     }
 
     @Test
@@ -984,9 +984,9 @@ public class ZookeeperClusterTest {
         String sizeLimit = "1Gi";
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
                 .editSpec()
-                .editZookeeper()
-                .withNewEphemeralStorage().withNewSizeLimit(sizeLimit).endEphemeralStorage()
-                .endZookeeper()
+                    .editZookeeper()
+                        .withNewEphemeralStorage().withNewSizeLimit(sizeLimit).endEphemeralStorage()
+                    .endZookeeper()
                 .endSpec()
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -945,7 +945,7 @@ public class ZookeeperClusterTest {
     }
 
     @Test
-    public void testGeneratePersistentVolumeClaimsephemeral()    {
+    public void testGeneratePersistentVolumeClaimsEphemeral()    {
         Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
                 .editSpec()
                 .editZookeeper()
@@ -962,6 +962,37 @@ public class ZookeeperClusterTest {
         List<PersistentVolumeClaim> pvcs = zc.generatePersistentVolumeClaims();
 
         assertEquals(0, pvcs.size());
+    }
+
+    @Test
+    public void testGenerateSTSWithPersistentVolumeEphemeral()    {
+        Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withNewEphemeralStorage().endEphemeralStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
+
+        StatefulSet ss = zc.generateStatefulSet(false, null, null);
+        assertEquals(null, ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit());
+    }
+
+    @Test
+    public void testGenerateSTSWithPersistentVolumeEphemeralWithSizeLimit()    {
+        String sizeLimit = "1Gi";
+        Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson))
+                .editSpec()
+                .editZookeeper()
+                .withNewEphemeralStorage().withNewSizeLimit(sizeLimit).endEphemeralStorage()
+                .endZookeeper()
+                .endSpec()
+                .build();
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
+
+        StatefulSet ss = zc.generateStatefulSet(false, null, null);
+        assertEquals(sizeLimit, ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount());
     }
 
     @Test

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -104,10 +104,12 @@ The `type` property is a discriminator that distinguishes the use of the type `E
 It must have the value `ephemeral` for the type `EphemeralStorage`.
 [options="header"]
 |====
-|Property     |Description
-|id    1.2+<.<|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+|Property          |Description
+|id         1.2+<.<|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |integer
-|type  1.2+<.<|Must be `ephemeral`.
+|sizeLimit  1.2+<.<|When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (i.e 1Gi).
+|string
+|type       1.2+<.<|Must be `ephemeral`.
 |string
 |====
 

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -107,7 +107,7 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 |Property          |Description
 |id         1.2+<.<|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |integer
-|sizeLimit  1.2+<.<|When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (i.e 1Gi).
+|sizeLimit  1.2+<.<|When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).
 |string
 |type       1.2+<.<|Must be `ephemeral`.
 |string

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -75,6 +75,9 @@ spec:
                       type: object
                     size:
                       type: string
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type:
                       type: string
                       enum:
@@ -106,6 +109,9 @@ spec:
                             type: object
                           size:
                             type: string
+                          sizeLimit:
+                            type: string
+                            pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                           type:
                             type: string
                             enum:
@@ -1344,6 +1350,9 @@ spec:
                       type: object
                     size:
                       type: string
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type:
                       type: string
                       enum:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -70,6 +70,9 @@ spec:
                       type: object
                     size:
                       type: string
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type:
                       type: string
                       enum:
@@ -101,6 +104,9 @@ spec:
                             type: object
                           size:
                             type: string
+                          sizeLimit:
+                            type: string
+                            pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                           type:
                             type: string
                             enum:
@@ -1339,6 +1345,9 @@ spec:
                       type: object
                     size:
                       type: string
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type:
                       type: string
                       enum:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

Contributes to strimzi/strimzi-kafka-operator#1505

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>

### Description

Add a `sizeLimit` to the ephemeral storage with type String and a Pattern of `^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$` so that it will catch setting it to things like "foo".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design` (no longer present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles - N/A
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

