### PR TITLE
Fix log.message.format.version in our metrics example

### DIFF
--- a/metrics/examples/kafka/kafka-metrics.yaml
+++ b/metrics/examples/kafka/kafka-metrics.yaml
@@ -19,7 +19,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.2"
+      log.message.format.version: "2.3"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like we forgot to update the `log.message.format.version` option in our metrics Kafka example and it is set to `2.2` instead of `2.3`.
