### PR TITLE
Try to fix #2187

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -22,6 +22,7 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeCluster;
 import io.strimzi.test.k8s.NoClusterException;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -70,6 +71,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
+@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public abstract class TopicOperatorBaseIT extends BaseITST {
 
@@ -535,7 +537,9 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
             async.countDown();
         });
         try {
-            async.await(600, TimeUnit.SECONDS);
+            if (!async.await(600, TimeUnit.SECONDS)) {
+                context.failNow(new TimeoutException());
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             context.failNow(e);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.operator.common.Util;
 import io.strimzi.test.BaseITST;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeCluster;
@@ -55,7 +54,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -64,14 +63,14 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
+@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public abstract class TopicOperatorBaseIT extends BaseITST {
 
@@ -96,7 +95,6 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
             }
         }
     };
-    protected final long timeout = 600_000L;
 
     protected volatile String deploymentId;
     protected Set<String> preExistingEvents;
@@ -169,7 +167,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         kubeClient = BaseITST.kubeClient().getClient();
         Crds.registerCustomKinds();
         LOGGER.info("Using namespace {}", NAMESPACE);
-        startTopicOperator(context);
+        startTopicOperator();
 
         // We can't delete events, so record the events which exist at the start of the test
         // and then waitForEvents() can ignore those
@@ -193,7 +191,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     protected abstract Properties kafkaClusterConfig();
 
     @AfterEach
-    public void teardown(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
+    public void teardown() throws InterruptedException, TimeoutException, ExecutionException {
         LOGGER.info("Tearing down test");
 
         boolean deletionEnabled = "true".equals(kafkaClusterConfig().getOrDefault(
@@ -207,13 +205,13 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
                 operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
                 LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
-                waitForTopicInKafka(context, new TopicName(item).toString(), false);
-                waitForTopicInKube(context, item.getMetadata().getName(), false);
+                waitForTopicInKafka(new TopicName(item).toString(), false);
+                waitForTopicInKube(item.getMetadata().getName(), false);
             }
             Thread.sleep(5_000);
         }
 
-        stopTopicOperator(context);
+        stopTopicOperator();
 
         if (!deletionEnabled && kubeClient != null) {
             List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
@@ -221,7 +219,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
             // Wait for the operator to delete all the existing topics in Kafka
             for (KafkaTopic item : items) {
                 operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
-                waitForTopicInKube(context, item.getMetadata().getName(), false);
+                waitForTopicInKube(item.getMetadata().getName(), false);
             }
         }
 
@@ -231,34 +229,24 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         }
         Runtime.getRuntime().removeShutdownHook(kafkaHook);
         LOGGER.info("Finished tearing down test");
-        context.completeNow();
         vertx.close();
     }
 
-    protected void startTopicOperator(VertxTestContext context) {
+    protected void startTopicOperator() throws InterruptedException, ExecutionException, TimeoutException {
 
         LOGGER.info("Starting Topic Operator");
         session = new Session(kubeClient, new Config(topicOperatorConfig()));
 
-        CountDownLatch async = new CountDownLatch(1);
+        CompletableFuture<Void> async = new CompletableFuture<>();
         vertx.deployVerticle(session, ar -> {
             if (ar.succeeded()) {
                 deploymentId = ar.result();
-                async.countDown();
+                async.complete(null);
             } else {
-                async.countDown();
-                ar.cause().printStackTrace();
-                context.failNow(new Throwable("Failed to deploy session"));
+                async.completeExceptionally(ar.cause());
             }
         });
-        try {
-            if (!async.await(60, TimeUnit.SECONDS)) {
-                context.failNow(new Throwable("Test timeout"));
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            context.failNow(e);
-        }
+        async.get(60, TimeUnit.SECONDS);
         LOGGER.info("Started Topic Operator");
     }
 
@@ -285,46 +273,43 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         }
     }
 
-    protected void stopTopicOperator(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void stopTopicOperator() throws InterruptedException, ExecutionException, TimeoutException {
         LOGGER.info("Stopping Topic Operator");
-        CountDownLatch async = new CountDownLatch(1);
+        CompletableFuture<Void> async = new CompletableFuture<>();
         if (deploymentId != null) {
             vertx.undeploy(deploymentId, ar -> {
                 deploymentId = null;
                 if (ar.failed()) {
                     LOGGER.error("Error undeploying session", ar.cause());
-                    context.failNow(new Throwable("Error undeploying session"));
-                    async.countDown();
+                    async.completeExceptionally(ar.cause());
                 } else {
-                    async.countDown();
+                    async.complete(null);
                 }
             });
         }
-        if (!async.await(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+        async.get(60, TimeUnit.SECONDS);
         LOGGER.info("Stopped Topic Operator");
     }
 
-    protected KafkaTopic createKafkaTopicResource(VertxTestContext context, KafkaTopic topicResource) throws InterruptedException, ExecutionException, TimeoutException {
+    protected KafkaTopic createKafkaTopicResource(KafkaTopic topicResource) throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = new TopicName(topicResource).toString();
         // Create a Topic Resource
         operation().inNamespace(NAMESPACE).create(topicResource);
 
         // Wait for the topic to be created
-        waitForTopicInKafka(context, topicName);
-        assertStatusReady(context, topicResource.getMetadata().getName());
+        waitForTopicInKafka(topicName);
+        assertStatusReady(topicResource.getMetadata().getName());
         return topicResource;
     }
 
-    protected void assertStatusReady(VertxTestContext testContext, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        waitFor(testContext, () -> {
+    protected void assertStatusReady(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        waitFor(() -> {
             KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
             if (kafkaTopic != null) {
                 if (kafkaTopic.getStatus() != null
                         && kafkaTopic.getStatus().getConditions() != null) {
                     List<Condition> conditions = kafkaTopic.getStatus().getConditions();
-                    testContext.verify(() -> assertThat(conditions.size() > 0, is(true)));
+                    assertThat(conditions.size() > 0, is(true));
                     if (conditions.stream().anyMatch(condition ->
                             "Ready".equals(condition.getType()) &&
                                     "True".equals(condition.getStatus()))) {
@@ -337,17 +322,17 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 LOGGER.info("{} does not exist", topicName);
             }
             return false;
-        }, 60000, "status ready for topic " + topicName);
+        }, "status ready for topic " + topicName);
     }
 
-    protected void assertStatusNotReady(VertxTestContext testContext, String topicName, String message) throws InterruptedException, ExecutionException, TimeoutException {
-        waitFor(testContext, () -> {
+    protected void assertStatusNotReady(String topicName, String message) throws InterruptedException, ExecutionException, TimeoutException {
+        waitFor(() -> {
             KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
             if (kafkaTopic != null) {
                 if (kafkaTopic.getStatus() != null
                         && kafkaTopic.getStatus().getConditions() != null) {
                     List<Condition> conditions = kafkaTopic.getStatus().getConditions();
-                    testContext.verify(() -> assertThat(conditions.size() > 0, is(true)));
+                    assertThat(conditions.size() > 0, is(true));
                     Optional<Condition> unreadyCondition = conditions.stream().filter(condition ->
                             "NotReady".equals(condition.getType()) &&
                             "True".equals(condition.getStatus())).findFirst();
@@ -362,41 +347,39 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 LOGGER.info("{} does not exist", topicName);
             }
             return false;
-        }, 60000, "status ready");
+        }, "status ready");
     }
 
-    protected KafkaTopic createKafkaTopicResource(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+    protected KafkaTopic createKafkaTopicResource(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
         KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
-        return createKafkaTopicResource(context, topicResource);
+        return createKafkaTopicResource(topicResource);
     }
 
     /**
      * Create a topic in Kafka with a single partition and RF=1.
-     * @param context The test context.
      * @param topicName The name of the topic.
      * @return The name of the KafkaTopic resource that was created in Kube.
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    protected String createTopic(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        return createTopic(context, topicName, new NewTopic(topicName, 1, (short) 1));
+    protected String createTopic(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        return createTopic(topicName, new NewTopic(topicName, 1, (short) 1));
     }
 
     /**
      * Create a topic in Kafka with a single partition and the given replica assignments
-     * @param context The test context.
      * @param topicName The name of the topic.
      * @param replicaAssignments The replica assignments.
      * @return The name of the KafkaTopic resource that was created in Kube.
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    protected String createTopic(VertxTestContext context, String topicName, List<Integer> replicaAssignments) throws InterruptedException, ExecutionException, TimeoutException {
-        return createTopic(context, topicName, new NewTopic(topicName, singletonMap(0, replicaAssignments)));
+    protected String createTopic(String topicName, List<Integer> replicaAssignments) throws InterruptedException, ExecutionException, TimeoutException {
+        return createTopic(topicName, new NewTopic(topicName, singletonMap(0, replicaAssignments)));
     }
 
-    private String createTopic(VertxTestContext context, String topicName, NewTopic o) throws InterruptedException, ExecutionException, TimeoutException {
+    private String createTopic(String topicName, NewTopic o) throws InterruptedException, ExecutionException, TimeoutException {
         LOGGER.info("Creating topic {}", topicName);
         // Create a topic
         String resourceName = new TopicName(topicName).asKubeName().toString();
@@ -404,40 +387,40 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         crt.all().get();
 
         // Wait for the resource to be created
-        waitForTopicInKube(context, resourceName);
+        waitForTopicInKube(resourceName);
 
         LOGGER.info("topic {} has been created", resourceName);
         return resourceName;
     }
 
-    protected void waitForTopicInKube(VertxTestContext context, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
-        waitForTopicInKube(context, resourceName, true);
+    protected void waitForTopicInKube(String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
+        waitForTopicInKube(resourceName, true);
     }
 
-    protected void waitForTopicInKube(VertxTestContext context, String resourceName, boolean exist) {
-        waitFor(context, () -> {
+    protected void waitForTopicInKube(String resourceName, boolean exist) throws TimeoutException, InterruptedException {
+        waitFor(() -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
             return topic != null == exist;
-        }, timeout, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
+        }, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
     }
 
-    protected void alterTopicConfigInKafkaAndAwaitReconciliation(VertxTestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void alterTopicConfigInKafkaAndAwaitReconciliation(String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         String key = "compression.type";
         final String changedValue = alterTopicConfigInKafka(topicName, key, value -> "snappy".equals(value) ? "lz4" : "snappy");
-        awaitTopicConfigInKube(context, resourceName, key, changedValue);
+        awaitTopicConfigInKube(resourceName, key, changedValue);
     }
 
-    protected void awaitTopicConfigInKube(VertxTestContext context, String resourceName, String key, String expectedValue) {
+    protected void awaitTopicConfigInKube(String resourceName, String key, String expectedValue) throws TimeoutException, InterruptedException {
 
         // Wait for the resource to be modified
-        waitFor(context, () -> {
+        waitFor(() -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {}, waiting for config change", resourceName);
             String gotValue = TopicSerialization.fromTopicResource(topic).getConfig().get(key);
             LOGGER.info("Expecting value {}, got value {}", expectedValue, gotValue);
             return expectedValue.equals(gotValue);
-        }, timeout, "Expected the config of topic " + resourceName + " to have " + key + "=" + expectedValue + " in Kube by now");
+        }, "Expected the config of topic " + resourceName + " to have " + key + "=" + expectedValue + " in Kube by now");
     }
 
     protected String alterTopicConfigInKafka(String topicName, String key, Function<String, String> mutator) throws InterruptedException, ExecutionException {
@@ -460,7 +443,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         return changedValue;
     }
 
-    protected void alterTopicNumPartitions(VertxTestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void alterTopicNumPartitions(String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         int changedValue = 2;
 
         NewPartitions newPartitions = NewPartitions.increaseTo(changedValue);
@@ -471,13 +454,13 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         createPartitionsResult.all().get();
 
         // Wait for the resource to be modified
-        waitFor(context, () -> {
+        waitFor(() -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {}, waiting for partitions change", resourceName);
             int gotValue = TopicSerialization.fromTopicResource(topic).getNumPartitions();
             LOGGER.info("Expected value {}, got value {}", changedValue, gotValue);
             return changedValue == gotValue;
-        }, timeout, "Expected the topic " + topicName + "to have " + changedValue + " partitions by now");
+        }, "Expected the topic " + topicName + "to have " + changedValue + " partitions by now");
     }
 
     protected org.apache.kafka.clients.admin.Config getTopicConfig(ConfigResource configResource) {
@@ -494,20 +477,20 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         return new ConfigResource(ConfigResource.Type.TOPIC, topicName);
     }
 
-    protected void createAndAlterTopicConfig(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        String resourceName = createTopic(context, topicName);
-        alterTopicConfigInKafkaAndAwaitReconciliation(context, topicName, resourceName);
+    protected void createAndAlterTopicConfig(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        String resourceName = createTopic(topicName);
+        alterTopicConfigInKafkaAndAwaitReconciliation(topicName, resourceName);
     }
 
-    protected void deleteTopicInKafkaAndAwaitReconciliation(VertxTestContext context, String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void deleteTopicInKafkaAndAwaitReconciliation(String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         deleteTopicInKafka(topicName, resourceName);
 
         // Wait for the resource to be deleted
-        waitFor(context, () -> {
+        waitFor(() -> {
             KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled topic {}, got {}, waiting for deletion", resourceName, topic);
             return topic == null;
-        }, timeout, "Expected the topic " + topicName + " to have been deleted by now");
+        }, "Expected the topic " + topicName + " to have been deleted by now");
     }
 
     protected void deleteTopicInKafka(String topicName, String resourceName) throws InterruptedException, ExecutionException {
@@ -518,36 +501,37 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
         LOGGER.info("Deleted topic {}", topicName);
     }
 
-    protected void createAndDeleteTopic(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        String resourceName = createTopic(context, topicName);
-        deleteTopicInKafkaAndAwaitReconciliation(context, topicName, resourceName);
+    protected void createAndDeleteTopic(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        String resourceName = createTopic(topicName);
+        deleteTopicInKafkaAndAwaitReconciliation(topicName, resourceName);
     }
 
-    protected void createAndAlterNumPartitions(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        String resourceName = createTopic(context, topicName);
-        alterTopicNumPartitions(context, topicName, resourceName);
+    protected void createAndAlterNumPartitions(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        String resourceName = createTopic(topicName);
+        alterTopicNumPartitions(topicName, resourceName);
     }
 
-    protected void waitFor(VertxTestContext context, BooleanSupplier ready, long timeout, String message) {
-        CountDownLatch async = new CountDownLatch(1);
-        Util.waitFor(vertx, message, 3_000, timeout, ready).setHandler(ar -> {
-            if (ar.failed()) {
-                context.failNow(ar.cause());
+    protected void waitFor(BooleanSupplier ready, String message) throws TimeoutException, InterruptedException {
+        // Note that this timeout for an individual wait must be less than
+        // the Vertx @Timeout for the test as a whole
+        long timeout = 120_000;
+        long deadline = System.currentTimeMillis() + timeout;
+
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                if (ready.getAsBoolean()) {
+                    return;
+                }
+            } catch (Throwable t) {
+                throw new AssertionError("Exception from condition while waiting for " + message, t);
             }
-            async.countDown();
-        });
-        try {
-            if (!async.await(600, TimeUnit.SECONDS)) {
-                context.failNow(new TimeoutException());
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            context.failNow(e);
+            Thread.sleep(3_000);
         }
+        throw new TimeoutException("Timeout waiting for " + message);
     }
 
-    protected void waitForEvent(VertxTestContext context, KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) throws InterruptedException, ExecutionException, TimeoutException {
-        waitFor(context, () -> {
+    protected void waitForEvent(KafkaTopic kafkaTopic, String expectedMessage, TopicOperator.EventType expectedType) throws InterruptedException, ExecutionException, TimeoutException {
+        waitFor(() -> {
             List<Event> items = kubeClient.events().inNamespace(NAMESPACE).withLabels(labels.labels()).list().getItems();
             List<Event> filtered = items.stream().
                     filter(evt -> !preExistingEvents.contains(evt.getMetadata().getUid())
@@ -562,19 +546,19 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                         event.getLastTimestamp() != null &&
                         Objects.equals("KafkaTopic", event.getInvolvedObject().getKind()) &&
                         Objects.equals(kafkaTopic.getMetadata().getName(), event.getInvolvedObject().getName()));
-        }, timeout, "Expected an error event");
+        }, "Expected an error event");
     }
 
     protected MixedOperation<KafkaTopic, KafkaTopicList, DoneableKafkaTopic, Resource<KafkaTopic, DoneableKafkaTopic>> operation() {
         return kubeClient.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class);
     }
 
-    protected void waitForTopicInKafka(VertxTestContext context, String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        waitForTopicInKafka(context, topicName, true);
+    protected void waitForTopicInKafka(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+        waitForTopicInKafka(topicName, true);
     }
 
-    protected void waitForTopicInKafka(VertxTestContext context, String topicName, boolean exist) {
-        waitFor(context, () -> {
+    protected void waitForTopicInKafka(String topicName, boolean exist) throws TimeoutException, InterruptedException {
+        waitFor(() -> {
             try {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
                 return exist;
@@ -588,14 +572,14 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-        }, timeout, "Expected topic '" + topicName + "' to " + (exist ? "exist" : "not exist") + " in Kafka by now");
+        }, "Expected topic '" + topicName + "' to " + (exist ? "exist" : "not exist") + " in Kafka by now");
     }
 
-    protected void deleteInKubeAndAwaitReconciliation(VertxTestContext context, String topicName, KafkaTopic topicResource) throws InterruptedException, ExecutionException, TimeoutException {
-        deleteInKube(context, topicResource.getMetadata().getName());
+    protected void deleteInKubeAndAwaitReconciliation(String topicName, KafkaTopic topicResource) throws InterruptedException, ExecutionException, TimeoutException {
+        deleteInKube(topicResource.getMetadata().getName());
 
         // Wait for the topic to be deleted
-        waitFor(context, () -> {
+        waitFor(() -> {
             try {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
                 return false;
@@ -609,26 +593,26 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-        }, timeout, "Expected topic to be deleted by now");
+        }, "Expected topic to be deleted by now");
     }
 
-    protected void deleteInKube(VertxTestContext context, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void deleteInKube(String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         // can now delete the topicResource
         operation().inNamespace(NAMESPACE).withName(resourceName).delete();
-        waitFor(context, () -> {
+        waitFor(() -> {
             return operation().inNamespace(NAMESPACE).withName(resourceName).get() == null;
-        }, Long.MAX_VALUE, "verified deletion of KafkaTopic " + resourceName);
+        }, "verified deletion of KafkaTopic " + resourceName);
     }
 
-    protected void awaitTopicConfigInKafka(VertxTestContext context, String topicName, String key, String expectedValue) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void awaitTopicConfigInKafka(String topicName, String key, String expectedValue) throws InterruptedException, ExecutionException, TimeoutException {
         // Wait for that to be reflected in the kafka topic
-        waitFor(context, () -> {
+        waitFor(() -> {
             ConfigResource configResource = topicConfigResource(topicName);
             org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
             String retention = config.get("retention.ms").value();
             LOGGER.debug("retention of {}, waiting for 12341234", retention);
             return expectedValue.equals(retention);
-        },  timeout, "Expected the topic " + topicName + " to have retention.ms=" + expectedValue + " in Kafka");
+        },  "Expected the topic " + topicName + " to have retention.ms=" + expectedValue + " in Kafka");
     }
 
     protected String alterTopicConfigInKube(String resourceName, String key, Function<String, String> mutator) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
@@ -27,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyMap;
@@ -35,6 +37,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorIT extends TopicOperatorBaseIT {
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -36,8 +35,9 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
+@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorIT extends TopicOperatorBaseIT {
 
@@ -57,55 +57,47 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
 
     @Test
-    public void testTopicAdded(VertxTestContext context) throws Exception {
-        createTopic(context, "test-topic-added");
-        context.completeNow();
+    public void testTopicAdded() throws Exception {
+        createTopic("test-topic-added");
     }
 
     @Test
-    public void testTopicAddedWithEncodableName(VertxTestContext context) throws Exception {
-        createTopic(context, "test-TOPIC_ADDED_ENCODABLE");
-        context.completeNow();
+    public void testTopicAddedWithEncodableName() throws Exception {
+        createTopic("test-TOPIC_ADDED_ENCODABLE");
     }
 
     @Test
-    public void testTopicDeleted(VertxTestContext context) throws Exception {
-        createAndDeleteTopic(context, "test-topic-deleted");
-        context.completeNow();
+    public void testTopicDeleted() throws Exception {
+        createAndDeleteTopic("test-topic-deleted");
     }
 
     @Test
-    public void testTopicDeletedWithEncodableName(VertxTestContext context) throws Exception {
-        createAndDeleteTopic(context, "test-TOPIC_DELETED_ENCODABLE");
-        context.completeNow();
+    public void testTopicDeletedWithEncodableName() throws Exception {
+        createAndDeleteTopic("test-TOPIC_DELETED_ENCODABLE");
     }
 
     @Test
-    public void testTopicConfigChanged(VertxTestContext context) throws Exception {
-        createAndAlterTopicConfig(context, "test-topic-config-changed");
-        context.completeNow();
+    public void testTopicConfigChanged() throws Exception {
+        createAndAlterTopicConfig("test-topic-config-changed");
     }
 
     @Test
-    public void testTopicConfigChangedWithEncodableName(VertxTestContext context) throws Exception {
-        createAndAlterTopicConfig(context, "test-TOPIC_CONFIG_CHANGED_ENCODABLE");
-        context.completeNow();
+    public void testTopicConfigChangedWithEncodableName() throws Exception {
+        createAndAlterTopicConfig("test-TOPIC_CONFIG_CHANGED_ENCODABLE");
     }
 
     @Test
-    public void testTopicNumPartitionsChanged(VertxTestContext context) throws Exception {
-        createAndAlterNumPartitions(context, "test-topic-partitions-changed");
-        context.completeNow();
+    public void testTopicNumPartitionsChanged() throws Exception {
+        createAndAlterNumPartitions("test-topic-partitions-changed");
     }
 
     @Test
-    public void testKafkaTopicAdded(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testKafkaTopicAdded() throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = "test-kafkatopic-created";
-        createKafkaTopicResource(context, topicName);
-        context.completeNow();
+        createKafkaTopicResource(topicName);
     }
 
-    void createKafkaTopicResourceError(VertxTestContext context, String topicName, Map<String, String> objectObjectMap, int rf,
+    void createKafkaTopicResourceError(String topicName, Map<String, String> objectObjectMap, int rf,
                                        String expectedMessage) throws InterruptedException, ExecutionException, TimeoutException {
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, objectObjectMap).build();
         KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(topic, labels);
@@ -113,39 +105,36 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
         // Create a Topic Resource
         operation().inNamespace(NAMESPACE).create(kafkaTopic);
-        assertStatusNotReady(context, topicName, expectedMessage);
+        assertStatusNotReady(topicName, expectedMessage);
     }
 
-    public void testKafkaTopicAddedWithMoreReplicasThanBrokers(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        createKafkaTopicResourceError(context, "test-resource-created-with-more-replicas-than-brokers", emptyMap(), 42, "Replication factor: 42 larger than available brokers: 1.");
+    public void testKafkaTopicAddedWithMoreReplicasThanBrokers() throws InterruptedException, ExecutionException, TimeoutException {
+        createKafkaTopicResourceError("test-resource-created-with-more-replicas-than-brokers", emptyMap(), 42, "Replication factor: 42 larger than available brokers: 1.");
     }
 
     @Test
-    public void testKafkaTopicAddedWithHigherMinIsrThanBrokers(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        createKafkaTopicResourceError(context, "test-resource-created-with-higher-min-isr-than-brokers",
+    public void testKafkaTopicAddedWithHigherMinIsrThanBrokers() throws InterruptedException, ExecutionException, TimeoutException {
+        createKafkaTopicResourceError("test-resource-created-with-higher-min-isr-than-brokers",
                 singletonMap("min.insync.replicas", "42"), 42,
                "Replication factor: 42 larger than available brokers: 1.");
-        context.completeNow();
     }
 
     @Test
-    public void testKafkaTopicAddedWithUnknownConfig(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        createKafkaTopicResourceError(context, "test-resource-created-with-unknown-config",
+    public void testKafkaTopicAddedWithUnknownConfig() throws InterruptedException, ExecutionException, TimeoutException {
+        createKafkaTopicResourceError("test-resource-created-with-unknown-config",
                 singletonMap("aardvark", "zebra"), 1,
                "Unknown topic config name: aardvark");
-        context.completeNow();
     }
 
     @Test
-    public void testKafkaTopicAddedWithInvalidConfig(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        createKafkaTopicResourceError(context, "test-resource-created-with-invalid-config",
+    public void testKafkaTopicAddedWithInvalidConfig() throws InterruptedException, ExecutionException, TimeoutException {
+        createKafkaTopicResourceError("test-resource-created-with-invalid-config",
                 singletonMap("message.format.version", "zebra"), 1,
                "Invalid value zebra for configuration message.format.version: Version `zebra` is not a valid version");
-        context.completeNow();
     }
 
     @Test
-    public void testKafkaTopicAddedWithBadData(VertxTestContext context) {
+    public void testKafkaTopicAddedWithBadData() {
         String topicName = "test-resource-created-with-bad-data";
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
         KafkaTopic kafkaTopic = TopicSerialization.toTopicResource(topic, labels);
@@ -154,37 +143,35 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         // Create a Topic Resource
         try {
             operation().inNamespace(NAMESPACE).create(kafkaTopic);
+            fail();
         } catch (KubernetesClientException e) {
             assertThat(e.getMessage().contains("spec.partitions in body should be greater than or equal to 1"), is(true));
-            context.completeNow();
         }
     }
 
     @Test
-    public void testKafkaTopicDeleted(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testKafkaTopicDeleted() throws InterruptedException, ExecutionException, TimeoutException {
         // create the Topic Resource
         String topicName = "test-kafkatopic-deleted";
-        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
-        deleteInKubeAndAwaitReconciliation(context, topicName, topicResource);
-        context.completeNow();
+        KafkaTopic topicResource = createKafkaTopicResource(topicName);
+        deleteInKubeAndAwaitReconciliation(topicName, topicResource);
     }
 
     @Test
-    public void testKafkaTopicModifiedRetentionChanged(VertxTestContext context) throws Exception {
+    public void testKafkaTopicModifiedRetentionChanged() throws Exception {
         // create the topic
         String topicName = "test-kafkatopic-modified-retention-changed";
-        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        KafkaTopic topicResource = createKafkaTopicResource(topicName);
         String expectedValue = alterTopicConfigInKube(topicResource.getMetadata().getName(),
                 "retention.ms", currentValue -> Integer.toString(Integer.parseInt(currentValue) + 1));
-        awaitTopicConfigInKafka(context, topicName, "retention.ms", expectedValue);
-        context.completeNow();
+        awaitTopicConfigInKafka(topicName, "retention.ms", expectedValue);
     }
 
     @Test
-    public void testKafkaTopicModifiedWithBadData(VertxTestContext context) throws Exception {
+    public void testKafkaTopicModifiedWithBadData() throws Exception {
         // create the topicResource
         String topicName = "test-kafkatopic-modified-with-bad-data";
-        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        KafkaTopic topicResource = createKafkaTopicResource(topicName);
 
         // now change the topicResource
         KafkaTopic changedTopic = new KafkaTopicBuilder(operation().inNamespace(NAMESPACE).withName(topicResource.getMetadata().getName()).get())
@@ -194,14 +181,13 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         } catch (KubernetesClientException e) {
             assertThat(e.getMessage().contains("spec.partitions in body should be greater than or equal to 1"), is(true));
         }
-        context.completeNow();
     }
 
     @Test
-    public void testKafkaTopicModifiedNameChanged(VertxTestContext context) throws Exception {
+    public void testKafkaTopicModifiedNameChanged() throws Exception {
         // create the topicResource
         String topicName = "test-kafkatopic-modified-name-changed";
-        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        KafkaTopic topicResource = createKafkaTopicResource(topicName);
 
         // now change the topicResource
         String changedName = topicName.toUpperCase(Locale.ENGLISH);
@@ -211,34 +197,32 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         operation().inNamespace(NAMESPACE).withName(topicResource.getMetadata().getName()).replace(changedTopic);
 
         // We expect this to cause a warning event
-        waitForEvent(context, topicResource,
+        waitForEvent(topicResource,
                 "Kafka topics cannot be renamed, but KafkaTopic's spec.topicName has changed.",
                 TopicOperator.EventType.WARNING);
-        context.completeNow();
 
     }
 
     @Test
-    public void testCreateTwoResourcesManagingOneTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testCreateTwoResourcesManagingOneTopic() throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = "two-resources-one-topic";
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
         KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
         KafkaTopic topicResource2 = new KafkaTopicBuilder(topicResource).withMetadata(new ObjectMetaBuilder(topicResource.getMetadata()).withName(topicName + "-1").build()).build();
         // create one
-        createKafkaTopicResource(context, topicResource2);
+        createKafkaTopicResource(topicResource2);
         // create another
         operation().inNamespace(NAMESPACE).create(topicResource);
 
-        waitForEvent(context, topicResource,
+        waitForEvent(topicResource,
                 "Failure processing KafkaTopic watch event ADDED on resource two-resources-one-topic with labels \\{.*\\}: " +
                         "Topic 'two-resources-one-topic' is already managed via KafkaTopic 'two-resources-one-topic-1' it cannot also be managed via the KafkaTopic 'two-resources-one-topic'",
                 TopicOperator.EventType.WARNING);
-        context.completeNow();
     }
 
 
     @Test
-    public void testReconcile(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReconcile() throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = "test-reconcile";
 
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
@@ -248,7 +232,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         operation().inNamespace(NAMESPACE).create(topicResource);
 
         // Wait for the resource to be created
-        waitFor(context, () -> {
+        waitFor(() -> {
             KafkaTopic createdResource = operation().inNamespace(NAMESPACE).withName(resourceName).get();
             LOGGER.info("Polled kafkatopic {} waiting for creation", resourceName);
 
@@ -259,22 +243,21 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
             }
 
             return createdResource != null;
-        }, timeout, "Expected the kafkatopic to have been created by now");
+        }, "Expected the kafkatopic to have been created by now");
 
         // trigger an immediate reconcile, while topic operator is dealing with resource modification
         session.topicOperator.reconcileAllTopics("periodic");
 
         // Wait for the topic to be created
-        waitForTopicInKafka(context, topicName);
-        assertStatusReady(context, topicName);
-        context.completeNow();
+        waitForTopicInKafka(topicName);
+        assertStatusReady(topicName);
     }
 
     // TODO: What happens if we create and then change labels to the resource predicate isn't matched any more
     //       What then happens if we change labels back?
 
     @Test
-    public void testKafkaTopicWithOwnerRef(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testKafkaTopicWithOwnerRef() throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = "test-kafka-topic-with-owner-ref-1";
 
         // this CM is created to be the owner of the KafkaTopic we're about to create.
@@ -305,7 +288,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         // create topic and test OR, labels, annotations
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap(), metadata).build();
         KafkaTopic topicResource = TopicSerialization.toTopicResource(topic, labels);
-        createKafkaTopicResource(context, topicResource);
+        createKafkaTopicResource(topicResource);
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().size(), is(1));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().get(0).getUid(), is(uid));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getAnnotations().size(), is(1));
@@ -319,7 +302,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         KafkaTopic topicResource2 = TopicSerialization.toTopicResource(topic2, labels);
         topicResource = TopicSerialization.toTopicResource(topic2, labels);
         topicResource.getMetadata().getAnnotations().put("han", "solo");
-        createKafkaTopicResource(context, topicResource2);
+        createKafkaTopicResource(topicResource2);
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().get(0).getUid(), is(uid));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getAnnotations().size(), is(2));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getAnnotations().get("iam"), is("groot"));
@@ -330,12 +313,11 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         Topic topic3 = new Topic.Builder(topicName, 1, (short) 1, emptyMap(), metadata).build();
         topic3.getMetadata().getLabels().put("stan", "lee");
         topicResource = TopicSerialization.toTopicResource(topic3, labels);
-        createKafkaTopicResource(context, topicResource);
+        createKafkaTopicResource(topicResource);
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().get(0).getUid(), is(uid));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().size(), is(6));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("stan"), is("lee"));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("iam"), is("root"));
-        context.completeNow();
     }
 
     /**
@@ -347,7 +329,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
      * 5. Verify topics A, X and Y exist on both sides
      */
     @Test
-    public void testReconciliationOnStartup(VertxTestContext context) throws ExecutionException, InterruptedException, TimeoutException {
+    public void testReconciliationOnStartup() throws ExecutionException, InterruptedException, TimeoutException {
         // 1. Create topic A in Kube and reconcile
         String topicNameZ = "topic-z";
         {
@@ -355,8 +337,8 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
             KafkaTopic topicResourceZ = TopicSerialization.toTopicResource(topicZ, labels);
             String resourceNameZ = topicResourceZ.getMetadata().getName();
             operation().inNamespace(NAMESPACE).create(topicResourceZ);
-            waitForTopicInKafka(context, topicNameZ);
-            assertStatusReady(context, topicNameZ);
+            waitForTopicInKafka(topicNameZ);
+            assertStatusReady(topicNameZ);
         }
 
         String topicNameA = "topic-a";
@@ -365,8 +347,8 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
             KafkaTopic topicResourceA = TopicSerialization.toTopicResource(topicA, labels);
             String resourceNameA = topicResourceA.getMetadata().getName();
             operation().inNamespace(NAMESPACE).create(topicResourceA);
-            waitForTopicInKafka(context, topicNameA);
-            assertStatusReady(context, topicNameA);
+            waitForTopicInKafka(topicNameA);
+            assertStatusReady(topicNameA);
         }
         String topicNameB = "topic-b";
         String resourceNameB;
@@ -375,8 +357,8 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
             KafkaTopic topicResourceB = TopicSerialization.toTopicResource(topicB, labels);
             resourceNameB = topicResourceB.getMetadata().getName();
             operation().inNamespace(NAMESPACE).create(topicResourceB);
-            waitForTopicInKafka(context, topicNameB);
-            assertStatusReady(context, topicNameB);
+            waitForTopicInKafka(topicNameB);
+            assertStatusReady(topicNameB);
         }
         String topicNameC = "topic-c";
         {
@@ -384,12 +366,12 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
             KafkaTopic topicResourceC = TopicSerialization.toTopicResource(topicC, labels);
             String resourceNameC = topicResourceC.getMetadata().getName();
             operation().inNamespace(NAMESPACE).create(topicResourceC);
-            waitForTopicInKafka(context, topicNameC);
-            assertStatusReady(context, topicNameC);
+            waitForTopicInKafka(topicNameC);
+            assertStatusReady(topicNameC);
         }
 
         // 2. Stop TO
-        stopTopicOperator(context);
+        stopTopicOperator();
 
         // 3. Modify topic A in kubernetes and topic Z in Kafka
         String alteredConfigA = alterTopicConfigInKafka(topicNameA,
@@ -399,7 +381,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
         // 3. Delete topic B in Kafka, delete topic C in Kubernetes
         deleteTopicInKafka(topicNameB, resourceNameB);
-        deleteInKube(context, topicNameC);
+        deleteInKube(topicNameC);
 
         // 3. Create topic X in Kafka, topic Y in Kubernetes
         String topicNameX = "topic-x";
@@ -418,30 +400,30 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         }
 
         // 4. Start TO
-        startTopicOperator(context);
+        startTopicOperator();
 
         // 5. Verify topics A, X and Y exist on both sides
-        waitForTopicInKafka(context, topicNameA);
-        waitForTopicInKafka(context, topicNameX);
-        waitForTopicInKafka(context, topicNameY);
-        assertStatusReady(context, topicNameA);
-        assertStatusReady(context, topicNameX);
-        assertStatusReady(context, topicNameY);
-        waitForTopicInKube(context, topicNameA);
-        waitForTopicInKube(context, topicNameX);
-        waitForTopicInKube(context, topicNameY);
+        waitForTopicInKafka(topicNameA);
+        waitForTopicInKafka(topicNameX);
+        waitForTopicInKafka(topicNameY);
+        assertStatusReady(topicNameA);
+        assertStatusReady(topicNameX);
+        assertStatusReady(topicNameY);
+        waitForTopicInKube(topicNameA);
+        waitForTopicInKube(topicNameX);
+        waitForTopicInKube(topicNameY);
 
         // 5. Verify topics B and C deleted on both sides
-        waitForTopicInKube(context, topicNameB, false);
-        waitForTopicInKube(context, topicNameC, false);
-        waitForTopicInKafka(context, topicNameB, false);
-        waitForTopicInKafka(context, topicNameC, false);
+        waitForTopicInKube(topicNameB, false);
+        waitForTopicInKube(topicNameC, false);
+        waitForTopicInKafka(topicNameB, false);
+        waitForTopicInKafka(topicNameC, false);
 
         // 5. Verify topics A and Z were changed.
-        awaitTopicConfigInKube(context, topicNameA, "retention.ms", alteredConfigA);
-        awaitTopicConfigInKube(context, topicNameZ, "retention.ms", alteredConfigZ);
-        awaitTopicConfigInKafka(context, topicNameA, "retention.ms", alteredConfigA);
-        awaitTopicConfigInKafka(context, topicNameZ, "retention.ms", alteredConfigZ);
-        context.completeNow();
+        awaitTopicConfigInKube(topicNameA, "retention.ms", alteredConfigA);
+        awaitTopicConfigInKube(topicNameZ, "retention.ms", alteredConfigZ);
+        awaitTopicConfigInKafka(topicNameA, "retention.ms", alteredConfigA);
+        awaitTopicConfigInKafka(topicNameZ, "retention.ms", alteredConfigZ);
     }
+
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import kafka.admin.ReassignPartitionsCommand;
@@ -23,11 +24,13 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.Future;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
@@ -14,8 +15,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@Timeout(value = 10, timeUnit = TimeUnit.MINUTES)
+@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
@@ -39,12 +39,12 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
         // create the Topic Resource
         String topicName = "test-topic-deletion-disabled";
         // The creation method will wait for the topic to be ready in K8s
-        KafkaTopic topicResource = createKafkaTopicResource(context, topicName);
+        KafkaTopic topicResource = createKafkaTopicResource(topicName);
         // Wait for the topic to be ready on the Kafka Broker
-        waitForTopicInKafka(context, topicName, true);
+        waitForTopicInKafka(topicName, true);
 
         // Delete the k8 KafkaTopic and wait for that to be deleted
-        deleteInKube(context, topicResource.getMetadata().getName());
+        deleteInKube(topicResource.getMetadata().getName());
 
         // trigger an immediate reconcile where, with with delete.topic.enable=false, the K8s KafkaTopic should be recreated
         Future<?> result = session.topicOperator.reconcileAllTopics("periodic");
@@ -55,7 +55,7 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
         } while (true);
 
         // Wait for the KafkaTopic to be recreated
-        waitForTopicInKube(context, topicName, true);
+        waitForTopicInKube(topicName, true);
         context.completeNow();
     }
 }


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

The PR hopefully fixes #2187. I think the problem was that although the code used 10 minute timeouts for various things the change to junit5 introduced a much shorter (1 minute?) timeout, which is how the tests were failing. Additionally, the use of `await()` was incorrect anyway, but I'd not observed this being a problem in practice due to the first problem.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

