### PR TITLE
[DOC] Minor doc updates from review

### DIFF
--- a/documentation/book/assembly-deployment-configuration.adoc
+++ b/documentation/book/assembly-deployment-configuration.adoc
@@ -16,6 +16,8 @@ This chapter describes how to configure different aspects of the supported deplo
 * Kafka Connect clusters
 * Kafka Connect clusters with _Source2Image_ support
 * Kafka Mirror Maker
+* Kafka Bridge
+* {oauth} token based authentication
 
 include::assembly-deployment-configuration-kafka.adoc[leveloffset=+1]
 

--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -6,7 +6,7 @@
 = {ProductName} resource upgrades
 For this release of {ProductName}, resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
 
-The `{KafkaApiVersionPrev}` API version was deprecated in release 1.2.
+The `{KafkaApiVersionPrev}` API version is deprecated.
 
 This section describes the upgrade steps for the resources.
 

--- a/documentation/book/assembly-upgrade-resources.adoc
+++ b/documentation/book/assembly-upgrade-resources.adoc
@@ -6,7 +6,7 @@
 = {ProductName} resource upgrades
 For this release of {ProductName}, resources that use the API version `{KafkaApiVersionPrev}` must be updated to use `{KafkaApiVersion}`.
 
-The `{KafkaApiVersionPrev}` API version is deprecated in release {ProductVersion}.
+The `{KafkaApiVersionPrev}` API version was deprecated in release 1.2.
 
 This section describes the upgrade steps for the resources.
 

--- a/documentation/book/con-custom-resources-status.adoc
+++ b/documentation/book/con-custom-resources-status.adoc
@@ -104,7 +104,7 @@ status:
 <3> The `observedGeneration` indicates the generation of the `Kafka` custom resource that was last reconciled by the Cluster Operator.
 <4> The `listeners` describe the current Kafka bootstrap addresses by type.
 +
-IMPORTANT: The status for `external` listeners is still under development and does not provide a specific IP address for external listeners of type `nodeport`.
+IMPORTANT: The address in the custom resource status for external listeners with type `nodeport` is currently not supported.
 
 NOTE: The Kafka bootstrap addresses listed in the status do not signify that those endpoints or the Kafka cluster is in a ready state.
 

--- a/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
@@ -68,7 +68,7 @@ listeners:
 On `ingress` listeners, you can use the `dnsAnnotations` property to add additional annotations to the ingress resources.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the ingress resources.
 
-.Example of an external listener of type `ingress` using Kubernetes External DNS annotations
+.Example of an external listener of type `ingress` using `dnsAnnotations`
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-ingress.adoc
@@ -68,7 +68,7 @@ listeners:
 On `ingress` listeners, you can use the `dnsAnnotations` property to add additional annotations to the ingress resources.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the ingress resources.
 
-.Example of an external listener of type `ingress` using {KubernetesExternalDNS} annotations
+.Example of an external listener of type `ingress` using Kubernetes External DNS annotations
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -32,7 +32,7 @@ For more information on using loadbalancers to access Kafka, see xref:proc-acces
 On `loadbalancer` listeners, you can use the `dnsAnnotations` property to add additional annotations to the loadbalancer services.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
 
-.Example of an external listener of type `loadbalancer` using {KubernetesExternalDNS} annotations
+.Example of an external listener of type `loadbalancer` using Kubernetes External DNS annotations
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -32,7 +32,7 @@ For more information on using loadbalancers to access Kafka, see xref:proc-acces
 On `loadbalancer` listeners, you can use the `dnsAnnotations` property to add additional annotations to the loadbalancer services.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
 
-.Example of an external listener of type `loadbalancer` using Kubernetes External DNS annotations
+.Example of an external listener of type `loadbalancer` using using `dnsAnnotations`
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-loadbalancers.adoc
@@ -32,7 +32,7 @@ For more information on using loadbalancers to access Kafka, see xref:proc-acces
 On `loadbalancer` listeners, you can use the `dnsAnnotations` property to add additional annotations to the loadbalancer services.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the loadbalancer services.
 
-.Example of an external listener of type `loadbalancer` using using `dnsAnnotations`
+.Example of an external listener of type `loadbalancer` using `dnsAnnotations`
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
@@ -59,7 +59,7 @@ For more information on using node ports to access Kafka, see xref:proc-accessin
 On `nodeport` listeners, you can use the `dnsAnnotations` property to add additional annotations to the nodeport services.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the cluster nodes.
 
-.Example of an external listener of type `nodeport` using Kubernetes External DNS annotations
+.Example of an external listener of type `nodeport` using `dnsAnnotations`
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
+++ b/documentation/book/con-kafka-broker-external-listeners-nodeports.adoc
@@ -59,7 +59,7 @@ For more information on using node ports to access Kafka, see xref:proc-accessin
 On `nodeport` listeners, you can use the `dnsAnnotations` property to add additional annotations to the nodeport services.
 You can use these annotations to instrument DNS tooling such as {KubernetesExternalDNS}, which automatically assigns DNS names to the cluster nodes.
 
-.Example of an external listener of type `nodeport` using {KubernetesExternalDNS} annotations
+.Example of an external listener of type `nodeport` using Kubernetes External DNS annotations
 [source,yaml,subs="attributes+"]
 ----
 # ...

--- a/documentation/book/proc-enabling-tracing-in-connect-mirror-maker-resources.adoc
+++ b/documentation/book/proc-enabling-tracing-in-connect-mirror-maker-resources.adoc
@@ -17,6 +17,7 @@ Perform these steps for each `KafkaMirrorMaker`, `KafkaConnect`, and `KafkaConne
 
 . In the `spec.template` property, configure the Jaeger tracer service. For example:
 +
+--
 .Jaeger tracer configuration for Kafka Connect
 [source,yaml,subs=attributes+]
 ----
@@ -29,17 +30,17 @@ spec:
   template:
     connectContainer: <1>
       env:
-        - name: JAEGER_SERVICE_NAME 
+        - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
         - name: JAEGER_AGENT_HOST
           value: jaeger-agent-name
         - name: JAEGER_AGENT_PORT
-          value: "6831"        
+          value: "6831"
   tracing: <2>
     type: jaeger
   #...
 ----
-+
+
 .Jaeger tracer configuration for Mirror Maker
 [source,yaml,subs=attributes+]
 ----
@@ -52,20 +53,19 @@ spec:
   template:
     mirrorMakerContainer: <1>
       env:
-        - name: JAEGER_SERVICE_NAME  
+        - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
         - name: JAEGER_AGENT_HOST
           value: jaeger-agent-name
         - name: JAEGER_AGENT_PORT
-          value: "6831" 
+          value: "6831"
   tracing: <2>
     type: jaeger
 #...
 ----
-+
 <1> Use the xref:ref-tracing-environment-variables-{context}[tracing environment variables] as template configuration properties.
-+
 <2> Set the `spec.tracing.type` property to `jaeger`.
+--
 
 . Create or update the resource:
 +


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

- Documentation

### Description

Edits to fix minor doc issues.

- Version reference for API resource updates should not refer to version.
- Updated statement: _The status for external listeners is still under development and does not provide a specific IP address for external listeners of type nodeport._ 
- Chapter 3 Deployment configuration (assembly-deployment-configuration-str).
>> The summary had no reference to the Kafka Bridge or Oauth 2.0 configuration. 
-  DNS names of external node port listeners showed link in image title (x3)  
con-kafka-broker-external-listeners-ingress.adoc
con-kafka-broker-external-listeners-loadbalancers.adoc
con-kafka-broker-external-listeners-nodeports.adoc
- Jaeger tracer configuration for Mirror Maker 
 >> Cosmetic issue with the callouts (1 1) (2 2)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

