### PR TITLE
Fabric8 deletion behaviour fix

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -334,7 +334,7 @@ public class KafkaAssemblyOperatorMockTest {
     private void updateClusterWithoutSecrets(Params params, VertxTestContext context, String... secrets) throws InterruptedException, ExecutionException, TimeoutException {
         KafkaAssemblyOperator kco = createCluster(params, context);
         for (String secret: secrets) {
-            mockClient.secrets().inNamespace(NAMESPACE).withName(secret).delete();
+            mockClient.secrets().inNamespace(NAMESPACE).withName(secret).cascading(true).delete();
             assertThat("Expected secret " + secret + " to be not exist",
                     mockClient.secrets().inNamespace(NAMESPACE).withName(secret).get(), is(nullValue()));
         }
@@ -359,7 +359,7 @@ public class KafkaAssemblyOperatorMockTest {
         setFields(params);
         KafkaAssemblyOperator kco = createCluster(params, context);
         for (String service: services) {
-            mockClient.services().inNamespace(NAMESPACE).withName(service).delete();
+            mockClient.services().inNamespace(NAMESPACE).withName(service).cascading(true).delete();
             assertThat("Expected service " + service + " to be not exist",
                     mockClient.services().inNamespace(NAMESPACE).withName(service).get(), is(nullValue()));
         }
@@ -410,7 +410,7 @@ public class KafkaAssemblyOperatorMockTest {
     private void updateClusterWithoutStatefulSet(Params params, VertxTestContext context, String statefulSet) throws InterruptedException, ExecutionException, TimeoutException {
         KafkaAssemblyOperator kco = createCluster(params, context);
 
-        mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).delete();
+        mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).cascading(true).delete();
         assertThat("Expected sts " + statefulSet + " to be not exist",
                 mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).get(), is(nullValue()));
 
@@ -608,7 +608,7 @@ public class KafkaAssemblyOperatorMockTest {
 
 
         LOGGER.info("Reconciling again -> delete");
-        kafkaAssembly(NAMESPACE, CLUSTER_NAME).delete();
+        kafkaAssembly(NAMESPACE, CLUSTER_NAME).cascading(true).delete();
         Checkpoint deleteAsync = context.checkpoint();
         kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
             if (ar.failed()) ar.cause().printStackTrace();

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
@@ -111,7 +111,7 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
                 // delete the first "old" Pod if there is one still remaining
                 if (podsForDeployments.get(deployment.getMetadata().getName()).size() > 0) {
                     String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
-                    mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
+                    mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).cascading(true).delete();
                 }
 
             }

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -324,7 +324,7 @@ class MockBuilder<T extends HasMetadata,
     }
 
     protected void mockDelete(String resourceName, R resource) {
-        when(resource.delete()).thenAnswer(i -> {
+        when(resource.cascading(true).delete()).thenAnswer(i -> {
             return doDelete(resourceName);
         });
     }

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/StatefulSetMockBuilder.java
@@ -193,14 +193,14 @@ class StatefulSetMockBuilder extends MockBuilder<StatefulSet, StatefulSetList, D
 
     @Override
     protected void mockDelete(String resourceName, RollableScalableResource<StatefulSet, DoneableStatefulSet> resource) {
-        when(resource.delete()).thenAnswer(i -> {
+        when(resource.cascading(true).delete()).thenAnswer(i -> {
             LOGGER.debug("delete {} {}", resourceType, resourceName);
             StatefulSet removed = db.remove(resourceName);
             if (removed != null) {
                 fireWatchers(resourceName, removed, Watcher.Action.DELETED, "delete");
                 for (Map.Entry<String, Pod> pod : new HashMap<>(podDb).entrySet()) {
                     if (pod.getKey().matches(resourceName + "-[0-9]+")) {
-                        mockPods.inNamespace(removed.getMetadata().getNamespace()).withName(pod.getKey()).delete();
+                        mockPods.inNamespace(removed.getMetadata().getNamespace()).withName(pod.getKey()).cascading(true).delete();
                     }
                 }
             }
@@ -226,7 +226,7 @@ class StatefulSetMockBuilder extends MockBuilder<StatefulSet, StatefulSetList, D
             LOGGER.debug("scaling down {} {} from {} to {}", resourceType, resourceName, oldScale, newScale);
             for (int i = oldScale - 1; i >= newScale; i--) {
                 String newPodName = argument.getMetadata().getName() + "-" + i;
-                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).delete();
+                mockPods.inNamespace(argument.getMetadata().getNamespace()).withName(newPodName).cascading(true).delete();
             }
         } else {
             db.put(resourceName, copyResource(argument));

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeRegressionTest.java
@@ -72,7 +72,7 @@ public class MockKubeRegressionTest {
 
             }
         });
-        client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).delete();
+        client.pods().inNamespace("ns").withName(ns.get(0).getMetadata().getName()).cascading(true).delete();
 
         assertThat(deleted.get(), is(true));
         assertThat(recreated.get(), is(true));
@@ -81,7 +81,7 @@ public class MockKubeRegressionTest {
         ns = client.pods().inNamespace("ns").list().getItems();
         assertThat(ns.size(), is(3));
 
-        client.apps().statefulSets().inNamespace("ns").withName("foo").delete();
+        client.apps().statefulSets().inNamespace("ns").withName("foo").cascading(true).delete();
 
     }
 }

--- a/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/io/strimzi/test/mockkube/MockKubeTest.java
@@ -243,7 +243,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         // TODO assertNull(gotResource);
 
         // Delete
-        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).delete(), is(true));
+        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).cascading(true).delete(), is(true));
         assertThat(w.lastEvent().action, is(Watcher.Action.DELETED));
         RT resource = (RT) w.lastEvent().resource;
         resource.getMetadata().setResourceVersion(null);
@@ -256,7 +256,7 @@ public class MockKubeTest<RT extends HasMetadata, LT extends KubernetesResource 
         gotResource = mixedOp.apply(client).withName(pod.getMetadata().getName()).get();
         assertThat(gotResource, is(nullValue()));
 
-        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).delete(), is(false));
+        assertThat(mixedOp.apply(client).withName(pod.getMetadata().getName()).cascading(true).delete(), is(false));
 
         // TODO Delete off a withLabels query, delete off a inNamespace
         // TODO inAnyNamespace()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -123,7 +123,7 @@ public class KafkaBridgeCrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaBridgeOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaBridgeOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaBridgeOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             KafkaBridge deletion = kafkaBridgeOperator.get(namespace, RESOURCE_NAME);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -122,7 +122,7 @@ public class KafkaConnectCrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaConnectOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaConnectOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaConnectOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             KafkaConnect deletion = kafkaConnectOperator.get(namespace, RESOURCE_NAME);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
@@ -122,7 +122,7 @@ public class KafkaConnectS2IcrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaConnectS2Ioperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaConnectS2Ioperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaConnectS2Ioperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             KafkaConnectS2I deletion = kafkaConnectS2Ioperator.get(namespace, RESOURCE_NAME);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
@@ -136,7 +136,7 @@ public class KafkaCrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             Kafka deletion = kafkaOperator.get(namespace, RESOURCE_NAME);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
@@ -123,7 +123,7 @@ public class KafkaMirrorMakerCrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaMirrorMakerOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaMirrorMakerOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaMirrorMakerOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             KafkaMirrorMaker deletion = kafkaMirrorMakerOperator.get(namespace, RESOURCE_NAME);

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -122,7 +122,7 @@ public class KafkaUserCrdOperatorIT {
     private Future<Void> deleteResource()    {
         // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
         // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaUserOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+        kafkaUserOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
 
         return kafkaUserOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
             KafkaUser deletion = kafkaUserOperator.get(namespace, RESOURCE_NAME);

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.19.0</sundrio.version>
 
-        <fabric8.kubernetes-client.version>4.6.2</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>4.6.2</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>4.6.2</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>4.6.4</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>4.6.4</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>4.6.4</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.0</okhttp.version>
         <okio.version>1.15.0</okio.version>

--- a/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
@@ -228,7 +228,7 @@ public class TopicST extends MessagingBaseST {
 
         String topicUid = KafkaTopicUtils.topicSnapshot(topicName);
         LOGGER.info("Going to delete topic {}", topicName);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).delete();
+        KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).cascading(true).delete();
         LOGGER.info("Topic {} deleted", topicName);
 
         KafkaTopicUtils.waitTopicHasRolled(topicName, topicUid);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -88,7 +88,7 @@ public class KubeClient {
     }
 
     public void deleteNamespace(String name) {
-        client.namespaces().withName(name).delete();
+        client.namespaces().withName(name).cascading(true).delete();
     }
 
     /**
@@ -100,7 +100,7 @@ public class KubeClient {
 
 
     public void deleteConfigMap(String configMapName) {
-        client.configMaps().inNamespace(getNamespace()).withName(configMapName).delete();
+        client.configMaps().inNamespace(getNamespace()).withName(configMapName).cascading(true).delete();
     }
 
     public ConfigMap getConfigMap(String configMapName) {
@@ -261,7 +261,7 @@ public class KubeClient {
     }
 
     public void deleteStatefulSet(String statefulSetName) {
-        client.apps().statefulSets().inNamespace(getNamespace()).withName(statefulSetName).delete();
+        client.apps().statefulSets().inNamespace(getNamespace()).withName(statefulSetName).cascading(true).delete();
     }
 
     public Deployment createOrReplaceDeployment(Deployment deployment) {
@@ -308,7 +308,7 @@ public class KubeClient {
      * @param deploymentConfigName deployment config name
      */
     public void deleteDeploymentConfig(String deploymentConfigName) {
-        client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).delete();
+        client.adapt(OpenShiftClient.class).deploymentConfigs().inNamespace(getNamespace()).withName(deploymentConfigName).cascading(true).delete();
     }
 
     /**
@@ -359,7 +359,7 @@ public class KubeClient {
     }
 
     public boolean deleteSecret(String secretName) {
-        return client.secrets().inNamespace(getNamespace()).withName(secretName).delete();
+        return client.secrets().inNamespace(getNamespace()).withName(secretName).cascading(true).delete();
     }
 
     public Service createService(Service service) {
@@ -412,7 +412,7 @@ public class KubeClient {
     }
 
     public void deleteService(String serviceName) {
-        client.services().inNamespace(getNamespace()).withName(serviceName).delete();
+        client.services().inNamespace(getNamespace()).withName(serviceName).cascading(true).delete();
     }
 
     public void deleteService(Service service) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -203,7 +203,7 @@ public abstract class TopicOperatorBaseIT {
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
                     LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
                     LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
                     waitForTopicInKafka(new TopicName(item).toString(), false);
                     waitForTopicInKube(item.getMetadata().getName(), false);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -203,7 +203,7 @@ public abstract class TopicOperatorBaseIT {
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
                     LOGGER.info("Deleting {} from Kube", item.getMetadata().getName());
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
                     LOGGER.info("Awaiting deletion of {} in Kafka", item.getMetadata().getName());
                     waitForTopicInKafka(new TopicName(item).toString(), false);
                     waitForTopicInKube(item.getMetadata().getName(), false);
@@ -218,7 +218,7 @@ public abstract class TopicOperatorBaseIT {
 
                 // Wait for the operator to delete all the existing topics in Kafka
                 for (KafkaTopic item : items) {
-                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).delete();
+                    operation().inNamespace(NAMESPACE).withName(item.getMetadata().getName()).cascading(true).delete();
                     waitForTopicInKube(item.getMetadata().getName(), false);
                 }
             }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2223

After https://github.com/fabric8io/kubernetes-client/pull/1807 was merged in fabric8 I think this bug should be fixed.
//edit: using 4.6.4 did not seem to help, using suggested `cascading(true)` where possible.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

