### PR TITLE
User pkcs12 support

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -59,6 +59,18 @@ public interface CertManager {
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException;
 
     /**
+     * Add the provided key and certificate to the keystore which is created if it doesn't exist
+     *
+     * @param keyFile path to the file containing the existing private key
+     * @param certFile path to the file which will contain the new signed certificate
+     * @param alias key and certificate alias in the keystore
+     * @param keyStoreFile path to the file related to the keystore
+     * @param keyStorePassword password for protecting the keystore
+     * @throws IOException If an input or output file could not be read/written.
+     */
+    void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException;
+
+    /**
      * Remove entries with provided aliases from the truststore
      *
      * @param aliases aliases to remove

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -135,9 +135,9 @@ public class OpenSslCertManager implements CertManager {
     @Override
     public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
 
-        List<String> cmd = new ArrayList<>(asList("openssl", "pkcs12", "-export", "-in", certFile.getAbsolutePath(),
+        List<String> cmd = asList("openssl", "pkcs12", "-export", "-in", certFile.getAbsolutePath(),
                 "-inkey", keyFile.getAbsolutePath(), "-name", alias, "-out", keyStoreFile.getAbsolutePath(), "-passout",
-                "pass:" + keyStorePassword));
+                "pass:" + keyStorePassword);
 
         exec(cmd);
     }

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -133,6 +133,16 @@ public class OpenSslCertManager implements CertManager {
     }
 
     @Override
+    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
+
+        List<String> cmd = new ArrayList<>(asList("openssl", "pkcs12", "-export", "-in", certFile.getAbsolutePath(),
+                "-inkey", keyFile.getAbsolutePath(), "-name", alias, "-out", keyStoreFile.getAbsolutePath(), "-passout",
+                "pass:" + keyStorePassword));
+
+        exec(cmd);
+    }
+
+    @Override
     public void deleteFromTrustStore(List<String> aliases, File trustStoreFile, String trustStorePassword)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
 

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -245,8 +245,7 @@ public class OpenSslCertManagerTest {
                     .append(Base64.getEncoder().encodeToString(storeKey.getEncoded()))
                     .append("-----END PRIVATE KEY-----");
 
-            assertTrue(sb.toString()
-                    .equals(new String(Files.readAllBytes(caKey.toPath())).replace("\n", "")));
+            assertThat(sb.toString(), is(new String(Files.readAllBytes(caKey.toPath())).replace("\n", "")));
 
             X509Certificate storeCert = (X509Certificate) store.getCertificate("ca");
             storeCert.verify(storeCert.getPublicKey());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1075,6 +1075,8 @@ public class KafkaCluster extends AbstractModel {
             CertAndKey cert = brokerCerts.get(KafkaCluster.kafkaPodName(cluster, i));
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".key", cert.keyAsBase64String());
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".crt", cert.certAsBase64String());
+            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
+            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
         return createSecret(KafkaCluster.brokersSecretName(cluster), data);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -30,8 +30,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,24 +190,46 @@ public class ModelUtils {
 
     public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName, String commonName, String keyCertName, Labels labels, OwnerReference ownerReference) {
         Map<String, String> data = new HashMap<>();
+        CertAndKey certAndKey = null;
         if (secret == null || clusterCa.certRenewed()) {
             log.debug("Generating certificates");
             try {
                 log.debug(keyCertName + " certificate to generate");
-                CertAndKey eoCertAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
-                data.put(keyCertName + ".key", eoCertAndKey.keyAsBase64String());
-                data.put(keyCertName + ".crt", eoCertAndKey.certAsBase64String());
-                data.put(keyCertName + ".p12", eoCertAndKey.keyStoreAsBase64String());
-                data.put(keyCertName + ".password", eoCertAndKey.storePasswordAsBase64String());
+                certAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
             } catch (IOException e) {
                 log.warn("Error while generating certificates", e);
             }
             log.debug("End generating certificates");
         } else {
-            data.put(keyCertName + ".key", secret.getData().get(keyCertName + ".key"));
-            data.put(keyCertName + ".crt", secret.getData().get(keyCertName + ".crt"));
-            data.put(keyCertName + ".p12", secret.getData().get(keyCertName + ".p12"));
-            data.put(keyCertName + ".password", secret.getData().get(keyCertName + ".password"));
+
+            if (secret.getData().get(keyCertName + ".p12") != null &&
+                    !secret.getData().get(keyCertName + ".p12").isEmpty() &&
+                    secret.getData().get(keyCertName + ".password") != null &&
+                    !secret.getData().get(keyCertName + ".password").isEmpty()) {
+
+                certAndKey = new CertAndKey(
+                        decodeFromSecret(secret, keyCertName + ".key"),
+                        decodeFromSecret(secret, keyCertName + ".crt"),
+                        null,
+                        decodeFromSecret(secret, keyCertName + ".p12"),
+                        new String(decodeFromSecret(secret, keyCertName + ".password"), StandardCharsets.US_ASCII)
+                );
+            } else {
+                try {
+                    // coming from an older operator version, the secret exists but without keystore and password
+                    certAndKey = clusterCa.addKeyAndCertToKeyStore(commonName,
+                            decodeFromSecret(secret, keyCertName + ".key"),
+                            decodeFromSecret(secret, keyCertName + ".crt"));
+                } catch (IOException e) {
+                    log.error("Error generating the keystore for {}", keyCertName, e);
+                }
+            }
+        }
+        if (certAndKey != null) {
+            data.put(keyCertName + ".key", certAndKey.keyAsBase64String());
+            data.put(keyCertName + ".crt", certAndKey.certAsBase64String());
+            data.put(keyCertName + ".p12", certAndKey.keyStoreAsBase64String());
+            data.put(keyCertName + ".password", certAndKey.storePasswordAsBase64String());
         }
         return createSecret(secretName, namespace, labels, ownerReference, data);
     }
@@ -322,5 +346,9 @@ public class ModelUtils {
      */
     public static Map<String, String> getCustomLabelsOrAnnotations(String envVarName)   {
         return Util.parseMap(System.getenv().get(envVarName));
+    }
+
+    private static byte[] decodeFromSecret(Secret secret, String key) {
+        return Base64.getDecoder().decode(secret.getData().get(key));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -195,6 +195,8 @@ public class ModelUtils {
                 CertAndKey eoCertAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
                 data.put(keyCertName + ".key", eoCertAndKey.keyAsBase64String());
                 data.put(keyCertName + ".crt", eoCertAndKey.certAsBase64String());
+                data.put(keyCertName + ".p12", eoCertAndKey.keyStoreAsBase64String());
+                data.put(keyCertName + ".password", eoCertAndKey.storePasswordAsBase64String());
             } catch (IOException e) {
                 log.warn("Error while generating certificates", e);
             }
@@ -202,6 +204,8 @@ public class ModelUtils {
         } else {
             data.put(keyCertName + ".key", secret.getData().get(keyCertName + ".key"));
             data.put(keyCertName + ".crt", secret.getData().get(keyCertName + ".crt"));
+            data.put(keyCertName + ".p12", secret.getData().get(keyCertName + ".p12"));
+            data.put(keyCertName + ".password", secret.getData().get(keyCertName + ".password"));
         }
         return createSecret(secretName, namespace, labels, ownerReference, data);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -466,6 +466,8 @@ public class ZookeeperCluster extends AbstractModel {
                 CertAndKey cert = certs.get(ZookeeperCluster.zookeeperPodName(cluster, i));
                 data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
                 data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
+                data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
+                data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
             }
 
         } catch (IOException e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -112,7 +112,9 @@ public class ZookeeperLeaderFinder {
      * and return the PemKeyCertOptions for using it for TLS authentication.
      */
     protected PemKeyCertOptions keyCertOptions(Secret coCertKeySecret) {
-        CertAndKey coCertKey = Ca.asCertAndKey(coCertKeySecret, "cluster-operator.key", "cluster-operator.crt");
+        CertAndKey coCertKey = Ca.asCertAndKey(coCertKeySecret,
+                                            "cluster-operator.key", "cluster-operator.crt",
+                                        "cluster-operator.p12", "cluster-operator.password");
         if (coCertKey == null) {
             throw missingSecretFuture(coCertKeySecret.getMetadata().getNamespace(), coCertKeySecret.getMetadata().getName());
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1078,9 +1078,9 @@ public class KafkaClusterTest {
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateBrokerSecret(null, emptyMap());
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key",
-                "foo-kafka-1.crt", "foo-kafka-1.key",
-                "foo-kafka-2.crt", "foo-kafka-2.key")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
+                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
+                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-kafka, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
@@ -1105,9 +1105,9 @@ public class KafkaClusterTest {
 
         Secret secret = generateBrokerSecret(Collections.singleton("123.10.125.140"), externalAddresses);
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key",
-                "foo-kafka-1.crt", "foo-kafka-1.key",
-                "foo-kafka-2.crt", "foo-kafka-2.key")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
+                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
+                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-kafka, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
@@ -1133,9 +1133,9 @@ public class KafkaClusterTest {
 
         Secret secret = generateBrokerSecret(TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses);
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key",
-                "foo-kafka-1.crt", "foo-kafka-1.key",
-                "foo-kafka-2.crt", "foo-kafka-2.key")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
+                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
+                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-kafka, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -340,9 +340,9 @@ public class ZookeeperClusterTest {
 
         Secret secret = zc.generateNodesSecret(clusterCa, ka);
         assertThat(secret.getData().keySet(), is(set(
-                "foo-zookeeper-0.crt",  "foo-zookeeper-0.key",
-                "foo-zookeeper-1.crt", "foo-zookeeper-1.key",
-                "foo-zookeeper-2.crt", "foo-zookeeper-2.key")));
+                "foo-zookeeper-0.crt",  "foo-zookeeper-0.key", "foo-zookeeper-0.p12", "foo-zookeeper-0.password",
+                "foo-zookeeper-1.crt", "foo-zookeeper-1.key", "foo-zookeeper-1.p12", "foo-zookeeper-1.password",
+                "foo-zookeeper-2.crt", "foo-zookeeper-2.key", "foo-zookeeper-2.p12", "foo-zookeeper-2.password")));
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-zookeeper, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -647,9 +647,9 @@ public class KafkaAssemblyOperatorMockTest {
                     mockClient.pods().inNamespace(NAMESPACE).withName(deletedPod).get(),
                     is(nullValue())));
 
-            // removing one pod, the related private and public keys should not be in the Secrets
+            // removing one pod, the related private and public keys, keystore and password should not be in the Secrets
             context.verify(() -> assertThat(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get().getData().size(),
-                    is(brokersInternalCerts - 2)));
+                    is(brokersInternalCerts - 4)));
 
             // TODO assert no rolling update
             updateAsync.flag();
@@ -684,9 +684,9 @@ public class KafkaAssemblyOperatorMockTest {
                     mockClient.pods().inNamespace(NAMESPACE).withName(newPod).get(),
                     is(notNullValue())));
 
-            // adding one pod, the related private and public keys should be added to the Secrets
+            // adding one pod, the related private and public keys, keystore and password should be added to the Secrets
             context.verify(() -> assertThat(mockClient.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get().getData().size(),
-                    is(brokersInternalCerts + 2)));
+                    is(brokersInternalCerts + 4)));
 
             // TODO assert no rolling update
             updateAsync.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -260,7 +260,9 @@ public class ZookeeperLeaderFinderTest {
                         .withNamespace(NAMESPACE)
                         .endMetadata()
                         .withData(map("cluster-operator.key", "notacert",
-                                "cluster-operator.crt", "notacert"))
+                                "cluster-operator.crt", "notacert",
+                                "cluster-operator.p12", "notatruststore",
+                                "cluster-operator.password", "notapassword"))
                         .build()).cause();
         assertThat(cause instanceof RuntimeException, is(true));
         assertThat(cause.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator\\.crt of Secret testcluster-cluster-operator-certs in namespace testns"));

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -258,6 +258,32 @@ public abstract class Ca {
         }
     }
 
+    public CertAndKey addKeyAndCertToKeyStore(String alias, byte[] key, byte[] cert) throws IOException {
+
+        File keyFile = File.createTempFile("tls", "key");
+        File certFile = File.createTempFile("tls", "cert");
+        File keyStoreFile = File.createTempFile("tls", "p12");
+
+        Files.write(keyFile.toPath(), key);
+        Files.write(certFile.toPath(), cert);
+
+        String keyStorePassword = passwordGenerator.generate();
+        certManager.addKeyAndCertToKeyStore(keyFile, certFile, alias, keyStoreFile, keyStorePassword);
+
+        CertAndKey result = new CertAndKey(
+                Files.readAllBytes(keyFile.toPath()),
+                Files.readAllBytes(certFile.toPath()),
+                null,
+                Files.readAllBytes(keyStoreFile.toPath()),
+                keyStorePassword);
+
+        delete(keyFile);
+        delete(certFile);
+        delete(keyStoreFile);
+
+        return result;
+    }
+
     private CertAndKey generateSignedCert(Subject subject,
                                             File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
         log.debug("Generating certificate {} with SAN {}, signed by CA {}", subject, subject.subjectAltNames(), this);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -353,7 +353,8 @@ public abstract class Ca {
            Function<Integer, Subject> subjectFn,
            Secret secret,
            Function<Integer, String> podNameFn) throws IOException {
-        int replicasInSecret = secret == null || this.certRenewed() ? 0 : secret.getData().size() / 4;
+        int replicasInSecret = secret == null || this.certRenewed() ? 0 :
+                (int) secret.getData().keySet().stream().filter(k -> k.contains(".crt")).count();
 
         File brokerCsrFile = File.createTempFile("tls", "broker-csr");
         File brokerKeyFile = File.createTempFile("tls", "broker-key");

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -267,7 +267,7 @@ public abstract class Ca {
                 certFile, subject, validityDays);
 
         String keyStorePassword = passwordGenerator.generate();
-        certManager.addKeyAndCertToKeyStore(keyFile, certFile, "test", keyStoreFile, keyStorePassword);
+        certManager.addKeyAndCertToKeyStore(keyFile, certFile, subject.commonName(), keyStoreFile, keyStorePassword);
 
         return new CertAndKey(
                 Files.readAllBytes(keyFile.toPath()),

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -347,7 +347,7 @@ public abstract class Ca {
             Collection<String> currentSbjAltNames =
                     getSubjectAltNames(asCertAndKey(secret,
                                                 podName + ".key", podName + ".crt",
-                                            podName + ".p12", podName + ".password").cert());
+                                                podName + ".p12", podName + ".password").cert());
 
             if (currentSbjAltNames != null && desiredSbjAltNames.containsAll(currentSbjAltNames) && currentSbjAltNames.containsAll(desiredSbjAltNames))   {
                 log.trace("Alternate subjects match. No need to refresh cert for pod {}.", podName);
@@ -356,7 +356,7 @@ public abstract class Ca {
                         podName,
                         asCertAndKey(secret,
                                 podName + ".key", podName + ".crt",
-                            podName + ".p12", podName + ".password"));
+                                podName + ".p12", podName + ".password"));
             } else {
                 if (log.isTraceEnabled()) {
                     if (currentSbjAltNames != null) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -231,6 +231,7 @@ public class MockCertManager implements CertManager {
     @Override
     public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
         // never called during the tests which use this MockCertManager
+        write(keyStoreFile, "key store");
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -229,6 +229,11 @@ public class MockCertManager implements CertManager {
     }
 
     @Override
+    public void addKeyAndCertToKeyStore(File keyFile, File certFile, String alias, File keyStoreFile, String keyStorePassword) throws IOException {
+        // never called during the tests which use this MockCertManager
+    }
+
+    @Override
     public void deleteFromTrustStore(List<String> aliases, File trustStoreFile, String trustStorePassword)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         // never called during the tests which use this MockCertManager

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -76,6 +76,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         OPERATION_TIMEOUT("Util:[0-9]+ - Exceeded timeout of.*while waiting for.*"),
         // This is whitelisted cause it's no real problem when this error appears, components are being created even after timeout
         RECONCILIATION_TIMEOUT("ERROR Abstract.*Operator:[0-9]+ - Reconciliation.*"),
+        RESOURCE_ALREADY_DELETED("Can't wait for .* Resource is no longer available"),
         ASSEMBLY_OPERATOR_RECONCILIATION_TIMEOUT("ERROR .*AssemblyOperator:[0-9]+ - Reconciliation.*failed.*");
 
         final String name;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -76,7 +76,6 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         OPERATION_TIMEOUT("Util:[0-9]+ - Exceeded timeout of.*while waiting for.*"),
         // This is whitelisted cause it's no real problem when this error appears, components are being created even after timeout
         RECONCILIATION_TIMEOUT("ERROR Abstract.*Operator:[0-9]+ - Reconciliation.*"),
-        RESOURCE_ALREADY_DELETED("Can't wait for .* Resource is no longer available"),
         ASSEMBLY_OPERATOR_RECONCILIATION_TIMEOUT("ERROR .*AssemblyOperator:[0-9]+ - Reconciliation.*failed.*");
 
         final String name;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -209,7 +209,7 @@ public class KafkaUserModel {
                                     decodeFromSecret(userSecret, "user.key"),
                                     decodeFromSecret(userSecret, "user.crt"));
                         } catch (IOException e) {
-                            log.error("Error generating signed certificate for user {}", name, e);
+                            log.error("Error generating the keystore for user {}", name, e);
                         }
                     }
                     return;

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -110,6 +110,8 @@ public class ResourceUtils {
                 .addToData("ca.crt", Base64.getEncoder().encodeToString("clients-ca-crt".getBytes()))
                 .addToData("user.key", Base64.getEncoder().encodeToString("expected-key".getBytes()))
                 .addToData("user.crt", Base64.getEncoder().encodeToString("expected-crt".getBytes()))
+                .addToData("user.p12", Base64.getEncoder().encodeToString("expected-p12".getBytes()))
+                .addToData("user.password", Base64.getEncoder().encodeToString("expected-password".getBytes()))
                 .build();
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.KafkaUserAuthorizationSimple;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.api.kafka.model.KafkaUserSpec;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -55,7 +55,6 @@ public class KafkaUserModelTest {
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         assertThat(model.authentication.getType(), is(KafkaUserTlsClientAuthentication.TYPE_TLS));
 
-        KafkaUserAuthorizationSimple simple = (KafkaUserAuthorizationSimple) tlsUser.getSpec().getAuthorization();
         assertThat(model.getSimpleAclRules().size(), is(ResourceUtils.createExpectedSimpleAclRules(tlsUser).size()));
         assertThat(model.getSimpleAclRules(), is(ResourceUtils.createExpectedSimpleAclRules(tlsUser)));
     }
@@ -88,6 +87,8 @@ public class KafkaUserModelTest {
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")), is("clients-ca-crt"));
         assertThat(new String(model.decodeFromSecret(generated, "user.crt")), is("crt file"));
         assertThat(new String(model.decodeFromSecret(generated, "user.key")), is("key file"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.p12")), is("key store"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.password")), is("aaaaaaaaaa"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generated);
@@ -107,6 +108,8 @@ public class KafkaUserModelTest {
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")),  is("different-clients-ca-crt"));
         assertThat(new String(model.decodeFromSecret(generated, "user.crt")), is("crt file"));
         assertThat(new String(model.decodeFromSecret(generated, "user.key")), is("key file"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.p12")), is("key store"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.password")), is("aaaaaaaaaa"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generated);
@@ -121,6 +124,8 @@ public class KafkaUserModelTest {
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")),  is("clients-ca-crt"));
         assertThat(new String(model.decodeFromSecret(generated, "user.crt")), is("expected-crt"));
         assertThat(new String(model.decodeFromSecret(generated, "user.key")), is("expected-key"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.p12")), is("expected-p12"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.password")), is("expected-password"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generated);
@@ -135,6 +140,8 @@ public class KafkaUserModelTest {
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")),  is("clients-ca-crt"));
         assertThat(new String(model.decodeFromSecret(generated, "user.crt")), is("crt file"));
         assertThat(new String(model.decodeFromSecret(generated, "user.key")), is("key file"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.p12")), is("key store"));
+        assertThat(new String(model.decodeFromSecret(generated, "user.password")), is("aaaaaaaaaa"));
 
         // Check owner reference
         checkOwnerReference(model.createOwnerReference(), generated);

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -65,7 +65,7 @@ public class KafkaUserModelTest {
         KafkaUserModel model = KafkaUserModel.fromCrd(mockCertManager, passwordGenerator, tlsUser, clientsCaCert, clientsCaKey, null);
         Secret generated = model.generateSecret();
 
-        assertThat(generated.getData().keySet(), is(set("ca.crt", "user.crt", "user.key")));
+        assertThat(generated.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
 
         assertThat(generated.getMetadata().getName(), is(ResourceUtils.NAME));
         assertThat(generated.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is related to the already merged one #2140.
This one creates a keystore with key/cert for brokers, zookeeper nodes, entity and cluster operator but mainly for Kafka user. The keystore is saved in the related Secrets with the password.
In this way a user can just export these pieces from the secret and don't need to create a keystore using keytool for his Java application for example.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

