### PR TITLE
Filter labels in fromCRD methods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -81,7 +81,7 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractModel {
 
-    protected static final String STRIMZI_CLUSTER_OPERATOR_NAME = "strimzi-cluster-operator";
+    public static final String STRIMZI_CLUSTER_OPERATOR_NAME = "strimzi-cluster-operator";
 
     protected static final Logger log = LogManager.getLogger(AbstractModel.class.getName());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -441,7 +441,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          */
         Future<ReconciliationState> reconcileCas(Supplier<Date> dateSupplier) {
             Labels selectorLabels = Labels.EMPTY.withKind(reconciliation.kind()).withCluster(reconciliation.name());
-            Labels caLabels = Labels.userLabels(kafkaAssembly.getMetadata().getLabels()).withKind(reconciliation.kind()).withCluster(reconciliation.name());
+            Labels caLabels = Labels.fromResource(kafkaAssembly)
+                    .withKind(reconciliation.kind())
+                    .withCluster(reconciliation.name())
+                    .withKubernetesName()
+                    .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
             Future<ReconciliationState> result = Future.future();
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
@@ -2558,7 +2563,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> clusterOperatorSecret() {
             oldCoSecret = clusterCa.clusterOperatorSecret();
 
-            Labels labels = Labels.userLabels(kafkaAssembly.getMetadata().getLabels()).withKind(reconciliation.kind()).withCluster(reconciliation.name());
+            Labels labels = Labels.fromResource(kafkaAssembly)
+                    .withKind(reconciliation.kind())
+                    .withCluster(reconciliation.name())
+                    .withKubernetesName()
+                    .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
 
             OwnerReference ownerRef = new OwnerReferenceBuilder()
                     .withApiVersion(kafkaAssembly.getApiVersion())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -336,7 +336,7 @@ public class ResourceUtils {
         ObjectMeta meta = new ObjectMeta();
         meta.setNamespace(clusterCmNamespace);
         meta.setName(clusterCmName);
-        meta.setLabels(Labels.userLabels(singletonMap("my-user-label", "cromulent")).toMap());
+        meta.setLabels(Labels.userLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests", "my-user-label", "cromulent")).toMap());
         result.setMetadata(meta);
 
         KafkaSpec spec = new KafkaSpec();
@@ -419,7 +419,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                         "my-user-label", "cromulent"))
                 .build())
                 .withNewSpec().endSpec()
@@ -434,7 +434,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(clusterCmName)
                         .withNamespace(clusterCmNamespace)
-                        .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec().endSpec()
@@ -449,7 +449,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(clusterCmName)
                         .withNamespace(clusterCmNamespace)
-                        .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -465,7 +465,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(clusterCmName)
                         .withNamespace(clusterCmNamespace)
-                        .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec().endSpec()
@@ -477,7 +477,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(clusterCmName)
                         .withNamespace(clusterCmNamespace)
-                        .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -495,7 +495,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(clusterCmName)
                         .withNamespace(clusterCmNamespace)
-                        .withLabels(TestUtils.map(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -32,6 +32,10 @@ public class Labels {
      *   <li>Kafka</li>
      *   <li>KafkaConnect</li>
      *   <li>KafkaConnectS2I</li>
+     *   <li>KafkaMirrorMaker</li>
+     *   <li>KafkaBridge</li>
+     *   <li>KafkaUser</li>
+     *   <li>KafkaTopic</li>
      * </ul>
      */
     public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "kind";
@@ -90,26 +94,26 @@ public class Labels {
      * @param userLabels The labels
      */
     public static Labels userLabels(Map<String, String> userLabels) {
-        
+
         if (userLabels == null) {
             return EMPTY;
         }
 
         List<String> invalidLabels = userLabels
-            .keySet()
-            .stream()
-            .filter(key -> key.startsWith(Labels.STRIMZI_DOMAIN))
-            .collect(Collectors.toList());
+                .keySet()
+                .stream()
+                .filter(key -> key.startsWith(Labels.STRIMZI_DOMAIN) && !key.startsWith(Labels.STRIMZI_CLUSTER_LABEL))
+                .collect(Collectors.toList());
         if (invalidLabels.size() > 0) {
             throw new IllegalArgumentException("Labels starting with " + STRIMZI_DOMAIN + " are not allowed in Custom Resources, such labels should be removed.");
         }
 
         // Remove Kubernetes Domain specific labels
         Map<String, String> filteredLabels = userLabels
-            .entrySet()
-            .stream()
-            .filter(entryset -> !entryset.getKey().startsWith(Labels.KUBERNETES_DOMAIN))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .entrySet()
+                .stream()
+                .filter(entryset -> !entryset.getKey().startsWith(Labels.KUBERNETES_DOMAIN))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         return new Labels(filteredLabels);
     }
@@ -131,7 +135,7 @@ public class Labels {
      * @return the labels of the given {@code resource}.
      */
     public static Labels fromResource(HasMetadata resource) {
-        return new Labels(resource.getMetadata().getLabels() != null ? resource.getMetadata().getLabels() : emptyMap());
+        return resource.getMetadata().getLabels() != null ? userLabels(resource.getMetadata().getLabels()) : EMPTY;
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -57,7 +57,7 @@ public class KafkaUserModel {
     public static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
     public static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
 
-    public static final String KAFKA_USER_OPERATOR_NAME = "strimzi-kafka-user-operator";
+    public static final String KAFKA_USER_OPERATOR_NAME = "strimzi-user-operator";
 
     // Owner Reference information
     private String ownerApiVersion;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR does some leftovers after #2117. It seems the `userLabels` method is not actually called whem copying the labels from the custom resources. Also the validation is a bit more complicated given the fact the KafkaUser and KafkaTopic have a valid `strimzi.io/cluster` label. This PR should filter / validate the labels for the custom resources but doesn't throw exception for the `strimzi.io/cluster` label.

It also adds the new labels to the certificate secrets which are handlied on the side.

This should address the issue #2107.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging