### PR TITLE
The username in the KafkaUser status needs to be a real username and not a name of the resource

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -325,7 +325,7 @@ public class KafkaUserModel {
         } else if (isScramUser()) {
             return getScramUserName(name);
         } else {
-            throw new RuntimeException("At least one authentication mechanism has to be selected");
+            return getName();
         }
     }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -183,7 +183,7 @@ public class KafkaUserOperator extends AbstractOperator<KafkaUser,
                 aclOperations.reconcile(KafkaUserModel.getScramUserName(userName), scramOrNoneAcls))
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(resource, userStatus, reconciliationResult.mapEmpty());
-                    userStatus.setUsername(user.getName());
+                    userStatus.setUsername(user.getUserName());
 
                     updateStatus(resource, reconciliation, userStatus).setHandler(statusResult -> {
                         // If both features succeeded, createOrUpdate succeeded as well

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -899,7 +899,7 @@ public class KafkaUserOperatorTest {
             context.assertFalse(res.succeeded());
 
             List<KafkaUser> capturedStatuses = userCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUsername(), ResourceUtils.NAME);
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUsername(), "CN=user");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getMessage(), failureMsg);
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "NotReady");
@@ -936,7 +936,7 @@ public class KafkaUserOperatorTest {
             context.assertTrue(res.succeeded());
 
             List<KafkaUser> capturedStatuses = userCaptor.getAllValues();
-            context.assertEquals(capturedStatuses.get(0).getStatus().getUsername(), ResourceUtils.NAME);
+            context.assertEquals(capturedStatuses.get(0).getStatus().getUsername(), "CN=user");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), "True");
             context.assertEquals(capturedStatuses.get(0).getStatus().getConditions().get(0).getType(), "Ready");
             async.complete();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a bug in the User Operator. In the Status section, we have a field named username. It should contain the actual username as seen by the broker. That is the same as the resource name for SCRAM SHA, btu for tls it is prefixed by `CN=`. Thsi should be visible from the status to make it clear to the users.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally