### PR TITLE
ST: correct reconciliation error message in matcher whitelist

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -64,12 +64,13 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
                 + "(?s)(.*?)"
                 + "io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH"),
         // fabric8 now throws exceptions, which doesn't influence kafka scaleup/scaledown
-        FABRIC_EIGHT_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:115 - Error while waiting for resource to be scaled."),
-        FABRIC_EIGHT_STATEFUL_SET_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:[0-9]+ - 0/.* pod(s) ready for StatefulSet: .*  after waiting for 0 seconds so giving up"),
+        FABRIC_EIGHT_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:[0-9]+ - Error while waiting for resource to be scaled."),
+        FABRIC_EIGHT_STATEFUL_SET_SCALEUP_ERROR("ERROR StatefulSetOperationsImpl:[0-9]+ - 0/.* pod(s).*after waiting for 0 seconds so giving up"),
         // This happen from time to time during CO startup, it doesn't influence CO behavior
         EXIT_ON_OUT_OF_MEMORY("ExitOnOutOfMemoryError"),
         OPERATION_TIMEOUT("Util:[0-9]+ - Exceeded timeout of.*while waiting for.*"),
-        RECONCILIATION_TIMEOUT("ERROR AbstractOperator:[0-9]+ - Reconciliation.*");
+        // This is whitelisted cause it's no real problem when this error appears, components are being created even after timeout
+        RECONCILIATION_TIMEOUT("ERROR Abstract.*Operator:[0-9]+ - Reconciliation.*");
 
         final String name;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
@@ -46,14 +46,11 @@ public class TestExecutionWatcher implements AfterTestExecutionCallback, Lifecyc
     @Override
     public void handleAfterAllMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
         String testClass = extensionContext.getRequiredTestClass().getName();
-        String testMethod = extensionContext.getRequiredTestMethod().getName();
 
         final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         String currentDate = simpleDateFormat.format(Calendar.getInstance().getTime());
-        String logDir = !testMethod.isEmpty() ?
-                TEST_LOG_DIR + testClass + "." + testMethod + "_" + currentDate
-                : TEST_LOG_DIR + currentDate;
+        String logDir = TEST_LOG_DIR + testClass + "_" + currentDate;
 
         LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
         logCollector.collectDeployments();


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Since we cherry-picked wrong whitelist value into `release-0.14.x` branch, this is fix for that and it add more flexibility into error message.

### Checklist

- [x] Make sure all tests pass
