### PR TITLE
Flake fix

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1176,7 +1176,11 @@ public class KafkaAssemblyOperatorTest {
         ops.reconcileAll("test", clusterCmNamespace, context.succeeding());
 
         if (!fooLatch.await(30, TimeUnit.SECONDS)) {
-            fail("foo not seen");
+            if (barLatch.getCount() > 0) {
+                fail("Neither foo nor bar seen");
+            } else {
+                fail("foo not seen");
+            }
         }
         if (!barLatch.await(30, TimeUnit.SECONDS)) {
             fail("bar not seen");
@@ -1267,7 +1271,11 @@ public class KafkaAssemblyOperatorTest {
         ops.reconcileAll("test", "*", context.succeeding());
 
         if (!fooLatch.await(30, TimeUnit.SECONDS)) {
-            fail("foo not seen");
+            if (barLatch.getCount() > 0) {
+                fail("Neither foo nor bar seen");
+            } else {
+                fail("foo not seen");
+            }
         }
         if (!barLatch.await(30, TimeUnit.SECONDS)) {
             fail("bar not seen");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

I think/hope this PR fixes the flaky test

```
[[1;31mERROR[m] testReconcileAllNamespaces{Params, VertxTestContext}[264]  Time elapsed: 60.011 s  <<< FAILURE!
java.lang.AssertionError: 
java.lang.AssertionError: 
Expected: is <[bar, foo]>
     but: was <[bar]>
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

