### PR TITLE
Refer to updated service account names in docs

### DIFF
--- a/documentation/modules/con-cluster-operator-rbac.adoc
+++ b/documentation/modules/con-cluster-operator-rbac.adoc
@@ -26,10 +26,10 @@ When the Cluster Operator deploys resources for a desired `Kafka` resource it al
 
 * The Kafka broker pods use a `ServiceAccount` called `_cluster-name_-kafka`
   - When the rack feature is used, the `strimzi-_cluster-name_-kafka-init` `ClusterRoleBinding` is used to grant this `ServiceAccount` access to the nodes within the cluster via a `ClusterRole` called `strimzi-kafka-broker`
-  - When the rack feature is not used no binding is created.
+  - When the rack feature is not used no binding is created
 * The Zookeeper pods use a `ServiceAccount` called `_cluster-name_-zookeeper`
 * The Entity Operator pod uses a `ServiceAccount` called `_cluster-name_-entity-operator`
-    - The Topic Operator produces Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`.
+    - The Topic Operator produces Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`
 * The pods for `KafkaConnect` and `KafkaConnectS2I` resources use a `ServiceAccount` called `_cluster-name_-cluster-connect`
 * The pods for `KafkaMirrorMaker` use a `ServiceAccount` called `_cluster-name_-mirror-maker`
 * The pods for `KafkaBridge` use a `ServiceAccount` called `_cluster-name_-bridge`

--- a/documentation/modules/con-cluster-operator-rbac.adoc
+++ b/documentation/modules/con-cluster-operator-rbac.adoc
@@ -29,7 +29,7 @@ When the Cluster Operator deploys resources for a desired `Kafka` resource it al
   - When the rack feature is not used no binding is created.
 * The Zookeeper pods use a `ServiceAccount` called `_cluster-name_-zookeeper`
 * The Entity Operator pod uses a `ServiceAccount` called `_cluster-name_-entity-operator`
-    - The Topic Operator and User Operator produce Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`.
+    - The Topic Operator produces Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`.
 * The pods for `KafkaConnect` and `KafkaConnectS2I` resources use a `ServiceAccount` called `_cluster-name_-cluster-connect`
 * The pods for `KafkaMirrorMaker` use a `ServiceAccount` called `_cluster-name_-mirror-maker`
 * The pods for `KafkaBridge` use a `ServiceAccount` called `_cluster-name_-bridge`

--- a/documentation/modules/con-cluster-operator-rbac.adoc
+++ b/documentation/modules/con-cluster-operator-rbac.adoc
@@ -31,6 +31,8 @@ When the Cluster Operator deploys resources for a desired `Kafka` resource it al
 * The Entity Operator pod uses a `ServiceAccount` called `_cluster-name_-entity-operator`
     - The Topic Operator and User Operator produce Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`.
 * The pods for `KafkaConnect` and `KafkaConnectS2I` resources use a `ServiceAccount` called `_cluster-name_-cluster-connect`
+* The pods for `KafkaMirrorMaker` use a `ServiceAccount` called `_cluster-name_-mirror-maker`
+* The pods for `KafkaBridge` use a `ServiceAccount` called `_cluster-name_-bridge`
 
 == `ServiceAccount`
 

--- a/documentation/modules/con-cluster-operator-rbac.adoc
+++ b/documentation/modules/con-cluster-operator-rbac.adoc
@@ -27,11 +27,10 @@ When the Cluster Operator deploys resources for a desired `Kafka` resource it al
 * The Kafka broker pods use a `ServiceAccount` called `_cluster-name_-kafka`
   - When the rack feature is used, the `strimzi-_cluster-name_-kafka-init` `ClusterRoleBinding` is used to grant this `ServiceAccount` access to the nodes within the cluster via a `ClusterRole` called `strimzi-kafka-broker`
   - When the rack feature is not used no binding is created.
-* The Zookeeper pods use the default `ServiceAccount`, as they do not need access to the Kubernetes resources.
-* The Topic Operator pod uses a `ServiceAccount` called `_cluster-name_-topic-operator`
-    - The Topic Operator produces Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-topic-operator` which grants this access via the `strimzi-topic-operator-role-binding` `RoleBinding`.
-
-The pods for `KafkaConnect` and `KafkaConnectS2I` resources use the default `ServiceAccount`, as they do not require access to the Kubernetes resources.
+* The Zookeeper pods use a `ServiceAccount` called `_cluster-name_-zookeeper`
+* The Entity Operator pod uses a `ServiceAccount` called `_cluster-name_-entity-operator`
+    - The Topic Operator and User Operator produce Kubernetes events with status information, so the `ServiceAccount` is bound to a `ClusterRole` called `strimzi-entity-operator` which grants this access via the `strimzi-entity-operator` `RoleBinding`.
+* The pods for `KafkaConnect` and `KafkaConnectS2I` resources use a `ServiceAccount` called `_cluster-name_-cluster-connect`
 
 == `ServiceAccount`
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Update documentation to use the correct service account names. It looks like work done for issue #1299 and PR #1369 ended the use of the default service accounts, however the documentation does not seem to have been updated to reflect this. I believe I have updated the docs correctly, however I am new to Strimzi so I would appreciate an accuracy check!

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

