### PR TITLE
Use the right shebang in our bash scripts for better portability

### DIFF
--- a/config-model-generator/build-config-models.sh
+++ b/config-model-generator/build-config-models.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh

--- a/systemtest/src/test/resources/oauth2/create_realm.sh
+++ b/systemtest/src/test/resources/oauth2/create_realm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 USERNAME=$1
 PASSWORD=$2


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We should use the right shebang in the bash scripts which are being run locally and not in Docker images (but prefrably even there) to make sure they are portable between operating systems and distributions. For example the bellow script `build-config-models.sh` doesn't work properly on MacOS because it is triggering Bash3 by using the fixed path.