### PR TITLE
[DOC] Section to describe how to use a configmap for logging

### DIFF
--- a/documentation/assemblies/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration.adoc
@@ -32,3 +32,5 @@ include::assembly-deployment-configuration-kafka-bridge.adoc[leveloffset=+1]
 include::assembly-oauth.adoc[leveloffset=+1]
 
 include::assembly-customizing-deployments.adoc[leveloffset=+1]
+
+include::assembly-external-logging.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-external-logging.adoc
+++ b/documentation/assemblies/assembly-external-logging.adoc
@@ -1,0 +1,36 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='external-logging_{context}']
+= External logging
+
+When setting the logging levels for a resource, you can specify them _inline_ directly in the `spec` of the resource YAML:
+
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: inline
+    loggers:
+      kafka.root.logger: "INFO"
+----
+
+Or you can specify _external_ logging:
+
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: external
+    name: _customConfigMap_
+----
+
+With external logging, logging properties are defined in a ConfigMap.
+The name of the ConfigMap is referenced in the `spec`.
+
+The advantages of using a ConfigMap are that the logging properties are maintained in one place and are accessible to more than one resource.
+
+include::../modules/proc-creating-configmap.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-external-logging.adoc
+++ b/documentation/assemblies/assembly-external-logging.adoc
@@ -5,7 +5,7 @@
 [id='external-logging_{context}']
 = External logging
 
-When setting the logging levels for a resource, you can specify them _inline_ directly in the `spec` of the resource YAML:
+When setting the logging levels for a resource, you can specify them _inline_ directly in the `spec.logging` property of the resource YAML:
 
 [source,shell,subs="+quotes,attributes"]
 ----
@@ -29,7 +29,7 @@ spec:
 ----
 
 With external logging, logging properties are defined in a ConfigMap.
-The name of the ConfigMap is referenced in the `spec`.
+The name of the ConfigMap is referenced in the `spec.logging.name` property.
 
 The advantages of using a ConfigMap are that the logging properties are maintained in one place and are accessible to more than one resource.
 

--- a/documentation/modules/proc-creating-configmap.adoc
+++ b/documentation/modules/proc-creating-configmap.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// assembly-external-logging.adoc
+
+[id='creating-configmap_{context}']
+= Creating a ConfigMap for logging
+
+To use a ConfigMap to define logging properties, you create the ConfigMap and then reference it as part of the logging definition in the `spec` of a resource.
+
+The ConfigMap must contain the appropriate logging configuration.
+
+* `log4j.properties` for Kafka components
+* `log4j2.properties` for the Topic Operator and User Operator
+
+Here we demonstrate how a ConfigMap defines a root logger for a Kafka resource.
+
+.Procedure
+
+. Create the ConfigMap.
++
+You can create the ConfigMap as a YAML file or from a properties file at the `kubectl` command line.
++
+ConfgMap example with a root logger definition for Kafka:
++
+[source,yaml,subs="+attributes"]
+----
+kind: ConfigMap
+apiVersion: {KafkaApiVersion}
+metadata:
+  name: logging-configmap
+data:
+  log4j.properties:
+  # logger settings for resource
+    kafka.root.logger: "INFO"
+----
++
+From the command line, using a properties file:
++
+[source,shell]
+----
+kubectl create configmap logging-configmap --from-file=log4j.properties
+----
++
+The properties file defines the logging configuration:
++
+[source,text]
+----
+# Define the root logger
+kafka.root.logger: "INFO"
+# ...
+----
+
+. Define _external_ logging in the `spec` of the resource, setting the `logging.name` to the name of the ConfigMap.
++
+[source,shell,subs="+quotes,attributes"]
+----
+spec:
+  # ...
+  logging:
+    type: external
+    name: logging-configmap
+----
+
+. Create or update the resource.
++
+[source,shell,subs=+quotes]
+----
+kubectl apply -f kafka.yaml
+----

--- a/documentation/modules/proc-creating-configmap.adoc
+++ b/documentation/modules/proc-creating-configmap.adoc
@@ -9,8 +9,10 @@ To use a ConfigMap to define logging properties, you create the ConfigMap and th
 
 The ConfigMap must contain the appropriate logging configuration.
 
-* `log4j.properties` for Kafka components
+* `log4j.properties` for Kafka components and the Kafka Bridge
 * `log4j2.properties` for the Topic Operator and User Operator
+
+The configuration must be placed under these properties.
 
 Here we demonstrate how a ConfigMap defines a root logger for a Kafka resource.
 
@@ -31,7 +33,7 @@ metadata:
 data:
   log4j.properties:
   # logger settings for resource
-    kafka.root.logger: "INFO"
+    kafka.root.logger="INFO"
 ----
 +
 From the command line, using a properties file:
@@ -46,7 +48,7 @@ The properties file defines the logging configuration:
 [source,text]
 ----
 # Define the root logger
-kafka.root.logger: "INFO"
+kafka.root.logger="INFO"
 # ...
 ----
 

--- a/documentation/modules/proc-creating-configmap.adoc
+++ b/documentation/modules/proc-creating-configmap.adoc
@@ -9,7 +9,7 @@ To use a ConfigMap to define logging properties, you create the ConfigMap and th
 
 The ConfigMap must contain the appropriate logging configuration.
 
-* `log4j.properties` for Kafka components and the Kafka Bridge
+* `log4j.properties` for Kafka components, ZooKeeper, and the Kafka Bridge
 * `log4j2.properties` for the Topic Operator and User Operator
 
 The configuration must be placed under these properties.
@@ -22,7 +22,7 @@ Here we demonstrate how a ConfigMap defines a root logger for a Kafka resource.
 +
 You can create the ConfigMap as a YAML file or from a properties file at the `kubectl` command line.
 +
-ConfgMap example with a root logger definition for Kafka:
+ConfigMap example with a root logger definition for Kafka:
 +
 [source,yaml,subs="+attributes"]
 ----
@@ -32,7 +32,6 @@ metadata:
   name: logging-configmap
 data:
   log4j.properties:
-  # logger settings for resource
     kafka.root.logger="INFO"
 ----
 +

--- a/documentation/modules/proc-creating-configmap.adoc
+++ b/documentation/modules/proc-creating-configmap.adoc
@@ -20,7 +20,7 @@ Here we demonstrate how a ConfigMap defines a root logger for a Kafka resource.
 
 . Create the ConfigMap.
 +
-You can create the ConfigMap as a YAML file or from a properties file at the `kubectl` command line.
+You can create the ConfigMap as a YAML file or from a properties file using `kubectl` at the command line.
 +
 ConfigMap example with a root logger definition for Kafka:
 +


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

- Documentation

### Description

New section that describes how a configmap can be used to define logging for a resource.
Procedure shows steps with examples.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

