### PR TITLE
ST: fix several system tests after some merged changes

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -31,7 +31,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
             // It's match start of the line which contains date in format yyyy-mm-dd hh:mm:ss
             String logLineSplitPattern = "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}";
             for (String line : ((String) actualValue).split(logLineSplitPattern)) {
-                if (line.contains("DEBUG") || line.contains("WARN")) {
+                if (line.contains("DEBUG") || line.contains("WARN") || line.contains("INFO")) {
                     continue;
                 }
                 String lineLowerCase = line.toLowerCase(Locale.ENGLISH);
@@ -76,7 +76,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         OPERATION_TIMEOUT("Util:[0-9]+ - Exceeded timeout of.*while waiting for.*"),
         // This is whitelisted cause it's no real problem when this error appears, components are being created even after timeout
         RECONCILIATION_TIMEOUT("ERROR Abstract.*Operator:[0-9]+ - Reconciliation.*"),
-        ASSEMBLY_OPERATOR_RECONCILIATION_TIMEOUT("ERROR .*AssemblyOperator:[0-9]+ - Reconciliation.*failed.*");
+        ASSEMBLY_OPERATOR_RECONCILIATION_TIMEOUT("ERROR .*AssemblyOperator:[0-9]+ - Reconciliation.*[fF]ailed.*");
 
         final String name;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -219,6 +219,7 @@ public class StUtils {
      * @return The snapshot of the StatefulSet after rolling update with Uid for every pod
      */
     public static Map<String, String> waitTillSsHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
+        LOGGER.info("Waiting for StatefulSet {} rolling update", name);
         TestUtils.waitFor("StatefulSet " + name + " rolling update",
                 Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT * 2, () -> {
                 try {
@@ -229,6 +230,7 @@ public class StUtils {
                 }
             });
         StUtils.waitForAllStatefulSetPodsReady(name, expectedPods);
+        LOGGER.info("StatefulSet {} rolling update finished", name);
         return ssSnapshot(name);
     }
 
@@ -240,10 +242,12 @@ public class StUtils {
      * @return The snapshot of the Deployment after rolling update with Uid for every pod
      */
     public static Map<String, String> waitTillDepHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
+        LOGGER.info("Waiting for Deployment {} rolling update", name);
         TestUtils.waitFor("Deployment " + name + " rolling update",
                 Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT, () -> depHasRolled(name, snapshot));
         StUtils.waitForDeploymentReady(name);
         StUtils.waitForPodsReady(kubeClient().getDeployment(name).getSpec().getSelector(), expectedPods, true);
+        LOGGER.info("Deployment {} rolling update finished", name);
         return depSnapshot(name);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1154,7 +1154,7 @@ class KafkaST extends MessagingBaseST {
     @Test
     void testManualTriggeringRollingUpdate() {
         String coPodName = kubeClient().listPods("name", "strimzi-cluster-operator").get(0).getMetadata().getName();
-        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 1, 1).done();
+        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 3, 3).done();
 
         String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
         String zkName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1154,49 +1154,54 @@ class KafkaST extends MessagingBaseST {
     @Test
     void testManualTriggeringRollingUpdate() {
         String coPodName = kubeClient().listPods("name", "strimzi-cluster-operator").get(0).getMetadata().getName();
-        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 1).done();
+        testMethodResources().kafkaEphemeral(CLUSTER_NAME, 1, 1).done();
+
+        String kafkaName = KafkaResources.kafkaStatefulSetName(CLUSTER_NAME);
+        String zkName = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
+        Map<String, String> kafkaPods = StUtils.ssSnapshot(kafkaName);
+        Map<String, String> zkPods = StUtils.ssSnapshot(zkName);
 
         // rolling update for kafka
+        LOGGER.info("Annotate Kafka StatefulSet {} with manual rolling update annotation", kafkaName);
         setOperationID(startTimeMeasuring(Operation.ROLLING_UPDATE));
         // set annotation to trigger Kafka rolling update
-        kubeClient().statefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
+        kubeClient().statefulSet(kafkaName).cascading(false).edit()
                 .editMetadata()
                     .addToAnnotations("strimzi.io/manual-rolling-update", "true")
                 .endMetadata().done();
 
         // check annotation to trigger rolling update
-        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME))
+        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(kafkaName)
                 .getMetadata().getAnnotations().get("strimzi.io/manual-rolling-update")), is(true));
 
         // wait when annotation will be removed
         waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, WAIT_FOR_ROLLING_UPDATE_TIMEOUT,
-            () -> getAnnotationsForSS(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)) == null
-                || !getAnnotationsForSS(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).containsKey("strimzi.io/manual-rolling-update"));
+            () -> getAnnotationsForSS(kafkaName) == null
+                || !getAnnotationsForSS(kafkaName).containsKey("strimzi.io/manual-rolling-update"));
 
         // check rolling update messages in CO log
-        String coLog = kubeClient().logs(coPodName);
-        assertThat(coLog, containsString("Rolling Kafka pod " + KafkaResources.kafkaStatefulSetName(CLUSTER_NAME) + "-0" + " due to manual rolling update"));
+        StUtils.waitTillSsHasRolled(kafkaName, 1, kafkaPods);
 
         // rolling update for zookeeper
+        LOGGER.info("Annotate Zookeeper StatefulSet {} with manual rolling update annotation", zkName);
         setOperationID(startTimeMeasuring(Operation.ROLLING_UPDATE));
         // set annotation to trigger Zookeeper rolling update
-        kubeClient().statefulSet(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).cascading(false).edit()
+        kubeClient().statefulSet(zkName).cascading(false).edit()
                 .editMetadata()
                     .addToAnnotations("strimzi.io/manual-rolling-update", "true")
                 .endMetadata().done();
 
         // check annotation to trigger rolling update
-        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME))
+        assertThat(Boolean.parseBoolean(kubeClient().getStatefulSet(zkName)
                 .getMetadata().getAnnotations().get("strimzi.io/manual-rolling-update")), is(true));
 
         // wait when annotation will be removed
         waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, WAIT_FOR_ROLLING_UPDATE_TIMEOUT,
-            () -> getAnnotationsForSS(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)) == null
-                || !getAnnotationsForSS(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).containsKey("strimzi.io/manual-rolling-update"));
+            () -> getAnnotationsForSS(zkName) == null
+                || !getAnnotationsForSS(zkName).containsKey("strimzi.io/manual-rolling-update"));
 
         // check rolling update messages in CO log
-        coLog = kubeClient().logs(coPodName);
-        assertThat(coLog, containsString("Rolling Zookeeper pod " + KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME) + "-0" + " to manual rolling update"));
+        StUtils.waitTillSsHasRolled(zkName, 1, zkPods);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR contains fixes for the following tests:
* KafkaST - in some cases, INFO log caused failure of the tests during final log check, INFO logs are now whitelisted (unless they contians NPE)
* LogSettingST - changed logic for GC logging tests (it's disabled by default now)
* KafkaST#testManualTriggeringRollingUpdate - remove CO log check and wait for rolling update is finished instead of it

### Checklist

- [x] Make sure all tests pass

