### PR TITLE
TO incremental fix

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -239,6 +239,7 @@ public class KafkaImpl implements Kafka {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Future<Void> updateTopicConfig(Topic topic) {
         Future<Void> handler = Future.future();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -10,7 +10,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTopicsResult;
@@ -23,7 +22,6 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -244,8 +242,8 @@ public class KafkaImpl implements Kafka {
     @Override
     public Future<Void> updateTopicConfig(Topic topic) {
         Future<Void> handler = Future.future();
-        Map<ConfigResource, Collection<AlterConfigOp>> configs = TopicSerialization.toTopicConfig(topic);
-        KafkaFuture<Void> future = adminClient.incrementalAlterConfigs(configs).values().get(configs.keySet().iterator().next());
+        Map<ConfigResource, Config> configs = TopicSerialization.toTopicConfig(topic);
+        KafkaFuture<Void> future = adminClient.alterConfigs(configs).values().get(configs.keySet().iterator().next());
         queueWork(new UniWork<>("updateTopicConfig", future, handler));
         return handler;
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -20,14 +19,12 @@ import org.apache.kafka.common.config.ConfigResource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.lang.String.format;
 
@@ -207,18 +204,17 @@ class TopicSerialization {
      * to the {@link Config} of the given topic.
      * @return
      */
-    public static Map<ConfigResource, Collection<AlterConfigOp>> toTopicConfig(Topic topic) {
-        Set<AlterConfigOp> alterConfigOps = new HashSet<>();
+    public static Map<ConfigResource, Config> toTopicConfig(Topic topic) {
+        List<ConfigEntry> entries = new ArrayList<>(topic.getConfig().size());
 
         for (Map.Entry<String, String> entry : topic.getConfig().entrySet()) {
             ConfigEntry configEntry = new ConfigEntry(entry.getKey(), entry.getValue());
-            AlterConfigOp alterConfigOp = new AlterConfigOp(configEntry, AlterConfigOp.OpType.SET);
-            alterConfigOps.add(alterConfigOp);
+            entries.add(configEntry);
         }
 
         return Collections.singletonMap(
                 new ConfigResource(ConfigResource.Type.TOPIC, topic.getTopicName().toString()),
-                alterConfigOps);
+                new Config(entries));
     }
 
     /**

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicSerializationTest.java
@@ -9,8 +9,6 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
-
-import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -19,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,16 +113,13 @@ public class TopicSerializationTest {
                 .withNumReplicas((short) 2)
                 .withMapName("gee")
                 .build();
-        Map<ConfigResource, Collection<AlterConfigOp>> config = TopicSerialization.toTopicConfig(topic);
+        Map<ConfigResource, Config> config = TopicSerialization.toTopicConfig(topic);
         assertThat(config.size(), is(1));
-        Map.Entry<ConfigResource, Collection<AlterConfigOp>> c = config.entrySet().iterator().next();
+        Map.Entry<ConfigResource, Config> c = config.entrySet().iterator().next();
         assertThat(c.getKey().type(), is(ConfigResource.Type.TOPIC));
+        assertThat(c.getValue().entries().size(), is(1));
         assertThat(c.getKey().name(), is("test-topic"));
-        assertThat(c.getValue().size(), is(1));
-        AlterConfigOp alterConfigOp = c.getValue().iterator().next();
-        assertThat(alterConfigOp.configEntry().name(), is("foo"));
-        assertThat(alterConfigOp.configEntry().value(), is("bar"));
-        assertThat(alterConfigOp.opType(), is(AlterConfigOp.OpType.SET));
+        assertThat(c.getValue().get("foo").value(), is("bar"));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The TO uses an `AdminClient` API which was added in 2.3.0 which means it can't be used with a Kafka 2.2.1 cluster. Meanwhile in `kafka-versions.yaml` we still support Kafka 2.2.1.

This PR fixes the usage of the problematic API.

To avoid making this kind of mistake in future we should consider pinning the `AdminClient` version used in the TO and CO to the oldest version present in `kafka-versions.yaml`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

