### PR TITLE
Fixed tracing enabled on Kafka Connect and Mirror Maker

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -43,7 +43,6 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnv;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvVarSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
-import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.common.model.Labels;
 
@@ -146,9 +145,13 @@ public class KafkaConnectCluster extends AbstractModel {
         kafkaConnect.tracing = spec.getTracing();
 
         KafkaConnectConfiguration config = new KafkaConnectConfiguration(spec.getConfig().entrySet());
-        if (kafkaConnect.tracing != null && JaegerTracing.TYPE_JAEGER.equals(kafkaConnect.tracing.getType()))   {
-            config.setConfigOption("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
-            config.setConfigOption("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+        if (kafkaConnect.tracing != null)   {
+            if (kafkaConnect.tracing.getType() != null) {
+                config.setConfigOption("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+                config.setConfigOption("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+            } else {
+                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
+            }
         }
         kafkaConnect.setConfiguration(config);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -146,12 +146,8 @@ public class KafkaConnectCluster extends AbstractModel {
 
         KafkaConnectConfiguration config = new KafkaConnectConfiguration(spec.getConfig().entrySet());
         if (kafkaConnect.tracing != null)   {
-            if (kafkaConnect.tracing.getType() != null) {
-                config.setConfigOption("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
-                config.setConfigOption("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
-            } else {
-                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
-            }
+            config.setConfigOption("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+            config.setConfigOption("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
         }
         kafkaConnect.setConfiguration(config);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -352,11 +352,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         KafkaMirrorMakerConsumerConfiguration config = new KafkaMirrorMakerConsumerConfiguration(consumer.getConfig().entrySet());
 
         if (tracing != null) {
-            if (tracing.getType() != null) {
-                config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
-            } else {
-                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
-            }
+            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
         }
 
         return config;
@@ -366,11 +362,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         KafkaMirrorMakerProducerConfiguration config = new KafkaMirrorMakerProducerConfiguration(producer.getConfig().entrySet());
 
         if (tracing != null) {
-            if (tracing.getType() != null) {
-                config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
-            } else {
-                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
-            }
+            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
         }
 
         return config;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -32,7 +32,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerSpec;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.template.KafkaMirrorMakerTemplate;
-import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.common.model.Labels;
 
@@ -352,8 +351,12 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     private KafkaMirrorMakerConsumerConfiguration getConsumerConfiguration()    {
         KafkaMirrorMakerConsumerConfiguration config = new KafkaMirrorMakerConsumerConfiguration(consumer.getConfig().entrySet());
 
-        if (tracing != null && JaegerTracing.TYPE_JAEGER.equals(tracing.getType())) {
-            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+        if (tracing != null) {
+            if (tracing.getType() != null) {
+                config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+            } else {
+                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
+            }
         }
 
         return config;
@@ -362,8 +365,12 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     private KafkaMirrorMakerProducerConfiguration getProducerConfiguration()    {
         KafkaMirrorMakerProducerConfiguration config = new KafkaMirrorMakerProducerConfiguration(producer.getConfig().entrySet());
 
-        if (tracing != null && JaegerTracing.TYPE_JAEGER.equals(tracing.getType())) {
-            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+        if (tracing != null) {
+            if (tracing.getType() != null) {
+                config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+            } else {
+                log.warn("The spec.tracing.type is not specified, tracing won't be enabled");
+            }
         }
 
         return config;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a trivial bug where if tracing is enabled with something which is not "jaeger", it doesn't set the interceptors classes anyway.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

