### PR TITLE
fix: reorder the address priority code to reflect the documentation

### DIFF
--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -148,12 +148,12 @@ public class InitWriter {
             return addressMap.get("ExternalDNS");
         } else if (addressMap.containsKey("ExternalIP"))  {
             return addressMap.get("ExternalIP");
+        } else if (addressMap.containsKey("Hostname")) {
+            return addressMap.get("Hostname");
         } else if (addressMap.containsKey("InternalDNS"))  {
             return addressMap.get("InternalDNS");
         } else if (addressMap.containsKey("InternalIP"))  {
             return addressMap.get("InternalIP");
-        } else if (addressMap.containsKey("Hostname")) {
-            return addressMap.get("Hostname");
         }
 
         return null;


### PR DESCRIPTION
#1970 # Type of change

- Bugfix

### Description

reorder the code that reads the address of the node to read the
address in the order that is documented

and add a test to check the order is correct

Contributes to: strimzi/strimzi-kafka-operator#2109

Signed-off-by: Chris Patmore <chrism.patmore@btinternet.com>

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

