### PR TITLE
fix: Update build echo for updating resources

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -35,7 +35,8 @@ if [ -n "$CHANGED_DERIVED" ] ; then
   echo "ERROR: Uncommitted changes in derived resources:"
   echo "$CHANGED_DERIVED"
   echo "Run the following to add up-to-date resources:"
-  echo "  make crd_install \\"
+  echo "  mvn clean verify -DskipTests -DskipITs \\"
+  echo "    && make crd_install \\"
   echo "    && git add install/ helm-charts/ documentation/book/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles"
   echo "    && git commit -s -m 'Update derived resources'"
   exit 1

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -35,7 +35,7 @@ if [ -n "$CHANGED_DERIVED" ] ; then
   echo "ERROR: Uncommitted changes in derived resources:"
   echo "$CHANGED_DERIVED"
   echo "Run the following to add up-to-date resources:"
-  echo "  mvn clean verify -DskipTests -DskipITs \\"
+  echo "  make crd_install \\"
   echo "    && git add install/ helm-charts/ documentation/book/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles"
   echo "    && git commit -s -m 'Update derived resources'"
   exit 1


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Update echo to suggest `make crd_install` rather than `mvn install` as that is now the recommended command.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

