### PR TITLE
Fix Max Heap estimation detection on Java 11

### DIFF
--- a/docker-images/kafka/scripts/dynamic_resources.sh
+++ b/docker-images/kafka/scripts/dynamic_resources.sh
@@ -4,7 +4,7 @@ function get_heap_size {
   FRACTION=$1
   MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
-  MAX_POSSIBLE_HEAP=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
+  MAX_POSSIBLE_HEAP=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
     |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When building and running the images with Java 11, the max heap detection doesn't work in the Kafka / Zookeeper pods. This happens when the memeory limit / requests are set and the -Xmx / -Xms options are supposed to be auto-detected.

The problem is that Java 11 doesn't support anymore the `-XX:+UseCGroupMemoryLimitForHeap` option. This PR replaces it with `-XX:+UseContainerSupport` which seems to work fine on our latest Java 8 builds and Java 11 builds and fixes the problem.

@tombentley Out of curiosity - why do we seem to have different version of the `dynamic_resources.sh` script for the Kafka based containers and for the operator containers? Would it make sense to use the same logic for both?