### PR TITLE
Fix ST execution for release-0.14.x branch

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/OpenShift.java
@@ -25,7 +25,7 @@ public class OpenShift implements KubeCluster {
     @Override
     public boolean isClusterUp() {
         try {
-            Exec.exec(OC, "cluster", "status");
+            Exec.exec(OC, "status");
             return true;
         } catch (KubeClusterException e) {
             if (e.result.exitStatus() == 1) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

`oc cluster status` is not working for execute tests against remote clusters. If you want to run tests against remote cluster, you always want to check `oc status`, because `oc cluster status` is trying to find cluster only on your localhost. 

### Checklist

- [x] Make sure all tests pass
