### PR TITLE
Fix platform assumptions after JUnit 5 migration

### DIFF
--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.certs;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,7 @@ public class OpenSslCertManagerTest {
 
     @BeforeAll
     public static void before() throws CertificateException {
-        assertThat(System.getProperty("os.name").contains("nux"), is(true));
+        Assumptions.assumeTrue(System.getProperty("os.name").contains("nux"));
         certFactory = CertificateFactory.getInstance("X.509");
         ssl = new OpenSslCertManager();
     }

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -7,6 +7,7 @@ package io.strimzi.certs;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -27,7 +28,7 @@ public class SecretCertProviderTest {
 
     @BeforeAll
     public static void before() {
-        assertThat(System.getProperty("os.name").contains("nux"), is(true));
+        Assumptions.assumeTrue(System.getProperty("os.name").contains("nux"));
         ssl = new OpenSslCertManager();
         secretCertProvider = new SecretCertProvider();
         ownerReference = new OwnerReferenceBuilder()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The JUnit 5 migration PR changed assumptions to asserts. That is causing failures on non-Unix platforms. This needs to be changed back to allow tests to pass (or be skipped) depending on the PR.