### PR TITLE
Remove year from copyright headers

### DIFF
--- a/.checkstyle/java.header
+++ b/.checkstyle/java.header
@@ -1,4 +1,4 @@
 ^/\*
-^ \* Copyright (20\d\d-)?20\d\d, Strimzi authors.
+^ \* Copyright Strimzi authors.
 ^ \* License: Apache License 2\.0 \(see the file LICENSE or http://apache\.org/licenses/LICENSE-2\.0\.html\)\.
 ^ \*/

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaBridgeList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaBridgeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaConnectList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaConnectList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaConnectS2IList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaConnectS2IList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaMirrorMakerList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaMirrorMakerList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaTopicList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaTopicList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaUserList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaUserList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclOperation.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclResourcePatternType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclResourcePatternType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertAndKeySecretSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertSecretSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateAuthority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/CertificateExpirationPolicy.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CertificateExpirationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ContainerEnvVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorJvmOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/GenericSecretSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeClientSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeConsumerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeProducerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2IResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2ISpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerClientSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerConsumerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerProducerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopicSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorizationSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserScramSha512ClientAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Logging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/PasswordSecretSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Sidecar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsClientAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecarLogLevel.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecarLogLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/UnknownPropertyPreserving.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/UnknownPropertyPreserving.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationPlain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.connect;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.connect;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.connect;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.connect;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBootstrapOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/ExternalListenerBrokerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerBrokerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/IngressListenerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationScramSha512.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerPlain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerTls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListeners.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBootstrapOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerBrokerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/LoadBalancerListenerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBootstrapOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerBrokerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerBootstrapOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerBootstrapOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerBrokerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerBrokerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/RouteListenerOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.listener;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaBridgeStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMakerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaUserStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaUserStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/JbodStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/SingleVolumeStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/SingleVolumeStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ContainerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaExporterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaExporterTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMakerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/MetadataTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ResourceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ResourceTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.tracing;

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.tracing;

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model;

--- a/api/src/test/java/io/strimzi/test/CronTest.java
+++ b/api/src/test/java/io/strimzi/test/CronTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test;

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertAndKey.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertAndKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.certs;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/KafkaUpgradeException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/KafkaUpgradeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ImagePullPolicy.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ImagePullPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaUpgrade.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaUpgrade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoCertificateSecretException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoCertificateSecretException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoImageException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoImageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/OrderedProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/OrderedPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.resource;

--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.build.kafka.metadata;

--- a/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModel.java
+++ b/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.config.model;

--- a/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModels.java
+++ b/config-model/src/main/java/io/strimzi/kafka/config/model/ConfigModels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.config.model;

--- a/config-model/src/main/java/io/strimzi/kafka/config/model/Scope.java
+++ b/config-model/src/main/java/io/strimzi/kafka/config/model/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.config.model;

--- a/config-model/src/main/java/io/strimzi/kafka/config/model/Type.java
+++ b/config-model/src/main/java/io/strimzi/kafka/config/model/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.config.model;

--- a/config-model/src/test/java/ConfigModelTest.java
+++ b/config-model/src/test/java/ConfigModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/KubeLinker.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/KubeLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Linker.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Linker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/OpenShiftOriginLinker.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/OpenShiftOriginLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Schema.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Description.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/DescriptionFile.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/DescriptionFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Example.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/KubeLink.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/KubeLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Maximum.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Maximum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Minimum.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Minimum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Pattern.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Pattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Type.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator.annotations;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdTestUtils.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CustomisedEnum.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CustomisedEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/NormalEnum.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/NormalEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/PropertyTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/PropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.crdgenerator;

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.agent;

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/BrokerAddress.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/BrokerAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/BrokerAddressTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/BrokerAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.init;

--- a/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
+++ b/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.mirrormaker.agent;

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.mockkube;

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.io.strimzi.test.mockkube;

--- a/operator-common/src/main/java/io/strimzi/operator/KubernetesVersion.java
+++ b/operator-common/src/main/java/io/strimzi/operator/KubernetesVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator;

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/InvalidResourceException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/InvalidResourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.model;

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/BackOff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/InvalidConfigParameterException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InvalidConfigParameterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/InvalidConfigurationException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InvalidConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/MaxAttemptsExceededException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MaxAttemptsExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/NamespaceAndName.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/NamespaceAndName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ValidationVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ValidationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableResourceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/EndpointOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/EndpointOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ImageStreamOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ImageStreamOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ReconcileResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/SecretOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/SecretOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StorageClassOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StorageClassOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/TimeoutException.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/TimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/main/java/io/strimzi/operator/common/process/ProcessHelper.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/process/ProcessHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.process;

--- a/operator-common/src/test/java/io/strimzi/operator/KubernetesVersionTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/KubernetesVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator;

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator;

--- a/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/BackOffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common;

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/NamespaceAndNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ResourceVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ResourceVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.model;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbtractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbtractReadyResourceOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleBindingOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ScalableResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ScalableResourceOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/StorageClassOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.common.operator.resource;

--- a/operator-common/src/test/java/io/strimzi/test/logging/TestLogger.java
+++ b/operator-common/src/test/java/io/strimzi/test/logging/TestLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.logging;

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/HttpBridgeBaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/HttpBridgeBaseST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/MessagingBaseST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/OpenShiftOnly.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/OpenShiftOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.annotations;

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/OpenShiftOnlyCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/OpenShiftOnlyCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.annotations;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientArgument.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.api;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientArgumentMap.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientArgumentMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.api;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/ClientType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.api;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/api/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/api/VerifiableClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.api;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/ClientHandlerBase.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/ClientHandlerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.lib;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/Consumer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.lib;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.lib;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.lib;

--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/Producer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/Producer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.clients.lib;

--- a/systemtest/src/main/java/io/strimzi/systemtest/interfaces/ExtensionContextParameterResolver.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/interfaces/ExtensionContextParameterResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.interfaces;

--- a/systemtest/src/main/java/io/strimzi/systemtest/interfaces/TestSeparator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/interfaces/TestSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.interfaces;

--- a/systemtest/src/main/java/io/strimzi/systemtest/k8s/Events.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/k8s/Events.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.k8s;

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.listeners;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasAllOfReasons.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasAllOfReasons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.matchers;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasAnyOfReasons.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasAnyOfReasons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.matchers;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasNoneOfReasons.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/HasNoneOfReasons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.matchers;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.matchers;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/Matchers.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/Matchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.matchers;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/BridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/BridgeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.utils;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.utils;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/LogCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.utils;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.utils;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestExecutionWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.utils;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/HelmChartST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMakerST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MultipleNamespaceST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.bridge;

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.bridge;

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.bridge;

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.metrics;

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/PrometheusST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.metrics;

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.oauth;

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.oauth;

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.oauth;

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.specific;

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.systemtest.tracing;

--- a/test/src/main/java/io/strimzi/test/BaseITST.java
+++ b/test/src/main/java/io/strimzi/test/BaseITST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test;

--- a/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
+++ b/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test;

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test;

--- a/test/src/main/java/io/strimzi/test/TimeoutException.java
+++ b/test/src/main/java/io/strimzi/test/TimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test;

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.executor;

--- a/test/src/main/java/io/strimzi/test/executor/ExecResult.java
+++ b/test/src/main/java/io/strimzi/test/executor/ExecResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.executor;

--- a/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/Helm.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Helm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterException.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/Kubectl.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Kubectl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/Minikube.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Minikube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/Minishift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Minishift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/NoClusterException.java
+++ b/test/src/main/java/io/strimzi/test/k8s/NoClusterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/Oc.java
+++ b/test/src/main/java/io/strimzi/test/k8s/Oc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.test.k8s;

--- a/test/src/main/java/io/strimzi/test/timemeasuring/Operation.java
+++ b/test/src/main/java/io/strimzi/test/timemeasuring/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/test/src/main/java/io/strimzi/test/timemeasuring/TimeMeasuringSystem.java
+++ b/test/src/main/java/io/strimzi/test/timemeasuring/TimeMeasuringSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/InvalidTopicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8s.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Kafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Labels.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Labels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/LogContext.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/LogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/OperatorException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/OperatorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ResourceName.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ResourceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicConfigsWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadata.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicMetadataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TransientOperatorException.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TransientOperatorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicsWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/AclBuilder.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/AclBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic.zk;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic.zk;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic.zk;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/LabelsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/LabelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockK8s.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicStore.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockZk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicBuilderTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicDiffTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicNameTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/Utils.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicsWatcherTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicsWatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/zk/ZkImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic.zk;

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/TracingAgent.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/TracingAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.tracing.agent;

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user;

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user;

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/NoCertificateSecretException.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/NoCertificateSecretException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model.acl;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model.acl;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceType.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model.acl;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/PasswordGenerator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/PasswordGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentialsOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user;

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user;

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model;

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model.acl;

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.model.acl;

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/PasswordGeneratorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/PasswordGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramShaCredentialsTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramShaCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Strimzi authors.
+ * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.user.operator;


### PR DESCRIPTION
Since it's come up a few times recently, this PR removes the year from the copyright headers in source files.