### PR TITLE
Add HasStatus interface

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -75,7 +76,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class Kafka extends CustomResource implements UnknownPropertyPreserving {
+public class Kafka extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaStatus> {
 
     public static final String V1BETA1 = "v1beta1";
     public static final String V1ALPHA1 = "v1alpha1";
@@ -134,6 +135,7 @@ public class Kafka extends CustomResource implements UnknownPropertyPreserving {
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka and ZooKeeper clusters, and Topic Operator.")
     public KafkaStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaBridgeStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -78,7 +79,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaBridge extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaBridge extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaBridgeStatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -130,6 +131,7 @@ public class KafkaBridge extends CustomResource implements UnknownPropertyPreser
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka Bridge.")
     public KafkaBridgeStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -75,7 +76,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaConnect extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaConnect extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaConnectStatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -135,6 +136,7 @@ public class KafkaConnect extends CustomResource implements UnknownPropertyPrese
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka Connect cluster.")
     public KafkaConnectStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2Istatus;
-import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -15,7 +15,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectS2Istatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -78,7 +80,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaConnectS2I extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaConnectS2I extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaConnectS2Istatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -138,6 +140,7 @@ public class KafkaConnectS2I extends CustomResource implements UnknownPropertyPr
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka Connect Source-to-Image (S2I) cluster.")
     public KafkaConnectS2Istatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -90,7 +91,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaMirrorMaker extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaMirrorMaker extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaMirrorMakerStatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -143,6 +144,7 @@ public class KafkaMirrorMaker extends CustomResource implements UnknownPropertyP
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of Kafka Mirror Maker.")
     public KafkaMirrorMakerStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -82,7 +83,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaTopic extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaTopic extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaTopicStatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -135,6 +136,7 @@ public class KafkaTopic extends CustomResource implements UnknownPropertyPreserv
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the topic.")
     public KafkaTopicStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.api.kafka.model.status.KafkaUserStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -81,7 +82,7 @@ import static java.util.Collections.unmodifiableList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode
-public class KafkaUser extends CustomResource implements UnknownPropertyPreserving {
+public class KafkaUser extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaUserStatus> {
 
     private static final long serialVersionUID = 1L;
 
@@ -134,6 +135,7 @@ public class KafkaUser extends CustomResource implements UnknownPropertyPreservi
         this.spec = spec;
     }
 
+    @Override
     @Description("The status of the Kafka User.")
     public KafkaUserStatus getStatus() {
         return status;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/HasStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/HasStatus.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.status;
+
+public interface HasStatus<S extends Status> {
+    S getStatus();
+}


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Refactoring

### Description

This PR adds a `HasStatus` interface for CRs which have a top-level `status` property which is (some subclass of) `Status`. This is useful for writing code which abstracts across CR types which have status. I plan to use it in #2073.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

