### PR TITLE
Make sure we always respect the temrination grace period set in the resources

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -291,9 +291,9 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
     }
 
     /**
-     * Sometimes, patching the resource is not enough. For exaple when the persistent volume claim templates are modified.
+     * Sometimes, patching the resource is not enough. For example when the persistent volume claim templates are modified.
      * In such case we need to delete the STS with cascading=false and recreate it.
-     * A rolling update shoud done finished after the STS is recreated.
+     * A rolling update should done finished after the STS is recreated.
      *
      * @param namespace Namespace of the resource which should be deleted
      * @param name Name of the resource which should be deleted
@@ -310,7 +310,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             long pollingIntervalMs = 1_000;
             long timeoutMs = operationTimeoutMs;
 
-            operation().inNamespace(namespace).withName(name).cascading(cascading).delete();
+            operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
 
             Future<Void> deletedFut = waitFor(namespace, name, pollingIntervalMs, timeoutMs, (ignore1, ignore2) -> {
                 StatefulSet sts = get(namespace, name);
@@ -356,7 +356,7 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         vertx.createSharedWorkerExecutor("kubernetes-ops-tool").executeBlocking(
             future -> {
                 try {
-                    Boolean deleted = operation().inNamespace(namespace).withName(name).cascading(cascading).delete();
+                    Boolean deleted = operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
 
                     if (deleted) {
                         log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -253,6 +254,7 @@ class MockBuilder<T extends HasMetadata,
             }
         });
         when(resource.createOrReplaceWithNew()).thenReturn(doneable(resource::createOrReplace));
+        when(resource.withGracePeriod(anyLong())).thenReturn(resource);
         mockCascading(resource);
         mockPatch(resourceName, resource);
         mockDelete(resourceName, resource);

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +85,7 @@ class StatefulSetMockBuilder extends MockBuilder<StatefulSet, StatefulSetList, D
     protected void nameScopedMocks(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
         super.nameScopedMocks(resourceName, resource);
         EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> c = mock(EditReplacePatchDeletable.class);
+        when(c.withGracePeriod(anyLong())).thenReturn(resource);
         when(resource.cascading(false)).thenReturn(c);
         mockNoncascadingPatch(resourceName, c);
         mockScale(resourceName, resource);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -147,7 +147,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
         vertx.executeBlocking(
             f -> {
                 try {
-                    Boolean delete = operation().withName(name).delete();
+                    Boolean delete = operation().withName(name).withGracePeriod(-1L).delete();
                     if (!Boolean.TRUE.equals(delete)) {
                         f.fail(new RuntimeException(resourceKind + "/" + name + " could not be deleted (returned " + delete + ")"));
                     } else {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -144,7 +144,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient, T ext
 
     protected Future<ReconcileResult<T>> internalDelete(String namespace, String name, boolean cascading) {
         try {
-            operation().inNamespace(namespace).withName(name).cascading(cascading).delete();
+            operation().inNamespace(namespace).withName(name).cascading(cascading).withGracePeriod(-1L).delete();
             log.debug("{} {} in namespace {} has been deleted", resourceKind, name, namespace);
             return Future.succeededFuture(ReconcileResult.deleted());
         } catch (Exception e) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
@@ -234,6 +235,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AtomicBoolean watchWasClosed = new AtomicBoolean(false);
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
         when(mockResource.delete()).thenReturn(true);
         when(mockResource.watch(any())).thenAnswer(invocation -> {
             Watcher<T> watcher = invocation.getArgument(0);
@@ -269,6 +271,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AtomicBoolean watchWasClosed = new AtomicBoolean(false);
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
         when(mockResource.delete()).thenReturn(true);
         when(mockResource.watch(any())).thenAnswer(invocation -> {
             Watcher<T> watcher = invocation.getArgument(0);
@@ -305,6 +308,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AtomicBoolean watchWasClosed = new AtomicBoolean(false);
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
         when(mockResource.delete()).thenReturn(Boolean.TRUE);
         when(mockResource.watch(any())).thenAnswer(invocation -> {
             Watcher<T> watcher = invocation.getArgument(0);
@@ -343,6 +347,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
 
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
         when(mockResource.delete()).thenThrow(ex);
         when(mockResource.watch(any())).thenAnswer(invocation -> {
             Watcher<T> watcher = invocation.getArgument(0);
@@ -409,6 +414,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AtomicBoolean watchWasClosed = new AtomicBoolean(false);
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
         when(mockResource.delete()).thenReturn(Boolean.FALSE);
         when(mockResource.watch(any())).thenAnswer(invocation -> {
             Watcher<T> watcher = invocation.getArgument(0);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

While working on #2133  I discovered a more important problem related to change in the behavior of Fabric8 during rolling updates. It seems to now delete pods with 0 termination grace period by default (essentially force deleting the pods). It overwrites whatever is configured in the pod. This means that regardless of the pre-stop hook rolling updates will nto do clean termination. To workaround the default behaviour I now specifically configure the temrination grace period to `-1` which tells Fabric8 to use the default Kubernetes settings from the Pod.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
