### PR TITLE
Fix Kafka pre-stop hook when Kafka is not connected to Zookeeper when the pod termination starts

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -263,8 +263,7 @@ public class EntityOperator extends AbstractModel {
                 .withVolumeMounts(createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
                         createVolumeMount(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT))
                 .withLifecycle(new LifecycleBuilder().withNewPreStop().withNewExec()
-                            .withCommand("/opt/stunnel/entity_operator_stunnel_pre_stop.sh",
-                                    String.valueOf(templateTerminationGracePeriodSeconds))
+                            .withCommand("/opt/stunnel/entity_operator_stunnel_pre_stop.sh")
                         .endExec().endPreStop().build())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, tlsSidecarImage))
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1411,8 +1411,7 @@ public class KafkaCluster extends AbstractModel {
                 .withVolumeMounts(createVolumeMount(BROKER_CERTS_VOLUME, TLS_SIDECAR_KAFKA_CERTS_VOLUME_MOUNT),
                         createVolumeMount(CLUSTER_CA_CERTS_VOLUME, TLS_SIDECAR_CLUSTER_CA_CERTS_VOLUME_MOUNT))
                 .withLifecycle(new LifecycleBuilder().withNewPreStop()
-                        .withNewExec().withCommand("/opt/stunnel/kafka_stunnel_pre_stop.sh",
-                                String.valueOf(templateTerminationGracePeriodSeconds))
+                        .withNewExec().withCommand("/opt/stunnel/kafka_stunnel_pre_stop.sh")
                         .endExec().endPreStop().build())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, tlsSidecarImage))
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -512,8 +512,7 @@ public class ZookeeperCluster extends AbstractModel {
                                 createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, "TCP"),
                                 createContainerPort(CLIENT_PORT_NAME, CLIENT_PORT, "TCP")))
                 .withLifecycle(new LifecycleBuilder().withNewPreStop()
-                        .withNewExec().withCommand("/opt/stunnel/zookeeper_stunnel_pre_stop.sh",
-                                String.valueOf(templateTerminationGracePeriodSeconds))
+                        .withNewExec().withCommand("/opt/stunnel/zookeeper_stunnel_pre_stop.sh")
                         .endExec().endPreStop().build())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, tlsSidecarImage))
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -41,7 +41,6 @@ public class StatefulSetDiff extends AbstractResourceDiff {
         + "|/spec/template/spec/dnsPolicy"
         + "|/spec/template/spec/restartPolicy"
         + "|/spec/template/spec/securityContext"
-        + "|/spec/template/spec/terminationGracePeriodSeconds"
         + "|/spec/template/spec/volumes/[0-9]+/configMap/defaultMode"
         + "|/spec/template/spec/volumes/[0-9]+/secret/defaultMode"
         + "|/spec/volumeClaimTemplates/[0-9]+/status"

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -222,7 +222,6 @@ public class EntityOperatorTest {
         assertEquals(Long.valueOf(123), dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds());
         assertNotNull(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle());
         assertTrue(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("/opt/stunnel/entity_operator_stunnel_pre_stop.sh"));
-        assertTrue(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("123"));
     }
 
     @Test
@@ -241,7 +240,6 @@ public class EntityOperatorTest {
         assertEquals(Long.valueOf(30), dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds());
         assertNotNull(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle());
         assertTrue(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("/opt/stunnel/entity_operator_stunnel_pre_stop.sh"));
-        assertTrue(dep.getSpec().getTemplate().getSpec().getContainers().get(2).getLifecycle().getPreStop().getExec().getCommand().contains("30"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1455,7 +1455,6 @@ public class KafkaClusterTest {
         Lifecycle lifecycle = ss.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertNotNull(lifecycle);
         assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("/opt/stunnel/kafka_stunnel_pre_stop.sh"));
-        assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("123"));
     }
 
     @Test
@@ -1470,7 +1469,6 @@ public class KafkaClusterTest {
         Lifecycle lifecycle = ss.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertNotNull(lifecycle);
         assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("/opt/stunnel/kafka_stunnel_pre_stop.sh"));
-        assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("30"));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -463,7 +463,6 @@ public class ZookeeperClusterTest {
         Lifecycle lifecycle = ss.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertNotNull(lifecycle);
         assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("/opt/stunnel/zookeeper_stunnel_pre_stop.sh"));
-        assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("123"));
     }
 
     @Test
@@ -478,7 +477,6 @@ public class ZookeeperClusterTest {
         Lifecycle lifecycle = ss.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertNotNull(lifecycle);
         assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("/opt/stunnel/zookeeper_stunnel_pre_stop.sh"));
-        assertTrue(lifecycle.getPreStop().getExec().getCommand().contains("30"));
     }
 
     @Test

--- a/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_pre_stop.sh
+++ b/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_pre_stop.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-GRACE_PERIOD=$1
-TIMER="0"
-
-while [ $TIMER -lt $GRACE_PERIOD ]; do
-  TIMER=$((TIMER + 1))
+while true; do
   CONNS=$(netstat -ant | grep -w 127.0.0.1:2181 | grep ESTABLISHED | wc -l)
 
   if [ "$CONNS" -eq "0" ]; then

--- a/docker-images/kafka/stunnel-scripts/kafka_stunnel_pre_stop.sh
+++ b/docker-images/kafka/stunnel-scripts/kafka_stunnel_pre_stop.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-GRACE_PERIOD=$1
-TIMER="0"
-
-while [ $TIMER -lt $GRACE_PERIOD ]; do
-  TIMER=$((TIMER + 1))
+while true; do
   CONNS=$(netstat -ant | grep -w 127.0.0.1:2181 | grep ESTABLISHED | wc -l)
+  LISTENERS=$(netstat -ant | grep -w :9091 | grep LISTEN | wc -l)
 
-  if [ "$CONNS" -eq "0" ]; then
+  if [ "$CONNS" -eq "0" ] && [ "$LISTENERS" -eq "0" ]; then
     break
   fi
 

--- a/docker-images/kafka/stunnel-scripts/zookeeper_stunnel_pre_stop.sh
+++ b/docker-images/kafka/stunnel-scripts/zookeeper_stunnel_pre_stop.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-GRACE_PERIOD=$1
-TIMER="0"
-
 # Build the regular expression
 ZOOKEEPER_ID=$(hostname | awk -F'-' '{print $NF+1}')
 PORT_SUFFIX=$((ZOOKEEPER_ID - 1))
 EXPRESSION="0.0.0.0\:2181${PORT_SUFFIX}|127.0.0.1\:2888${PORT_SUFFIX}|127.0.0.1\:3888${PORT_SUFFIX}"
 
-while [ $TIMER -lt $GRACE_PERIOD ]; do
-  TIMER=$((TIMER + 1))
+while true; do
   LINES=$(netstat -ant | grep -wE "(${EXPRESSION})" | grep LISTEN | wc -l)
 
   if [ "$LINES" -eq "0" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our current pre-stop hook does not work perfectly when the deletion of the Kafka pod is triggered at the time when it doesn't have Zookeeper connection. The old check will nto find any established connection, terminate the sidecar pod and not give chance to the Zookeeper to reconnect and shutdown cleanly. This seems to actually cause problems in one particular situation when both Kafka and ZK run on the same Kubernetes host and the Kafka is connected to the this specific Zookeeper pod. When you drain such node (e.g. to upgrade your cluster or for regular maintenance), both pods will terminate at the same time, Kafka will loose its connection to the ZK, the pre-stop in the Kafka pod TLS sidecar will see no connections and terminate. That leaves Kafka stranded.

This PR should fix the problem to not only checking whether there are any ZK connections, but also whether the Kafka broker is still listening on its port 9091. That should prevent the situations described above from happening -> the temporary loss of Zoo connection will not clode the 9091 port and keep the sidecar running and give the broker a chance to recover. 

The downside of this is that deleting clusters through garbage collection (which is asynchronous and might delete Zoos earlier than Kafkas) might take longer because we will be waiting the whole grace period for the clean shutdown. But this should be worth the clean shutdown in other situations.

With this PR I also fixed several other minor things:
* The pre-stop doesn't have anymore its own grace period timer. It will be temrinated by Kubernetes when the grace period expires, so removing the timer simplifies the code
* The diffing of the grace period configuration in the StatefulSets is not independent from the pre-stop hook configuration.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
