### PR TITLE
Fix handling of the Kafka Exporter service template

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -124,11 +124,11 @@ public class KafkaExporter extends AbstractModel {
                 if (template.getDeployment() != null && template.getDeployment().getMetadata() != null) {
                     kafkaExporter.templateDeploymentLabels = template.getDeployment().getMetadata().getLabels();
                     kafkaExporter.templateDeploymentAnnotations = template.getDeployment().getMetadata().getAnnotations();
+                }
 
-                    if (template.getService() != null && template.getService().getMetadata() != null)  {
-                        kafkaExporter.templateServiceLabels = template.getService().getMetadata().getLabels();
-                        kafkaExporter.templateServiceAnnotations = template.getService().getMetadata().getAnnotations();
-                    }
+                if (template.getService() != null && template.getService().getMetadata() != null)  {
+                    kafkaExporter.templateServiceLabels = template.getService().getMetadata().getLabels();
+                    kafkaExporter.templateServiceAnnotations = template.getService().getMetadata().getAnnotations();
                 }
 
                 if (template.getContainer() != null && template.getContainer().getEnv() != null) {
@@ -181,7 +181,7 @@ public class KafkaExporter extends AbstractModel {
         List<ServicePort> ports = new ArrayList<>(1);
 
         ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
-        return createService("ClusterIP", ports, getPrometheusAnnotations());
+        return createService("ClusterIP", ports, mergeLabelsOrAnnotations(getPrometheusAnnotations(), templateServiceAnnotations));
     }
 
     protected List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -329,6 +329,9 @@ public class KafkaExporterTest {
         Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
         Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
 
+        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+
         Kafka resource =
                 new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
                 .editSpec()
@@ -348,6 +351,12 @@ public class KafkaExporterTest {
                                 .withNewPriorityClassName("top-priority")
                                 .withNewSchedulerName("my-scheduler")
                             .endPod()
+                            .withNewService()
+                                .withNewMetadata()
+                                    .withLabels(svcLabels)
+                                    .withAnnotations(svcAnots)
+                                .endMetadata()
+                            .endService()
                         .endTemplate()
                     .endKafkaExporter()
                 .endSpec()
@@ -364,6 +373,11 @@ public class KafkaExporterTest {
         assertTrue(dep.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()));
         assertEquals("top-priority", dep.getSpec().getTemplate().getSpec().getPriorityClassName());
         assertEquals("my-scheduler", dep.getSpec().getTemplate().getSpec().getSchedulerName());
+
+        // Check Service
+        Service svc = ke.generateService();
+        assertTrue(svc.getMetadata().getLabels().entrySet().containsAll(svcLabels.entrySet()));
+        assertTrue(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnots.entrySet()));
     }
 
     @AfterClass


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The service template for Kafka Exporter is not handled properly:
* It is ignored when deployment template is not set
* The annotations are ignored even in that case
* There is no test

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally