### PR TITLE
Update CrdITs to work with K8s 1.16 and check that invalid CRs throw exeptions

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -10,8 +10,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -41,11 +44,17 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaBridgeWithMissingRequired() {
-        try {
-            createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.bootstrapServers in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml");
+            });
+
+        String expectedString1 = "spec.bootstrapServers in body is required";
+        String expectedString2 = "spec.bootstrapServers: Required value";
+
+        assertThat(exception.getMessage(),
+                anyOf(containsStringIgnoringCase(expectedString1), containsStringIgnoringCase(expectedString2)));
     }
 
     @Test
@@ -60,12 +69,21 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaBridgeWithTlsAuthWithMissingRequired() {
-        try {
-            createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.authentication.certificateAndKey.certificate in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.authentication.certificateAndKey.key in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml");
+            });
+
+        String expectedMsg1a = "spec.authentication.certificateAndKey.certificate in body is required";
+        String expectedMsg1b = "spec.authentication.certificateAndKey.key in body is required";
+
+        String expectedMsg2a = "spec.authentication.certificateAndKey.certificate: Required value";
+        String expectedMsg2b = "spec.authentication.certificateAndKey.key: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                allOf(containsStringIgnoringCase(expectedMsg1a), containsStringIgnoringCase(expectedMsg1b)),
+                allOf(containsStringIgnoringCase(expectedMsg2a), containsStringIgnoringCase(expectedMsg2b))));
     }
 
     @Test
@@ -85,20 +103,30 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaBridgeWithWrongTracingType() {
-        try {
-            createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.tracing.type in body should be one of [jaeger]"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml");
+            });
+
+        String expectedMsg1 = "spec.tracing.type in body should be one of [jaeger]";
+        String expectedMsg2 = "spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\"";
+
+        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
     }
 
     @Test
     void testKafkaBridgeWithMissingTracingType() {
-        try {
-            createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.tracing.type in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
+            });
+
+        String expectedMsg1 = "spec.tracing.type in body is required";
+        String expectedMsg2 = "spec.tracing.type: Required value";
+
+        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -10,8 +10,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -45,20 +48,29 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaConnectWithMissingRequired() {
-        try {
-            createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.bootstrapServers in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml");
+            });
+
+        String expectedMsg1 = "spec.bootstrapServers in body is required";
+        String expectedMsg2 = "spec.bootstrapServers: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
     }
 
     @Test
     void testKafkaConnectWithInvalidReplicas() {
-        try {
-            createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-replicas.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.replicas in body must be of type integer: \"string\""), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-replicas.yaml");
+            });
+
+        assertThat(exception.getMessage(),
+                containsStringIgnoringCase("spec.replicas in body must be of type integer: \"string\""));
     }
 
     @Test
@@ -73,12 +85,21 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaConnectWithTlsAuthWithMissingRequired() {
-        try {
-            createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.authentication.certificateAndKey.certificate in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.authentication.certificateAndKey.key in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
+            });
+
+        String expectedMsg1a = "spec.authentication.certificateAndKey.certificate in body is required";
+        String expectedMsg1b = "spec.authentication.certificateAndKey.key in body is required";
+
+        String expectedMsg2a = "spec.authentication.certificateAndKey.certificate: Required value";
+        String expectedMsg2b = "spec.authentication.certificateAndKey.key: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                allOf(containsStringIgnoringCase(expectedMsg1a), containsStringIgnoringCase(expectedMsg1b)),
+                allOf(containsStringIgnoringCase(expectedMsg2a), containsStringIgnoringCase(expectedMsg2b))));
     }
 
     @Test
@@ -98,11 +119,17 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
 
     @Test
     public void testKafkaConnectWithInvalidExternalConfiguration() {
-        try {
-            createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.externalConfiguration.env.valueFrom in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml");
+            });
+
+        String expectedMsg1 = "spec.externalConfiguration.env.valueFrom in body is required";
+        String expectedMsg2 = "spec.externalConfiguration.env.valueFrom: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -68,18 +68,6 @@ public class KafkaCrdIT extends AbstractCrdIT {
     }
 
     @Test
-    void testKafkaWithInvalidResourceMemory() {
-        Throwable exception = assertThrows(
-            KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(Kafka.class, "Kafka-with-invalid-resource-memory.yaml");
-            });
-
-        assertThat(exception.getMessage(),
-                containsStringIgnoringCase("spec.kafka.resources.limits.memory in body should match '[0-9]+([kKmMgGtTpPeE]i?)?$'"));
-    }
-
-    @Test
     public void testKafkaWithEntityOperator() {
         createDelete(Kafka.class, "Kafka-with-entity-operator.yaml");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -10,8 +10,11 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterException;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -46,13 +49,30 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaMirrorMakerWithMissingRequired() {
-        try {
-            createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-missing-required-property.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.consumer.bootstrapServers in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.producer in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.whitelist in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-missing-required-property.yaml");
+            });
+
+        String expectedMsg1a = "spec.consumer.bootstrapServers in body is required";
+        String expectedMsg1b = "spec.producer in body is required";
+        String expectedMsg1c = "spec.whitelist in body is required";
+
+        String expectedMsg2a = "spec.consumer.bootstrapServers: Required value";
+        String expectedMSg2b = "spec.whitelist: Required value";
+        String expectedMsg2c = "spec.producer: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                allOf(
+                        containsStringIgnoringCase(expectedMsg1a),
+                        containsStringIgnoringCase(expectedMsg1b),
+                        containsStringIgnoringCase(expectedMsg1c)),
+                allOf(
+                        containsStringIgnoringCase(expectedMsg2a),
+                        containsStringIgnoringCase(expectedMSg2b),
+                        containsStringIgnoringCase(expectedMsg2c))
+                ));
     }
 
     @Test
@@ -67,12 +87,28 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaMirrorMakerWithTlsAuthWithMissingRequired() {
-        try {
-            createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.producer.authentication.certificateAndKey.certificate in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.producer.authentication.certificateAndKey.key in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
+            });
+
+        String expectedMsg1a = "spec.producer.authentication.certificateAndKey.certificate in body is required";
+        String expectedMsg1b = "spec.producer.authentication.certificateAndKey.key in body is required";
+
+        String expectedMsg2a = "spec.producer.authentication.certificateAndKey.certificate: Required value";
+        String expectedMSg2b = "spec.producer.authentication.certificateAndKey.key: Required value";
+        String expectedMsg2c = "spec.whitelist: Required value";
+
+        assertThat(exception.getMessage(), anyOf(
+                allOf(
+                        containsStringIgnoringCase(expectedMsg1a),
+                        containsStringIgnoringCase(expectedMsg1b)),
+                allOf(
+                        containsStringIgnoringCase(expectedMsg2a),
+                        containsStringIgnoringCase(expectedMSg2b),
+                        containsStringIgnoringCase(expectedMsg2c))
+        ));
     }
 
     @Test

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -10,8 +10,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -45,12 +48,24 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaTopicWithMissingProperty() {
-        try {
-            createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.partitions in body is required"), is(true));
-            assertThat(e.getMessage().contains("spec.replicas in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml");
+            });
+
+        String expectedMsg1a = "spec.partitions in body is required";
+        String expectedMsg1b = "spec.replicas in body is required";
+        String expectedMsg2a = "spec.partitions: Required value";
+        String expectedMsg2b = "spec.replicas: Required value";
+        assertThat(exception.getMessage(), anyOf(
+                allOf(
+                        containsStringIgnoringCase(expectedMsg1a),
+                        containsStringIgnoringCase(expectedMsg1b)),
+                allOf(
+                        containsStringIgnoringCase(expectedMsg2a),
+                        containsStringIgnoringCase(expectedMsg2b))
+                ));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -10,8 +10,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -45,11 +46,13 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
 
     @Test
     void testKafkaUserWithMissingRequired() {
-        try {
-            createDelete(KafkaUser.class, "KafkaUser-with-missing-required.yaml");
-        } catch (KubeClusterException.InvalidResource e) {
-            assertThat(e.getMessage().contains("spec.authentication in body is required"), is(true));
-        }
+        Throwable exception = assertThrows(
+            KubeClusterException.InvalidResource.class,
+            () -> {
+                createDelete(KafkaUser.class, "KafkaUser-with-missing-required.yaml");
+            });
+
+        assertThat(exception.getMessage(), containsStringIgnoringCase("spec.authentication in body is required"));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -5,14 +5,9 @@
 package io.strimzi.api.kafka.model;
 
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeClusterException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The purpose of this test is to confirm that we can create a
@@ -42,17 +37,6 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
     @Test
     void testKafkaUserWithExtraProperty() {
         createDelete(KafkaUser.class, "KafkaUser-with-extra-property.yaml");
-    }
-
-    @Test
-    void testKafkaUserWithMissingRequired() {
-        Throwable exception = assertThrows(
-            KubeClusterException.InvalidResource.class,
-            () -> {
-                createDelete(KafkaUser.class, "KafkaUser-with-missing-required.yaml");
-            });
-
-        assertThat(exception.getMessage(), containsStringIgnoringCase("spec.authentication in body is required"));
     }
 
     @BeforeAll

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser-with-missing-required.yaml
@@ -1,6 +1,0 @@
-apiVersion: kafka.strimzi.io/v1beta1
-kind: KafkaUser
-metadata:
-  name: missing-required
-spec:
-  {}


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This PR updates the `Kafka*CrdIT` tests to work with the new error message format of K8s 1.16 (used by the latest version of minikube) and also adds assertions to check that invalid CRs actually throw an error (which the previous tests did not check).

This address issue #2229. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging