### PR TITLE
Allow to override the auto-detected Kubernetes version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improve Kafka Exporter Grafana dashboard
 * Add sizeLimit option to ephemeral storage (#1505)
 * Add `schedulerName` to `podTemplate` (#2114)
+* Allow overriding the auto-detected Kubernetes version
 
 ## 0.14.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -8,9 +8,9 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NoImageException;
 import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator;
 
 import java.util.Arrays;
@@ -177,10 +177,10 @@ public class ClusterOperatorConfig {
 
     private static KafkaVersion.Lookup parseKafkaVersions(String kafkaImages, String connectImages, String connectS2IImages, String mirrorMakerImages) {
         KafkaVersion.Lookup lookup = new KafkaVersion.Lookup(
-                ModelUtils.parseMap(kafkaImages),
-                ModelUtils.parseMap(connectImages),
-                ModelUtils.parseMap(connectS2IImages),
-                ModelUtils.parseMap(mirrorMakerImages));
+                Util.parseMap(kafkaImages),
+                Util.parseMap(connectImages),
+                Util.parseMap(connectS2IImages),
+                Util.parseMap(mirrorMakerImages));
         try {
             lookup.validateKafkaImages(lookup.supportedVersions());
             lookup.validateKafkaConnectImages(lookup.supportedVersions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -24,6 +24,7 @@ import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,12 +32,10 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringTokenizer;
 
 public class ModelUtils {
 
@@ -89,32 +88,6 @@ public class ModelUtils {
     public static String defaultResourceLabels(String cluster) {
         return String.format("%s=%s",
                 Labels.STRIMZI_CLUSTER_LABEL, cluster);
-    }
-
-    /**
-     * Parse a map from String.
-     * For example a map of images {@code 2.0.0=strimzi/kafka:latest-kafka-2.0.0, 2.1.0=strimzi/kafka:latest-kafka-2.1.0}
-     * or a map with labels / annotations {@code key1=value1 key2=value2}.
-     *
-     * @param str The string to parse.
-     *
-     * @return The parsed map.
-     */
-    public static Map<String, String> parseMap(String str) {
-        if (str != null) {
-            StringTokenizer tok = new StringTokenizer(str, ", \t\n\r");
-            HashMap<String, String> map = new HashMap<>();
-            while (tok.hasMoreTokens()) {
-                String record = tok.nextToken();
-                int endIndex = record.indexOf('=');
-                String key = record.substring(0, endIndex);
-                String value = record.substring(endIndex + 1);
-                map.put(key.trim(), value.trim());
-            }
-            return Collections.unmodifiableMap(map);
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**
@@ -344,6 +317,6 @@ public class ModelUtils {
      * @return A map with labels or annotations
      */
     public static Map<String, String> getCustomLabelsOrAnnotations(String envVarName)   {
-        return parseMap(System.getenv().get(envVarName));
+        return Util.parseMap(System.getenv().get(envVarName));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.operator.cluster.model.ModelUtils.parseMap;
+import static io.strimzi.operator.common.Util.parseMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/documentation/modules/ref-operators-cluster-operator-configuration.adoc
+++ b/documentation/modules/ref-operators-cluster-operator-configuration.adoc
@@ -92,3 +92,23 @@ A comma-separated list of `Secret` names.
 The secrets referenced here contain the credentials to the container registries where the container images are pulled from.
 The secrets are used in the `imagePullSecrets` field for all `Pods` created by the Cluster Operator.
 Changing this list results in a rolling update of all your Kafka, Kafka Connect, and Kafka Mirror Maker clusters.
+
+`STRIMZI_KUBERNETES_VERSION`:: Optional.
+Overrides the Kubernetes version information detected from the API server.
+See the example below:
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_KUBERNETES_VERSION
+    value: |
+           major=1
+           minor=16
+           gitVersion=v1.16.2
+           gitCommit=c97fe5036ef3df2967d086711e6c0c405941e14b
+           gitTreeState=clean
+           buildDate=2019-10-15T19:09:08Z
+           goVersion=go1.12.10
+           compiler=gc
+           platform=linux/amd64
+----

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -11,6 +11,10 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
 import java.util.function.BooleanSupplier;
 
 public class Util {
@@ -71,5 +75,36 @@ public class Util {
         handler.handle(null);
 
         return fut;
+    }
+
+    /**
+     * Parse a map from String.
+     * For example a map of images {@code 2.0.0=strimzi/kafka:latest-kafka-2.0.0, 2.1.0=strimzi/kafka:latest-kafka-2.1.0}
+     * or a map with labels / annotations {@code key1=value1 key2=value2}.
+     *
+     * @param str The string to parse.
+     *
+     * @return The parsed map.
+     */
+    public static Map<String, String> parseMap(String str) {
+        if (str != null) {
+            StringTokenizer tok = new StringTokenizer(str, ", \t\n\r");
+            HashMap<String, String> map = new HashMap<>();
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+
+                if (endIndex == -1)  {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                map.put(key.trim(), value.trim());
+            }
+            return Collections.unmodifiableMap(map);
+        } else {
+            return Collections.emptyMap();
+        }
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -4,9 +4,10 @@
  */
 package io.strimzi.operator;
 
-
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
+import io.strimzi.operator.common.Util;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -19,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -211,6 +213,24 @@ public class PlatformFeaturesAvailabilityTest {
 
         async.awaitSuccess();
         stopMockApi(context, mockHttp);
+    }
+
+    @Test
+    public void versionInfoFromMap(TestContext context) throws ParseException {
+        String version =  "major=1\n" +
+                "minor=16\n" +
+                "gitVersion=v1.16.2\n" +
+                "gitCommit=c97fe5036ef3df2967d086711e6c0c405941e14b\n" +
+                "gitTreeState=clean\n" +
+                "buildDate=2019-10-15T19:09:08Z\n" +
+                "goVersion=go1.12.10\n" +
+                "compiler=gc\n" +
+                "platform=linux/amd64";
+
+        VersionInfo vi = new VersionInfo(Util.parseMap(version));
+
+        context.assertEquals("1", vi.getMajor());
+        context.assertEquals("16", vi.getMinor());
     }
 
     public HttpServer startMockApi(TestContext context, String version, List<String> apis)   {

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.strimzi.operator.common.Util.parseMap;
+import static org.junit.Assert.assertEquals;
+
+public class UtilTest {
+    @Test
+    public void testParseMap() {
+        String stringMap = "key1=value1\n" +
+                "key2=value2";
+
+        Map<String, String> m = parseMap(stringMap);
+        assertEquals(2, m.size());
+        assertEquals("value1", m.get("key1"));
+        assertEquals("value2", m.get("key2"));
+    }
+
+    @Test
+    public void testParseMapNull() {
+        Map<String, String> m = parseMap(null);
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void testParseMapEmptyString() {
+        String stringMap = "";
+
+        Map<String, String> m = parseMap(null);
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void testParseMapEmptyValue() {
+        String stringMap = "key1=value1\n" +
+                "key2=";
+
+        Map<String, String> m = parseMap(stringMap);
+        assertEquals(2, m.size());
+        assertEquals("value1", m.get("key1"));
+        assertEquals("", m.get("key2"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testParseMapInvalid() {
+        String stringMap = "key1=value1\n" +
+                "key2";
+
+        Map<String, String> m = parseMap(stringMap);
+        assertEquals(2, m.size());
+        assertEquals("value1", m.get("key1"));
+        assertEquals("", m.get("key2"));
+    }
+
+    @Test
+    public void testParseMapValueWithEquals() {
+        String stringMap = "key1=value1\n" +
+                "key2=value2=value3";
+
+        Map<String, String> m = parseMap(stringMap);
+        assertEquals(2, m.size());
+        assertEquals("value1", m.get("key1"));
+        assertEquals("value2=value3", m.get("key2"));
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Strimzi detects the Kubernetes version and other information from the `/version` endpoint of the Kubernetes API server. But sometimes, it is useful to be able to override this information. One of such cases is desceibed in #1976 - when the API server of K3S provides a date which cannot be parsed by the Fabric8 client library. Other reasons might be to test different behaviours of Strimzi CO on different versions.

This PR allows to override the version infromation using an environment variable `STRIMZI_KUBERNETES_VERSION`. You can define it in the Cluster Operator for example like this:

```yaml
  - name: STRIMZI_KUBERNETES_VERSION
    value: |
           major=1
           minor=16
           gitVersion=v1.16.2
           gitCommit=c97fe5036ef3df2967d086711e6c0c405941e14b
           gitTreeState=clean
           buildDate=2019-10-15T19:09:08Z
           goVersion=go1.12.10
           compiler=gc
           platform=linux/amd64
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md