### PR TITLE
Use quite build when publishing to Nexus

### DIFF
--- a/.travis/push-to-nexus.sh
+++ b/.travis/push-to-nexus.sh
@@ -3,7 +3,7 @@
 openssl aes-256-cbc -K $encrypted_cdaf52794220_key -iv $encrypted_cdaf52794220_iv -in .travis/signing.gpg.enc -out signing.gpg -d
 gpg --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh package gpg:sign deploy
+GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.travis/settings.xml  -pl ./,crd-generator,api -P ossrh package gpg:sign deploy
 
 rm -rf signing.gpg
 gpg --delete-keys


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When pushing to Nexus at the end of the master builds on Java 8, we run the maven build without the `-q` option. That produces a lot of output and causes problems on Travis where the output log has only a limited size.  After this PR the quiete build should be used and make the output smaller.