### PR TITLE
feat: JVM Option to output GC logs to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `schedulerName` to `podTemplate` (#2114)
 * Allow overriding the auto-detected Kubernetes version
 * Garbage Collection (GC) logging disabled by default
+* Add JVM option to output GC logs to a file
 
 ## 0.14.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JvmOptions.java
@@ -31,6 +31,7 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     private String xmx;
     private String xms;
+    private String xloggc;
     private Boolean server;
     private boolean gcLoggingEnabled = false;
     private Map<String, String> xx;
@@ -56,6 +57,16 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
 
     public void setXms(String xms) {
         this.xms = xms;
+    }
+
+    @JsonProperty("-Xloggc")
+    @Description("-Xloggc option to to the JVM")
+    public String getXloggc() {
+        return xloggc;
+    }
+
+    public void setXloggc(String xloggc) {
+        this.xloggc = xloggc;
     }
 
     @JsonProperty("-server")

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -11,22 +11,25 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 public class JvmOptionsTest {
     @Test
-    public void testXmxXms() {
+    public void testXmxXmsXloggc() {
         JvmOptions opts = TestUtils.fromJson("{" +
                 "  \"-Xmx\": \"2g\"," +
-                "  \"-Xms\": \"1g\"" +
+                "  \"-Xms\": \"1g\"," +
+                " \"-Xloggc\": \"file.log\"" +
                 "}", JvmOptions.class);
 
         assertThat(opts.getXms(), is("1g"));
         assertThat(opts.getXmx(), is("2g"));
+        assertThat(opts.getXloggc(), is("file.log"));
     }
 
     @Test
-    public void testEmptyXmxXms() {
+    public void testEmptyXmxXmsXloggc() {
         JvmOptions opts = TestUtils.fromJson("{}", JvmOptions.class);
 
         assertThat(opts.getXms(), is(nullValue()));
         assertThat(opts.getXmx(), is(nullValue()));
+        assertThat(opts.getXloggc(), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -996,6 +996,12 @@ public abstract class AbstractModel {
             }
         }
 
+        // Define `Xloggc` and set the filepath to output gc logs
+        String xloggc = jvmOptions != null ? jvmOptions.getXloggc() : null;
+        if (xloggc != null) {
+            kafkaHeapOpts.append(' ').append("-Xloggc:").append(xloggc);
+        }
+
         String trim = kafkaHeapOpts.toString().trim();
         if (!trim.isEmpty()) {
             envVars.add(buildEnvVar(ENV_VAR_KAFKA_HEAP_OPTS, trim));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -686,6 +686,8 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-Kafka
 |Property                 |Description
 |-XX               1.2+<.<|A map of -XX options to the JVM.
 |map
+|-Xloggc           1.2+<.<|-Xloggc option to to the JVM.
+|string
 |-Xms              1.2+<.<|-Xms option to to the JVM.
 |string
 |-Xmx              1.2+<.<|-Xmx option to to the JVM.

--- a/documentation/modules/proc-configuring-jvm-options.adoc
+++ b/documentation/modules/proc-configuring-jvm-options.adoc
@@ -27,6 +27,7 @@ spec:
     jvmOptions:
       "-Xmx": "8g"
       "-Xms": "8g"
+      "-Xloggc": "/tmp/gc.log"
     # ...
   zookeeper:
     # ...

--- a/documentation/modules/ref-jvm-options.adoc
+++ b/documentation/modules/ref-jvm-options.adoc
@@ -122,3 +122,18 @@ jvmOptions:
   gcLoggingEnabled: true
 # ...
 ----
+
+=== Output Garbage collector logs to a file
+
+The `jvmOptions` section can also be configured to output the garbage collector (GC) logging to a file.
+Once GC logging has been enabled (see above) you can direct the GC logs to a file.
+To enable it, set the `Xloggc` property as follows:
+
+.Example of enabling output of GC logs to a file
+[source,yaml,subs=attributes+]
+----
+# ...
+jvmOptions:
+  "-Xloggc": "/tmp/gc.log"
+# ...
+----

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -796,6 +796,8 @@ spec:
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                    -Xloggc:
+                      type: string
                     gcLoggingEnabled:
                       type: boolean
                 resources:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -85,6 +85,8 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                -Xloggc:
+                  type: string
                 gcLoggingEnabled:
                   type: boolean
             affinity:

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -92,6 +92,8 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                -Xloggc:
+                  type: string
                 gcLoggingEnabled:
                   type: boolean
             affinity:

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -526,6 +526,8 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                -Xloggc:
+                  type: string
                 gcLoggingEnabled:
                   type: boolean
             logging:

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -183,6 +183,8 @@ spec:
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                -Xloggc:
+                  type: string
                 gcLoggingEnabled:
                   type: boolean
             logging:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -785,6 +785,8 @@ spec:
                   properties:
                     -XX:
                       type: object
+                    -Xloggc:
+                      type: string
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
@@ -1617,6 +1619,8 @@ spec:
                   properties:
                     -XX:
                       type: object
+                    -Xloggc:
+                      type: string
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -74,6 +74,8 @@ spec:
               properties:
                 -XX:
                   type: object
+                -Xloggc:
+                  type: string
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -81,6 +81,8 @@ spec:
               properties:
                 -XX:
                   type: object
+                -Xloggc:
+                  type: string
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -515,6 +515,8 @@ spec:
               properties:
                 -XX:
                   type: object
+                -Xloggc:
+                  type: string
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -172,6 +172,8 @@ spec:
               properties:
                 -XX:
                   type: object
+                -Xloggc:
+                  type: string
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

Added a JVM option to allow user to specify a file to output
GC logs to, when they are enabled

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

Closes: #2216

Signed-off-by: Tom Jefferson <thomas.jefferson1@ibm.com>

