### PR TITLE
Added the ephemeral-single example

### DIFF
--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 2.3.0
+    replicas: 1
+    listeners:
+      plain: {}
+      tls: {}
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "2.3"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

### Type of change 

Enhancement / new feature

### Description

This PR adds a new example `kafka-ephemeral-single.yaml` based on the existing `kafka-ephemeral.yaml`, suitable for CI builds and quick tests. For the Jaeger Operator, we currently run our end-to-end tests with the regular ephemeral example, but it would be better/faster to use a single-replica setup for that. Instead of having a copy of this example in our repository, we thought it could be more advantageous to have it here.
