### PR TITLE
Use requests instead of limits for determining Xmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.16.0
 
+* When not explicitly configured by the user in `jvmOptions`, `-Xmx` option is calculated from memory requests rather than from memory limits
+
 ## 0.15.0
 
 * Drop support for Kafka 2.1.0, 2.1.1, and 2.2.0

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -981,7 +981,7 @@ public abstract class AbstractModel {
             kafkaHeapOpts.append(' ').append("-Xmx").append(xmx);
         } else {
             ResourceRequirements resources = getResources();
-            Map<String, Quantity> cpuMemory = resources == null ? null : resources.getLimits();
+            Map<String, Quantity> cpuMemory = resources == null ? null : resources.getRequests();
             // Delegate to the container to figure out only when CGroup memory limits are defined to prevent allocating
             // too much memory on the kubelet.
             if (cpuMemory != null && cpuMemory.get("memory") != null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -95,15 +95,15 @@ public class AbstractModelTest {
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
-    private ResourceRequirements getResourceLimit() {
+    private ResourceRequirements getResourceRequest() {
         return new ResourceRequirementsBuilder()
-                .addToLimits("memory", new Quantity("16000000000")).build();
+                .addToRequests("memory", new Quantity("16000000000")).build();
     }
 
     @Test
     public void testJvmMemoryOptionsDefaultWithMemoryLimit() {
         Map<String, String> env = getStringStringMap(null, "4",
-                0.5, 5_000_000_000L, getResourceLimit());
+                0.5, 5_000_000_000L, getResourceRequest());
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is("0.5"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("5000000000"));
@@ -112,7 +112,7 @@ public class AbstractModelTest {
     @Test
     public void testJvmMemoryOptionsMemoryRequest() {
         Map<String, String> env = getStringStringMap(null, null,
-                0.7, 10_000_000_000L, getResourceLimit());
+                0.7, 10_000_000_000L, getResourceRequest());
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is("0.7"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("10000000000"));


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2203

It was not clear for me, how the setting of `ENV_VAR_DYNAMIC_HEAP_MAX` worked with the user's value. Please take a look and feel free to describe how it should work.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

