### PR TITLE
Avoid using vertx junit extension in TopicOperatorBaseIT and subclasses

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -21,8 +21,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeCluster;
 import io.strimzi.test.k8s.NoClusterException;
 import io.vertx.core.Vertx;
-import io.vertx.junit5.Timeout;
-import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -70,7 +68,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public abstract class TopicOperatorBaseIT extends BaseITST {
 
@@ -136,7 +133,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     }
 
     @BeforeEach
-    public void setup(VertxTestContext context) throws Exception {
+    public void setup() throws Exception {
         vertx = Vertx.vertx();
         LOGGER.info("Setting up test");
         kubeCluster().before();
@@ -177,7 +174,6 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 collect(Collectors.toSet());
 
         LOGGER.info("Finished setting up test");
-        context.completeNow();
     }
 
     /**

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -12,22 +12,18 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.vertx.junit5.Timeout;
-import io.vertx.junit5.VertxExtension;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyMap;
@@ -37,8 +33,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
-@ExtendWith(VertxExtension.class)
 public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -9,27 +9,21 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.vertx.junit5.Timeout;
-import io.vertx.junit5.VertxExtension;
 import kafka.admin.ReassignPartitionsCommand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
-@ExtendWith(VertxExtension.class)
 public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorReplicationIT.class);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -6,20 +6,13 @@ package io.strimzi.operator.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.Future;
-import io.vertx.junit5.Timeout;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 import kafka.server.KafkaConfig$;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
-@ExtendWith(VertxExtension.class)
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
     @Override
@@ -35,7 +28,7 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
     }
 
     @Test
-    public void testKafkaTopicDeletionDisabled(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testKafkaTopicDeletionDisabled() throws InterruptedException, ExecutionException, TimeoutException {
         // create the Topic Resource
         String topicName = "test-topic-deletion-disabled";
         // The creation method will wait for the topic to be ready in K8s
@@ -56,7 +49,6 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
         // Wait for the KafkaTopic to be recreated
         waitForTopicInKube(topicName, true);
-        context.completeNow();
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

Following #2188 @ppatierno observed `java.lang.IllegalArgumentException: Hook previously registered` from `TopicOperatorIT`. Logically the only way for this to happen is it setup() from one test is being run before teardown() from a previous test. #2188 removed most of the use of vertx junit (which looks like it must be the cause). This PR completely removes the dependency on vertx junit, so `TopicOperatorIT` will be run without any async using default junit5 runner.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

