### PR TITLE
[DOC] Updated images directory attribute

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -3,7 +3,7 @@
 :doctype: book
 :experimental:
 :idprefix:
-:imagesdir: images
+:imagesdir: shared/images
 :numbered:
 :sectanchors!:
 :sectnums:


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change
- Documentation

### Description

This pull request changes the AsciiDoc attribute for image locations. The new location is:

`:imagesdir: shared/images`

This will fix the broken images and diagrams in the Latest version of the Strimzi documentation. For example, a screenshot for OAuth is missing in: https://strimzi.io/docs/latest/#example_client_authentication_flows

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

