### PR TITLE
feat: Implement kubernetes recommended labels

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -79,6 +79,8 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractModel {
 
+    protected static final String STRIMZI_CLUSTER_OPERATOR_NAME = "strimzi-cluster-operator";
+
     protected static final Logger log = LogManager.getLogger(AbstractModel.class.getName());
 
     protected static final String DEFAULT_JVM_XMS = "128M";
@@ -184,7 +186,10 @@ public abstract class AbstractModel {
     protected AbstractModel(String namespace, String cluster, Labels labels) {
         this.cluster = cluster;
         this.namespace = namespace;
-        this.labels = labels.withCluster(cluster);
+        this.labels = labels.withCluster(cluster)
+                            .withKubernetesName()
+                            .withKubernetesInstance(cluster)
+                            .withKubernetesManagedBy(STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     public Labels getLabels() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -93,7 +93,10 @@ public class KafkaBridgeClusterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, name,
-                Labels.STRIMZI_KIND_LABEL, KafkaBridge.RESOURCE_KIND);
+                Labels.STRIMZI_KIND_LABEL, KafkaBridge.RESOURCE_KIND,
+                Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -148,7 +148,14 @@ public class KafkaClusterTest {
     }
 
     private Map<String, String> expectedLabels()    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster, "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster), Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
+        return TestUtils.map(
+            Labels.STRIMZI_CLUSTER_LABEL, cluster,
+            "my-user-label", "cromulent",
+            Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster),
+            Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
+            Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+            Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -116,7 +116,10 @@ public class KafkaConnectClusterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, name,
-                Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND);
+                Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
+                Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -115,8 +115,13 @@ public class KafkaConnectS2IClusterTest {
     }
 
     private Map<String, String> expectedLabels(String name)    {
-        return TestUtils.map("my-user-label", "cromulent", Labels.STRIMZI_CLUSTER_LABEL, cluster,
-                Labels.STRIMZI_NAME_LABEL, name, Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND);
+        return TestUtils.map("my-user-label", "cromulent", 
+            Labels.STRIMZI_CLUSTER_LABEL, cluster,
+            Labels.STRIMZI_NAME_LABEL, name,
+            Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND,
+            Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+            Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -96,7 +96,10 @@ public class KafkaExporterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
-                Labels.STRIMZI_NAME_LABEL, name);
+                Labels.STRIMZI_NAME_LABEL, name,
+                Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -121,7 +121,10 @@ public class KafkaMirrorMakerClusterTest {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND,
-                Labels.STRIMZI_NAME_LABEL, name);
+                Labels.STRIMZI_NAME_LABEL, name,
+                Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+                Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -129,7 +129,13 @@ public class ZookeeperClusterTest {
     }
 
     private Map<String, String> expectedLabels()    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster, "my-user-label", "cromulent", Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster), Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
+        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster,
+            "my-user-label", "cromulent",
+            Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster),
+            Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
+            Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
+            Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
     @Test

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -20,6 +20,7 @@ import static java.util.Collections.unmodifiableMap;
 public class Labels {
 
     public static final String STRIMZI_DOMAIN = "strimzi.io/";
+    public static final String KUBERNETES_DOMAIN = "app.kubernetes.io/";
 
     /**
      * The kind of a Kubernetes / OpenShift Resource. It contains the same value as the Kind of the corresponding
@@ -46,6 +47,13 @@ public class Labels {
      * but is different in some cases (e.g. headful and headless services)
      */
     public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "name";
+
+    public static final String KUBERNETES_NAME_LABEL = KUBERNETES_DOMAIN + "name";
+    public static final String KUBERNETES_NAME = "strimzi";
+
+    public static final String KUBERNETES_INSTANCE_LABEL = KUBERNETES_DOMAIN + "instance";
+
+    public static final String KUBERNETES_MANAGED_BY_LABEL = KUBERNETES_DOMAIN + "managed-by";
 
     /**
      * Used to identify individual pods
@@ -177,6 +185,33 @@ public class Labels {
      */
     public Labels withCluster(String cluster) {
         return with(STRIMZI_CLUSTER_LABEL, cluster);
+    }
+    
+    /**
+     * The same labels as this instance, but with the application name {@code strimzi} for the {@code app.kubernetes.io/name} key.
+     * @return A new instance with the given kubernetes application name added.
+     */
+    public Labels withKubernetesName() {
+        return with(Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code instance} for the {@code app.kubernetes.io/instance} key.
+     * @param instance The instance to add.
+     * @return A new instance with the given kubernetes application instance added.
+     */
+    public Labels withKubernetesInstance(String instance) {
+        return with(Labels.KUBERNETES_INSTANCE_LABEL, instance);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code operatorName} for the {@code app.kubernetes.io/managed-by} key.
+     * @param operatorName The name of the operator managing this resource.
+     * @return A new instance with the given operator that is managing this resourse.
+     */
+    public Labels withKubernetesManagedBy(String operatorName) {
+        // Make configurable?
+        return with(Labels.KUBERNETES_MANAGED_BY_LABEL, operatorName);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -210,7 +210,6 @@ public class Labels {
      * @return A new instance with the given operator that is managing this resourse.
      */
     public Labels withKubernetesManagedBy(String operatorName) {
-        // Make configurable?
         return with(Labels.KUBERNETES_MANAGED_BY_LABEL, operatorName);
     }
 


### PR DESCRIPTION
Implement the kubernetes recommended labels:
app.kubernetes.io/name
app.kubernetes.io/instance
app.kubernetes.io/managed-by
Applies for all operators
Each resource is labelled with which operator
component it is managed by

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

