### PR TITLE
Added tracing support for the Kafka Bridge

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
+import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
@@ -29,7 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({
         "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "consumer",
         "producer", "resources", "jvmOptions", "logging",
-        "metrics", "livenessProbe", "readinessProbe", "template"})
+        "metrics", "livenessProbe", "readinessProbe", "template", "tracing"})
 @EqualsAndHashCode
 public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -52,6 +53,7 @@ public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable 
     private Probe readinessProbe;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
     private KafkaBridgeTemplate template;
+    private Tracing tracing;
 
     @Description("The number of pods in the `Deployment`.")
     @Minimum(0)
@@ -205,6 +207,16 @@ public class KafkaBridgeSpec implements UnknownPropertyPreserving, Serializable 
 
     public void setReadinessProbe(Probe readinessProbe) {
         this.readinessProbe = readinessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The configuration of tracing in Kafka Bridge.")
+    public Tracing getTracing() {
+        return tracing;
+    }
+
+    public void setTracing(Tracing tracing) {
+        this.tracing = tracing;
     }
 
     @Override

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -77,6 +77,29 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
         createDelete(KafkaBridge.class, "KafkaBridge-with-template.yaml");
     }
 
+    @Test
+    void testKafkaBridgeWithJaegerTracing() {
+        createDelete(KafkaBridge.class, "KafkaBridge-with-jaeger-tracing.yaml");
+    }
+
+    @Test
+    void testKafkaBridgeWithWrongTracingType() {
+        try {
+            createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.tracing.type in body should be one of [jaeger]"));
+        }
+    }
+
+    @Test
+    void testKafkaBridgeWithMissingTracingType() {
+        try {
+            createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
+        } catch (KubeClusterException.InvalidResource e) {
+            assertTrue(e.getMessage().contains("spec.tracing.type in body is required"));
+        }
+    }
+
     @BeforeAll
     void setupEnvironment() {
         createNamespace(NAMESPACE);

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-jaeger-tracing.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-jaeger-tracing.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaBridge
+metadata:
+  name: test-kafka-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka:9092
+  tracing:
+    type: jaeger

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-missing-tracing-type.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-missing-tracing-type.yaml
@@ -1,0 +1,8 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaBridge
+metadata:
+  name: test-kafka-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka:9092
+  tracing: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-wrong-tracing-type.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-wrong-tracing-type.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaBridge
+metadata:
+  name: test-kafka-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka:9092
+  tracing:
+    type: wrongtype

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -28,6 +28,8 @@ import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuthBuilder;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.tracing.JaegerTracing;
+import io.strimzi.api.kafka.model.tracing.JaegerTracingBuilder;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -910,5 +912,20 @@ public class KafkaBridgeClusterTest {
         assertEquals(new Integer(30), cont.getReadinessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(31), cont.getReadinessProbe().getPeriodSeconds());
         assertEquals(new Integer(32), cont.getReadinessProbe().getTimeoutSeconds());
+    }
+
+    @Test
+    public void testTracingConfiguration() {
+        KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
+                .editSpec()
+                    .withJaegerTracing(new JaegerTracing())
+                .endSpec()
+                .build();
+
+        KafkaBridgeCluster kb = KafkaBridgeCluster.fromCrd(resource, VERSIONS);
+        Deployment deployment = kb.generateDeployment(new HashMap<>(), true, null, null);
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+
+        assertEquals("jaeger", AbstractModel.containerEnvVars(container).get(KafkaBridgeCluster.ENV_VAR_STRIMZI_TRACING));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -29,7 +29,6 @@ import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuthB
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.tracing.JaegerTracing;
-import io.strimzi.api.kafka.model.tracing.JaegerTracingBuilder;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1342,7 +1342,7 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 [id='type-JaegerTracing-{context}']
 ### `JaegerTracing` schema reference
 
-Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 
 
 The `type` property is a discriminator that distinguishes the use of the type `JaegerTracing` from other subtypes which may be added in the future.
@@ -2118,6 +2118,8 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |xref:type-Probe-{context}[`Probe`]
 |template          1.2+<.<|Template for Kafka Bridge resources. The template allows users to specify how is the `Deployment` and `Pods` generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
+|tracing           1.2+<.<|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|xref:type-JaegerTracing-{context}[`JaegerTracing`]
 |====
 
 [id='type-KafkaBridgeTls-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -568,6 +568,15 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+              required:
+              - type
           required:
           - bootstrapServers
         status:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -563,6 +563,15 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+              required:
+              - type
           required:
           - bootstrapServers
         status:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the integration of the tracing support for the Kafka Bridge in the cluster operator.
The related documentation update will be reported in a different PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

