### PR TITLE
Fix KafkaBridge.spec.kafka typos in Kafka Bridge docs

### DIFF
--- a/documentation/modules/con-kafka-bridge-authentication.adoc
+++ b/documentation/modules/con-kafka-bridge-authentication.adoc
@@ -5,7 +5,7 @@
 [id='con-kafka-bridge-authentication-{context}']
 = Authentication support in Kafka Bridge
 
-Authentication is configured through the `authentication` property in `KafkaBridge.spec.kafka`.
+Authentication is configured through the `authentication` property in `KafkaBridge.spec`.
 The `authentication` property specifies the type of the authentication mechanisms which should be used and additional configuration details depending on the mechanism.
 The currently supported authentication types are:
 

--- a/documentation/modules/ref-kafka-bridge-tls.adoc
+++ b/documentation/modules/ref-kafka-bridge-tls.adoc
@@ -5,7 +5,7 @@
 [id='ref-kafka-bridge-tls-{context}']
 = TLS support for Kafka connection to the Kafka Bridge
 
-TLS support for Kafka connection is configured in the `tls` property in `KafkaBridge.spec.kafka`.
+TLS support for Kafka connection is configured in the `tls` property in `KafkaBridge.spec`.
 The `tls` property contains a list of secrets with key names under which the certificates are stored.
 The certificates must be stored in X509 format.
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

There is a typo in the Kafka Bridge docs which refers to `KafkaBridge.spec.kafka` instead of `KafkaBridge.spec`. This PR fixes it.