### PR TITLE
Use longer timeout on KAOT.testReconcile() and ...AllNamespaces()

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -76,6 +76,7 @@ import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
@@ -1079,6 +1080,7 @@ public class KafkaAssemblyOperatorTest {
 
     @ParameterizedTest
     @MethodSource("data")
+    @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
     public void testReconcile(Params params, VertxTestContext context) throws InterruptedException {
         setFields(params);
 
@@ -1175,14 +1177,14 @@ public class KafkaAssemblyOperatorTest {
         // Now try to reconcile all the Kafka clusters
         ops.reconcileAll("test", clusterCmNamespace, context.succeeding());
 
-        if (!fooLatch.await(30, TimeUnit.SECONDS)) {
+        if (!fooLatch.await(2, TimeUnit.MINUTES)) {
             if (barLatch.getCount() > 0) {
                 fail("Neither foo nor bar seen");
             } else {
                 fail("foo not seen");
             }
         }
-        if (!barLatch.await(30, TimeUnit.SECONDS)) {
+        if (!barLatch.await(2, TimeUnit.MINUTES)) {
             fail("bar not seen");
         }
         context.completeNow();
@@ -1190,6 +1192,7 @@ public class KafkaAssemblyOperatorTest {
 
     @ParameterizedTest
     @MethodSource("data")
+    @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
     public void testReconcileAllNamespaces(Params params, VertxTestContext context) throws InterruptedException {
         setFields(params);
 
@@ -1270,14 +1273,14 @@ public class KafkaAssemblyOperatorTest {
         // Now try to reconcile all the Kafka clusters
         ops.reconcileAll("test", "*", context.succeeding());
 
-        if (!fooLatch.await(30, TimeUnit.SECONDS)) {
+        if (!fooLatch.await(2, TimeUnit.MINUTES)) {
             if (barLatch.getCount() > 0) {
                 fail("Neither foo nor bar seen");
             } else {
                 fail("foo not seen");
             }
         }
-        if (!barLatch.await(30, TimeUnit.SECONDS)) {
+        if (!barLatch.await(2, TimeUnit.MINUTES)) {
             fail("bar not seen");
         }
         context.completeNow();


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

Use longer timeout on `KafkaAssemblyOperatorTest.testReconcile()` and `...AllNamespaces()` because they sometimes still fail on Travis.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

