### PR TITLE
Fix lock management issue with early lock release - Closes #2260

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -179,8 +179,8 @@ public abstract class AbstractOperator<
                             handler.fail(callableRes.cause());
                         }
 
-                        log.debug("{}: Lock {} released", reconciliation, lockName);
                         lock.release();
+                        log.debug("{}: Lock {} released", reconciliation, lockName);
                     });
                 } catch (Throwable ex) {
                     lock.release();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #2260, the Connector Operator PR broke the locking mechanism for ensuring multiple reconciliation of the same CR would never run in parallel.

This PR releases the lock only in exception or after the callable finishs and returns some result.

This PR should fix the issue #2260.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging