### PR TITLE
ST: Add clients with consume/produce to upgrade tests

### DIFF
--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -145,14 +145,50 @@
   },
   {
     "fromVersion":"0.14.0",
-    "toVersion":"HEAD",
+    "toVersion":"0.15.0",
     "fromExamples":"strimzi-0.14.0",
-    "toExamples":"HEAD",
+    "toExamples":"strimzi-0.15.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-0.14.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
+    "imagesBeforeKafkaUpdate": {
+      "zookeeper": "strimzi/kafka:0.15.0-kafka-2.3.1",
+      "kafka": "strimzi/kafka:0.15.0-kafka-2.3.0",
+      "topicOperator": "strimzi/operator:0.15.0",
+      "userOperator": "strimzi/operator:0.15.0"
+    },
+    "imagesAfterKafkaUpdate": {
+      "zookeeper": "strimzi/kafka:0.15.0-kafka-2.3.1",
+      "kafka": "strimzi/kafka:0.15.0-kafka-2.3.1",
+      "topicOperator": "strimzi/operator:0.15.0",
+      "userOperator": "strimzi/operator:0.15.0"
+    },
+    "proceduresBefore": {
+      "kafkaVersion": "",
+      "logMessageVersion": ""
+    },
+    "proceduresAfter": {
+      "kafkaVersion": "2.3.1",
+      "logMessageVersion": ""
+    },
+    "client": {
+      "beforeKafkaUpdate": "strimzi/test-client:0.14.0-kafka-2.3.0",
+      "afterKafkaUpdate": "strimzi/test-client:0.15.0-kafka-2.3.1"
+    },
+    "supportedK8sVersion": {
+      "version": "latest",
+      "reason" : "Test is working on all environment used by QE."
+    }
+  },
+  {
+    "fromVersion":"0.15.0",
+    "toVersion":"HEAD",
+    "fromExamples":"strimzi-0.15.0",
+    "toExamples":"HEAD",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.15.0/strimzi-0.15.0.zip",
     "urlTo":"HEAD",
     "imagesBeforeKafkaUpdate": {
-      "zookeeper": "strimzi/kafka:latest-kafka-2.3.0",
-      "kafka": "strimzi/kafka:latest-kafka-2.3.0",
+      "zookeeper": "strimzi/kafka:latest-kafka-2.3.1",
+      "kafka": "strimzi/kafka:latest-kafka-2.3.1",
       "topicOperator": "strimzi/operator:latest",
       "userOperator": "strimzi/operator:latest"
     },
@@ -171,7 +207,7 @@
       "logMessageVersion": ""
     },
     "client": {
-      "beforeKafkaUpdate": "strimzi/test-client:0.14.0-kafka-2.3.0",
+      "beforeKafkaUpdate": "strimzi/test-client:0.15.0-kafka-2.3.1",
       "afterKafkaUpdate": "strimzi/test-client:latest-kafka-2.3.1"
     },
     "supportedK8sVersion": {

--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -63,7 +63,7 @@
       "logMessageVersion": "2.2"
     },
     "client": {
-      "beforeKafkaUpdate": "strimzi/test-client:0.11.4-kafka-2.1.0",
+      "beforeKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
       "afterKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.2.1"
     },
     "supportedK8sVersion": {

--- a/systemtest/src/test/java/io/strimzi/systemtest/MessagingBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MessagingBaseST.java
@@ -136,7 +136,11 @@ public class MessagingBaseST extends AbstractST {
         ClientArgumentMap consumerArguments = new ClientArgumentMap();
         consumerArguments.put(ClientArgument.BROKER_LIST, bootstrapServer);
         consumerArguments.put(ClientArgument.GROUP_ID, "my-group" + rng.nextInt(Integer.MAX_VALUE));
-        if (allowParameter("2.3.0")) {
+
+        String image = kubeClient().getPod(podName).getSpec().getContainers().get(0).getImage();
+        String clientVersion = image.substring(image.length() - 5);
+
+        if (allowParameter("2.3.0", clientVersion)) {
             consumerArguments.put(ClientArgument.GROUP_INSTANCE_ID, "instance" + rng.nextInt(Integer.MAX_VALUE));
         }
         consumerArguments.put(ClientArgument.VERBOSE, "");
@@ -174,9 +178,9 @@ public class MessagingBaseST extends AbstractST {
                 sent == received);
     }
 
-    private boolean allowParameter(String minimalVersion) {
+    private boolean allowParameter(String minimalVersion, String clientVersion) {
         Pattern pattern = Pattern.compile("(?<major>[0-9]).(?<minor>[0-9]).(?<micro>[0-9])");
-        Matcher current = pattern.matcher(Environment.ST_KAFKA_VERSION);
+        Matcher current = pattern.matcher(clientVersion);
         Matcher minimal = pattern.matcher(minimalVersion);
         if (current.find() && minimal.find()) {
             return Integer.parseInt(current.group("major")) >= Integer.parseInt(minimal.group("major"))

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -105,7 +105,7 @@ public class StrimziUpgradeST extends MessagingBaseST {
             Thread.sleep(10000);
 
             // Deploy clients and exchange messages
-            KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get();
+            KafkaUser kafkaUser = TestUtils.fromYamlString(cmdKubeClient().getResourceAsYaml("kafkauser", userName), KafkaUser.class);
             deployClients(parameters.getJsonObject("client").getString("beforeKafkaUpdate"), kafkaUser);
 
             final String defaultKafkaClientsPodName =

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.logs.LogCollector;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
-import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.LogCollector;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -12,6 +12,10 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.logs.LogCollector;
 import io.strimzi.systemtest.utils.FileUtils;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.utils.LogCollector;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -43,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(UPGRADE)
-public class StrimziUpgradeST extends AbstractST {
+public class StrimziUpgradeST extends MessagingBaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(StrimziUpgradeST.class);
 
@@ -68,6 +72,9 @@ public class StrimziUpgradeST extends AbstractST {
         File kafkaEphemeralYaml = null;
         File kafkaTopicYaml = null;
         File kafkaUserYaml = null;
+        String kafkaClusterName = "my-cluster";
+        String topicName = "my-topic";
+        String userName = "my-user";
 
         try {
             String url = parameters.getString("urlFrom");
@@ -93,6 +100,20 @@ public class StrimziUpgradeST extends AbstractST {
             kafkaUserYaml = new File(dir, parameters.getString("fromExamples") + "/examples/user/kafka-user.yaml");
             cmdKubeClient().create(kafkaUserYaml);
 
+            // Wait until user will be created
+            // We cannot use utils wait for that, because in older version there were no status field for CRs
+            Thread.sleep(10000);
+
+            // Deploy clients and exchange messages
+            KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get();
+            deployClients(parameters.getJsonObject("client").getString("beforeKafkaUpdate"), kafkaUser);
+
+            final String defaultKafkaClientsPodName =
+                    kubeClient().listPodsByPrefixInName(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+            int sent = sendMessages(50, kafkaClusterName, true, topicName, kafkaUser, defaultKafkaClientsPodName);
+            int received = receiveMessages(50, kafkaClusterName, true, topicName, kafkaUser, defaultKafkaClientsPodName);
+            assertSentAndReceivedMessages(sent, received);
+
             makeSnapshots();
             logPodImages();
             // Execution of required procedures before upgrading CO
@@ -100,8 +121,8 @@ public class StrimziUpgradeST extends AbstractST {
 
             // Upgrade the CO
             // Modify + apply installation files
+            LOGGER.info("Going to update CO from {} to {}", parameters.getString("fromVersion"), parameters.getString("toVersion"));
             if ("HEAD" .equals(parameters.getString("toVersion"))) {
-                LOGGER.info("Updating");
                 coDir = new File("../install/cluster-operator");
                 upgradeClusterOperator(coDir, parameters.getJsonObject("imagesBeforeKafkaUpdate"));
             } else {
@@ -119,18 +140,38 @@ public class StrimziUpgradeST extends AbstractST {
             logPodImages();
             checkAllImages(parameters.getJsonObject("imagesAfterKafkaUpdate"));
 
+            // Delete old clients
+            kubeClient().deleteDeployment(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS);
+            StUtils.waitForDeploymentDeletion(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS);
+
+            deployClients(parameters.getJsonObject("client").getString("afterKafkaUpdate"), kafkaUser);
+
+            final String afterUpgradeKafkaClientsPodName =
+                    kubeClient().listPodsByPrefixInName(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+            received = receiveMessages(50, kafkaClusterName, true, topicName, kafkaUser, afterUpgradeKafkaClientsPodName);
+            assertSentAndReceivedMessages(sent, received);
+
             // Check errors in CO log
             assertNoCoErrorsLogged(0);
 
             // Tidy up
         } catch (KubeClusterException e) {
-            if (kafkaEphemeralYaml != null) {
-                cmdKubeClient().delete(kafkaEphemeralYaml);
-            }
-            if (coDir != null) {
-                cmdKubeClient().delete(coDir);
-            }
             e.printStackTrace();
+            try {
+                if (kafkaEphemeralYaml != null) {
+                    cmdKubeClient().delete(kafkaEphemeralYaml);
+                }
+            } catch (Exception ex) {
+                LOGGER.warn("Failed to delete resources: {}", kafkaEphemeralYaml.getName());
+            }
+            try {
+                if (coDir != null) {
+                    cmdKubeClient().delete(coDir);
+                }
+            } catch (Exception ex) {
+                LOGGER.warn("Failed to delete resources: {}", coDir.getName());
+            }
+
             throw e;
         } finally {
             // Get current date to create a unique folder
@@ -148,7 +189,7 @@ public class StrimziUpgradeST extends AbstractST {
 
     private void upgradeClusterOperator(File coInstallDir, JsonObject images) {
         copyModifyApply(coInstallDir);
-        LOGGER.info("Waiting for CO deployment");
+        LOGGER.info("Waiting for CO upgrade");
         DeploymentUtils.waitForDeploymentReady("strimzi-cluster-operator", 1);
         waitForRollingUpdate();
         checkAllImages(images);
@@ -169,10 +210,14 @@ public class StrimziUpgradeST extends AbstractST {
     private void deleteInstalledYamls(File root) {
         if (root != null) {
             Arrays.stream(Objects.requireNonNull(root.listFiles())).sorted().forEach(f -> {
-                if (f.getName().matches(".*RoleBinding.*")) {
-                    cmdKubeClient().deleteContent(TestUtils.changeRoleBindingSubject(f, NAMESPACE));
-                } else {
-                    cmdKubeClient().delete(f);
+                try {
+                    if (f.getName().matches(".*RoleBinding.*")) {
+                        cmdKubeClient().deleteContent(TestUtils.changeRoleBindingSubject(f, NAMESPACE));
+                    } else {
+                        cmdKubeClient().delete(f);
+                    }
+                } catch (Exception ex) {
+                    LOGGER.warn("Failed to delete resources: {}", f.getName());
                 }
             });
         }
@@ -239,8 +284,8 @@ public class StrimziUpgradeST extends AbstractST {
         List<Pod> pods1 = kubeClient().listPods(matchLabels);
         for (Pod pod : pods1) {
             if (!image.equals(pod.getSpec().getContainers().get(container).getImage())) {
-                LOGGER.debug("Expected image: {} \nCurrent image: {}", image, pod.getSpec().getContainers().get(container).getImage());
-                assertThat("Used image is not valid!", pod.getSpec().getContainers().get(container).getImage(), is(image));
+                LOGGER.debug("Expected image for pod {}: {} \nCurrent image: {}", pod.getMetadata().getName(), image, pod.getSpec().getContainers().get(container).getImage());
+                assertThat("Used image for pod " + pod.getMetadata().getName() + " is not valid!", pod.getSpec().getContainers().get(container).getImage(), is(image));
             }
         }
     }
@@ -283,6 +328,20 @@ public class StrimziUpgradeST extends AbstractST {
             LOGGER.info("Pod {} has image {}", pod.getMetadata().getName(), pod.getSpec().getContainers().get(0).getImage());
             LOGGER.info("Pod {} has image {}", pod.getMetadata().getName(), pod.getSpec().getContainers().get(1).getImage());
         }
+    }
+
+    void deployClients(String image, KafkaUser kafkaUser) {
+        // Deploy new clients
+        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, kafkaUser)
+            .editSpec()
+                .editTemplate()
+                    .editSpec()
+                        .editFirstContainer()
+                            .withImage(image)
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec().done();
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.logs.LogCollector;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
-import io.strimzi.systemtest.utils.LogCollector;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
@@ -141,7 +140,7 @@ public class StrimziUpgradeST extends MessagingBaseST {
 
             // Delete old clients
             kubeClient().deleteDeployment(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS);
-            StUtils.waitForDeploymentDeletion(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS);
+            DeploymentUtils.waitForDeploymentDeletion(kafkaClusterName + "-" + Constants.KAFKA_CLIENTS);
 
             deployClients(parameters.getJsonObject("client").getString("afterKafkaUpdate"), kafkaUser);
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

- Enhancement / new feature

### Description

Producers and consumers weren't used during upgrade. This PR deploy clients during upgrade, producer/consume messages before upgrade and then consume the same messages after upgrade.

Also I added there some try/catch blocks which allow us better debug in case of tests failure (no suppressed exceptions during delete phase).

### Checklist

- [x] Make sure all tests pass

