### PR TITLE
Netpol egress rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `schedulerName` to `podTemplate` (#2114)
 * Allow overriding the auto-detected Kubernetes version
 * Garbage Collection (GC) logging disabled by default
+* Add egress rules to Kafka and Zookeeper
 
 ## 0.14.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -36,6 +36,8 @@ import io.fabric8.kubernetes.api.model.extensions.IngressTLS;
 import io.fabric8.kubernetes.api.model.extensions.IngressTLSBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyBuilder;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyEgressRule;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyEgressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeer;
@@ -1708,6 +1710,15 @@ public class KafkaCluster extends AbstractModel {
 
         rules.add(replicationRule);
 
+        List<NetworkPolicyEgressRule> egressRules = new ArrayList<>(5);
+
+        NetworkPolicyEgressRule replicationEgressRule = new NetworkPolicyEgressRuleBuilder()
+                .withPorts(replicationPort)
+                .withTo(kafkaClusterPeer)
+                .build();
+
+        egressRules.add(replicationEgressRule);
+
         // Free access to 9092, 9093 and 9094 ports
         if (listeners != null) {
             if (listeners.getPlain() != null) {
@@ -1769,6 +1780,7 @@ public class KafkaCluster extends AbstractModel {
                 .withNewSpec()
                     .withPodSelector(labelSelector)
                     .withIngress(rules)
+                    .withEgress(egressRules)
                 .endSpec()
                 .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1712,7 +1712,7 @@ public class KafkaCluster extends AbstractModel {
                     .endFrom().build());
 
             // Restrict outbound connections to replication port and zookeeper client port
-            String zookeeperClientPort = zookeeperConnect.replace(ZookeeperCluster.serviceName(cluster) + ":", "");
+            Integer zookeeperClientPort = Integer.parseInt(zookeeperConnect.replace(ZookeeperCluster.serviceName(cluster) + ":", ""));
             egressRules.add(new NetworkPolicyEgressRuleBuilder()
                     .addNewPort().withNewPort(zookeeperClientPort).endPort()
                     .addNewTo()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1407,7 +1407,7 @@ public class KafkaClusterTest {
                         .getPorts()
                         .get(0)
                         .getPort()
-                        .equals(new IntOrString("2181")))
+                        .equals(new IntOrString(2181)))
                 .map(NetworkPolicyEgressRule::getTo)
                 .findFirst()
                 .orElse(null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -68,7 +68,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class ZookeeperClusterTest {
 
     private static final KafkaVersion.Lookup VERSIONS = new KafkaVersion.Lookup(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyEgressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
@@ -808,6 +809,15 @@ public class ZookeeperClusterTest {
         assertThat(metricsRule.getPorts().size(), is(1));
         assertThat(metricsRule.getPorts().get(0).getPort(), is(new IntOrString(9404)));
         assertThat(metricsRule.getFrom().size(), is(0));
+
+        // Egress
+        List<NetworkPolicyEgressRule> egressRules = np.getSpec().getEgress();
+        assertThat(egressRules.size(), is(1));
+
+        NetworkPolicyEgressRule zooEgressRule = egressRules.get(0);
+        assertThat(zooEgressRule.getPorts().size(), is(2));
+        assertThat(zooEgressRule.getPorts().get(0).getPort(), is(new IntOrString(2888)));
+        assertThat(zooEgressRule.getPorts().get(1).getPort(), is(new IntOrString(3888)));
     }
 
     @Test


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

Add Egress to protect other pods in the event that a container within the cluster is compromised by limiting the ports and destinations to which the compromised container can communicate.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

