### PR TITLE
Add support for Istio protocol selection in service port names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 * Garbage Collection (GC) logging disabled by default
 * Providing PKCS12 truststore and password in the cluster and clients CA certificates Secrets
 * Providing PKCS12 keystore and password in the TLS based KafkaUser related Secret
-* Add support for Istio protocol selection in service port names
-
+* Add support for Istio protocol selection in service port names  
+Note: Strimzi is essentially addind a `tcp-` prefix to the port names in Kafka services and headless services.  
+(e.g clientstls -> tcp-clientstls)
 ## 0.14.0
 
 * Add support for configuring Ingress class (#1716)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Garbage Collection (GC) logging disabled by default
 * Providing PKCS12 truststore and password in the cluster and clients CA certificates Secrets
 * Providing PKCS12 keystore and password in the TLS based KafkaUser related Secret
+* Add support for Istio protocol selection in service port names
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 * Providing PKCS12 truststore and password in the cluster and clients CA certificates Secrets
 * Providing PKCS12 keystore and password in the TLS based KafkaUser related Secret
 * Add support for Istio protocol selection in service port names  
-Note: Strimzi is essentially addind a `tcp-` prefix to the port names in Kafka services and headless services.  
+Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka services and headless services.  
 (e.g clientstls -> tcp-clientstls)
+
 ## 0.14.0
 
 * Add support for configuring Ingress class (#1716)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -144,16 +144,16 @@ public class KafkaCluster extends AbstractModel {
     protected static final String ENV_VAR_STRIMZI_EXTERNAL_OAUTH_CLIENT_SECRET = "STRIMZI_EXTERNAL_OAUTH_CLIENT_SECRET";
 
     protected static final int CLIENT_PORT = 9092;
-    protected static final String CLIENT_PORT_NAME = "clients";
+    protected static final String CLIENT_PORT_NAME = "tcp-clients";
 
     public static final int REPLICATION_PORT = 9091;
-    protected static final String REPLICATION_PORT_NAME = "replication";
+    protected static final String REPLICATION_PORT_NAME = "tcp-replication";
 
     protected static final int CLIENT_TLS_PORT = 9093;
-    protected static final String CLIENT_TLS_PORT_NAME = "clientstls";
+    protected static final String CLIENT_TLS_PORT_NAME = "tcp-clientstls";
 
     protected static final int EXTERNAL_PORT = 9094;
-    protected static final String EXTERNAL_PORT_NAME = "external";
+    protected static final String EXTERNAL_PORT_NAME = "tcp-external";
 
     protected static final int ROUTE_PORT = 443;
     protected static final String ROUTE_PORT_NAME = "route";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -143,6 +143,9 @@ public class KafkaCluster extends AbstractModel {
     protected static final String ENV_VAR_STRIMZI_CLIENTTLS_OAUTH_CLIENT_SECRET = "STRIMZI_CLIENTTLS_OAUTH_CLIENT_SECRET";
     protected static final String ENV_VAR_STRIMZI_EXTERNAL_OAUTH_CLIENT_SECRET = "STRIMZI_EXTERNAL_OAUTH_CLIENT_SECRET";
 
+    // For port names in services, a 'tcp-' prefix is added to support Istio protocol selection
+    // This helps Istio to avoid using a wildcard listener and instead present IP:PORT pairs which effects
+    // proper listener, routing and metrics configuration sent to Envoy
     protected static final int CLIENT_PORT = 9092;
     protected static final String CLIENT_PORT_NAME = "tcp-clients";
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
TL;DR Adding "tcp-" prefix to 9092/9093/9094 port names in services.

This PR adds a support for Istio protocol selection in service port names.
The change mainly resolves an issue with Istio creating a wildcard listener in Envoy (e.g 0.0.0.0:9093) and thus forces a single destination rule for all services using this port and also causes Mixer metrics to appear with wrong names when having multiple Strimzi clusters.
Also this can cause collisions with other services that also use the same port (9093) (e.g Prometheus alert manager)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X ] Make sure all tests pass
- [X ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [X ] Update CHANGELOG.md

