### PR TITLE
Added logging exception and finally to clean

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -302,26 +302,31 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     }
 
     protected void assertStatusReady(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        waitFor(() -> {
-            KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
-            if (kafkaTopic != null) {
-                if (kafkaTopic.getStatus() != null
-                        && kafkaTopic.getStatus().getConditions() != null) {
-                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
-                    assertThat(conditions.size() > 0, is(true));
-                    if (conditions.stream().anyMatch(condition ->
-                            "Ready".equals(condition.getType()) &&
-                                    "True".equals(condition.getStatus()))) {
-                        return true;
-                    } else {
-                        LOGGER.info(conditions);
+        try {
+            waitFor(() -> {
+                KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
+                if (kafkaTopic != null) {
+                    if (kafkaTopic.getStatus() != null
+                            && kafkaTopic.getStatus().getConditions() != null) {
+                        List<Condition> conditions = kafkaTopic.getStatus().getConditions();
+                        assertThat(conditions.size() > 0, is(true));
+                        if (conditions.stream().anyMatch(condition ->
+                                "Ready".equals(condition.getType()) &&
+                                        "True".equals(condition.getStatus()))) {
+                            return true;
+                        } else {
+                            LOGGER.info(conditions);
+                        }
                     }
+                } else {
+                    LOGGER.info("{} does not exist", topicName);
                 }
-            } else {
-                LOGGER.info("{} does not exist", topicName);
-            }
-            return false;
-        }, "status ready for topic " + topicName);
+                return false;
+            }, "status ready for topic " + topicName);
+        } catch (Exception e) {
+            LOGGER.info("KafkaTopic = {" + operation().inNamespace(NAMESPACE).withName(topicName).get() + "}");
+            throw e;
+        }
     }
 
     protected void assertStatusNotReady(String topicName, String message) throws InterruptedException, ExecutionException, TimeoutException {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -200,7 +200,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
                     LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(false).withPropagationPolicy("Background").delete();
                     LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
                     waitForTopicInKafka(new TopicName(item).toString(), false);
                     waitForTopicInKube(item.getMetadata().getName(), false);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -188,44 +188,47 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
 
     @AfterEach
     public void teardown() throws InterruptedException, TimeoutException, ExecutionException {
-        LOGGER.info("Tearing down test");
+        try {
+            LOGGER.info("Tearing down test");
 
-        boolean deletionEnabled = "true".equals(kafkaClusterConfig().getOrDefault(
-                KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "true"));
+            boolean deletionEnabled = "true".equals(kafkaClusterConfig().getOrDefault(
+                    KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "true"));
 
-        if (deletionEnabled && kubeClient != null) {
-            List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
+            if (deletionEnabled && kubeClient != null) {
+                List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
 
-            // Wait for the operator to delete all the existing topics in Kafka
-            for (KafkaTopic item : items) {
-                LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
-                LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
-                waitForTopicInKafka(new TopicName(item).toString(), false);
-                waitForTopicInKube(item.getMetadata().getName(), false);
+                // Wait for the operator to delete all the existing topics in Kafka
+                for (KafkaTopic item : items) {
+                    LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
+                    LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
+                    waitForTopicInKafka(new TopicName(item).toString(), false);
+                    waitForTopicInKube(item.getMetadata().getName(), false);
+                }
+                Thread.sleep(5_000);
             }
-            Thread.sleep(5_000);
-        }
 
-        stopTopicOperator();
+            stopTopicOperator();
 
-        if (!deletionEnabled && kubeClient != null) {
-            List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
+            if (!deletionEnabled && kubeClient != null) {
+                List<KafkaTopic> items = operation().inNamespace(NAMESPACE).list().getItems();
 
-            // Wait for the operator to delete all the existing topics in Kafka
-            for (KafkaTopic item : items) {
-                operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
-                waitForTopicInKube(item.getMetadata().getName(), false);
+                // Wait for the operator to delete all the existing topics in Kafka
+                for (KafkaTopic item : items) {
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
+                    waitForTopicInKube(item.getMetadata().getName(), false);
+                }
             }
-        }
+        } finally {
 
-        adminClient.close();
-        if (kafkaCluster != null) {
-            kafkaCluster.shutdown();
+            adminClient.close();
+            if (kafkaCluster != null) {
+                kafkaCluster.shutdown();
+            }
+            Runtime.getRuntime().removeShutdownHook(kafkaHook);
+            LOGGER.info("Finished tearing down test");
+            vertx.close();
         }
-        Runtime.getRuntime().removeShutdownHook(kafkaHook);
-        LOGGER.info("Finished tearing down test");
-        vertx.close();
     }
 
     protected void startTopicOperator() throws InterruptedException, ExecutionException, TimeoutException {
@@ -394,11 +397,16 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     }
 
     protected void waitForTopicInKube(String resourceName, boolean exist) throws TimeoutException, InterruptedException {
-        waitFor(() -> {
-            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-            LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
-            return topic != null == exist;
-        }, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
+        try {
+            waitFor(() -> {
+                KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+                LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
+                return topic != null == exist;
+            }, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
+        } catch (Exception e) {
+            LOGGER.info("KafkaTopic = {" + operation().inNamespace(NAMESPACE).withName(resourceName).get() + "}");
+            throw e;
+        }
     }
 
     protected void alterTopicConfigInKafkaAndAwaitReconciliation(String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -602,7 +602,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
 
     protected void deleteInKube(String resourceName) throws InterruptedException, ExecutionException, TimeoutException {
         // can now delete the topicResource
-        operation().inNamespace(NAMESPACE).withName(resourceName).delete();
+        operation().inNamespace(NAMESPACE).withName(resourceName).cascading(true).delete();
         waitFor(() -> {
             return operation().inNamespace(NAMESPACE).withName(resourceName).get() == null;
         }, "verified deletion of KafkaTopic " + resourceName);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -200,7 +200,7 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
                     LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(false).withPropagationPolicy("Background").delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
                     LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
                     waitForTopicInKafka(new TopicName(item).toString(), false);
                     waitForTopicInKube(item.getMetadata().getName(), false);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -302,31 +302,26 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     }
 
     protected void assertStatusReady(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
-        try {
-            waitFor(() -> {
-                KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
-                if (kafkaTopic != null) {
-                    if (kafkaTopic.getStatus() != null
-                            && kafkaTopic.getStatus().getConditions() != null) {
-                        List<Condition> conditions = kafkaTopic.getStatus().getConditions();
-                        assertThat(conditions.size() > 0, is(true));
-                        if (conditions.stream().anyMatch(condition ->
-                                "Ready".equals(condition.getType()) &&
-                                        "True".equals(condition.getStatus()))) {
-                            return true;
-                        } else {
-                            LOGGER.info(conditions);
-                        }
+        waitFor(() -> {
+            KafkaTopic kafkaTopic = operation().inNamespace(NAMESPACE).withName(topicName).get();
+            if (kafkaTopic != null) {
+                if (kafkaTopic.getStatus() != null
+                        && kafkaTopic.getStatus().getConditions() != null) {
+                    List<Condition> conditions = kafkaTopic.getStatus().getConditions();
+                    assertThat(conditions.size() > 0, is(true));
+                    if (conditions.stream().anyMatch(condition ->
+                            "Ready".equals(condition.getType()) &&
+                                    "True".equals(condition.getStatus()))) {
+                        return true;
+                    } else {
+                        LOGGER.info(conditions);
                     }
-                } else {
-                    LOGGER.info("{} does not exist", topicName);
                 }
-                return false;
-            }, "status ready for topic " + topicName);
-        } catch (Exception e) {
-            LOGGER.info("KafkaTopic = {" + operation().inNamespace(NAMESPACE).withName(topicName).get() + "}");
-            throw e;
-        }
+            } else {
+                LOGGER.info("{} does not exist", topicName);
+            }
+            return false;
+        }, "status ready for topic " + topicName);
     }
 
     protected void assertStatusNotReady(String topicName, String message) throws InterruptedException, ExecutionException, TimeoutException {
@@ -402,16 +397,11 @@ public abstract class TopicOperatorBaseIT extends BaseITST {
     }
 
     protected void waitForTopicInKube(String resourceName, boolean exist) throws TimeoutException, InterruptedException {
-        try {
-            waitFor(() -> {
-                KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
-                LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
-                return topic != null == exist;
-            }, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
-        } catch (Exception e) {
-            LOGGER.info("KafkaTopic = {" + operation().inNamespace(NAMESPACE).withName(resourceName).get() + "}");
-            throw e;
-        }
+        waitFor(() -> {
+            KafkaTopic topic = operation().inNamespace(NAMESPACE).withName(resourceName).get();
+            LOGGER.info("Polled topic {} waiting for " + (exist ? "existence" : "non-existence"), resourceName);
+            return topic != null == exist;
+        }, "Expected the KafkaTopic '" + resourceName + "' to " + (exist ? "exist" : "not exist") + " in Kubernetes by now");
     }
 
     protected void alterTopicConfigInKafkaAndAwaitReconciliation(String topicName, String resourceName) throws InterruptedException, ExecutionException, TimeoutException {


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

PR for getting more log on the testKafkaTopicAddedWithInvalidConfig failure and "hook already registered".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

