### PR TITLE
Allow to disable default PDB creation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({
         "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "consumer",
         "producer", "resources", "jvmOptions", "logging",
-        "metrics", "livenessProbe", "readinessProbe", "template"})
+        "metrics", "livenessProbe", "readinessProbe", "template", "enableDefaultPodDisruptionBudget"})
 @EqualsAndHashCode
 public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -50,6 +50,7 @@ public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable 
     private Map<String, Object> metrics;
     private Probe livenessProbe;
     private Probe readinessProbe;
+    private Boolean enableDefaultPodDisruptionBudget = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
     private KafkaBridgeTemplate template;
 
@@ -205,6 +206,16 @@ public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable 
 
     public void setReadinessProbe(Probe readinessProbe) {
         this.readinessProbe = readinessProbe;
+    }
+
+    @Description("Flag to create default pod disruption budget. By default `true`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget == null ? true : enableDefaultPodDisruptionBudget;
+    }
+
+    public void setEnableDefaultPodDisruptionBudget(Boolean enableDefaultPodDisruptionBudget) {
+        this.enableDefaultPodDisruptionBudget = enableDefaultPodDisruptionBudget;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -41,7 +41,7 @@ import java.util.Map;
         "affinity", "tolerations",
         "livenessProbe", "readinessProbe",
         "jvmOptions", "resources",
-        "metrics", "logging", "tlsSidecar", "template"})
+        "metrics", "logging", "tlsSidecar", "template", "enableDefaultPodDisruptionBudget"})
 @EqualsAndHashCode
 public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -77,6 +77,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
     private KafkaListeners listeners;
     private KafkaAuthorization authorization;
     private KafkaClusterTemplate template;
+    private Boolean enableDefaultPodDisruptionBudget = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The kafka broker version. Defaults to {DefaultKafkaVersion}. " +
@@ -268,6 +269,16 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
 
     public void setAuthorization(KafkaAuthorization authorization) {
         this.authorization = authorization;
+    }
+
+    @Description("Flag to create default pod disruption budget. By default `true`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget == null ? true : enableDefaultPodDisruptionBudget;
+    }
+
+    public void setEnableDefaultPodDisruptionBudget(Boolean enableDefaultPodDisruptionBudget) {
+        this.enableDefaultPodDisruptionBudget = enableDefaultPodDisruptionBudget;
     }
 
     @Description("Template for Kafka cluster resources. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "replicas", "image",
         "livenessProbe", "readinessProbe", "jvmOptions",
-        "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
+        "affinity", "tolerations", "logging", "metrics", "tracing", "template", "enableDefaultPodDisruptionBudget"})
 @EqualsAndHashCode(doNotUseGetters = true)
 public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving {
 
@@ -63,6 +63,7 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
     private KafkaClientAuthentication authentication;
     private KafkaConnectTemplate template;
     private ExternalConfiguration externalConfiguration;
+    private Boolean enableDefaultPodDisruptionBudget = true;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -253,6 +254,16 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
 
     public void setExternalConfiguration(ExternalConfiguration externalConfiguration) {
         this.externalConfiguration = externalConfiguration;
+    }
+
+    @Description("Flag to create default pod disruption budget. By default `true`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget == null ? true : enableDefaultPodDisruptionBudget;
+    }
+
+    public void setEnableDefaultPodDisruptionBudget(Boolean enableDefaultPodDisruptionBudget) {
+        this.enableDefaultPodDisruptionBudget = enableDefaultPodDisruptionBudget;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
         "replicas", "image", "whitelist",
         "consumer", "producer", "resources",
         "affinity", "tolerations", "jvmOptions",
-        "logging", "metrics", "tracing", "template"})
+        "logging", "metrics", "tracing", "template", "enableDefaultPodDisruptionBudget"})
 @EqualsAndHashCode
 public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -56,6 +56,7 @@ public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializ
     private Map<String, Object> metrics;
     private Tracing tracing;
     private KafkaMirrorMakerTemplate template;
+    private Boolean enableDefaultPodDisruptionBudget = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The number of pods in the `Deployment`.")
@@ -228,6 +229,16 @@ public class KafkaMirrorMakerSpec implements UnknownPropertyPreserving, Serializ
 
     public void setTemplate(KafkaMirrorMakerTemplate template) {
         this.template = template;
+    }
+
+    @Description("Flag to create default pod disruption budget. By default `true`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget == null ? true : enableDefaultPodDisruptionBudget;
+    }
+
+    public void setEnableDefaultPodDisruptionBudget(Boolean enableDefaultPodDisruptionBudget) {
+        this.enableDefaultPodDisruptionBudget = enableDefaultPodDisruptionBudget;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -38,7 +38,7 @@ import java.util.Map;
         "affinity", "tolerations",
         "livenessProbe", "readinessProbe",
         "jvmOptions", "resources",
-         "metrics", "logging", "tlsSidecar", "template"})
+         "metrics", "logging", "tlsSidecar", "template", "enableDefaultPodDisruptionBudget"})
 @EqualsAndHashCode
 public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -64,6 +64,7 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
     private Map<String, Object> metrics;
     private Affinity affinity;
     private List<Toleration> tolerations;
+    private Boolean enableDefaultPodDisruptionBudget = true;
     private ZookeeperClusterTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -203,6 +204,16 @@ public class ZookeeperClusterSpec implements UnknownPropertyPreserving, Serializ
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    @Description("Flag to create default pod disruption budget. By default `true`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget == null ? true : enableDefaultPodDisruptionBudget;
+    }
+
+    public void setEnableDefaultPodDisruptionBudget(Boolean enableDefaultPodDisruptionBudget) {
+        this.enableDefaultPodDisruptionBudget = enableDefaultPodDisruptionBudget;
     }
 
     @Description("Template for Zookeeper cluster resources. " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -149,6 +149,8 @@ public abstract class AbstractModel {
     private Logging logging;
     protected boolean gcLoggingEnabled = true;
 
+    protected boolean enableDefaultPodDisruptionBudget = true;
+
     // Templates
     protected Map<String, String> templateStatefulSetLabels;
     protected Map<String, String> templateStatefulSetAnnotations;
@@ -264,6 +266,13 @@ public abstract class AbstractModel {
      */
     public boolean isMetricsEnabled() {
         return isMetricsEnabled;
+    }
+
+    /**
+     * @return Whether enableDefaultPodDisruptionBudget is enabled.
+     */
+    public boolean isEnableDefaultPodDisruptionBudget() {
+        return enableDefaultPodDisruptionBudget;
     }
 
     protected void setMetricsEnabled(boolean isMetricsEnabled) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -198,6 +198,8 @@ public class KafkaBridgeCluster extends AbstractModel {
         }
         kafkaBridgeCluster.setOwnerReference(kafkaBridge);
 
+        kafkaBridgeCluster.enableDefaultPodDisruptionBudget = spec.getEnableDefaultPodDisruptionBudget();
+
         return kafkaBridgeCluster;
     }
     

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -550,6 +550,7 @@ public class KafkaCluster extends AbstractModel {
         }
 
         result.kafkaVersion = versions.version(kafkaClusterSpec.getVersion());
+        result.enableDefaultPodDisruptionBudget = kafkaClusterSpec.getEnableDefaultPodDisruptionBudget();
         return result;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -215,6 +215,8 @@ public class KafkaConnectCluster extends AbstractModel {
             }
         }
 
+        kafkaConnect.enableDefaultPodDisruptionBudget = spec.getEnableDefaultPodDisruptionBudget();
+
         return kafkaConnect;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -193,6 +193,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
         kafkaMirrorMakerCluster.setOwnerReference(kafkaMirrorMaker);
 
+        kafkaMirrorMakerCluster.enableDefaultPodDisruptionBudget = spec.getEnableDefaultPodDisruptionBudget();
+
         return kafkaMirrorMakerCluster;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -284,6 +284,8 @@ public class ZookeeperCluster extends AbstractModel {
             ModelUtils.parsePodDisruptionBudgetTemplate(zk, template.getPodDisruptionBudget());
         }
 
+        zk.enableDefaultPodDisruptionBudget = zookeeperClusterSpec.getEnableDefaultPodDisruptionBudget();
+
         return zk;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1132,7 +1132,11 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkPodDisruptionBudget() {
-            return withVoid(podDisruptionBudgetOperator.reconcile(namespace, zkCluster.getName(), zkCluster.generatePodDisruptionBudget()));
+            if (zkCluster.isEnableDefaultPodDisruptionBudget()) {
+                return withVoid(podDisruptionBudgetOperator.reconcile(namespace, zkCluster.getName(), zkCluster.generatePodDisruptionBudget()));
+            } else {
+                return withVoid(Future.succeededFuture());
+            }
         }
 
         Future<ReconciliationState> zkStatefulSet() {
@@ -1715,7 +1719,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaPodDisruptionBudget() {
-            return withVoid(podDisruptionBudgetOperator.reconcile(namespace, kafkaCluster.getName(), kafkaCluster.generatePodDisruptionBudget()));
+            if (kafkaCluster.isEnableDefaultPodDisruptionBudget()) {
+                return withVoid(podDisruptionBudgetOperator.reconcile(namespace, kafkaCluster.getName(), kafkaCluster.generatePodDisruptionBudget()));
+            } else return withVoid(Future.succeededFuture());
         }
 
         int getPodIndexFromPvcName(String pvcName)  {

--- a/documentation/book/appendix_crds.adoc
+++ b/documentation/book/appendix_crds.adoc
@@ -49,48 +49,50 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 [options="header"]
 |====
-|Property                    |Description
-|replicas             1.2+<.<|The number of pods in the cluster.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the cluster.
 |integer
-|image                1.2+<.<|The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
+|image                             1.2+<.<|The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.
 |string
-|storage              1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim, jbod].
+|storage                           1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim, jbod].
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`], xref:type-JbodStorage-{context}[`JbodStorage`]
-|listeners            1.2+<.<|Configures listeners of Kafka brokers.
+|listeners                         1.2+<.<|Configures listeners of Kafka brokers.
 |xref:type-KafkaListeners-{context}[`KafkaListeners`]
-|authorization        1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
+|authorization                     1.2+<.<|Authorization configuration for Kafka brokers. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
 |xref:type-KafkaAuthorizationSimple-{context}[`KafkaAuthorizationSimple`]
-|config               1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user.
+|config                            1.2+<.<|The kafka broker config. Properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., principal.builder.class, log.dir, zookeeper.connect, zookeeper.set.acl, authorizer., super.user.
 |map
-|rack                 1.2+<.<|Configuration of the `broker.rack` broker config.
+|rack                              1.2+<.<|Configuration of the `broker.rack` broker config.
 |xref:type-Rack-{context}[`Rack`]
-|brokerRackInitImage  1.2+<.<|The image of the init container used for initializing the `broker.rack`.
+|brokerRackInitImage               1.2+<.<|The image of the init container used for initializing the `broker.rack`.
 |string
-|affinity             1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.kafka.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity                          1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.kafka.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|tolerations          1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.kafka.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations                       1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.kafka.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|livenessProbe        1.2+<.<|Pod liveness checking.
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe       1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions           1.2+<.<|JVM Options for pods.
+|jvmOptions                        1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|resources            1.2+<.<|CPU and memory resources to reserve.
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|metrics              1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
+|metrics                           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|logging              1.2+<.<|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|tlsSidecar           1.2+<.<|TLS sidecar configuration.
+|tlsSidecar                        1.2+<.<|TLS sidecar configuration.
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
-|template             1.2+<.<|Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
+|template                          1.2+<.<|Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
 |xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
-|version              1.2+<.<|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
+|boolean
+|version                           1.2+<.<|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
 
@@ -917,39 +919,41 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 [options="header"]
 |====
-|Property               |Description
-|replicas        1.2+<.<|The number of pods in the cluster.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the cluster.
 |integer
-|image           1.2+<.<|The docker image for the pods.
+|image                             1.2+<.<|The docker image for the pods.
 |string
-|storage         1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
+|storage                           1.2+<.<|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
-|config          1.2+<.<|The zookeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme.
+|config                            1.2+<.<|The zookeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme.
 |map
-|affinity        1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.zookeeper.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity                          1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.zookeeper.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|tolerations     1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.zookeeper.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations                       1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.zookeeper.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions      1.2+<.<|JVM Options for pods.
+|jvmOptions                        1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|resources       1.2+<.<|CPU and memory resources to reserve.
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|metrics         1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
+|metrics                           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|logging         1.2+<.<|Logging configuration for Zookeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Zookeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|tlsSidecar      1.2+<.<|TLS sidecar configuration.
+|tlsSidecar                        1.2+<.<|TLS sidecar configuration.
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
-|template        1.2+<.<|Template for Zookeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
+|template                          1.2+<.<|Template for Zookeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
 |xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
+|boolean
 |====
 
 [id='type-ZookeeperClusterTemplate-{context}']
@@ -1294,46 +1298,48 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 
 [options="header"]
 |====
-|Property                      |Description
-|replicas               1.2+<.<|The number of pods in the Kafka Connect group.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
-|image                  1.2+<.<|The docker image for the pods.
+|image                             1.2+<.<|The docker image for the pods.
 |string
-|livenessProbe          1.2+<.<|Pod liveness checking.
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe         1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions             1.2+<.<|JVM Options for pods.
+|jvmOptions                        1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|affinity               1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity                          1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|tolerations            1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations                       1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|logging                1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics                1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
+|metrics                           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|tracing                1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                           1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
+|template                          1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
+|boolean
+|authentication                    1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|bootstrapServers                  1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|config                            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
 |map
-|externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|externalConfiguration             1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|resources              1.2+<.<|CPU and memory resources to reserve.
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|tls                    1.2+<.<|TLS configuration.
+|tls                               1.2+<.<|TLS configuration.
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
-|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version                           1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
 
@@ -1614,48 +1620,50 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 
 [options="header"]
 |====
-|Property                         |Description
-|replicas                  1.2+<.<|The number of pods in the Kafka Connect group.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
-|image                     1.2+<.<|The docker image for the pods.
+|image                             1.2+<.<|The docker image for the pods.
 |string
-|livenessProbe             1.2+<.<|Pod liveness checking.
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe            1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|jvmOptions                1.2+<.<|JVM Options for pods.
+|jvmOptions                        1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|affinity                  1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity                          1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|logging                   1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Kafka Connect. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics                   1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
+|metrics                           1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|template                  1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
+|template                          1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication                    1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|bootstrapServers          1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|bootstrapServers                  1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
-|config                    1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|config                            1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
 |map
-|externalConfiguration     1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-|xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|insecureSourceRepository  1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
 |boolean
-|resources                 1.2+<.<|CPU and memory resources to reserve.
+|externalConfiguration             1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
+|insecureSourceRepository          1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
+|boolean
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|tls                       1.2+<.<|TLS configuration.
+|tls                               1.2+<.<|TLS configuration.
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
-|tolerations               1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations                       1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|tracing                   1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                           1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|version                   1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version                           1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
 
@@ -1931,42 +1939,44 @@ Used in: xref:type-KafkaMirrorMaker-{context}[`KafkaMirrorMaker`]
 
 [options="header"]
 |====
-|Property               |Description
-|replicas        1.2+<.<|The number of pods in the `Deployment`.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the `Deployment`.
 |integer
-|image           1.2+<.<|The docker image for the pods.
+|image                             1.2+<.<|The docker image for the pods.
 |string
-|whitelist       1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
+|whitelist                         1.2+<.<|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the whitelist `'A\|B'`. Or, as a special case, you can mirror all topics using the whitelist '*'. You can also specify multiple regular expressions separated by commas.
 |string
-|consumer        1.2+<.<|Configuration of source cluster.
+|consumer                          1.2+<.<|Configuration of source cluster.
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]
-|producer        1.2+<.<|Configuration of target cluster.
+|producer                          1.2+<.<|Configuration of target cluster.
 |xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
-|resources       1.2+<.<|CPU and memory resources to reserve.
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|affinity        1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
+|affinity                          1.2+<.<|*The property `affinity` has been deprecated. This feature should now be configured at path `spec.template.pod.affinity`.* The pod's affinity rules. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[core/v1 affinity].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
-|tolerations     1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
+|tolerations                       1.2+<.<|*The property `tolerations` has been deprecated. This feature should now be configured at path `spec.template.pod.tolerations`.* The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
-|jvmOptions      1.2+<.<|JVM Options for pods.
+|jvmOptions                        1.2+<.<|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging         1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Mirror Maker. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics         1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
+|metrics                           1.2+<.<|The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
 |map
-|tracing         1.2+<.<|The configuration of tracing in Kafka Mirror Maker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing                           1.2+<.<|The configuration of tracing in Kafka Mirror Maker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template        1.2+<.<|Template to specify how Kafka Mirror Maker resources, `Deployments` and `Pods`, are generated.
+|template                          1.2+<.<|Template to specify how Kafka Mirror Maker resources, `Deployments` and `Pods`, are generated.
 |xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
-|livenessProbe   1.2+<.<|Pod liveness checking.
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
+|boolean
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe  1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|version         1.2+<.<|The Kafka Mirror Maker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
+|version                           1.2+<.<|The Kafka Mirror Maker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
 
@@ -2085,37 +2095,39 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 
 [options="header"]
 |====
-|Property                 |Description
-|replicas          1.2+<.<|The number of pods in the `Deployment`.
+|Property                                 |Description
+|replicas                          1.2+<.<|The number of pods in the `Deployment`.
 |integer
-|image             1.2+<.<|The docker image for the pods.
+|image                             1.2+<.<|The docker image for the pods.
 |string
-|bootstrapServers  1.2+<.<|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+|bootstrapServers                  1.2+<.<|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
 |string
-|tls               1.2+<.<|TLS configuration for connecting Kafka Bridge to the cluster.
+|tls                               1.2+<.<|TLS configuration for connecting Kafka Bridge to the cluster.
 |xref:type-KafkaBridgeTls-{context}[`KafkaBridgeTls`]
-|authentication    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|authentication                    1.2+<.<|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|http              1.2+<.<|The HTTP related configuration.
+|http                              1.2+<.<|The HTTP related configuration.
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
-|consumer          1.2+<.<|Kafka consumer related configuration.
+|consumer                          1.2+<.<|Kafka consumer related configuration.
 |xref:type-KafkaBridgeConsumerSpec-{context}[`KafkaBridgeConsumerSpec`]
-|producer          1.2+<.<|Kafka producer related configuration.
+|producer                          1.2+<.<|Kafka producer related configuration.
 |xref:type-KafkaBridgeProducerSpec-{context}[`KafkaBridgeProducerSpec`]
-|resources         1.2+<.<|CPU and memory resources to reserve.
+|resources                         1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|jvmOptions        1.2+<.<|**Currently not supported** JVM Options for pods.
+|jvmOptions                        1.2+<.<|**Currently not supported** JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging           1.2+<.<|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging                           1.2+<.<|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|metrics           1.2+<.<|**Currently not supported** The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
+|metrics                           1.2+<.<|**Currently not supported** The Prometheus JMX Exporter configuration. See {JMXExporter} for details of the structure of this configuration.
 |map
-|livenessProbe     1.2+<.<|Pod liveness checking.
+|livenessProbe                     1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe    1.2+<.<|Pod readiness checking.
+|readinessProbe                    1.2+<.<|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|template          1.2+<.<|Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
+|template                          1.2+<.<|Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
+|enableDefaultPodDisruptionBudget  1.2+<.<|Flag to create default pod disruption budget. By default `true`.
+|boolean
 |====
 
 [id='type-KafkaBridgeTls-{context}']

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1308,6 +1308,8 @@ spec:
                                 type: string
                               value:
                                 type: string
+                enableDefaultPodDisruptionBudget:
+                  type: boolean
                 version:
                   type: string
               required:
@@ -2066,6 +2068,8 @@ spec:
                                 type: string
                               value:
                                 type: string
+                enableDefaultPodDisruptionBudget:
+                  type: boolean
               required:
               - replicas
               - storage

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -665,6 +665,8 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            enableDefaultPodDisruptionBudget:
+              type: boolean
             authentication:
               type: object
               properties:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -730,6 +730,8 @@ spec:
               type: string
             config:
               type: object
+            enableDefaultPodDisruptionBudget:
+              type: boolean
             externalConfiguration:
               type: object
               properties:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -873,6 +873,8 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            enableDefaultPodDisruptionBudget:
+              type: boolean
             livenessProbe:
               type: object
               properties:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -561,6 +561,8 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            enableDefaultPodDisruptionBudget:
+              type: boolean
           required:
           - bootstrapServers
         status:


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Strimzi provides <cluster>-kafka and <cluster>-zookeeper podDisruptionBudget as following. However, there should be a way to disable this default podDisruptionBudget.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

