### PR TITLE
Restore lock timeout to it's previous value.

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -48,10 +48,6 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         L extends KubernetesResourceList/*<T>*/, D extends Doneable<T>, R extends Resource<T, D>>
     extends AbstractOperator<T, AbstractWatchableResourceOperator<C, T, L, D, R>> {
 
-    private static final Logger log = LogManager.getLogger(AbstractAssemblyOperator.class.getName());
-
-    protected static final int LOCK_TIMEOUT_MS = 10000;
-
     protected final PlatformFeaturesAvailability pfa;
     protected final SecretOperator secretOperations;
     protected final CertManager certManager;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -30,8 +30,6 @@ import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -48,7 +48,7 @@ public abstract class AbstractOperator<
             implements Operator {
 
     private static final Logger log = LogManager.getLogger(AbstractOperator.class);
-    private static final int LOCK_TIMEOUT_MS = 10;
+    protected static final int LOCK_TIMEOUT_MS = 10000;
     protected final Vertx vertx;
     protected final S resourceOperator;
     private final String kind;


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

Before the refactoring of AAO it seems we were using a lock timeout of 10,000ms, and this inadvertently got changed to 10ms. It appears this is the cause of failing CI on travis, so let's restore the old value.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

