### PR TITLE
Remove hardcoded timeouts

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -253,7 +253,7 @@ public class KafkaRoller {
                         log.debug("Pod {} is controller and there are other pods to roll", podId);
                         throw new ForceableProblem("Pod " + podName(podId) + " is currently the controller and there are other pods still to roll");
                     } else {
-                        if (canRoll(adminClient, podId, 1_000, TimeUnit.MILLISECONDS)) {
+                        if (canRoll(adminClient, podId, 60_000, TimeUnit.MILLISECONDS)) {
                             log.debug("Pod {} can be rolled now", podId);
                             restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -253,7 +253,7 @@ public class KafkaRoller {
                         log.debug("Pod {} is controller and there are other pods to roll", podId);
                         throw new ForceableProblem("Pod " + podName(podId) + " is currently the controller and there are other pods still to roll");
                     } else {
-                        if (canRoll(adminClient, podId, operationTimeoutMs, TimeUnit.MILLISECONDS)) {
+                        if (canRoll(adminClient, podId, 1_000, TimeUnit.MILLISECONDS)) {
                             log.debug("Pod {} can be rolled now", podId);
                             restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                         } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Refactoring

### Description
Removing hardcoded timeouts for operations. Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2262

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

