### PR TITLE
Make collision detection multi-platform

### DIFF
--- a/Makefile.os
+++ b/Makefile.os
@@ -2,6 +2,8 @@ FIND = find
 SED = sed
 GREP = grep
 CP = cp
+UNIQ = uniq
+SORT = sort
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -9,4 +11,6 @@ ifeq ($(UNAME_S),Darwin)
 	SED = gsed
 	GREP = ggrep
 	CP = gcp
+	UNIQ = guniq
+	SORT = gsort
 endif

--- a/docker-images/build.sh
+++ b/docker-images/build.sh
@@ -2,6 +2,7 @@
 set -e
 
 source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh
+source $(dirname $(realpath $0))/../multi-platform-support.sh
 
 # Image directories
 base_images="base"
@@ -127,7 +128,7 @@ function fetch_and_unpack_kafka_binaries {
         then
             unzipped_dir=`mktemp -d`
             ./extract-jars.sh "$dist_dir/libs" "$unzipped_dir"
-            ./find-colliding-classes.sh "$unzipped_dir" | awk '{print $1}' | sort | uniq > "$whilelist_file" || true
+            ./find-colliding-classes.sh "$unzipped_dir" | awk '{print $1}' | $SORT | $UNIQ > "$whilelist_file" || true
             rm -rf $unzipped_dir
         fi
     done

--- a/docker-images/find-colliding-classes.sh
+++ b/docker-images/find-colliding-classes.sh
@@ -2,15 +2,17 @@
 # $1: Directory containing (directories containing) .class files
 unzipped_dir=$1
 
+source $(dirname $(realpath $0))/../multi-platform-support.sh
+
 # compute list of <md5> <classfile>
 find $unzipped_dir ! -empty -type f -name '*.class' -a ! -name 'module-info.class' -exec md5sum {} + | \
   # split into <md5> <jarname> <classname>
-  sed -E 's#([a-z0-9]+).*/([^/]*[.]jar)/(.*)#\1\t\2\t\3#' | \
+  $SED -E 's#([a-z0-9]+).*/([^/]*[.]jar)/(.*)#\1\t\2\t\3#' | \
   # sort by classname
-  sort -r -k 3 | \
+  $SORT -r -k 3 | \
   # find duplicate classname
-  uniq -D -f2 | \
+  $UNIQ -D -f2 | \
   # swap column order => <classname> <jarname> <md5>
   awk '{printf("%s\t%s\t%s\n",$2,$3,$1);}' | \
   # find unique md5 (i.e. classfiles differ)
-  uniq -u -f2
+  $UNIQ -u -f2

--- a/multi-platform-support.sh
+++ b/multi-platform-support.sh
@@ -10,6 +10,8 @@ CP=cp
 SED=sed
 GREP=grep
 WC=wc
+UNIQ=uniq
+SORT=sort
 
 UNAME_S=$(uname -s)
 if [ $UNAME_S = "Darwin" ];
@@ -20,4 +22,6 @@ then
     SED=gsed
     GREP=ggrep
     WC=gwc
+    UNIQ=guniq
+    SORT=gsort
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

PR #2253 added support for detection classes which are included in the docker images multiple times through 3rd party dependencies. But it didn't make the stuff multiplatform - it is using tools such as `sort` or `uniq` which are different on BSD like sstems (MacOS) and GNU (Linux). This PR fixes this by using the multiplatform support already used in many other scripts.