### PR TITLE
Refactor MockKube and fix a problem with pod recreation.

### DIFF
--- a/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/CustomResourceMockBuilder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+class CustomResourceMockBuilder<T extends CustomResource, L extends KubernetesResource & KubernetesResourceList<T>, D extends Doneable<T>> extends MockBuilder<T, L, D, Resource<T, D>> {
+    public CustomResourceMockBuilder(MockKube.MockedCrd<T, L, D> mockedCrd) {
+        super(mockedCrd.getCrClass(), mockedCrd.getCrListClass(), mockedCrd.getCrDoneableClass(), castClass(Resource.class), mockedCrd.getInstances());
+    }
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatusBuilder;
+import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, DoneableDeployment, RollableScalableResource<Deployment,
+                DoneableDeployment>> {
+    private static final Logger LOGGER = LogManager.getLogger(DeploymentMockBuilder.class);
+
+    private final MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods;
+    private Map<String, List<String>> podsForDeployments = new HashMap<>();
+
+    public DeploymentMockBuilder(Map<String, Deployment> depDb, MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods) {
+        super(Deployment.class, DeploymentList.class, DoneableDeployment.class, castClass(RollableScalableResource.class), depDb);
+        this.mockPods = mockPods;
+    }
+
+    @Override
+    protected void mockCreate(String resourceName, RollableScalableResource<Deployment, DoneableDeployment> resource) {
+        when(resource.create(any())).thenAnswer(invocation -> {
+            checkNotExists(resourceName);
+            Deployment deployment = invocation.getArgument(0);
+            LOGGER.debug("create {} {} -> {}", resourceType, resourceName, deployment);
+            deployment.getMetadata().setGeneration(Long.valueOf(0));
+            deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());
+            db.put(resourceName, copyResource(deployment));
+            for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
+                String uuid = UUID.randomUUID().toString();
+                String podName = deployment.getMetadata().getName() + "-" + uuid;
+                LOGGER.debug("create Pod {} because it's in Deployment {}", podName, resourceName);
+                Pod pod = new PodBuilder()
+                        .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
+                            .withUid(uuid)
+                            .withNamespace(deployment.getMetadata().getNamespace())
+                            .withName(podName)
+                        .endMetadata()
+                        .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
+                        .build();
+                mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podName).create(pod);
+                podsForDeployments.compute(deployment.getMetadata().getName(), (deploymentName, podsInDeployment) -> {
+                    if (podsInDeployment == null) {
+                        podsInDeployment = new ArrayList<>(2);
+                    }
+                    podsInDeployment.add(podName);
+                    return podsInDeployment;
+                });
+            }
+            return deployment;
+        });
+    }
+
+    @Override
+    protected void mockPatch(String resourceName, RollableScalableResource<Deployment, DoneableDeployment> resource) {
+        when(resource.patch(any())).thenAnswer(invocation -> {
+            Deployment deployment = invocation.getArgument(0);
+            deployment.getMetadata().setGeneration(Long.valueOf(0));
+            deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());
+            LOGGER.debug("patched {} {} -> {}", resourceType, resourceName, deployment);
+            db.put(resourceName, copyResource(deployment));
+            List<String> newPodNames = new ArrayList<>();
+            for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
+                // create a "new" Pod
+                String uuid = UUID.randomUUID().toString();
+                String newPodName = deployment.getMetadata().getName() + "-" + uuid;
+
+                Pod newPod = new PodBuilder()
+                        .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
+                            .withUid(uuid)
+                            .withNamespace(deployment.getMetadata().getNamespace())
+                            .withName(newPodName)
+                        .endMetadata()
+                        .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
+                        .build();
+                mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(newPodName).create(newPod);
+                newPodNames.add(newPodName);
+
+                // delete the first one "old" Pod
+                String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
+                mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
+            }
+            podsForDeployments.get(deployment.getMetadata().getName()).addAll(newPodNames);
+
+            return deployment;
+        });
+    }
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Partially mocks the Fabric8 API for a given resource type.
+ * Essentially this mocks some/most of the calls from the fabric 8 Kubernetes client API which look like:
+ * <pre><code>
+ *   ...inNamespace(namespace).{doThing()}
+ *   ...inNamespace(namespace).withName(name).{doThing()}
+ * </code></pre>
+ *
+ * @param <T> The resource type (e.g. Pod)
+ * @param <L> The list type (e.g. PodList)
+ * @param <D> The doneable type (e.g. DoneablePod)
+ * @param <R> The resource type (e.g. Resource, or ScalableResource)
+ */
+class MockBuilder<T extends HasMetadata,
+        L extends KubernetesResource/*<T>*/ & KubernetesResourceList/*<T>*/,
+        D extends Doneable<T>,
+        R extends Resource<T, D>> {
+
+    /**
+     * This method is just used to appease javac and avoid having a very ugly "double cast" (cast to raw Class,
+     * followed by a cast to parameterised Class) in all the calls to
+     * {@link MockBuilder#MockBuilder(Class, Class, Class, Class, Map)}
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T extends HasMetadata, D extends Doneable<T>, R extends Resource<T, D>, R2 extends Resource> Class<R> castClass(Class<R2> c) {
+        return (Class) c;
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(MockBuilder.class);
+
+    protected final Class<T> resourceTypeClass;
+    protected final Class<L> listClass;
+    protected final Class<D> doneableClass;
+    protected final Class<R> resourceClass;
+    /** In-memory database of resource name to resource instance */
+    protected final Map<String, T> db;
+    protected final String resourceType;
+    protected final Collection<PredicatedWatcher<T>> watchers = Collections.synchronizedList(new ArrayList<>(2));
+    private List<Observer<T>> observers = null;
+
+    public MockBuilder(Class<T> resourceTypeClass, Class<L> listClass, Class<D> doneableClass,
+                       Class<R> resourceClass, Map<String, T> db) {
+        this.resourceTypeClass = resourceTypeClass;
+        this.resourceType = resourceTypeClass.getSimpleName();
+        this.doneableClass = doneableClass;
+        this.resourceClass = resourceClass;
+        this.db = db;
+        this.listClass = listClass;
+    }
+
+    public MockBuilder<T, L, D, R> addObserver(Observer<T> observer) {
+        if (observers == null) {
+            observers = new ArrayList<>();
+        }
+        this.observers.add(observer);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected T copyResource(T resource) {
+        if (resource == null) {
+            return null;
+        }
+        try {
+            D doneableInstance = doneableClass.getDeclaredConstructor(resourceTypeClass).newInstance(resource);
+            return (T) Doneable.class.getMethod("done").invoke(doneableInstance);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Generate a stateful mock for CRUD-like interactions.
+     * @return The mock
+     */
+    @SuppressWarnings("unchecked")
+    public MixedOperation<T, L, D, R> build() {
+        MixedOperation<T, L, D, R> mixed = mock(MixedOperation.class);
+
+        when(mixed.inNamespace(any())).thenReturn(mixed);
+        when(mixed.list()).thenAnswer(i -> mockList(p -> true));
+        when(mixed.withLabels(any())).thenAnswer(i -> {
+            MixedOperation<T, L, D, R> mixedWithLabels = mock(MixedOperation.class);
+            Map<String, String> labels = i.getArgument(0);
+            when(mixedWithLabels.list()).thenAnswer(i2 -> mockList(p -> {
+                Map<String, String> m = new HashMap(p.getMetadata().getLabels());
+                m.keySet().retainAll(labels.keySet());
+                return labels.equals(m);
+            }));
+            return mixedWithLabels;
+        });
+        when(mixed.withName(any())).thenAnswer(invocation -> {
+            String resourceName = invocation.getArgument(0);
+            R resource = mock(resourceClass);
+            nameScopedMocks(resourceName, resource);
+            return resource;
+        });
+        when(mixed.watch(any())).thenAnswer(i -> {
+            Watcher watcher = i.getArgument(0);
+            LOGGER.debug("Watcher {} installed on {}", watcher, mixed);
+            return addWatcher(PredicatedWatcher.watcher(watcher));
+        });
+        when(mixed.create(any())).thenAnswer(i -> {
+            T resource = i.getArgument(0);
+            String resourceName = resource.getMetadata().getName();
+            return doCreate(resourceName, resource);
+        });
+        when(mixed.createNew()).thenReturn(doneable(mixed::create));
+        when(mixed.createOrReplace(any())).thenAnswer(i -> {
+            T resource = i.getArgument(0);
+            String resourceName = resource.getMetadata().getName();
+            if (db.containsKey(resourceName)) {
+                return mixed.withName(resourceName).patch(resource);
+            } else {
+                return doCreate(resourceName, resource);
+            }
+        });
+        when(mixed.createOrReplaceWithNew()).thenReturn(doneable(mixed::createOrReplace));
+        when(mixed.delete(ArgumentMatchers.<T[]>any())).thenAnswer(i -> {
+            T resource = i.getArgument(0);
+            String resourceName = resource.getMetadata().getName();
+            return doDelete(resourceName);
+        });
+        when(mixed.withLabel(any())).thenAnswer(i -> {
+            String label = i.getArgument(0);
+            return mockWithLabel(label);
+        });
+        when(mixed.withLabel(any(), any())).thenAnswer(i -> {
+            String label = i.getArgument(0);
+            String value = i.getArgument(1);
+            return mockWithLabels(singletonMap(label, value));
+        });
+        when(mixed.withLabels(any())).thenAnswer(i -> {
+            Map<String, String> labels = i.getArgument(0);
+            return mockWithLabels(labels);
+        });
+        return mixed;
+    }
+
+    D doneable(io.fabric8.kubernetes.api.builder.Function<T, T> f) {
+        try {
+            Constructor<D> declaredConstructor = doneableClass.getDeclaredConstructor(io.fabric8.kubernetes.api.builder.Function.class);
+            return declaredConstructor.newInstance(f);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public MixedOperation<T, L, D, R> build2(Supplier<MixedOperation<T, L, D, R>> x) {
+        MixedOperation<T, L, D, R> build = build();
+        when(x.get()).thenReturn(build);
+        return build;
+    }
+
+    MixedOperation<T, L, D, R> mockWithLabels(Map<String, String> labels) {
+        return mockWithLabelPredicate(p -> {
+            Map<String, String> m = new HashMap<>(p.getMetadata().getLabels());
+            m.keySet().retainAll(labels.keySet());
+            return labels.equals(m);
+        });
+    }
+
+    MixedOperation<T, L, D, R> mockWithLabel(String label) {
+        return mockWithLabelPredicate(p -> p.getMetadata().getLabels().containsKey(label));
+    }
+
+    @SuppressWarnings("unchecked")
+    MixedOperation<T, L, D, R> mockWithLabelPredicate(Predicate<T> predicate) {
+        MixedOperation<T, L, D, R> mixedWithLabels = mock(MixedOperation.class);
+        when(mixedWithLabels.list()).thenAnswer(i2 -> {
+            return mockList(predicate);
+        });
+        when(mixedWithLabels.watch(any())).thenAnswer(i2 -> {
+            Watcher watcher = i2.getArgument(0);
+            return addWatcher(PredicatedWatcher.predicatedWatcher("watch on labeled", predicate, watcher));
+        });
+        return mixedWithLabels;
+    }
+
+    @SuppressWarnings("unchecked")
+    private KubernetesResourceList<T> mockList(Predicate<? super T> predicate) {
+        KubernetesResourceList<T> l = mock(listClass);
+        Collection<T> values;
+        synchronized (db) {
+            values = db.values().stream().filter(predicate).map(resource -> copyResource(resource)).collect(Collectors.toList());
+        }
+        when(l.getItems()).thenAnswer(i3 -> {
+            LOGGER.debug("{} list -> {}", resourceTypeClass.getSimpleName(), values);
+            return values;
+        });
+        return l;
+    }
+
+    /**
+     * Mock operations on the given {@code resource} which are scoped to accessing the given {@code resourceName}.
+     * For example the methods accessible from
+     * {@code client.configMaps().inNamespace(ns).withName(resourceName)...}
+     *
+     * @param resourceName The resource name
+     * @param resource The (mocked) resource
+     */
+    @SuppressWarnings("unchecked")
+    protected void nameScopedMocks(String resourceName, R resource) {
+        mockGet(resourceName, resource);
+        mockWatch(resourceName, resource);
+        mockCreate(resourceName, resource);
+        when(resource.createNew()).thenReturn(doneable(resource::create));
+        when(resource.createOrReplace(any())).thenAnswer(i -> {
+            T resource2 = i.getArgument(0);
+            if (db.containsKey(resourceName)) {
+                return resource.patch(resource2);
+            } else {
+                return doCreate(resourceName, resource2);
+            }
+        });
+        when(resource.createOrReplaceWithNew()).thenReturn(doneable(resource::createOrReplace));
+        mockCascading(resource);
+        mockPatch(resourceName, resource);
+        mockDelete(resourceName, resource);
+        if (Readiness.isReadinessApplicable(resourceTypeClass)) {
+            mockIsReady(resourceName, resource);
+        }
+    }
+
+    protected void checkNotExists(String resourceName) {
+        if (db.containsKey(resourceName)) {
+            throw new KubernetesClientException(resourceType + " " + resourceName + " already exists");
+        }
+    }
+
+    protected void checkDoesExist(String resourceName) {
+        if (!db.containsKey(resourceName)) {
+            throw new KubernetesClientException(resourceType + " " + resourceName + " does not exist");
+        }
+    }
+
+    protected void mockDelete(String resourceName, R resource) {
+        when(resource.delete()).thenAnswer(i -> {
+            return doDelete(resourceName);
+        });
+    }
+
+    private Object doDelete(String resourceName) {
+        LOGGER.debug("delete {} {}", resourceType, resourceName);
+        T removed = db.remove(resourceName);
+        if (removed != null) {
+            fireWatchers(resourceName, removed, Watcher.Action.DELETED);
+        }
+        return removed != null;
+    }
+
+
+    protected void fireWatchers(String resourceName, T resource, Watcher.Action action) {
+        if (observers != null) {
+            for (Observer<T> observer : observers) {
+                LOGGER.debug("Firing observer.beforeWatcherFire() {} on {} due to {}", observer, resourceName, action);
+                observer.beforeWatcherFire(action, resource);
+            }
+        }
+        LOGGER.debug("Firing watchers on {}", resourceName);
+        for (PredicatedWatcher<T> watcher : watchers) {
+            LOGGER.debug("Firing watcher {} on {} due to {}", watcher, resourceName, action);
+            watcher.maybeFire(resource, action);
+        }
+        LOGGER.debug("Finished firing watchers on {}", resourceName);
+        if (observers != null) {
+            for (int i = observers.size() - 1; i >= 0; i--) {
+                Observer<T> observer = observers.get(i);
+                LOGGER.debug("Firing observer.afterWatcherFire() {} on {} due to {}", observer, resourceName, action);
+                observer.afterWatcherFire(action, resource);
+            }
+        }
+    }
+
+    protected void mockPatch(String resourceName, R resource) {
+        when(resource.patch(any())).thenAnswer(invocation -> {
+            checkDoesExist(resourceName);
+            T argument = copyResource(invocation.getArgument(0));
+            LOGGER.debug("patch {} {} -> {}", resourceType, resourceName, resource);
+            db.put(resourceName, argument);
+            fireWatchers(resourceName, argument, Watcher.Action.MODIFIED);
+            return argument;
+        });
+    }
+
+    protected void mockCascading(R resource) {
+        when(resource.cascading(anyBoolean())).thenReturn(resource);
+    }
+
+    protected void mockWatch(String resourceName, R resource) {
+        when(resource.watch(any())).thenAnswer(i -> {
+            return mockedWatcher(resourceName, i);
+        });
+    }
+
+    private Watch mockedWatcher(String resourceName, InvocationOnMock i) {
+        Watcher<T> watcher = i.getArgument(0);
+        LOGGER.debug("watch {} {} ", resourceType, watcher);
+        return addWatcher(PredicatedWatcher.namedWatcher(resourceName, watcher));
+    }
+
+    private Watch addWatcher(PredicatedWatcher<T> predicatedWatcher) {
+        watchers.add(predicatedWatcher);
+        return () -> {
+            watchers.remove(predicatedWatcher);
+            LOGGER.debug("Watcher {} removed", predicatedWatcher);
+        };
+    }
+
+    protected void mockCreate(String resourceName, R resource) {
+        when(resource.create(any())).thenAnswer(i -> {
+            T argument = i.getArgument(0);
+            return doCreate(resourceName, argument);
+        });
+    }
+
+    private T doCreate(String resourceName, T argument) {
+        checkNotExists(resourceName);
+        LOGGER.debug("create {} {} -> {}", resourceType, resourceName, argument);
+        db.put(resourceName, copyResource(argument));
+        fireWatchers(resourceName, argument, Watcher.Action.ADDED);
+        return copyResource(argument);
+    }
+
+    protected OngoingStubbing<T> mockGet(String resourceName, R resource) {
+        return when(resource.get()).thenAnswer(i -> {
+            T r = copyResource(db.get(resourceName));
+            LOGGER.debug("{} {} get {}", resourceType, resourceName, r);
+            return r;
+        });
+    }
+
+    protected OngoingStubbing<Boolean> mockIsReady(String resourceName, R resource) {
+        return when(resource.isReady()).thenAnswer(i -> {
+            LOGGER.debug("{} {} is ready", resourceType, resourceName);
+            return Boolean.TRUE;
+        });
+    }
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -19,30 +19,23 @@ import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentList;
-import io.fabric8.kubernetes.api.model.apps.DeploymentStatusBuilder;
 import io.fabric8.kubernetes.api.model.apps.DoneableDeployment;
 import io.fabric8.kubernetes.api.model.apps.DoneableStatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
-import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
 import io.fabric8.kubernetes.api.model.networking.DoneableNetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyList;
@@ -57,12 +50,8 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CreateOrReplaceable;
-import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NetworkAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -71,7 +60,6 @@ import io.fabric8.kubernetes.client.dsl.PolicyAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
-import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.openshift.api.model.DoneableRoute;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
@@ -81,38 +69,25 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.mockito.ArgumentMatchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class MockKube {
-    private static final Logger LOGGER = LogManager.getLogger(MockKube.class);
 
     private final Map<String, ConfigMap> cmDb = db(emptySet(), ConfigMap.class, DoneableConfigMap.class);
     private final Map<String, PersistentVolumeClaim> pvcDb = db(emptySet(), PersistentVolumeClaim.class, DoneablePersistentVolumeClaim.class);
@@ -131,7 +106,7 @@ public class MockKube {
     private final Map<String, ClusterRoleBinding> pdbCrb = db(emptySet(), ClusterRoleBinding.class,
             DoneableClusterRoleBinding.class);
 
-    private Map<String, List<String>> podsForDeployments = new HashMap<>();
+
     private Map<String, CreateOrReplaceable> crdMixedOps = new HashMap<>();
 
     public MockKube withInitialCms(Set<ConfigMap> initialCms) {
@@ -172,6 +147,7 @@ public class MockKube {
         private final Class<L> crListClass;
         private final Class<D> crDoneableClass;
         private final Map<String, T> instances;
+
         private MockedCrd(CustomResourceDefinition crd, Class<T> crClass, Class<L> crListClass, Class<D> crDoneableClass) {
             this.crd = crd;
             this.crClass = crClass;
@@ -179,6 +155,27 @@ public class MockKube {
             this.crDoneableClass = crDoneableClass;
             instances = db(emptySet(), crClass, crDoneableClass);
         }
+
+        Map<String, T> getInstances() {
+            return instances;
+        }
+
+        CustomResourceDefinition getCrd() {
+            return crd;
+        }
+
+        Class<T> getCrClass() {
+            return crClass;
+        }
+
+        Class<L> getCrListClass() {
+            return crListClass;
+        }
+
+        Class<D> getCrDoneableClass() {
+            return crDoneableClass;
+        }
+
         public MockedCrd<T, L, D> withInitialInstances(Set<T> instances) {
             for (T instance : instances) {
                 this.instances.put(instance.getMetadata().getName(), instance);
@@ -199,41 +196,45 @@ public class MockKube {
 
     @SuppressWarnings("unchecked")
     public KubernetesClient build() {
-        KubernetesClient mockClient = mock(KubernetesClient.class);
-        OpenShiftClient mockOpenShiftClient = mock(OpenShiftClient.class);
-        MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> mockCms = buildConfigMaps();
-        MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim,
-                Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPvcs = buildPvcs();
-        MixedOperation<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> mockEndpoints = buildEndpoints();
-        MixedOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> mockSvc = buildServices();
-        MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods = buildPods();
+
+        MockBuilder<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> configMapMockBuilder = new MockBuilder<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>>(ConfigMap.class, ConfigMapList.class, DoneableConfigMap.class, MockBuilder.castClass(Resource.class), cmDb);
+        MockBuilder<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> endpointMockBuilder = new MockBuilder<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>>(Endpoints.class, EndpointsList.class, DoneableEndpoints.class, MockBuilder.castClass(Resource.class), endpointDb);
+        ServiceMockBuilder serviceMockBuilder = new ServiceMockBuilder(svcDb, endpointDb);
+        MockBuilder<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>> secretMockBuilder = new MockBuilder<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>>(Secret.class, SecretList.class, DoneableSecret.class, MockBuilder.castClass(Resource.class), secretDb);
+        MockBuilder<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> serviceAccountMockBuilder = new MockBuilder<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>>(ServiceAccount.class, ServiceAccountList.class, DoneableServiceAccount.class, MockBuilder.castClass(Resource.class), serviceAccountDb);
+        MockBuilder<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> routeMockBuilder = new MockBuilder<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>>(Route.class, RouteList.class, DoneableRoute.class, MockBuilder.castClass(Resource.class), routeDb);
+        MockBuilder<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> podDisruptionBudgedMockBuilder = new MockBuilder<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget, Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>>(PodDisruptionBudget.class, PodDisruptionBudgetList.class, DoneablePodDisruptionBudget.class, MockBuilder.castClass(Resource.class), pdbDb);
+        MockBuilder<RoleBinding, RoleBindingList, DoneableRoleBinding, Resource<RoleBinding, DoneableRoleBinding>> roleBindingMockBuilder = new MockBuilder<RoleBinding, RoleBindingList, DoneableRoleBinding, Resource<RoleBinding, DoneableRoleBinding>>(RoleBinding.class, RoleBindingList.class, DoneableRoleBinding.class, MockBuilder.castClass(Resource.class), pdbRb);
+        MockBuilder<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding, Resource<ClusterRoleBinding, DoneableClusterRoleBinding>> clusterRoleBindingMockBuilder = new MockBuilder<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding, Resource<ClusterRoleBinding, DoneableClusterRoleBinding>>(ClusterRoleBinding.class, ClusterRoleBindingList.class, DoneableClusterRoleBinding.class, MockBuilder.castClass(Resource.class), pdbCrb);
+        MockBuilder<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> networkPolicyMockBuilder = new MockBuilder<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>>(NetworkPolicy.class, NetworkPolicyList.class, DoneableNetworkPolicy.class, MockBuilder.castClass(Resource.class), policyDb);
+
+        Map<String, Pod> podDb1 = podDb;
+        MockBuilder<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> podMockBuilder = new MockBuilder<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>>(Pod.class, PodList.class, DoneablePod.class, MockBuilder.castClass(PodResource.class), podDb1);
+        MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods = podMockBuilder.build();
+
+        MockBuilder<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> persistentVolumeClaimMockBuilder = new MockBuilder<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>>(PersistentVolumeClaim.class, PersistentVolumeClaimList.class, DoneablePersistentVolumeClaim.class, MockBuilder.castClass(Resource.class), pvcDb);
+        MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPersistentVolumeClaims = persistentVolumeClaimMockBuilder.build();
+        DeploymentMockBuilder mockDep = new DeploymentMockBuilder(depDb, mockPods);
         MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet,
-                RollableScalableResource<StatefulSet, DoneableStatefulSet>> mockSs = buildStatefulSets(mockPods, mockPvcs);
-        MixedOperation<Deployment, DeploymentList, DoneableDeployment, RollableScalableResource<Deployment,
-                DoneableDeployment>> mockDep = buildDeployments(mockPods);
-        MixedOperation<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>> mockSecrets = buildSecrets();
-        MixedOperation<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount,
-                DoneableServiceAccount>> mockServiceAccounts = buildServiceAccount();
-        MixedOperation<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy,
-                DoneableNetworkPolicy>> mockNetworkPolicy = buildNetworkPolicy();
-        MixedOperation<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> mockRoute = buildRoute();
-        MixedOperation<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget,
-                Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> mockPdb = buildPdb();
-        MixedOperation<RoleBinding, RoleBindingList, DoneableRoleBinding,
-                Resource<RoleBinding, DoneableRoleBinding>> mockRb = buildRb();
-        MixedOperation<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding,
-                Resource<ClusterRoleBinding, DoneableClusterRoleBinding>> mockCrb = buildCrb();
+                RollableScalableResource<StatefulSet, DoneableStatefulSet>> mockSs = buildStatefulSets(podMockBuilder, mockPods, mockPersistentVolumeClaims);
 
-        when(mockClient.configMaps()).thenReturn(mockCms);
-        when(mockClient.services()).thenReturn(mockSvc);
-        AppsAPIGroupDSL api = mock(AppsAPIGroupDSL.class);
-
-        when(api.statefulSets()).thenReturn(mockSs);
-        when(api.deployments()).thenReturn(mockDep);
-        when(mockClient.apps()).thenReturn(api);
+        // Top level group
+        KubernetesClient mockClient = mock(KubernetesClient.class);
+        configMapMockBuilder.build2(mockClient::configMaps);
+        serviceMockBuilder.build2(mockClient::services);
+        secretMockBuilder.build2(mockClient::secrets);
+        serviceAccountMockBuilder.build2(mockClient::serviceAccounts);
         when(mockClient.pods()).thenReturn(mockPods);
-        when(mockClient.endpoints()).thenReturn(mockEndpoints);
-        when(mockClient.persistentVolumeClaims()).thenReturn(mockPvcs);
+        endpointMockBuilder.build2(mockClient::endpoints);
+        when(mockClient.persistentVolumeClaims()).thenReturn(mockPersistentVolumeClaims);
+
+        // API group
+        AppsAPIGroupDSL api = mock(AppsAPIGroupDSL.class);
+        when(mockClient.apps()).thenReturn(api);
+        when(api.statefulSets()).thenReturn(mockSs);
+        mockDep.build2(api::deployments);
+
+        // Custom Resources
         if (mockedCrds != null && !mockedCrds.isEmpty()) {
             NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition,
                     Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>>
@@ -251,7 +252,7 @@ public class MockKube {
                                 String key = crdArg.getSpec().getGroup() + "##" + crdArg.getSpec().getVersion();
                                 CreateOrReplaceable crdMixedOp = crdMixedOps.get(key);
                                 if (crdMixedOp == null) {
-                                    crdMixedOp = buildCrd((MockedCrd) mockedCrd);
+                                    crdMixedOp = (MixedOperation<CustomResource, ? extends KubernetesResource, Doneable<CustomResource>, Resource<CustomResource, Doneable<CustomResource>>>) new CustomResourceMockBuilder<>((MockedCrd) mockedCrd).build();
                                     crdMixedOps.put(key, crdMixedOp);
                                 }
                                 return crdMixedOp;
@@ -263,23 +264,28 @@ public class MockKube {
             when(mockClient.customResourceDefinitions()).thenReturn(crds);
         }
 
-        when(mockClient.secrets()).thenReturn(mockSecrets);
-        when(mockClient.serviceAccounts()).thenReturn(mockServiceAccounts);
+        // Network group
         NetworkAPIGroupDSL network = mock(NetworkAPIGroupDSL.class);
         when(mockClient.network()).thenReturn(network);
-        when(network.networkPolicies()).thenReturn(mockNetworkPolicy);
-        when(mockClient.adapt(OpenShiftClient.class)).thenReturn(mockOpenShiftClient);
-        when(mockOpenShiftClient.routes()).thenReturn(mockRoute);
+        networkPolicyMockBuilder.build2(network::networkPolicies);
+
+        // Policy group
         PolicyAPIGroupDSL policy = mock(PolicyAPIGroupDSL.class);
         when(mockClient.policy()).thenReturn(policy);
+        podDisruptionBudgedMockBuilder.build2(mockClient.policy()::podDisruptionBudget);
+
+        // RBAC group
         RbacAPIGroupDSL rbac = mock(RbacAPIGroupDSL.class);
         when(mockClient.rbac()).thenReturn(rbac);
-        when(mockClient.policy().podDisruptionBudget()).thenReturn(mockPdb);
-        when(mockClient.rbac().roleBindings()).thenReturn(mockRb);
-        when(mockClient.rbac().clusterRoleBindings()).thenReturn(mockCrb);
+        roleBindingMockBuilder.build2(mockClient.rbac()::roleBindings);
+        clusterRoleBindingMockBuilder.build2(mockClient.rbac()::clusterRoleBindings);
+
+        // Openshift group
+        OpenShiftClient mockOpenShiftClient = mock(OpenShiftClient.class);
+        when(mockClient.adapt(OpenShiftClient.class)).thenReturn(mockOpenShiftClient);
+        routeMockBuilder.build2(mockOpenShiftClient::routes);
 
         mockHttpClient(mockClient);
-
         return mockClient;
     }
 
@@ -306,482 +312,15 @@ public class MockKube {
         }
     }
 
-    private MixedOperation<Deployment, DeploymentList, DoneableDeployment, RollableScalableResource<Deployment, DoneableDeployment>>
-            buildDeployments(MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods) {
-        return new AbstractMockBuilder<Deployment, DeploymentList, DoneableDeployment, RollableScalableResource<Deployment,
-                DoneableDeployment>>(
-            Deployment.class, DeploymentList.class, DoneableDeployment.class, castClass(RollableScalableResource.class), depDb) {
-            @Override
-            protected void nameScopedMocks(RollableScalableResource<Deployment, DoneableDeployment> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockWatch(resourceName, resource);
-                //mockCreate(resourceName, resource);
-                when(resource.create(any())).thenAnswer(invocation -> {
-                    checkNotExists(resourceName);
-                    Deployment deployment = invocation.getArgument(0);
-                    LOGGER.debug("create {} {} -> {}", resourceType, resourceName, deployment);
-                    deployment.getMetadata().setGeneration(Long.valueOf(0));
-                    deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());
-                    depDb.put(resourceName, copyResource(deployment));
-                    for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
-                        String uuid = UUID.randomUUID().toString();
-                        String podName = deployment.getMetadata().getName() + "-" + uuid;
-                        LOGGER.debug("create Pod {} because it's in Deployment {}", podName, resourceName);
-                        Pod pod = new PodBuilder()
-                                .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
-                                    .withUid(uuid)
-                                    .withNamespace(deployment.getMetadata().getNamespace())
-                                    .withName(podName)
-                                .endMetadata()
-                                .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
-                                .build();
-                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podName).create(pod);
-                        podsForDeployments.computeIfAbsent(deployment.getMetadata().getName(), s -> new ArrayList<>());
-                        podsForDeployments.get(deployment.getMetadata().getName()).add(podName);
-                    }
-                    return deployment;
-                });
-                mockCascading(resource);
-                //mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-                when(resource.patch(any())).thenAnswer(invocation -> {
-                    Deployment deployment = invocation.getArgument(0);
-                    deployment.getMetadata().setGeneration(Long.valueOf(0));
-                    deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());
-                    LOGGER.debug("patched {} {} -> {}", resourceType, resourceName, deployment);
-                    depDb.put(resourceName, copyResource(deployment));
-                    List<String> newPodNames = new ArrayList<>();
-                    for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
-                        // create a "new" Pod
-                        String uuid = UUID.randomUUID().toString();
-                        String newPodName = deployment.getMetadata().getName() + "-" + uuid;
-
-                        Pod newPod = new PodBuilder()
-                                .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
-                                    .withUid(uuid)
-                                    .withNamespace(deployment.getMetadata().getNamespace())
-                                    .withName(newPodName)
-                                .endMetadata()
-                                .withNewSpecLike(deployment.getSpec().getTemplate().getSpec()).endSpec()
-                                .build();
-                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(newPodName).create(newPod);
-                        newPodNames.add(newPodName);
-
-                        // delete the first one "old" Pod
-                        String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
-                        mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
-                    }
-                    podsForDeployments.get(deployment.getMetadata().getName()).addAll(newPodNames);
-
-                    return deployment;
-                });
-                when(resource.isReady()).thenReturn(true);
-            }
-        }.build();
-    }
-
     private MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>>
-        buildStatefulSets(MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods,
-                      MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim,
-                              Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPvcs) {
+        buildStatefulSets(MockBuilder<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> podMockBuilder, MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods,
+                          MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim,
+                                  Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPvcs) {
         MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet,
-                DoneableStatefulSet>> result = new AbstractMockBuilder<StatefulSet, StatefulSetList, DoneableStatefulSet,
-                RollableScalableResource<StatefulSet, DoneableStatefulSet>>(
-                StatefulSet.class, StatefulSetList.class, DoneableStatefulSet.class, castClass(RollableScalableResource.class), ssDb) {
-
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    protected void nameScopedMocks(RollableScalableResource<StatefulSet, DoneableStatefulSet> resource, String resourceName) {
-                        mockGet(resourceName, resource);
-                        //mockCreate("endpoint", endpointDb, resourceName, resource);
-                        mockCascading(resource);
-                        mockPatch(resourceName, resource);
-                        when(resource.delete()).thenAnswer(i -> {
-                            LOGGER.debug("delete {} {}", resourceType, resourceName);
-                            StatefulSet removed = ssDb.remove(resourceName);
-                            if (removed != null) {
-                                fireWatchers(resourceName, removed, Watcher.Action.DELETED);
-                                for (Map.Entry<String, Pod> pod : new HashMap<>(podDb).entrySet()) {
-                                    if (pod.getKey().matches(resourceName + "-[0-9]+")) {
-                                        mockPods.inNamespace(removed.getMetadata().getNamespace()).withName(pod.getKey()).delete();
-                                    }
-                                }
-                            }
-                            return removed != null;
-                        });
-                        mockIsReady(resourceName, resource);
-                        when(resource.create(any())).thenAnswer(cinvocation -> {
-                            checkNotExists(resourceName);
-                            StatefulSet argument = cinvocation.getArgument(0);
-                            LOGGER.debug("create {} {} -> {}", resourceType, resourceName, argument);
-                            StatefulSet value = copyResource(argument);
-                            value.setStatus(new StatefulSetStatus());
-                            ssDb.put(resourceName, value);
-                            for (int i = 0; i < argument.getSpec().getReplicas(); i++) {
-                                final int podNum = i;
-                                String podName = argument.getMetadata().getName() + "-" + podNum;
-                                LOGGER.debug("create Pod {} because it's in StatefulSet {}", podName, resourceName);
-                                Pod pod = new PodBuilder().withNewMetadataLike(argument.getSpec().getTemplate().getMetadata())
-                                        .withUid(UUID.randomUUID().toString())
-                                        .withNamespace(argument.getMetadata().getNamespace())
-                                        .withName(podName)
-                                        .endMetadata()
-                                        .withNewSpecLike(argument.getSpec().getTemplate().getSpec()).endSpec()
-                                        .build();
-                                //podDb.put(podName,
-                                //        pod);
-                                if (mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(podName).get() == null) {
-                                    mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(podName).create(pod);
-                                    addPodRestarter(mockPods, resourceName, podNum, podName);
-                                }
-
-                                if (value.getSpec().getVolumeClaimTemplates().size() > 0) {
-
-                                    for (PersistentVolumeClaim pvcTemplate: value.getSpec().getVolumeClaimTemplates()) {
-
-                                        String pvcName = pvcTemplate.getMetadata().getName() + "-" + podName;
-                                        if (mockPvcs.inNamespace(argument.getMetadata().getNamespace()).withName(pvcName).get() == null) {
-
-                                            LOGGER.debug("create Pvc {} because it's in VolumeClaimTemplate of StatefulSet {}", pvcName, resourceName);
-                                            PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
-                                                    .withNewMetadata()
-                                                        .withLabels(argument.getSpec().getSelector().getMatchLabels())
-                                                        .withNamespace(argument.getMetadata().getNamespace())
-                                                        .withName(pvcName)
-                                                    .endMetadata()
-                                                    .build();
-                                            mockPvcs.inNamespace(argument.getMetadata().getNamespace()).withName(pvcName).create(pvc);
-                                        }
-                                    }
-
-                                }
-                            }
-                            return argument;
-                        });
-                        EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> c = mock(EditReplacePatchDeletable.class);
-                        when(resource.cascading(false)).thenReturn(c);
-                        when(c.patch(any())).thenAnswer(patchInvocation -> {
-                            StatefulSet argument = patchInvocation.getArgument(0);
-                            return doPatch(resourceName, argument);
-                        });
-                        when(resource.scale(anyInt(), anyBoolean())).thenAnswer(invocation -> {
-                            checkDoesExist(resourceName);
-                            StatefulSet ss = copyResource(ssDb.get(resourceName));
-                            int newScale = invocation.getArgument(0);
-                            ss.getSpec().setReplicas(newScale);
-                            return doPatch(resourceName, ss);
-                        });
-                        when(resource.scale(anyInt())).thenAnswer(invocation -> {
-                            checkDoesExist(resourceName);
-                            StatefulSet ss = copyResource(ssDb.get(resourceName));
-                            int newScale = invocation.getArgument(0);
-                            ss.getSpec().setReplicas(newScale);
-                            return doPatch(resourceName, ss);
-                        });
-                        when(resource.isReady()).thenAnswer(i -> {
-                            LOGGER.debug("{} {} is ready", resourceType, resourceName);
-                            return true;
-                        });
-                        when(c.delete()).thenAnswer(i -> {
-                            LOGGER.info("delete {} {}", resourceType, resourceName);
-                            StatefulSet removed = ssDb.remove(resourceName);
-                            return removed != null;
-                        });
-                    }
-
-                    private StatefulSet doPatch(String resourceName, StatefulSet argument) {
-                        int oldScale = ssDb.get(resourceName).getSpec().getReplicas();
-                        int newScale = argument.getSpec().getReplicas();
-                        if (newScale > oldScale) {
-                            LOGGER.debug("scaling up {} {} from {} to {}", resourceType, resourceName, oldScale, newScale);
-                            Pod examplePod = mockPods.inNamespace(argument.getMetadata().getNamespace())
-                                    .withName(argument.getMetadata().getName() + "-0").get();
-                            for (int i = oldScale; i < newScale; i++) {
-                                String newPodName = argument.getMetadata().getName() + "-" + i;
-                                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).create(
-                                        new PodBuilder(examplePod).editMetadata().withName(newPodName).endMetadata().build());
-                            }
-                            ssDb.put(resourceName, copyResource(argument));
-                        } else if (newScale < oldScale) {
-                            ssDb.put(resourceName, copyResource(argument));
-                            LOGGER.debug("scaling down {} {} from {} to {}", resourceType, resourceName, oldScale, newScale);
-                            for (int i = oldScale - 1; i >= newScale; i--) {
-                                String newPodName = argument.getMetadata().getName() + "-" + i;
-                                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).delete();
-                            }
-                        } else {
-                            ssDb.put(resourceName, copyResource(argument));
-                        }
-                        return argument;
-                    }
-                }.build();
-
-        for (StatefulSet ss : this.ssDb.values()) {
-            for (Pod initialPod : this.podDb.values()) {
-                String podName = initialPod.getMetadata().getName();
-                String ssName = ss.getMetadata().getName();
-                if (podName.matches(ssName + "-[0-9]+")) {
-                    addPodRestarter(
-                            mockPods,
-                            ssName,
-                            Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1)),
-                            podName);
-                }
-            }
-        }
-
+                DoneableStatefulSet>> result = new StatefulSetMockBuilder(podMockBuilder, ssDb, podDb, mockPods, mockPvcs).build();
         return result;
     }
 
-    private void addPodRestarter(MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods,
-                                 String resourceName, int podNum, String podName) {
-        mockPods.inNamespace(any()).withName(podName).watch(new Watcher<Pod>() {
-            public String toString() {
-                return MockKube.class.getSimpleName() + " SS pod restarter";
-            }
-
-            @Override
-            public void eventReceived(Action action, Pod resource) {
-                if (action == Action.DELETED) {
-                    //String podName = resource.getMetadata().getName();
-                    String podNamespace = resource.getMetadata().getNamespace();
-                    StatefulSet statefulSet = ssDb.get(resourceName);
-                    if (/*podName.matches(resourceName + "-" + "[0-9]+")
-                                    && */
-                            statefulSet != null &&
-                            podNum <
-                            statefulSet.getSpec().getReplicas()) {
-                        ObjectMeta templateMeta = statefulSet.getSpec().getTemplate().getMetadata();
-                        Pod copy = new DoneablePod(resource)
-                                .withNewMetadataLike(templateMeta)
-                                .withUid(UUID.randomUUID().toString())
-                                .withNamespace(podNamespace)
-                                .withName(podName)
-                                .endMetadata()
-                                .withNewSpecLike(statefulSet.getSpec().getTemplate().getSpec()).endSpec()
-                                .done();
-                        LOGGER.debug("Recreating Pod {} because it's in StatefulSet {}", podName, resourceName);
-                        mockPods.inNamespace(podNamespace).withName(podName).create(copy);
-                    }
-                }
-            }
-
-            @Override
-            public void onClose(KubernetesClientException e) {
-
-            }
-        });
-    }
-
-    private MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> buildPods() {
-        return new AbstractMockBuilder<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>>(
-                Pod.class, PodList.class, DoneablePod.class, castClass(PodResource.class), podDb) {
-
-            @Override
-            protected void nameScopedMocks(PodResource<Pod, DoneablePod> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockWatch(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-                mockIsReady(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> buildServices() {
-        return new AbstractMockBuilder<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>>(
-                Service.class, ServiceList.class, DoneableService.class, castClass(ServiceResource.class), svcDb) {
-
-            @Override
-            protected void nameScopedMocks(ServiceResource<Service, DoneableService> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                //mockCreate("endpoint", endpointDb, resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-                when(resource.create(any())).thenAnswer(i -> {
-                    Service argument = i.getArgument(0);
-                    svcDb.put(resourceName, copyResource(argument));
-                    LOGGER.debug("create {} (and endpoint) {} ", resourceType, resourceName);
-                    endpointDb.put(resourceName, new Endpoints());
-                    return argument;
-                });
-            }
-        }.build();
-    }
-
-    private MixedOperation<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> buildEndpoints() {
-        return new AbstractMockBuilder<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>>(
-                Endpoints.class, EndpointsList.class, DoneableEndpoints.class, castClass(Resource.class), endpointDb) {
-            @Override
-            protected void nameScopedMocks(Resource<Endpoints, DoneableEndpoints> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-                mockIsReady(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim,
-            Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> buildPvcs() {
-        return new AbstractMockBuilder<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim,
-                Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>>(
-                PersistentVolumeClaim.class, PersistentVolumeClaimList.class, DoneablePersistentVolumeClaim.class, castClass(Resource.class), pvcDb) {
-            @Override
-            protected void nameScopedMocks(Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> buildConfigMaps() {
-        return new AbstractMockBuilder<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>>(
-            ConfigMap.class, ConfigMapList.class, DoneableConfigMap.class, castClass(Resource.class), cmDb) {
-            @Override
-            protected void nameScopedMocks(Resource<ConfigMap, DoneableConfigMap> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockWatch(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-
-    private MixedOperation<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>> buildSecrets() {
-        return new AbstractMockBuilder<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>>(
-                Secret.class, SecretList.class, DoneableSecret.class, castClass(Resource.class), secretDb) {
-            @Override
-            protected void nameScopedMocks(Resource<Secret, DoneableSecret> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>>
-        buildServiceAccount() {
-        return new AbstractMockBuilder<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>>(
-                ServiceAccount.class, ServiceAccountList.class, DoneableServiceAccount.class, castClass(Resource.class), serviceAccountDb) {
-            @Override
-            protected void nameScopedMocks(Resource<ServiceAccount, DoneableServiceAccount> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>> buildNetworkPolicy() {
-        return new AbstractMockBuilder<NetworkPolicy, NetworkPolicyList, DoneableNetworkPolicy, Resource<NetworkPolicy, DoneableNetworkPolicy>>(
-                NetworkPolicy.class, NetworkPolicyList.class, DoneableNetworkPolicy.class, castClass(Resource.class), policyDb) {
-            @Override
-            protected void nameScopedMocks(Resource<NetworkPolicy, DoneableNetworkPolicy> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> buildRoute() {
-        return new AbstractMockBuilder<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>>(
-                Route.class, RouteList.class, DoneableRoute.class, castClass(Resource.class), routeDb) {
-            @Override
-            protected void nameScopedMocks(Resource<Route, DoneableRoute> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget,
-            Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>> buildPdb() {
-        return new AbstractMockBuilder<PodDisruptionBudget, PodDisruptionBudgetList, DoneablePodDisruptionBudget,
-                Resource<PodDisruptionBudget, DoneablePodDisruptionBudget>>(
-                PodDisruptionBudget.class, PodDisruptionBudgetList.class, DoneablePodDisruptionBudget.class, castClass(Resource.class), pdbDb) {
-            @Override
-            protected void nameScopedMocks(Resource<PodDisruptionBudget, DoneablePodDisruptionBudget> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<RoleBinding, RoleBindingList, DoneableRoleBinding,
-            Resource<RoleBinding, DoneableRoleBinding>> buildRb() {
-        return new AbstractMockBuilder<RoleBinding, RoleBindingList, DoneableRoleBinding,
-                Resource<RoleBinding, DoneableRoleBinding>>(
-                RoleBinding.class, RoleBindingList.class, DoneableRoleBinding.class, castClass(Resource.class), pdbRb) {
-            @Override
-            protected void nameScopedMocks(Resource<RoleBinding, DoneableRoleBinding> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private MixedOperation<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding,
-            Resource<ClusterRoleBinding, DoneableClusterRoleBinding>> buildCrb() {
-        return new AbstractMockBuilder<ClusterRoleBinding, ClusterRoleBindingList,
-                DoneableClusterRoleBinding, Resource<ClusterRoleBinding, DoneableClusterRoleBinding>>(
-                ClusterRoleBinding.class, ClusterRoleBindingList.class, DoneableClusterRoleBinding.class,
-                castClass(Resource.class), pdbCrb) {
-            @Override
-            protected void nameScopedMocks(Resource<ClusterRoleBinding, DoneableClusterRoleBinding> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
-
-    private <T extends CustomResource,
-            L extends KubernetesResource & KubernetesResourceList<T>,
-            D extends Doneable<T>>
-        MixedOperation<T, L, D, Resource<T, D>> buildCrd(MockedCrd<T, L, D> mockedCrd) {
-        return new AbstractMockBuilder<T, L, D, Resource<T, D>>(
-                mockedCrd.crClass, mockedCrd.crListClass, mockedCrd.crDoneableClass, castClass(Resource.class), mockedCrd.instances) {
-            @Override
-            protected void nameScopedMocks(Resource<T, D> resource, String resourceName) {
-                mockGet(resourceName, resource);
-                mockWatch(resourceName, resource);
-                mockCreate(resourceName, resource);
-                mockCascading(resource);
-                mockPatch(resourceName, resource);
-                mockDelete(resourceName, resource);
-            }
-        }.build();
-    }
 
     private static <T extends HasMetadata, D extends Doneable<T>> Map<String, T> db(Collection<T> initialResources, Class<T> cls, Class<D> doneableClass) {
         return new ConcurrentHashMap<>(initialResources.stream().collect(Collectors.toMap(
@@ -799,323 +338,5 @@ public class MockKube {
             throw new RuntimeException(e);
         }
     }
-
-    /*
-     * @param db In-memory db of resources (e.g. ConfigMap's by their name)
-     * @param resourceClass The type of {@link Resource} class
-     * @param extraMocksOnResource A callback for adding extra mocks to the mock for the Resource type.
-     *                             This is necessary for those things like scalable and "ready-able" resources.
-     * @param <CM> The type of resource (e.g. ConfigMap)
-     * @param <CML> The type of listable resource
-     * @param <DCM> The type of doneable resource
-     * @param <R> The type of the Resource
-     */
-    static abstract class AbstractMockBuilder<CM extends HasMetadata,
-            CML extends KubernetesResource/*<CM>*/ & KubernetesResourceList/*<CM>*/,
-            DCM extends Doneable<CM>,
-            R extends Resource<CM, DCM>> {
-
-        protected final Class<CM> resourceTypeClass;
-        protected final Class<DCM> doneableClass;
-        protected final Class<R> resourceClass;
-        private final Map<String, CM> db;
-        protected final Class<CML> listClass;
-        protected final String resourceType;
-
-        static class PredicatedWatcher<CM extends HasMetadata> {
-            private final String str;
-            private final Watcher<CM> watcher;
-            private final Predicate<CM> predicate;
-
-            private PredicatedWatcher(String str, Predicate<CM> predicate, Watcher<CM> watcher) {
-                this.str = str;
-                this.watcher = watcher;
-                this.predicate = predicate;
-            }
-
-            static <CM extends HasMetadata> PredicatedWatcher<CM> watcher(Watcher<CM> watcher) {
-                return new PredicatedWatcher<>("watch on all", resource1 -> ((Predicate<CM>) resource -> true).test(resource1), watcher);
-            }
-
-            static <CM extends HasMetadata> PredicatedWatcher<CM> namedWatcher(String name, Watcher<CM> watcher) {
-                return new PredicatedWatcher<>("watch on named " + name, resource1 -> ((Predicate<CM>) resource -> name.equals(resource.getMetadata().getName())).test(resource1), watcher);
-            }
-
-            static <CM extends HasMetadata> PredicatedWatcher<CM> predicatedWatcher(String desc, Predicate<CM> predicate, Watcher<CM> watcher) {
-                return new PredicatedWatcher<>(desc, resource -> predicate.test(resource), watcher);
-            }
-
-            public String toString() {
-                return str;
-            }
-        }
-
-        protected final Collection<PredicatedWatcher<CM>> watchers = Collections.synchronizedList(new ArrayList<>(2));
-
-        public AbstractMockBuilder(Class<CM> resourceTypeClass, Class<CML> listClass, Class<DCM> doneableClass,
-                                   Class<R> resourceClass, Map<String, CM> db) {
-            this.resourceTypeClass = resourceTypeClass;
-            this.resourceType = resourceTypeClass.getSimpleName();
-            this.doneableClass = doneableClass;
-            this.resourceClass = resourceClass;
-            this.db = db;
-            this.listClass = listClass;
-        }
-
-        @SuppressWarnings("unchecked")
-        protected CM copyResource(CM resource) {
-            if (resource == null) {
-                return null;
-            }
-            try {
-                DCM doneableInstance = doneableClass.getDeclaredConstructor(resourceTypeClass).newInstance(resource);
-                CM done = (CM) Doneable.class.getMethod("done").invoke(doneableInstance);
-                return done;
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        /**
-         * Generate a stateful mock for CRUD-like interactions.
-         * @return The mock
-         */
-        @SuppressWarnings("unchecked")
-        public MixedOperation<CM, CML, DCM, R> build() {
-            MixedOperation<CM, CML, DCM, R> mixed = mock(MixedOperation.class);
-
-            when(mixed.inNamespace(any())).thenReturn(mixed);
-            when(mixed.list()).thenAnswer(i -> mockList(p -> true));
-            when(mixed.withLabels(any())).thenAnswer(i -> {
-                MixedOperation<CM, CML, DCM, R> mixedWithLabels = mock(MixedOperation.class);
-                Map<String, String> labels = i.getArgument(0);
-                when(mixedWithLabels.list()).thenAnswer(i2 -> mockList(p -> {
-                    Map<String, String> m = new HashMap(p.getMetadata().getLabels());
-                    m.keySet().retainAll(labels.keySet());
-                    return labels.equals(m);
-                }));
-                return mixedWithLabels;
-            });
-            when(mixed.withName(any())).thenAnswer(invocation -> {
-                String resourceName = invocation.getArgument(0);
-                R resource = mock(resourceClass);
-                nameScopedMocks(resource, resourceName);
-                return resource;
-            });
-            when(mixed.watch(any())).thenAnswer(i -> {
-                Watcher watcher = i.getArgument(0);
-                LOGGER.debug("Watcher {} installed on {}", watcher, mixed);
-                return addWatcher(PredicatedWatcher.watcher(watcher));
-            });
-            when(mixed.create(any())).thenAnswer(i -> {
-                CM resource = i.getArgument(0);
-                String resourceName = resource.getMetadata().getName();
-                return mockCreate(resourceName, resource);
-            });
-            when(mixed.delete(ArgumentMatchers.<CM[]>any())).thenAnswer(i -> {
-                CM resource = i.getArgument(0);
-                String resourceName = resource.getMetadata().getName();
-                return mockDelete(resourceName);
-            });
-            when(mixed.withLabel(any())).thenAnswer(i -> {
-                String label = i.getArgument(0);
-                return mockWithLabel(label);
-            });
-            when(mixed.withLabel(any(), any())).thenAnswer(i -> {
-                String label = i.getArgument(0);
-                String value = i.getArgument(1);
-                return mockWithLabels(singletonMap(label, value));
-            });
-            when(mixed.withLabels(any())).thenAnswer(i -> {
-                Map<String, String> labels = i.getArgument(0);
-                return mockWithLabels(labels);
-            });
-            return mixed;
-        }
-
-        @SuppressWarnings("unchecked")
-        public NonNamespaceOperation<CM, CML, DCM, R> buildNonNamespaced() {
-            // TODO factor out common with build(), which is more-or-less identical
-            NonNamespaceOperation<CM, CML, DCM, R> mixed = mock(NonNamespaceOperation.class);
-
-            when(mixed.list()).thenAnswer(i -> mockList(p -> true));
-            when(mixed.withLabels(any())).thenAnswer(i -> {
-                Map<String, String> labels = i.getArgument(0);
-                return mockWithLabels(labels);
-            });
-            when(mixed.withName(any())).thenAnswer(invocation -> {
-                String resourceName = invocation.getArgument(0);
-                R resource = mock(resourceClass);
-                nameScopedMocks(resource, resourceName);
-                return resource;
-            });
-            return mixed;
-        }
-
-        MixedOperation<CM, CML, DCM, R> mockWithLabels(Map<String, String> labels) {
-            return mockWithLabels(p -> {
-                Map<String, String> m = new HashMap<>(p.getMetadata().getLabels());
-                m.keySet().retainAll(labels.keySet());
-                return labels.equals(m);
-            });
-        }
-
-        MixedOperation<CM, CML, DCM, R> mockWithLabel(String label) {
-            return mockWithLabels(p -> p.getMetadata().getLabels().containsKey(label));
-        }
-
-        @SuppressWarnings("unchecked")
-        MixedOperation<CM, CML, DCM, R> mockWithLabels(Predicate<CM> predicate) {
-            MixedOperation<CM, CML, DCM, R> mixedWithLabels = mock(MixedOperation.class);
-            when(mixedWithLabels.list()).thenAnswer(i2 -> {
-                return mockList(predicate);
-            });
-            when(mixedWithLabels.watch(any())).thenAnswer(i2 -> {
-                Watcher watcher = i2.getArgument(0);
-                return addWatcher(PredicatedWatcher.predicatedWatcher("watch on labeled", predicate, watcher));
-            });
-            return mixedWithLabels;
-        }
-
-        @SuppressWarnings("unchecked")
-        private KubernetesResourceList<CM> mockList(Predicate<? super CM> predicate) {
-            KubernetesResourceList<CM> l = mock(listClass);
-            Collection<CM> values;
-            synchronized (db) {
-                values = db.values().stream().filter(predicate).map(resource -> copyResource(resource)).collect(Collectors.toList());
-            }
-            when(l.getItems()).thenAnswer(i3 -> {
-                LOGGER.debug("{} list -> {}", resourceTypeClass.getSimpleName(), values);
-                return values;
-            });
-            return l;
-        }
-
-        /**
-         * Mock operations on the given {@code resource} which are scoped to accessing the given {@code resourceName}.
-         * For example the methods accessible from
-         * {@code client.configMaps().inNamespace(ns).withName(resourceName)...}
-         *
-         * @param resource
-         * @param resourceName
-         */
-        protected abstract void nameScopedMocks(R resource, String resourceName);
-
-        protected void checkNotExists(String resourceName) {
-            if (db.containsKey(resourceName)) {
-                throw new KubernetesClientException(resourceType + " " + resourceName + " already exists");
-            }
-        }
-
-        protected void checkDoesExist(String resourceName) {
-            if (!db.containsKey(resourceName)) {
-                throw new KubernetesClientException(resourceType + " " + resourceName + " does not exist");
-            }
-        }
-
-        protected void mockDelete(String resourceName, R resource) {
-            when(resource.delete()).thenAnswer(i -> {
-                return mockDelete(resourceName);
-            });
-        }
-
-        private Object mockDelete(String resourceName) {
-            LOGGER.debug("delete {} {}", resourceType, resourceName);
-            CM removed = db.remove(resourceName);
-            if (removed != null) {
-                fireWatchers(resourceName, removed, Watcher.Action.DELETED);
-            }
-            return removed != null;
-        }
-
-        protected void fireWatchers(String resourceName, CM removed, Watcher.Action action) {
-            LOGGER.debug("Firing watchers on {}", resourceName);
-            for (PredicatedWatcher<CM> watcher : watchers) {
-                if (watcher.predicate.test(removed)) {
-                    LOGGER.debug("Firing watcher {} with {} and resource {}", watcher, action, removed);
-                    watcher.watcher.eventReceived(action, removed);
-                }
-            }
-            LOGGER.debug("Finished firing watchers on {}", resourceName);
-        }
-
-        protected void mockPatch(String resourceName, R resource) {
-            when(resource.patch(any())).thenAnswer(invocation -> {
-                checkDoesExist(resourceName);
-                CM argument = copyResource(invocation.getArgument(0));
-                LOGGER.debug("patch {} {} -> {}", resourceType, resourceName, resource);
-                db.put(resourceName, argument);
-                fireWatchers(resourceName, argument, Watcher.Action.MODIFIED);
-                return argument;
-            });
-        }
-
-        protected void mockCascading(R resource) {
-            when(resource.cascading(anyBoolean())).thenReturn(resource);
-        }
-
-        protected void mockWatch(String resourceName, R resource) {
-            when(resource.watch(any())).thenAnswer(i -> {
-                return mockedWatcher(resourceName, i);
-            });
-        }
-
-        private Watch mockedWatcher(String resourceName, InvocationOnMock i) {
-            Watcher<CM> watcher = i.getArgument(0);
-            LOGGER.debug("watch {} {} ", resourceType, watcher);
-            return addWatcher(PredicatedWatcher.namedWatcher(resourceName, watcher));
-        }
-
-        private Watch addWatcher(PredicatedWatcher<CM> predicatedWatcher) {
-            watchers.add(predicatedWatcher);
-            return () -> {
-                watchers.remove(predicatedWatcher);
-                LOGGER.debug("Watcher {} removed", predicatedWatcher);
-            };
-        }
-
-        protected void mockCreate(String resourceName, R resource) {
-            when(resource.create(any())).thenAnswer(i -> {
-                CM argument = i.getArgument(0);
-                return mockCreate(resourceName, argument);
-            });
-        }
-
-        private CM mockCreate(String resourceName, CM argument) {
-            checkNotExists(resourceName);
-            LOGGER.debug("create {} {} -> {}", resourceType, resourceName, argument);
-            db.put(resourceName, copyResource(argument));
-            fireWatchers(resourceName, argument, Watcher.Action.ADDED);
-            return copyResource(argument);
-        }
-
-        protected OngoingStubbing<CM> mockGet(String resourceName, R resource) {
-            return when(resource.get()).thenAnswer(i -> {
-                CM r = copyResource(db.get(resourceName));
-                LOGGER.debug("{} {} get {}", resourceType, resourceName, r);
-                return r;
-            });
-        }
-
-        protected OngoingStubbing<Boolean> mockIsReady(String resourceName, R resource) {
-            return when(resource.isReady()).thenAnswer(i -> {
-                LOGGER.debug("{} {} is ready", resourceType, resourceName);
-                return Boolean.TRUE;
-            });
-        }
-    }
-
-    /**
-     * This method is just used to appease javac and avoid having a very ugly "double cast" (cast to raw Class,
-     * followed by a cast to parameterised Class) in all the calls to
-     * {@link AbstractMockBuilder#AbstractMockBuilder(Class, Class, Class, Class, Map)}
-     */
-    @SuppressWarnings("unchecked")
-    private static <T extends HasMetadata, D extends Doneable<T>, R extends Resource<T, D>, R2 extends Resource>
-            Class<R> castClass(Class<R2> c) {
-        return (Class) c;
-    }
-
-
 
 }

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/Observer.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/Observer.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.client.Watcher;
+
+public interface Observer<T> {
+
+    void beforeWatcherFire(Watcher.Action action, T resource);
+    void afterWatcherFire(Watcher.Action action, T resource);
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/PredicatedWatcher.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/PredicatedWatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.Watcher;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.function.Predicate;
+
+/**
+ * A Watcher guarded by a Predicate; {@link #maybeFire(HasMetadata, Watcher.Action)}
+ * will call the watcher only if the predicate matches.
+ * This is used to support watches on resources matching selectors, for example.
+ * @param <CM> The resource type of the Watcher
+ */
+class PredicatedWatcher<CM extends HasMetadata> {
+    private static final Logger LOGGER = LogManager.getLogger(PredicatedWatcher.class);
+    private final String str;
+    private final Watcher<CM> watcher;
+    private final Predicate<CM> predicate;
+
+    private PredicatedWatcher(String str, Predicate<CM> predicate, Watcher<CM> watcher) {
+        this.str = str;
+        this.watcher = watcher;
+        this.predicate = predicate;
+    }
+
+    public Watcher<CM> watcher() {
+        return watcher;
+    }
+
+    public Predicate<CM> predicate() {
+        return predicate;
+    }
+
+    static <CM extends HasMetadata> PredicatedWatcher<CM> watcher(Watcher<CM> watcher) {
+        return new PredicatedWatcher<>("watch on all", resource1 -> ((Predicate<CM>) resource -> true).test(resource1), watcher);
+    }
+
+    static <CM extends HasMetadata> PredicatedWatcher<CM> namedWatcher(String name, Watcher<CM> watcher) {
+        return new PredicatedWatcher<>("watch on named " + name, resource1 -> ((Predicate<CM>) resource -> name.equals(resource.getMetadata().getName())).test(resource1), watcher);
+    }
+
+    static <CM extends HasMetadata> PredicatedWatcher<CM> predicatedWatcher(String desc, Predicate<CM> predicate, Watcher<CM> watcher) {
+        return new PredicatedWatcher<>(desc, resource -> predicate.test(resource), watcher);
+    }
+
+    public String toString() {
+        return str;
+    }
+
+    public void maybeFire(CM removed, Watcher.Action action) {
+        if (predicate.test(removed)) {
+            LOGGER.debug("Firing watcher {} with {} and resource {}", watcher, action, removed);
+            watcher.eventReceived(action, removed);
+        }
+    }
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/ServiceMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/ServiceMockBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.DoneableService;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ServiceMockBuilder extends MockBuilder<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> {
+
+    private static final Logger LOGGER = LogManager.getLogger(ServiceMockBuilder.class);
+
+    private final Map<String, Endpoints> endpointsDb;
+
+    public ServiceMockBuilder(Map<String, Service> svcDb, Map<String, Endpoints> endpointsDb) {
+        super(Service.class, ServiceList.class, DoneableService.class, castClass(ServiceResource.class), svcDb);
+        this.endpointsDb = endpointsDb;
+    }
+
+    /** Override Service creation to also create Endpoints */
+    @Override
+    protected void mockCreate(String resourceName, ServiceResource<Service, DoneableService> resource) {
+        when(resource.create(any())).thenAnswer(i -> {
+            Service argument = i.getArgument(0);
+            db.put(resourceName, copyResource(argument));
+            LOGGER.debug("create {} (and endpoint) {} ", resourceType, resourceName);
+            endpointsDb.put(resourceName, new Endpoints());
+            return argument;
+        });
+    }
+}

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.DoneableStatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StatefulSetMockBuilder extends MockBuilder<StatefulSet, StatefulSetList, DoneableStatefulSet,
+        RollableScalableResource<StatefulSet, DoneableStatefulSet>> {
+
+    private static final Logger LOGGER = LogManager.getLogger(StatefulSetMockBuilder.class);
+
+    private final MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods;
+    private final MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPvcs;
+    private final Map<String, Pod> podDb;
+
+    public StatefulSetMockBuilder(MockBuilder<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> podMockBuilder, Map<String, StatefulSet> ssDb,
+                                  Map<String, Pod> podDb,
+                                  MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockPods, MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> mockPvcs) {
+        super(StatefulSet.class, StatefulSetList.class, DoneableStatefulSet.class, castClass(RollableScalableResource.class), ssDb);
+        podMockBuilder.addObserver(new Observer<Pod>() {
+            @Override
+            public void beforeWatcherFire(Watcher.Action action, Pod resource) {
+
+            }
+
+            @Override
+            public void afterWatcherFire(Watcher.Action action, Pod resource) {
+                if (action == Watcher.Action.DELETED) {
+                    List<OwnerReference> ownerReferences = resource.getMetadata().getOwnerReferences();
+                    if (ownerReferences != null) {
+                        for (OwnerReference ownerReference : ownerReferences) {
+                            if ("StatefulSet".equals(ownerReference.getKind())) {
+                                String stsName = ownerReference.getName();
+                                String podName = resource.getMetadata().getName();
+                                doRecreatePod(resource.getMetadata().getNamespace(),
+                                        stsName,
+                                        podName);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        this.podDb = podDb;
+        this.mockPods = mockPods;
+        this.mockPvcs = mockPvcs;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void nameScopedMocks(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
+        super.nameScopedMocks(resourceName, resource);
+        EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> c = mock(EditReplacePatchDeletable.class);
+        when(resource.cascading(false)).thenReturn(c);
+        mockNoncascadingPatch(resourceName, c);
+        mockScale(resourceName, resource);
+        mockNoncascadingDelete(resourceName, c);
+    }
+
+    private void mockNoncascadingDelete(String resourceName, EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> c) {
+        when(c.delete()).thenAnswer(i -> {
+            LOGGER.info("delete {} {}", resourceType, resourceName);
+            StatefulSet removed = db.remove(resourceName);
+            return removed != null;
+        });
+    }
+
+    private void mockNoncascadingPatch(String resourceName, EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> c) {
+        when(c.patch(any())).thenAnswer(patchInvocation -> {
+            StatefulSet argument = patchInvocation.getArgument(0);
+            return doPatch(resourceName, argument);
+        });
+    }
+
+    private void mockScale(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
+        when(resource.scale(anyInt(), anyBoolean())).thenAnswer(invocation -> {
+            checkDoesExist(resourceName);
+            StatefulSet ss = copyResource(db.get(resourceName));
+            int newScale = invocation.getArgument(0);
+            ss.getSpec().setReplicas(newScale);
+            return doPatch(resourceName, ss);
+        });
+        when(resource.scale(anyInt())).thenAnswer(invocation -> {
+            checkDoesExist(resourceName);
+            StatefulSet ss = copyResource(db.get(resourceName));
+            int newScale = invocation.getArgument(0);
+            ss.getSpec().setReplicas(newScale);
+            return doPatch(resourceName, ss);
+        });
+    }
+
+    @Override
+    protected void mockCreate(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
+        when(resource.create(any())).thenAnswer(cinvocation -> {
+            checkNotExists(resourceName);
+            StatefulSet argument = cinvocation.getArgument(0);
+            LOGGER.debug("create {} {} -> {}", resourceType, resourceName, argument);
+            StatefulSet value = copyResource(argument);
+            value.setStatus(new StatefulSetStatus());
+            db.put(resourceName, value);
+            for (int i = 0; i < argument.getSpec().getReplicas(); i++) {
+                final int podNum = i;
+                String podName = argument.getMetadata().getName() + "-" + podNum;
+                LOGGER.debug("create Pod {} because it's in StatefulSet {}", podName, resourceName);
+                mockPods.inNamespace(argument.getMetadata().getNamespace()).createOrReplace(doCreatePod(argument, podName));
+
+                if (value.getSpec().getVolumeClaimTemplates().size() > 0) {
+
+                    for (PersistentVolumeClaim pvcTemplate: value.getSpec().getVolumeClaimTemplates()) {
+
+                        String pvcName = pvcTemplate.getMetadata().getName() + "-" + podName;
+                        if (mockPvcs.inNamespace(argument.getMetadata().getNamespace()).withName(pvcName).get() == null) {
+
+                            LOGGER.debug("create Pvc {} because it's in VolumeClaimTemplate of StatefulSet {}", pvcName, resourceName);
+                            PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                                    .withNewMetadata()
+                                        .withLabels(argument.getSpec().getSelector().getMatchLabels())
+                                        .withNamespace(argument.getMetadata().getNamespace())
+                                        .withName(pvcName)
+                                    .endMetadata()
+                                    .build();
+                            mockPvcs.inNamespace(argument.getMetadata().getNamespace()).withName(pvcName).create(pvc);
+                        }
+                    }
+
+                }
+            }
+            return argument;
+        });
+    }
+
+    private Pod doCreatePod(StatefulSet sts, String podName) {
+        return new PodBuilder().withNewMetadataLike(sts.getSpec().getTemplate().getMetadata())
+                                .withUid(UUID.randomUUID().toString())
+                                .withNamespace(sts.getMetadata().getNamespace())
+                                .withName(podName)
+                                .addNewOwnerReference()
+                                    .withKind(sts.getKind())
+                                    .withName(sts.getMetadata().getName())
+                                .endOwnerReference()
+                            .endMetadata()
+                            .withNewSpecLike(sts.getSpec().getTemplate().getSpec()).endSpec()
+                            .build();
+    }
+
+    private void doRecreatePod(String namespace,
+                               String stsName,
+                               String podName) {
+        int podNum = Integer.parseInt(podName.substring(stsName.length() + 1));
+        StatefulSet statefulSet = db.get(stsName);
+        if (statefulSet != null &&
+                podNum < statefulSet.getSpec().getReplicas()) {
+            Pod copy = doCreatePod(statefulSet, podName);
+            LOGGER.debug("Recreating Pod {} because it's in StatefulSet {}", podName, stsName);
+            mockPods.inNamespace(namespace).withName(podName).create(copy);
+        }
+    }
+
+    @Override
+    protected void mockDelete(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
+        when(resource.delete()).thenAnswer(i -> {
+            LOGGER.debug("delete {} {}", resourceType, resourceName);
+            StatefulSet removed = db.remove(resourceName);
+            if (removed != null) {
+                fireWatchers(resourceName, removed, Watcher.Action.DELETED);
+                for (Map.Entry<String, Pod> pod : new HashMap<>(podDb).entrySet()) {
+                    if (pod.getKey().matches(resourceName + "-[0-9]+")) {
+                        mockPods.inNamespace(removed.getMetadata().getNamespace()).withName(pod.getKey()).delete();
+                    }
+                }
+            }
+            return removed != null;
+        });
+    }
+
+    private StatefulSet doPatch(String resourceName, StatefulSet argument) {
+        int oldScale = db.get(resourceName).getSpec().getReplicas();
+        int newScale = argument.getSpec().getReplicas();
+        if (newScale > oldScale) {
+            LOGGER.debug("scaling up {} {} from {} to {}", resourceType, resourceName, oldScale, newScale);
+            Pod examplePod = mockPods.inNamespace(argument.getMetadata().getNamespace())
+                    .withName(argument.getMetadata().getName() + "-0").get();
+            for (int i = oldScale; i < newScale; i++) {
+                String newPodName = argument.getMetadata().getName() + "-" + i;
+                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).create(
+                        new PodBuilder(examplePod).editMetadata().withName(newPodName).endMetadata().build());
+            }
+            db.put(resourceName, copyResource(argument));
+        } else if (newScale < oldScale) {
+            db.put(resourceName, copyResource(argument));
+            LOGGER.debug("scaling down {} {} from {} to {}", resourceType, resourceName, oldScale, newScale);
+            for (int i = oldScale - 1; i >= newScale; i--) {
+                String newPodName = argument.getMetadata().getName() + "-" + i;
+                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).delete();
+            }
+        } else {
+            db.put(resourceName, copyResource(argument));
+        }
+        return argument;
+    }
+}

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.io.strimzi.test.mockkube;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.strimzi.test.mockkube.MockKube;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+
+public class MockKubeRegressionTest {
+
+    private KubernetesClient client;
+
+    @Before
+    public void before() {
+        client = new MockKube().build();
+    }
+
+    @Test
+    public void test1() {
+        client.apps().statefulSets().inNamespace("ns").withName("foo").createNew()
+                .withNewMetadata()
+                    .withName("foo")
+                    .withNamespace("ns")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(3)
+                    .withNewTemplate()
+                        .withNewMetadata().endMetadata()
+                        .withNewSpec().endSpec()
+                    .endTemplate()
+                .endSpec()
+            .done();
+
+        List<Pod> ns = client.pods().inNamespace("ns").list().getItems();
+        assertEquals(3, ns.size());
+
+        AtomicBoolean deleted = new AtomicBoolean(false);
+        AtomicBoolean recreated = new AtomicBoolean(false);
+        Watch watch = client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).watch(new Watcher<Pod>() {
+            @Override
+            public void eventReceived(Action action, Pod resource) {
+                if (action == Action.DELETED) {
+                    if (deleted.getAndSet(true)) {
+                        Assert.fail("Deleted twice");
+                    }
+                } else if (action == Action.ADDED) {
+                    if (!deleted.get()) {
+                        Assert.fail("Created before deleted");
+                    }
+                    if (recreated.getAndSet(true)) {
+                        Assert.fail("Recreated twice");
+                    }
+                }
+            }
+
+            @Override
+            public void onClose(KubernetesClientException cause) {
+
+            }
+        });
+        client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).delete();
+
+        Assert.assertTrue(deleted.get());
+        Assert.assertTrue(recreated.get());
+        watch.close();
+
+        ns = client.pods().inNamespace("ns").list().getItems();
+        assertEquals(3, ns.size());
+
+        client.apps().statefulSets().inNamespace("ns").withName("foo").delete();
+
+    }
+}

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
@@ -52,6 +52,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
     KubernetesClient client;
 
     @Parameterized.Parameters(name = "{index}: {0}")
+    @SuppressWarnings("unchecked")
     public static Iterable<Object[]> parameters() {
         return Arrays.<Object[]>asList(
                 new Object[]{Pod.class,
@@ -150,6 +151,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void podCreateDeleteUnscoped() {
         MyWatcher w = new MyWatcher();
         mixedOp().watch(w);
@@ -181,6 +183,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void podNameScopedCreateListGetDelete() {
         MyWatcher w = new MyWatcher();
         mixedOp().watch(w);
@@ -256,6 +259,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void watches() {
         RT pod = pod();
 

--- a/mockkube/src/test/resources/log4j2.properties
+++ b/mockkube/src/test/resources/log4j2.properties
@@ -1,0 +1,15 @@
+name = STConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d] %p %m (%c:%L)%n
+
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false
+
+logger.clients.name = org.apache.kafka.clients
+logger.clients.level = info
+


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

The problem was due to the fact that we were using watchers
to recreated delected pods in a statefulset. Because the "recreation watcher"
was fired first (and because the whole thing is single threaded) it meant
we recreated the pod (for fired the creation event) before other watchers had
been told of the deletion.

The solution was to introduce a separate Observer mechanism so that such
recreations can be done after all watches are fired. This should be easily
extensible for other things should that be necessary (e.g. Deployments if we had any tests which actually needed that functionality).

The refactoring should make the whole thing a bit more understandable, and I managed to eliminate quite a lot of duplication.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

