### PR TITLE
feat: Enable internal connections for JMX port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # CHANGELOG
 
 ## 0.16.0
@@ -12,6 +13,7 @@
 * Add `schedulerName` to `podTemplate` (#2114)
 * Allow overriding the auto-detected Kubernetes version
 * Garbage Collection (GC) logging disabled by default
+* Expose JMX port on Kafka brokers via an internal service
 * Providing PKCS12 truststore and password in the cluster and clients CA certificates Secrets
 * Providing PKCS12 keystore and password in the TLS based KafkaUser related Secret
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -40,7 +40,7 @@ import java.util.Map;
         "rack", "brokerRackInitImage",
         "affinity", "tolerations",
         "livenessProbe", "readinessProbe",
-        "jvmOptions", "resources",
+        "jvmOptions", "jmxOptions", "resources",
         "metrics", "logging", "tlsSidecar", "template"})
 @EqualsAndHashCode
 public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable {
@@ -71,6 +71,7 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
     private Probe livenessProbe;
     private Probe readinessProbe;
     private JvmOptions jvmOptions;
+    private KafkaJmxOptions kafkaJmxOptions;
     private Map<String, Object> metrics;
     private Affinity affinity;
     private List<Toleration> tolerations;
@@ -209,6 +210,17 @@ public class KafkaClusterSpec implements UnknownPropertyPreserving, Serializable
 
     public void setJvmOptions(JvmOptions jvmOptions) {
         this.jvmOptions = jvmOptions;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("JMX Options for Kafka brokers")
+    @JsonProperty("jmxMetrics")
+    public KafkaJmxOptions getKafkaJmxOptions() {
+        return kafkaJmxOptions;
+    }
+
+    public void setKafkaJmxOptions(KafkaJmxOptions kafkaJmxOptions) {
+        this.kafkaJmxOptions = kafkaJmxOptions;
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"isEnabled"})
+@EqualsAndHashCode
+public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    private boolean isEnabled;
+
+    @Description("Description for whether jmx options are enabled")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}
+

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.test.TestUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KafkaJmxOptionsTest {
+    @Test
+    public void testEnabled() {
+        KafkaJmxOptions opts = TestUtils.fromJson("{" +
+                "\"enabled\": \"true\"" +
+                "}", KafkaJmxOptions.class);
+
+        assertThat(opts.isEnabled(), is(true));
+    }
+
+    @Test
+    public void testEmptyEnabled() {
+        KafkaJmxOptions opts = TestUtils.fromJson("{}", KafkaJmxOptions.class);
+
+        assertThat(opts.isEnabled(), is(false));
+    }
+
+
+
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -28,6 +28,7 @@ import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IBuilder;
 import io.strimzi.api.kafka.model.KafkaExporterSpec;
+import io.strimzi.api.kafka.model.KafkaJmxOptions;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
@@ -340,6 +341,7 @@ public class ResourceUtils {
     public static Kafka createKafkaCluster(String clusterCmNamespace, String clusterCmName, int replicas,
                                            String image, int healthDelay, int healthTimeout,
                                            Map<String, Object> metricsCm,
+                                           boolean isJmxEnabled,
                                            Map<String, Object> kafkaConfiguration,
                                            Map<String, Object> zooConfiguration,
                                            Storage kafkaStorage,
@@ -373,6 +375,12 @@ public class ResourceUtils {
         if (metricsCm != null) {
             kafkaClusterSpec.setMetrics(metricsCm);
         }
+        KafkaJmxOptions jmxOptions = new KafkaJmxOptions();
+        if (isJmxEnabled) {
+            jmxOptions.setEnabled(true);
+        }
+        kafkaClusterSpec.setKafkaJmxOptions(jmxOptions);
+
         if (kafkaConfiguration != null) {
             kafkaClusterSpec.setConfig(kafkaConfiguration);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -123,7 +123,7 @@ public class KafkaExporterTest {
     @Test
     public void testFromConfigMapDefaultConfig() {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, null,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, null, kafkaLogJson, zooLogJson, new KafkaExporterSpec());
         KafkaExporter ke = KafkaExporter.fromCrd(resource, VERSIONS);
         assertThat(ke.getImage(), is(KafkaVersionTestUtils.DEFAULT_KAFKA_IMAGE));
@@ -232,7 +232,7 @@ public class KafkaExporterTest {
                 .build();
 
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, null, kafkaLogJson, zooLogJson, exporterSpec);
         KafkaExporter ke = KafkaExporter.fromCrd(resource, VERSIONS);
 
@@ -268,7 +268,7 @@ public class KafkaExporterTest {
                 .build();
 
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false,  kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, null, kafkaLogJson, zooLogJson, exporterSpec);
         KafkaExporter ke = KafkaExporter.fromCrd(resource, VERSIONS);
 
@@ -280,7 +280,7 @@ public class KafkaExporterTest {
     @Test
     public void testExporterNotDeployed() {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, null, kafkaLogJson, zooLogJson, null);
         KafkaExporter ke = KafkaExporter.fromCrd(resource, VERSIONS);
 
@@ -308,7 +308,7 @@ public class KafkaExporterTest {
     @Test
     public void testGenerateServiceWhenDisabled()   {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, null, kafkaLogJson, zooLogJson, null);
         KafkaExporter ke = KafkaExporter.fromCrd(resource, VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -93,7 +93,7 @@ public class TopicOperatorTest {
             .withTlsSidecar(tlsSidecar)
             .build();
 
-    private final Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig, kafkaStorage, zkStorage, topicOperator, kafkaLogJson, zooLogJson, null);
+    private final Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig, kafkaStorage, zkStorage, topicOperator, kafkaLogJson, zooLogJson, null);
     private final TopicOperator tc = TopicOperator.fromCrd(resource, VERSIONS);
 
     private List<EnvVar> getExpectedEnvVars() {
@@ -122,7 +122,7 @@ public class TopicOperatorTest {
     @Test
     public void testFromConfigMapDefaultConfig() {
         Kafka resource = ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, metricsCm, kafkaConfig, zooConfig,
+                healthDelay, healthTimeout, metricsCm, false, kafkaConfig, zooConfig,
                 kafkaStorage, zkStorage, new TopicOperatorSpec(), kafkaLogJson, zooLogJson, null);
         TopicOperator tc = TopicOperator.fromCrd(resource, VERSIONS);
         assertThat(tc.getImage(), is("strimzi/operator:latest"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -100,7 +100,7 @@ public class ZookeeperClusterTest {
             .withReadinessProbe(new ProbeBuilder().withInitialDelaySeconds(tlsHealthDelay).withTimeoutSeconds(tlsHealthTimeout).build())
             .build();
 
-    private final Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson, null, null, null, kafkaLogConfigJson, zooLogConfigJson, null))
+    private final Kafka ka = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, false, configurationJson, zooConfigurationJson, null, null, null, kafkaLogConfigJson, zooLogConfigJson, null))
             .editSpec()
                 .editZookeeper()
                     .withTlsSidecar(tlsSidecar)

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -25,6 +25,13 @@ fi
 rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
 export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
+if [ "$KAFKA_JMX_ENABLED" = "true" ]; then
+  # opening jmx port on 9404 insecurely
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9404 -Dcom.sun.management.jmxremote.rmi.port=9404 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote.authenticate=false "
+fi
+
+KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
+
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then
   export KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"

--- a/documentation/assemblies/assembly-jmx-options.adoc
+++ b/documentation/assemblies/assembly-jmx-options.adoc
@@ -1,0 +1,11 @@
+// Save the context of the assembly that is including this one.
+// This is necessary for including assemblies in assemblies.
+// See also the complementary step on the last line of this file.
+
+[id='assembly-jmx-options-{context}']
+
+= Jmx Metrics metrics
+
+{ProductName} supports JMX Metrics on the Kafka brokers. When metrics are enabled, they are exposed on port 9404.
+
+include::../modules/ref-jmx-options.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -90,6 +90,8 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |template             1.2+<.<|Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
 |xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
+|jmxMetrics           1.2+<.<|JMX Options for Kafka brokers.
+|xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
 |version              1.2+<.<|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
@@ -909,6 +911,19 @@ Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |string
 |value  1.2+<.<|The environment variable value.
 |string
+|====
+
+[id='type-KafkaJmxOptions-{context}']
+### `KafkaJmxOptions` schema reference
+
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+
+
+[options="header"]
+|====
+|Property        |Description
+|enabled  1.2+<.<|Description for whether jmx options are enabled.
+|boolean
 |====
 
 [id='type-ZookeeperClusterSpec-{context}']

--- a/documentation/modules/con-kafka-jmx-options.adoc
+++ b/documentation/modules/con-kafka-jmx-options.adoc
@@ -1,0 +1,16 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration-kafka-mirror-maker.adoc
+
+[id='con-kafka-jmx-options-{context}']
+
+= JMX Options
+
+Use the `jmxOptions` property to expose the JMX port on kafka brokers via the kafka broker headless service. You can
+access the Kafka broker JMX by deploying a pod into the cluster and then referencing the specific broker you want
+on the kafka broker headless service on port 9404.
+
+JMX options allow you to gather JMX metrics from the Kafka brokers and also invoke MBean operations on the kafka broker.
+This can be used to gather JMX metrics and export to remote sinks such as logstash and Splunk.
+
+For more information on the supported options, see xref:ref-jmx-options-deployment-configuration-kafka[JMX configuration].

--- a/documentation/modules/ref-jmx-options.adoc
+++ b/documentation/modules/ref-jmx-options.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// assembly-jvm-options.adoc
+
+[id='ref-jmx-options-{context}']
+= JMX configuration
+
+JMX options can be configured using the `jmxOptions` property in following resources:
+
+* `Kafka.spec.kafka`
+
+.Example configuring jmx options
+[source,yaml,subs=attributes+]
+----
+# ...
+jmxOptions:
+  enabled: true
+# ...
+----
+
+In the above example, the JMX port on the Kafka brokers are opened and then the metrics port on the kafka headless service
+is opened. This will allow you to deploy a pod internally into a cluster and address the JMX port on the kafka broker
+by performing `<name of kafka broker>-<name of headless service>`
+
+
+If nothing is specified, then it won't open up any ports on the kafka broker or the headless service.
+
+---

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1315,6 +1315,11 @@ spec:
                                 type: string
                               value:
                                 type: string
+                jmxMetrics:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
                 version:
                   type: string
               required:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1310,6 +1310,11 @@ spec:
                                 type: string
                               value:
                                 type: string
+                jmxMetrics:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
                 version:
                   type: string
               required:


### PR DESCRIPTION
Created a new field in the Kafka CRD which would allow you to enable the
JMX metrics on the kafka broker. When the field is specified, the kafka
broker starts up with port 9404 for the JMX. Then it exposes 9404 on the
kafka headless service to be able to collect the metrics.

Signed-off-by: Julian Goh <juliangohsl@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

