### PR TITLE
Fixed PKCS12 name and password in system tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/clients/lib/KafkaClientProperties.java
@@ -124,9 +124,9 @@ class KafkaClientProperties {
         try {
             Secret clusterCaCertSecret = kubeClient(namespace).getSecret(KafkaResources.clusterCaCertificateSecretName(clusterName));
 
-            String tsPassword = new String(Base64.getDecoder().decode(clusterCaCertSecret.getData().get("truststore.password")), StandardCharsets.US_ASCII);
+            String tsPassword = new String(Base64.getDecoder().decode(clusterCaCertSecret.getData().get("ca.password")), StandardCharsets.US_ASCII);
             File tsFile = File.createTempFile(KafkaClientProperties.class.getName(), ".truststore");
-            String truststore = clusterCaCertSecret.getData().get("truststore.p12");
+            String truststore = clusterCaCertSecret.getData().get("ca.p12");
             Files.write(tsFile.toPath(), Base64.getDecoder().decode(truststore));
             tsFile.deleteOnExit();
             properties.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

This PR fixes STs failing due to change to names of truststore and related password for clients.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

