### PR TITLE
Use non-cascading patch when patching BuildConfig

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
@@ -35,6 +35,7 @@ public class BuildConfigOperator extends AbstractResourceOperator<OpenShiftClien
     @Override
     protected Future<ReconcileResult<BuildConfig>> internalPatch(String namespace, String name, BuildConfig current, BuildConfig desired) {
         desired.getSpec().setTriggers(current.getSpec().getTriggers());
-        return super.internalPatch(namespace, name, current, desired);
+        // Cascading needs to be set to false to make sure the Builds are not deleted during reconciliation
+        return super.internalPatch(namespace, name, current, desired, false);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
@@ -14,6 +14,8 @@ import io.fabric8.openshift.api.model.DoneableBuildConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
 
 import static org.mockito.Mockito.when;
 
@@ -49,5 +51,11 @@ public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenSh
             .withNewSpec()
                 .withTriggers(new BuildTriggerPolicy())
             .endSpec().build();
+    }
+
+    @Override
+    @Test
+    public void createWhenExistsIsAPatch(TestContext context) {
+        createWhenExistsIsAPatch(context, false);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -205,6 +205,6 @@ class ConnectS2IST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Duration.ofMinutes(5).toMillis()).done();
+        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Duration.ofSeconds(30).toMillis()).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -205,7 +205,6 @@ class ConnectS2IST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Duration.ofMinutes(5).toMillis()).done();
-        testClassResources().clusterOperator(NAMESPACE, Constants.RECONCILIATION_INTERVAL, Duration.ofSeconds(30).toMillis()).done();
+        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT,  Constants.RECONCILIATION_INTERVAL).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -38,7 +38,6 @@ class ConnectS2IST extends AbstractST {
     private static final String CONNECT_S2I_TOPIC_NAME = "connect-s2i-topic-example";
 
     @Test
-    @Tag(ACCEPTANCE)
     void testDeployS2IWithMongoDBPlugin() {
         testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -205,6 +205,7 @@ class ConnectS2IST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
+        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Duration.ofMinutes(5).toMillis()).done();
         testClassResources().clusterOperator(NAMESPACE, Constants.RECONCILIATION_INTERVAL, Duration.ofSeconds(30).toMillis()).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -205,6 +205,6 @@ class ConnectS2IST extends AbstractST {
         createTestClassResources();
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        testClassResources().clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Duration.ofSeconds(30).toMillis()).done();
+        testClassResources().clusterOperator(NAMESPACE, Constants.RECONCILIATION_INTERVAL, Duration.ofSeconds(30).toMillis()).done();
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When reconciling the `BuildConfig`, it seems that cascading patch always deletes all existing `Builds` belonging to this `BuildConfig`. If the build is running, it is deleted in the middle. Doing the build as non-cascading seems to address this issue.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally