### PR TITLE
Fix filenames and locations for CO logs and pod dumps

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -152,10 +152,11 @@ for pod in $pods; do
 done;
 
 # getting CO deployment from the pod
+$platform get deployment strimzi-cluster-operator -o yaml -n $namespace > $direct/reports/deployments/cluster-operator.yaml
+$platform get pod -l strimzi.io/kind=cluster-operator -o yaml -n $namespace > $direct/reports/pods/cluster-operator.yaml
 co_pod=$($platform get pod -l strimzi.io/kind=cluster-operator -o name -n $namespace)
-$platform get pod -l strimzi.io/kind=cluster-operator -o yaml -n $namespace > $direct/reports/deployments/cluster-operator.yaml
-$platform logs $co_pod -n $namespace > $direct/reports/podLogs/cluster-operator.yaml
-$platform logs $co_pod -p -n $namespace 2>/dev/null > $direct/reports/podLogs/previous-cluster-operator.yaml
+$platform logs $co_pod -n $namespace > $direct/reports/podLogs/cluster-operator.log
+$platform logs $co_pod -p -n $namespace 2>/dev/null > $direct/reports/podLogs/previous-cluster-operator.log
 
 # getting CO replicaset
 co_rs=$($platform get replicaset -l strimzi.io/kind=cluster-operator -o name -n $namespace)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `report.sh` tool seems to currently dump CO logs into file with the YAML extension and pod YAML into `deployments`. This PR fixes the names, path and adds additional dump of the CO deployment.

