### PR TITLE
Add support for schedulerName field in the Pod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop support for Kafka 2.1.0, 2.1.1, and 2.2.0
 * Improve Kafka Exporter Grafana dashboard
 * Add sizeLimit option to ephemeral storage (#1505)
+* Add `schedulerName` to `podTemplate` (#2114)
 
 ## 0.14.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -45,6 +45,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     private Affinity affinity;
     private List<Toleration> tolerations;
     private String priorityClassName;
+    private String schedulerName;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metadata applied to the resource.")
@@ -125,6 +126,17 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
+    }
+
+    @Description("The name of the scheduler used to dispatch this `Pod`. " +
+            "If not specified, the default scheduler will be used.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getSchedulerName() {
+        return schedulerName;
+    }
+
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -171,6 +171,7 @@ public abstract class AbstractModel {
     protected Map<String, String> templatePodDisruptionBudgetAnnotations;
     protected int templatePodDisruptionBudgetMaxUnavailable = 1;
     protected String templatePodPriorityClassName;
+    protected String templatePodSchedulerName;
 
     // Owner Reference information
     private String ownerApiVersion;
@@ -823,6 +824,7 @@ public abstract class AbstractModel {
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(securityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
+                            .withSchedulerName(templatePodSchedulerName != null ? templatePodSchedulerName : "default-scheduler")
                         .endSpec()
                     .endTemplate()
                     .withVolumeClaimTemplates(volumeClaims)
@@ -870,6 +872,7 @@ public abstract class AbstractModel {
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(templateSecurityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
+                            .withSchedulerName(templatePodSchedulerName)
                         .endSpec()
                     .endTemplate()
                 .endSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -24,7 +24,6 @@ import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.template.EntityOperatorTemplate;
-import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Labels;
 
@@ -151,19 +150,7 @@ public class EntityOperator extends AbstractModel {
                     result.templateDeploymentAnnotations = template.getDeployment().getMetadata().getAnnotations();
                 }
 
-                if (template.getPod() != null)  {
-                    PodTemplate pod = template.getPod();
-
-                    if (pod.getMetadata() != null) {
-                        result.templatePodLabels = pod.getMetadata().getLabels();
-                        result.templatePodAnnotations = pod.getMetadata().getAnnotations();
-                    }
-
-                    result.templateTerminationGracePeriodSeconds = pod.getTerminationGracePeriodSeconds();
-                    result.templateImagePullSecrets = pod.getImagePullSecrets();
-                    result.templateSecurityContext = pod.getSecurityContext();
-                    result.templatePodPriorityClassName = pod.getPriorityClassName();
-                }
+                ModelUtils.parsePodTemplate(result, template.getPod());
 
                 if (template.getTopicOperatorContainer() != null && template.getTopicOperatorContainer().getEnv() != null) {
                     topicOperator.setContainerEnvVars(template.getTopicOperatorContainer().getEnv());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -139,6 +139,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                             .withImagePullSecrets(templateImagePullSecrets != null ? templateImagePullSecrets : imagePullSecrets)
                             .withSecurityContext(templateSecurityContext)
                             .withPriorityClassName(templatePodPriorityClassName)
+                            .withSchedulerName(templatePodSchedulerName)
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -289,6 +289,7 @@ public class ModelUtils {
             model.templateImagePullSecrets = pod.getImagePullSecrets();
             model.templateSecurityContext = pod.getSecurityContext();
             model.templatePodPriorityClassName = pod.getPriorityClassName();
+            model.templatePodSchedulerName = pod.getSchedulerName();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -40,7 +40,6 @@ public class StatefulSetDiff extends AbstractResourceDiff {
         + "|/spec/template/spec/containers/[0-9]+/terminationMessagePolicy"
         + "|/spec/template/spec/dnsPolicy"
         + "|/spec/template/spec/restartPolicy"
-        + "|/spec/template/spec/schedulerName"
         + "|/spec/template/spec/securityContext"
         + "|/spec/template/spec/terminationGracePeriodSeconds"
         + "|/spec/template/spec/volumes/[0-9]+/configMap/defaultMode"

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -181,6 +181,7 @@ public class EntityOperatorTest {
                                             .withAnnotations(podAnots)
                                         .endMetadata()
                                         .withNewPriorityClassName("top-priority")
+                                        .withNewSchedulerName("my-scheduler")
                                     .endPod()
                                 .endTemplate()
                             .endEntityOperator()
@@ -197,6 +198,7 @@ public class EntityOperatorTest {
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -376,6 +376,7 @@ public class KafkaBridgeClusterTest {
                                 .withAnnotations(podAnots)
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
+                            .withNewSchedulerName("my-scheduler")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -403,6 +404,7 @@ public class KafkaBridgeClusterTest {
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check Service
         Service svc = kbc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -349,6 +349,8 @@ public class KafkaClusterTest {
         assertEquals(expectedLabels(), ss.getMetadata().getLabels());
         assertEquals(expectedSelectorLabels(), ss.getSpec().getSelector().getMatchLabels());
 
+        assertEquals("default-scheduler", ss.getSpec().getTemplate().getSpec().getSchedulerName());
+
         List<Container> containers = ss.getSpec().getTemplate().getSpec().getContainers();
 
         assertEquals(2, containers.size());
@@ -1213,6 +1215,7 @@ public class KafkaClusterTest {
                                     .withAnnotations(podAnots)
                                 .endMetadata()
                                 .withNewPriorityClassName("top-priority")
+                                .withNewSchedulerName("my-scheduler")
                             .endPod()
                             .withNewBootstrapService()
                                 .withNewMetadata()
@@ -1271,6 +1274,7 @@ public class KafkaClusterTest {
         // Check Pods
         assertTrue(ss.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(ss.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", ss.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -449,6 +449,7 @@ public class KafkaConnectClusterTest {
                                 .withAnnotations(podAnots)
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
+                            .withNewSchedulerName("my-scheduler")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -476,6 +477,7 @@ public class KafkaConnectClusterTest {
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -510,6 +510,7 @@ public class KafkaConnectS2IClusterTest {
                                 .withAnnotations(podAnots)
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
+                            .withNewSchedulerName("my-scheduler")
                         .endPod()
                         .withNewApiService()
                             .withNewMetadata()
@@ -537,6 +538,7 @@ public class KafkaConnectS2IClusterTest {
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check Service
         Service svc = kc.generateService();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -536,6 +536,7 @@ public class KafkaMirrorMakerClusterTest {
                                 .withAnnotations(podAnots)
                             .endMetadata()
                             .withNewPriorityClassName("top-priority")
+                            .withNewSchedulerName("my-scheduler")
                         .endPod()
                         .withNewPodDisruptionBudget()
                             .withNewMetadata()
@@ -557,6 +558,7 @@ public class KafkaMirrorMakerClusterTest {
         // Check Pods
         assertTrue(dep.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check PodDisruptionBudget
         PodDisruptionBudget pdb = mmc.generatePodDisruptionBudget();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -238,6 +238,8 @@ public class ZookeeperClusterTest {
         assertEquals(expectedLabels(), ss.getMetadata().getLabels());
         assertEquals(expectedSelectorLabels(), ss.getSpec().getSelector().getMatchLabels());
 
+        assertEquals("default-scheduler", ss.getSpec().getTemplate().getSpec().getSchedulerName());
+
         List<Container> containers = ss.getSpec().getTemplate().getSpec().getContainers();
 
         assertEquals(2, containers.size());
@@ -387,6 +389,7 @@ public class ZookeeperClusterTest {
                                     .withAnnotations(podAnots)
                                 .endMetadata()
                                 .withNewPriorityClassName("top-priority")
+                                .withNewSchedulerName("my-scheduler")
                             .endPod()
                             .withNewClientService()
                                 .withNewMetadata()
@@ -421,6 +424,7 @@ public class ZookeeperClusterTest {
         // Check Pods
         assertTrue(ss.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()));
         assertTrue(ss.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
+        assertEquals("my-scheduler", ss.getSpec().getTemplate().getSpec().getSchedulerName());
 
         // Check Service
         Service svc = zc.generateService();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -860,6 +860,8 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core[Affinity]
 |priorityClassName              1.2+<.<|The name of the Priority Class to which these pods will be assigned.
 |string
+|schedulerName                  1.2+<.<|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
+|string
 |tolerations                    1.2+<.<|The pod's tolerations. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[core/v1 toleration].
 
 

--- a/documentation/modules/con-customizing-pods.adoc
+++ b/documentation/modules/con-customizing-pods.adoc
@@ -33,6 +33,10 @@ For more information about configuring SecurityContext, see {K8sConfigureSecurit
 |Configures the name of the Priority Class which will be used for given a Pod.
 For more information about Priority Classes, see {K8sPriorityClass}.
 
+|`schedulerName`
+| The name of the scheduler used to dispatch this `Pod`.
+If not specified, the default scheduler will be used.
+
 |===
 
 These fields are effective on each type of cluster (Kafka and Zookeeper; Kafka Connect and Kafka Connect with S2I support; and Kafka Mirror Maker).

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1159,6 +1159,8 @@ spec:
                                         type: string
                         priorityClassName:
                           type: string
+                        schedulerName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -1988,6 +1990,8 @@ spec:
                                       topologyKey:
                                         type: string
                         priorityClassName:
+                          type: string
+                        schedulerName:
                           type: string
                         tolerations:
                           type: array
@@ -3112,6 +3116,8 @@ spec:
                                         type: string
                         priorityClassName:
                           type: string
+                        schedulerName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -3499,6 +3505,8 @@ spec:
                                       topologyKey:
                                         type: string
                         priorityClassName:
+                          type: string
+                        schedulerName:
                           type: string
                         tolerations:
                           type: array

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -620,6 +620,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -596,6 +596,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -838,6 +838,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -516,6 +516,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1154,6 +1154,8 @@ spec:
                                         type: string
                         priorityClassName:
                           type: string
+                        schedulerName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -1983,6 +1985,8 @@ spec:
                                       topologyKey:
                                         type: string
                         priorityClassName:
+                          type: string
+                        schedulerName:
                           type: string
                         tolerations:
                           type: array
@@ -3107,6 +3111,8 @@ spec:
                                         type: string
                         priorityClassName:
                           type: string
+                        schedulerName:
+                          type: string
                         tolerations:
                           type: array
                           items:
@@ -3494,6 +3500,8 @@ spec:
                                       topologyKey:
                                         type: string
                         priorityClassName:
+                          type: string
+                        schedulerName:
                           type: string
                         tolerations:
                           type: array

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -615,6 +615,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -591,6 +591,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -833,6 +833,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -511,6 +511,8 @@ spec:
                                     type: string
                     priorityClassName:
                       type: string
+                    schedulerName:
+                      type: string
                     tolerations:
                       type: array
                       items:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for the `schedulerName` field into the `podTemplate` as discussed in the issue #2106. This allows users to plug custom schedulers which for example do better scheduling based on the storage, network etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

