### PR TITLE
Fix URL in bridge status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -50,12 +50,12 @@ public class KafkaBridgeResources {
 
     /**
      * Returns the URL of the Kafka Bridge for a {@code KafkaBridge} cluster of the given name.
-     * @param bridgeName  The {@code metadata.name} of the {@code KafkaBridge} resource.
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaBridge} resource.
      * @param namespace The namespace where the {@code KafkaBridge} cluster is running.
      * @param port The port on which the {@code KafkaBridge} is available.
      * @return The URL of {@code KafkaBridge}.
      */
-    public static String url(String bridgeName, String namespace, int port) {
-        return "http://" + serviceName(bridgeName) + "." + namespace + ".svc:" + port;
+    public static String url(String clusterName, String namespace, int port) {
+        return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -108,7 +108,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                 if (bridge.getHttp() != null) {
                     port = bridge.getHttp().getPort();
                 }
-                kafkaBridgeStatus.setUrl(KafkaBridgeResources.url(bridge.getName(), namespace, port));
+                kafkaBridgeStatus.setUrl(KafkaBridgeResources.url(bridge.getCluster(), namespace, port));
 
                 updateStatus(assemblyResource, reconciliation, kafkaBridgeStatus).setHandler(statusResult -> {
                     // If both features succeeded, createOrUpdate succeeded as well

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -172,7 +172,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "Ready");
 
@@ -667,7 +667,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
             // Verify status
             List<KafkaBridge> capturedStatuses = bridgeCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-bridge-service.test.svc:8080");
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUrl(), "http://foo-bridge-service.test.svc:8080");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a bug in the KafkaBridge status. The URL is wrong:

```yaml
status:
  conditions:
  - lastTransitionTime: "2019-10-15T14:21:40.520Z"
    status: "True"
    type: Ready
  observedGeneration: 1
  url: http://my-bridge-bridge-bridge-service.myproject.svc:8080
```

The resource is named `my-bridge`, so the service name / URL is `my-bridge-bridge-service` and not `my-bridge-bridge-bridge-service`. This Pr should fix it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally