### PR TITLE
Support oneOf constraint in CRD schemas

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/OneOf.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/OneOf.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface OneOf {
+    /** @return List of alternatives */
+    Alternative[] value();
+
+    @interface Alternative {
+
+        @interface Property {
+            /** @return The name of a property */
+            String value();
+            /** @return Whether this property is required */
+            boolean required() default true;
+        }
+
+        /** @return Properties in this alternative */
+        Property[] value();
+    }
+}
+

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -14,8 +14,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CrdGeneratorTest {
     @Test
@@ -24,7 +23,7 @@ public class CrdGeneratorTest {
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
-        assertThat(CrdTestUtils.readResource("simpleTest.yaml"), is(s));
+        assertEquals(CrdTestUtils.readResource("simpleTest.yaml"), s);
     }
 
     @Test
@@ -39,6 +38,6 @@ public class CrdGeneratorTest {
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
-        assertThat(CrdTestUtils.readResource("simpleTestHelmMetadata.yaml"), is(s));
+        assertEquals(CrdTestUtils.readResource("simpleTestHelmMetadata.yaml"), s);
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.Pattern;
 
 import java.util.List;
@@ -42,6 +43,7 @@ import java.util.Map;
         )
     }
     ))
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or"))})
 public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource {
 
     private String ignored;
@@ -106,6 +108,9 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     public List<? extends U> listOfWildcardTypeVar3;
 
     public List<? extends List<? extends U>> listOfWildcardTypeVar4;
+
+    private String either;
+    private String or;
 
 
     @Description("Example of complex type.")

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -414,5 +414,14 @@ spec:
         stringProperty:
           type: "string"
           pattern: ".*"
+      oneOf:
+      - properties:
+          either: {}
+        required:
+        - "either"
+      - properties:
+          or: {}
+        required:
+        - "or"
       required:
       - "stringProperty"

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -420,5 +420,14 @@ spec:
         stringProperty:
           type: "string"
           pattern: ".*"
+      oneOf:
+      - properties:
+          either: {}
+        required:
+        - "either"
+      - properties:
+          or: {}
+        required:
+        - "or"
       required:
       - "stringProperty"


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds support for `oneOf` constraint in the generated JSON schema described in [#2073](https://github.com/strimzi/strimzi-kafka-operator/pull/2073#issuecomment-557008451). 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

