### PR TITLE
Structural schema

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -43,7 +43,7 @@ public abstract class AbstractCrdIT extends BaseITST {
         RuntimeException thrown2 = null;
         try {
             try {
-                cmdKubeClient().applyContent(ssStr);
+                cmdKubeClient().applyContent(ssStr, false);
             } catch (RuntimeException t) {
                 thrown = t;
             }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -288,27 +288,21 @@ public class CrdGenerator {
     private ObjectNode buildValidation(Class<? extends CustomResource> crdClass) {
         ObjectNode result = nf.objectNode();
         // OpenShift Origin 3.10-rc0 doesn't like the `type: object` in schema root
-        result.set("openAPIV3Schema", buildObjectSchema(crdClass, crdClass, false));
+        result.set("openAPIV3Schema", buildObjectSchema(crdClass, crdClass));
         return result;
     }
 
     private ObjectNode buildObjectSchema(AnnotatedElement annotatedElement, Class<?> crdClass) {
-        return buildObjectSchema(annotatedElement, crdClass, true);
-    }
-
-    private ObjectNode buildObjectSchema(AnnotatedElement annotatedElement, Class<?> crdClass, boolean printType) {
 
         ObjectNode result = nf.objectNode();
 
-        buildObjectSchema(result, crdClass, printType);
+        buildObjectSchema(result, crdClass);
         return result;
     }
 
-    private void buildObjectSchema(ObjectNode result, Class<?> crdClass, boolean printType) {
+    private void buildObjectSchema(ObjectNode result, Class<?> crdClass) {
         checkClass(crdClass);
-        if (printType) {
-            result.put("type", "object");
-        }
+        result.put("type", "object");
 
         result.set("properties", buildSchemaProperties(crdClass));
         ArrayNode required = buildSchemaRequired(crdClass);
@@ -461,7 +455,7 @@ public class CrdGenerator {
                 || long.class.equals(elementType)) {
             itemResult.put("type", "integer");
         } else  {
-            buildObjectSchema(itemResult, elementType, true);
+            buildObjectSchema(itemResult, elementType);
         }
         return result;
     }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -287,7 +287,6 @@ public class CrdGenerator {
 
     private ObjectNode buildValidation(Class<? extends CustomResource> crdClass) {
         ObjectNode result = nf.objectNode();
-        // OpenShift Origin 3.10-rc0 doesn't like the `type: object` in schema root
         result.set("openAPIV3Schema", buildObjectSchema(crdClass, crdClass));
         return result;
     }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -14,8 +14,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CrdGeneratorTest {
     @Test
@@ -24,7 +23,7 @@ public class CrdGeneratorTest {
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
-        assertThat(CrdTestUtils.readResource("simpleTest.yaml"), is(s));
+        assertEquals(CrdTestUtils.readResource("simpleTest.yaml"), s);
     }
 
     @Test
@@ -39,6 +38,6 @@ public class CrdGeneratorTest {
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
-        assertThat(CrdTestUtils.readResource("simpleTestHelmMetadata.yaml"), is(s));
+        assertEquals(CrdTestUtils.readResource("simpleTestHelmMetadata.yaml"), s);
     }
 }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -25,6 +25,7 @@ spec:
     type: "integer"
   validation:
     openAPIV3Schema:
+      type: "object"
       properties:
         affinity:
           type: "object"

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -31,6 +31,7 @@ spec:
     type: "integer"
   validation:
     openAPIV3Schema:
+      type: "object"
       properties:
         affinity:
           type: "object"

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -40,6 +40,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -36,6 +36,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -36,6 +36,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -40,6 +40,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -40,6 +40,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -46,6 +46,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -38,6 +38,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -35,6 +35,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -31,6 +31,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -31,6 +31,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -35,6 +35,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -35,6 +35,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -41,6 +41,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -33,6 +33,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -35,6 +35,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -35,6 +35,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/AbstractST.java
@@ -652,7 +652,9 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
      * @param operationTimeout timeout for CO operations
      */
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout) {
-        testClassResources.deleteResources();
+        if (testClassResources != null) {
+            testClassResources.deleteResources();
+        }
 
         deleteClusterOperatorInstallFiles();
         deleteNamespaces();
@@ -968,7 +970,9 @@ public abstract class AbstractST extends BaseITST implements TestSeparator {
     }
 
     protected void tearDownEnvironmentAfterAll() {
-        testClassResources.deleteResources();
+        if (testClassResources != null) {
+            testClassResources.deleteResources();
+        }
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
@@ -32,7 +32,8 @@ public class CrdST extends AbstractST {
     public void testNoNonstructualSchemas() {
         List<CustomResourceDefinition> crds = kubeClient().listCustomResourceDefinition();
         List<String> nonstructural = crds.stream().filter(crd -> {
-            return crd.getStatus().getConditions().stream().anyMatch(condition -> {
+            return crd.getSpec().getGroup().endsWith("strimzi.io")
+                && crd.getStatus().getConditions().stream().anyMatch(condition -> {
                 return "NonStructuralSchema".equals(condition.getType())
                         && "True".equals(condition.getStatus());
             });

--- a/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(ACCEPTANCE)
+public class CrdST extends AbstractST {
+
+    private static final Logger LOGGER = LogManager.getLogger(CrdST.class);
+
+//    message: 'spec.validation.openAPIV3Schema.type: Required value: must not be empty
+//    at the root'
+//    reason: Violations
+//    status: "True"
+//    type: NonStructuralSchema
+
+    @Tag(ACCEPTANCE)
+    @Test
+    public void testNoNonstructualSchemas() {
+        List<CustomResourceDefinition> crds = kubeClient().listCustomResourceDefinition();
+        List<String> nonstructural = crds.stream().filter(crd -> {
+            return crd.getStatus().getConditions().stream().anyMatch(condition -> {
+                return "NonStructuralSchema".equals(condition.getType())
+                        && "True".equals(condition.getStatus());
+            });
+        }).map(crd -> {
+            return crd.getSpec().getNames().getPlural() + "." + crd.getSpec().getGroup();
+        }).collect(Collectors.toList());
+        assertTrue(nonstructural.isEmpty(), "Nonstructural schemas: " + nonstructural);
+    }
+
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CrdST.java
@@ -34,9 +34,9 @@ public class CrdST extends AbstractST {
         List<String> nonstructural = crds.stream().filter(crd -> {
             return crd.getSpec().getGroup().endsWith("strimzi.io")
                 && crd.getStatus().getConditions().stream().anyMatch(condition -> {
-                return "NonStructuralSchema".equals(condition.getType())
+                    return "NonStructuralSchema".equals(condition.getType())
                         && "True".equals(condition.getStatus());
-            });
+                });
         }).map(crd -> {
             return crd.getSpec().getNames().getPlural() + "." + crd.getSpec().getGroup();
         }).collect(Collectors.toList());

--- a/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
@@ -81,8 +81,10 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     private List<String> namespacedCommand(List<String> rest) {
         List<String> result = new ArrayList<>();
         result.add(cmd());
-        result.add("--namespace");
-        result.add(namespace);
+        if (namespace != null) {
+            result.add("--namespace");
+            result.add(namespace);
+        }
         result.addAll(rest);
         return result;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/BaseCmdKubeClient.java
@@ -184,9 +184,13 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     @SuppressWarnings("unchecked")
-    public K applyContent(String yamlContent) {
+    public K applyContent(String yamlContent, boolean validate) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(APPLY, "-f", "-"));
+            List<String> command = namespacedCommand(APPLY, "-f", "-");
+            if (!validate) {
+                command.add("--validate=false");
+            }
+            Exec.exec(yamlContent, command);
             return (K) this;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeCmdClient.java
@@ -63,7 +63,11 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     /** Returns an equivalent client, but logged in as cluster admin. */
     K clientWithAdmin();
 
-    K applyContent(String yamlContent);
+    default K applyContent(String yamlContent) {
+        return applyContent(yamlContent, true);
+    }
+
+    K applyContent(String yamlContent, boolean validate);
 
     K deleteContent(String yamlContent);
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kubernetes 1.15 introduced the idea of [structural schemas](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/) which CRDs in `apiextensions.k8s.io/v1` [started enforcing](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema).

Our schemas were not structural because the top level object lacked a `type`. This was added as a workaround for openshift 3.10-rc0 which we no longer support. So this PR adds the `type` back and also adds a tiny ST which checks the `status` of the CRD to check that kube doesn't think our CRDs are non-structural.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

