### PR TITLE
Count the consumed messages rate on 1 minute only and fix null values

### DIFF
--- a/metrics/examples/grafana/strimzi-kafka-exporter.json
+++ b/metrics/examples/grafana/strimzi-kafka-exporter.json
@@ -834,7 +834,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[5m])/5/60) by (consumergroup, topic)",
+          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[1m])/60) by (consumergroup, topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{consumergroup}} (topic: {{topic}})",

--- a/metrics/examples/grafana/strimzi-kafka.json
+++ b/metrics/examples/grafana/strimzi-kafka.json
@@ -472,7 +472,7 @@
       "colorValue": true,
       "colors": [
         "#508642",
-        "rgba(237, 129, 40, 0.89)",
+        "#ef843c",
         "#bf1b00"
       ],
       "datasource": "${DS_PROMETHEUS}",
@@ -542,7 +542,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],
@@ -554,7 +554,7 @@
       "colorValue": true,
       "colors": [
         "#508642",
-        "rgba(237, 129, 40, 0.89)",
+        "#ef843c",
         "#bf1b00"
       ],
       "datasource": "${DS_PROMETHEUS}",
@@ -617,7 +617,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": "1,5",
+      "thresholds": "1,1",
       "title": "Partitions under mininimum ISR",
       "type": "singlestat",
       "valueFontSize": "200%",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

* In the Kafka Exporter dashboard we have a chart with a rate of consumed messages. It is currently calculated over 5 minutes while all our other charts are over 1 minute. We should keep all charts at the same settings.
* It also adds some more default values to map `null` to `0` and uses the same coloring and thresholds as for other similar fields.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally