### PR TITLE
Squash NPE

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2466,6 +2466,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         private boolean isPodUpToDate(StatefulSet ss, Pod pod) {
+            if (ss == null || pod == null) {
+                log.debug("{}: Statefulset or pod is null in isPodUpToDate() => pod is \"up to date\".", reconciliation);
+                return true;
+            }
             final int ssGeneration = StatefulSetOperator.getSsGeneration(ss);
             final int podGeneration = StatefulSetOperator.getPodGeneration(pod);
             log.debug("Rolling update of {}/{}: pod {} has {}={}; ss has {}={}",


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

An NPE was observed during system testing which was caused by either the STS or Pod being null. From the logs it appears this happened because the STS or Pod was deleted during the test. This fixes the NPE, but does not address the wider problem of races when a resource is deleted part way through a reconciliation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

