### PR TITLE
Added PKCS12 trustore and password generation for older cluster and clients CA secrets

### DIFF
--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -54,7 +54,7 @@ public class SecretCertProviderTest {
         Secret secret = secretCertProvider.createSecret("my-namespace", "my-secret",
                 "ca.key", "ca.crt",
                 key, cert,
-                "truststore.p12", "truststore.password",
+                "ca.p12", "ca.password",
                 store, "123456",
                 emptyMap(), emptyMap(), ownerReference);
 
@@ -65,8 +65,8 @@ public class SecretCertProviderTest {
         assertThat(secret.getData().size(), is(4));
         assertThat(Arrays.equals(Files.readAllBytes(key.toPath()), decoder.decode(secret.getData().get("ca.key"))), is(true));
         assertThat(Arrays.equals(Files.readAllBytes(cert.toPath()), decoder.decode(secret.getData().get("ca.crt"))), is(true));
-        assertThat(Arrays.equals(Files.readAllBytes(store.toPath()), decoder.decode(secret.getData().get("truststore.p12"))), is(true));
-        assertThat(new String(decoder.decode(secret.getData().get("truststore.password"))), is("123456"));
+        assertThat(Arrays.equals(Files.readAllBytes(store.toPath()), decoder.decode(secret.getData().get("ca.p12"))), is(true));
+        assertThat(new String(decoder.decode(secret.getData().get("ca.password"))), is("123456"));
 
         key.delete();
         cert.delete();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -210,8 +210,8 @@ public class ResourceUtils {
                     .withLabels(Labels.forCluster(clusterName).withKind(Kafka.RESOURCE_KIND).toMap())
                 .endMetadata()
                 .addToData("ca.crt", caCert)
-                .addToData("truststore.p12", caStore)
-                .addToData("truststore.password", caStorePassword)
+                .addToData("ca.p12", caStore)
+                .addToData("ca.password", caStorePassword)
                 .build();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -723,7 +723,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClusterCaCertStore.equals(x509Certificate(newClusterCaCert)), is(true));
         Map.Entry oldClusterCaCert = clusterCaCertData.entrySet().iterator().next();
         assertThat(oldClusterCaCert.getValue(), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(oldClusterCaCert.getValue().toString())), is(true));
+        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(String.valueOf(oldClusterCaCert.getValue()))), is(true));
         assertThat(x509Certificate(newClusterCaCert).getSubjectDN().getName(), is("CN=cluster-ca v1, O=io.strimzi"));
 
         Secret clusterCaKeySecret = c.getAllValues().get(1);
@@ -752,7 +752,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClientsCaCertStore.equals(x509Certificate(newClientsCaCert)), is(true));
         Map.Entry oldClientsCaCert = clientsCaCertData.entrySet().iterator().next();
         assertThat(oldClientsCaCert.getValue(), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(oldClientsCaCert.getValue().toString())), is(true));
+        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(String.valueOf(oldClientsCaCert.getValue()))), is(true));
         assertThat(x509Certificate(newClientsCaCert).getSubjectDN().getName(), is("CN=clients-ca v1, O=io.strimzi"));
 
         Secret clientsCaKeySecret = c.getAllValues().get(3);
@@ -930,7 +930,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClusterCaCertStore.equals(x509Certificate(newClusterCaCert)), is(true));
         Map.Entry oldClusterCaCert = clusterCaCertData.entrySet().iterator().next();
         assertThat(oldClusterCaCert.getValue(), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
-        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(oldClusterCaCert.getValue().toString())), is(true));
+        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(String.valueOf(oldClusterCaCert.getValue()))), is(true));
         assertThat(x509Certificate(newClusterCaCert).getSubjectDN().getName(), is("CN=cluster-ca v1, O=io.strimzi"));
 
         Secret clusterCaKeySecret = c.getAllValues().get(1);
@@ -960,7 +960,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClientsCaCertStore.equals(x509Certificate(newClientsCaCert)), is(true));
         Map.Entry oldClientsCaCert = clientsCaCertData.entrySet().iterator().next();
         assertThat(oldClientsCaCert.getValue(), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
-        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(oldClientsCaCert.getValue().toString())), is(true));
+        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(String.valueOf(oldClientsCaCert.getValue()))), is(true));
         assertThat(x509Certificate(newClientsCaCert).getSubjectDN().getName(), is("CN=clients-ca v1, O=io.strimzi"));
 
         Secret clientsCaKeySecret = c.getAllValues().get(3);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -338,14 +338,14 @@ public class CertificateRenewalTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        // remove trustore and password to simulate Secrets coming from an older version
+        // remove truststore and password to simulate Secrets coming from an older version
         initialClusterCaCertSecret.getData().remove(CA_STORE);
         initialClusterCaCertSecret.getData().remove(CA_STORE_PASSWORD);
 
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        // remove trustore and password to simulate Secrets coming from an older version
+        // remove truststore and password to simulate Secrets coming from an older version
         initialClientsCaCertSecret.getData().remove(CA_STORE);
         initialClientsCaCertSecret.getData().remove(CA_STORE_PASSWORD);
 
@@ -708,6 +708,12 @@ public class CertificateRenewalTest {
         Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
         assertThat(clusterCaCertData.size(), is(4));
         X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
+        String oldClusterCaCertKey = clusterCaCertData.keySet()
+                                                .stream()
+                                                .filter(alias -> alias.startsWith("ca-"))
+                                                .findAny()
+                                                .get();
+        X509Certificate oldX509ClusterCaCertStore = getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData);
         String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
         String newClusterCaCertStore = clusterCaCertData.remove(CA_STORE);
         String newClusterCaCertStorePassword = clusterCaCertData.remove(CA_STORE_PASSWORD);
@@ -717,6 +723,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClusterCaCertStore.equals(x509Certificate(newClusterCaCert)), is(true));
         Map.Entry oldClusterCaCert = clusterCaCertData.entrySet().iterator().next();
         assertThat(oldClusterCaCert.getValue(), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(oldClusterCaCert.getValue().toString())), is(true));
         assertThat(x509Certificate(newClusterCaCert).getSubjectDN().getName(), is("CN=cluster-ca v1, O=io.strimzi"));
 
         Secret clusterCaKeySecret = c.getAllValues().get(1);
@@ -730,6 +737,12 @@ public class CertificateRenewalTest {
         Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
         assertThat(clientsCaCertData.size(), is(4));
         X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
+        String oldClientsCaCertKey = clusterCaCertData.keySet()
+                                                    .stream()
+                                                    .filter(alias -> alias.startsWith("ca-"))
+                                                    .findAny()
+                                                    .get();
+        X509Certificate oldX509ClientsCaCertStore = getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData);
         String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
         String newClientsCaCertStore = clientsCaCertData.remove(CA_STORE);
         String newClientsCaCertStorePassword = clientsCaCertData.remove(CA_STORE_PASSWORD);
@@ -739,6 +752,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClientsCaCertStore.equals(x509Certificate(newClientsCaCert)), is(true));
         Map.Entry oldClientsCaCert = clientsCaCertData.entrySet().iterator().next();
         assertThat(oldClientsCaCert.getValue(), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(oldClientsCaCert.getValue().toString())), is(true));
         assertThat(x509Certificate(newClientsCaCert).getSubjectDN().getName(), is("CN=clients-ca v1, O=io.strimzi"));
 
         Secret clientsCaKeySecret = c.getAllValues().get(3);
@@ -901,6 +915,12 @@ public class CertificateRenewalTest {
         assertThat(c.getAllValues().get(0).getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("1"));
         assertThat(clusterCaCertData.size(), is(4));
         X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
+        String oldClusterCaCertKey = clusterCaCertData.keySet()
+                                                .stream()
+                                                .filter(alias -> alias.startsWith("ca-"))
+                                                .findAny()
+                                                .get();
+        X509Certificate oldX509ClusterCaCertStore = getCertificateFromTrustStore(oldClusterCaCertKey, clusterCaCertData);
         String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
         String newClusterCaCertStore = clusterCaCertData.remove(CA_STORE);
         String newClusterCaCertStorePassword = clusterCaCertData.remove(CA_STORE_PASSWORD);
@@ -910,6 +930,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClusterCaCertStore.equals(x509Certificate(newClusterCaCert)), is(true));
         Map.Entry oldClusterCaCert = clusterCaCertData.entrySet().iterator().next();
         assertThat(oldClusterCaCert.getValue(), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
+        assertThat(oldX509ClusterCaCertStore.equals(x509Certificate(oldClusterCaCert.getValue().toString())), is(true));
         assertThat(x509Certificate(newClusterCaCert).getSubjectDN().getName(), is("CN=cluster-ca v1, O=io.strimzi"));
 
         Secret clusterCaKeySecret = c.getAllValues().get(1);
@@ -924,6 +945,12 @@ public class CertificateRenewalTest {
         assertThat(c.getAllValues().get(2).getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("1"));
         assertThat(clientsCaCertData.size(), is(4));
         X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
+        String oldClientsCaCertKey = clusterCaCertData.keySet()
+                                                    .stream()
+                                                    .filter(alias -> alias.startsWith("ca-"))
+                                                    .findAny()
+                                                    .get();
+        X509Certificate oldX509ClientsCaCertStore = getCertificateFromTrustStore(oldClientsCaCertKey, clientsCaCertData);
         String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
         String newClientsCaCertStore = clientsCaCertData.remove(CA_STORE);
         String newClientsCaCertStorePassword = clientsCaCertData.remove(CA_STORE_PASSWORD);
@@ -933,6 +960,7 @@ public class CertificateRenewalTest {
         assertThat(newX509ClientsCaCertStore.equals(x509Certificate(newClientsCaCert)), is(true));
         Map.Entry oldClientsCaCert = clientsCaCertData.entrySet().iterator().next();
         assertThat(oldClientsCaCert.getValue(), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
+        assertThat(oldX509ClientsCaCertStore.equals(x509Certificate(oldClientsCaCert.getValue().toString())), is(true));
         assertThat(x509Certificate(newClientsCaCert).getSubjectDN().getName(), is("CN=clients-ca v1, O=io.strimzi"));
 
         Secret clientsCaKeySecret = c.getAllValues().get(3);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -737,7 +737,7 @@ public class CertificateRenewalTest {
         Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
         assertThat(clientsCaCertData.size(), is(4));
         X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
-        String oldClientsCaCertKey = clusterCaCertData.keySet()
+        String oldClientsCaCertKey = clientsCaCertData.keySet()
                                                     .stream()
                                                     .filter(alias -> alias.startsWith("ca-"))
                                                     .findAny()
@@ -945,7 +945,7 @@ public class CertificateRenewalTest {
         assertThat(c.getAllValues().get(2).getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("1"));
         assertThat(clientsCaCertData.size(), is(4));
         X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
-        String oldClientsCaCertKey = clusterCaCertData.keySet()
+        String oldClientsCaCertKey = clientsCaCertData.keySet()
                                                     .stream()
                                                     .filter(alias -> alias.startsWith("ca-"))
                                                     .findAny()


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fixes #2171. It generates the missing PKCS12 truststore and related password for already existing secrets for cluster and clients CA; it happens during a Strimzi upgrade coming from a version less or equals 0.14.0.
This PR also proposes to change the truststore and password keys in the Secrets to `ca.p12` and `ca.password` instead of the current `truststore.p12` and `truststore.password`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

