### PR TITLE
Fix ephemeral storage size

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -12,6 +12,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
@@ -648,11 +650,14 @@ public abstract class AbstractModel {
     }
 
     protected Volume createEmptyDirVolume(String name, String sizeLimit) {
+        EmptyDirVolumeSource emptyDirVolumeSource = new EmptyDirVolumeSourceBuilder().build();
+        if (sizeLimit != null && !sizeLimit.isEmpty()) {
+            emptyDirVolumeSource.setSizeLimit(new Quantity(sizeLimit));
+        }
+
         Volume volume = new VolumeBuilder()
             .withName(name)
-                .withNewEmptyDir()
-                    .withNewSizeLimit(sizeLimit == null || sizeLimit.isEmpty() ? null : sizeLimit)
-                .endEmptyDir()
+                .withEmptyDir(emptyDirVolumeSource)
             .build();
         log.trace("Created emptyDir Volume named '{}' with sizeLimit '{}'", name, sizeLimit);
         return volume;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -246,7 +246,7 @@ public class AbstractModelTest {
             }
         };
         Volume volume = am.createEmptyDirVolume("bar", null);
-        Assert.assertNull(volume.getEmptyDir().getSizeLimit().getAmount());
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
     }
 
     @Test
@@ -263,6 +263,6 @@ public class AbstractModelTest {
             }
         };
         Volume volume = am.createEmptyDirVolume("bar", "");
-        Assert.assertNull(volume.getEmptyDir().getSizeLimit().getAmount());
+        Assert.assertNull(volume.getEmptyDir().getSizeLimit());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -302,7 +302,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
         StatefulSet ss = kc.generateStatefulSet(false, null, null);
-        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount());
+        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -976,7 +976,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(ka, VERSIONS);
 
         StatefulSet ss = zc.generateStatefulSet(false, null, null);
-        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount());
+        assertNull(ss.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
After https://github.com/strimzi/strimzi-kafka-operator/pull/2083/ the CO started misbehaving.

```
2019-10-16 10:26:42 DEBUG StatefulSetDiff:99 - StatefulSet myproject/my-cluster-zookeeper differs: {"op":"add","path":"/spec/template/spec/volumes/0/emptyDir/sizeLimit","value":null}
2019-10-16 10:26:42 DEBUG StatefulSetDiff:100 - Current StatefulSet path /spec/template/spec/volumes/0/emptyDir/sizeLimit has value 
2019-10-16 10:26:42 DEBUG StatefulSetDiff:101 - Desired StatefulSet path /spec/template/spec/volumes/0/emptyDir/sizeLimit has value null
```

There was a diff between current and desired STS what caused indefinite rolling of zk and k pods.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

