### PR TITLE
[MO] - [fix] -> adding control of available connect service

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -35,6 +35,13 @@ public class KafkaConnectUtils {
         LOGGER.info("Kafka Connector {} is ready", name);
     }
 
+    public static void waitUntilKafkaConnectRestApiIsAvailable(String podNamePrefix) {
+        LOGGER.info("Waiting until kafka connect service is present");
+        TestUtils.waitFor("Waiting until kafka connect service is present", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
+            () -> cmdKubeClient().execInPod(podNamePrefix, "/bin/bash", "-c", "curl -I http://localhost:8083/connectors").out().contains("HTTP/1.1 200 OK\n"));
+        LOGGER.info("Kafka connect service is present");
+    }
+
     public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String message) {
         LOGGER.info("Waiting for messages in file sink");
         TestUtils.waitFor("messages in file sink", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_SEND_RECEIVE_MSG,

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -143,6 +143,8 @@ class ConnectST extends AbstractST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
+        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME);
 
         waitForClusterAvailability(NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, 2);
@@ -329,6 +331,8 @@ class ConnectST extends AbstractST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
         String kafkaConnectLogs = kubeClient().logs(kafkaConnectPodName);
+
+        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
         LOGGER.info("Verifying that in kafka connect logs are everything fine");
         assertThat(kafkaConnectLogs, not(containsString("ERROR")));

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -143,7 +143,7 @@ class ConnectST extends AbstractST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
-        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME);
 
@@ -332,7 +332,7 @@ class ConnectST extends AbstractST {
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
         String kafkaConnectLogs = kubeClient().logs(kafkaConnectPodName);
 
-        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
         LOGGER.info("Verifying that in kafka connect logs are everything fine");
         assertThat(kafkaConnectLogs, not(containsString("ERROR")));

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -132,7 +132,7 @@ public class OauthPlainST extends OauthBaseST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
-        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -132,6 +132,8 @@ public class OauthPlainST extends OauthBaseST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
+        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
 
         String message = "Hello world - " + END_MESSAGE_OFFSET;

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -139,7 +139,7 @@ public class OauthTlsST extends OauthBaseST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
-        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -139,6 +139,8 @@ public class OauthTlsST extends OauthBaseST {
 
         String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
 
+        StUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+
         KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
 
         String message = "Hello world - " + END_MESSAGE_OFFSET;


### PR DESCRIPTION
Signed-off-by: Seequick1 <morsak@redhat.com>

### Type of change

- Bugfix

### Description

The tests using Kafka connect is flaky in case of creating connector, which sometimes was created and sometimes not. In our test cases we were not waiting until service is present. This problem will resolve problem.

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass
