### PR TITLE
Bump Fabric8 dependency to 4.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.19.0</sundrio.version>
 
-        <fabric8.kubernetes-client.version>4.6.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>4.6.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>4.6.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>4.6.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>4.6.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>4.6.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.0</okhttp.version>
         <vertx.version>3.7.1</vertx.version>


### PR DESCRIPTION
### Type of change

- Regular task

### Description

Fabric8 released new patch release 4.6.2 with some minor bugfixes. This PR updates Strimzi to use it.