### PR TITLE
Use `admin.` configuration prefix in Kafka Connect configuration

### DIFF
--- a/docker-images/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_connect_config_generator.sh
@@ -17,6 +17,9 @@ producer.ssl.truststore.password=${CERTS_STORE_PASSWORD}
 
 consumer.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
 consumer.ssl.truststore.password=${CERTS_STORE_PASSWORD}
+
+admin.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12
+admin.ssl.truststore.password=${CERTS_STORE_PASSWORD}
 EOF
 )
     fi
@@ -34,6 +37,10 @@ producer.ssl.keystore.type=PKCS12
 consumer.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
 consumer.ssl.keystore.password=${CERTS_STORE_PASSWORD}
 consumer.ssl.keystore.type=PKCS12
+
+admin.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12
+admin.ssl.keystore.password=${CERTS_STORE_PASSWORD}
+admin.ssl.keystore.type=PKCS12
 EOF
 )
     fi
@@ -76,6 +83,7 @@ if [ -n "$KAFKA_CONNECT_SASL_MECHANISM" ]; then
         OAUTH_CALLBACK_CLASS="sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
         OAUTH_CALLBACK_CLASS_PRODUCER="producer.${OAUTH_CALLBACK_CLASS}"
         OAUTH_CALLBACK_CLASS_CONSUMER="consumer.${OAUTH_CALLBACK_CLASS}"
+        OAUTH_CALLBACK_CLASS_ADMIN="admin.${OAUTH_CALLBACK_CLASS}"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
@@ -88,6 +96,9 @@ ${OAUTH_CALLBACK_CLASS_PRODUCER}
 consumer.sasl.mechanism=${SASL_MECHANISM}
 consumer.sasl.jaas.config=${JAAS_CONFIG}
 ${OAUTH_CALLBACK_CLASS_CONSUMER}
+admin.sasl.mechanism=${SASL_MECHANISM}
+admin.sasl.jaas.config=${JAAS_CONFIG}
+${OAUTH_CALLBACK_CLASS_ADMIN}
 
 EOF
 )
@@ -109,6 +120,7 @@ ${KAFKA_CONNECT_CONFIGURATION}
 security.protocol=${SECURITY_PROTOCOL}
 producer.security.protocol=${SECURITY_PROTOCOL}
 consumer.security.protocol=${SECURITY_PROTOCOL}
+admin.security.protocol=${SECURITY_PROTOCOL}
 ${TLS_CONFIGURATION}
 ${TLS_AUTH_CONFIGURATION}
 ${SASL_AUTH_CONFIGURATION}


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Kafka Connect is currently configured in following way:
* Without prefix for AdminClient used by KafkaConnect it self
* Producer prefix
* Consumer prefix

However, there seems to be the `admin.` prefix missing whihc is used by some toppics created by connectors. For example the dead letter queue topic. The issue can be reproduced for example by deploying the following connector:

```bash
curl -X POST -H "Content-Type: application/json" --data '{ "name": "sink-test", "config": { "connector.class": "FileStreamSink", "tasks.max": "3", "topics": "kafka-test-apps", "file": "/tmp/test.sink.txt", "errors.deadletterqueue.topic.replication.factor": 1, "errors.deadletterqueue.topic.name": "dlq-es-sink",
"errors.deadletterqueue.context.headers.enable": true } }' http://localhost:8083/connectors
```

Which will crash the connect and in the log you can see that it is trying to authenticate without the correct authentication. This PR should fix it by adding the `admin.` prefix to the configuration file and using it with the regular configuration for authentication.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally