### PR TITLE
Reduce the log level for Zookeeper and Kafka in integration tests

### DIFF
--- a/topic-operator/src/test/resources/log4j2-test.properties
+++ b/topic-operator/src/test/resources/log4j2-test.properties
@@ -38,7 +38,3 @@ logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = WARN
 logger.zookeeper.additivity = false
 logger.zookeeper.appenderRef.console3.ref = ZOOKEEPER
-
-# Zookeeper Client is pretty verbose at INFO level, so for brevity use ERROR everywhere ...
-#logger.zkclient.name = org.I0Itec.zkclient
-#logger.zkclient=WARN

--- a/user-operator/src/test/resources/log4j2-test.properties
+++ b/user-operator/src/test/resources/log4j2-test.properties
@@ -20,11 +20,11 @@ appender.console2.layout.type = PatternLayout
 appender.console2.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [KAFKA] %-5p %c{1}:%L - %m%n
 
 logger.orgkafka.name = org.apache.kafka
-logger.orgkafka.level = INFO
+logger.orgkafka.level = WARN
 logger.orgkafka.additivity = false
 logger.orgkafka.appenderRef.console2.ref = KAFKA
 logger.kafka.name = kafka
-logger.kafka.level = INFO
+logger.kafka.level = WARN
 logger.kafka.additivity = false
 logger.kafka.appenderRef.console2.ref = KAFKA
 
@@ -35,10 +35,6 @@ appender.console3.layout.type = PatternLayout
 appender.console3.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [ZOOKEEPER] %-5p %c{1}:%L - %m%n
 
 logger.zookeeper.name = org.apache.zookeeper
-logger.zookeeper.level = INFO
+logger.zookeeper.level = WARN
 logger.zookeeper.additivity = false
 logger.zookeeper.appenderRef.console3.ref = ZOOKEEPER
-
-# Zookeeper Client is pretty verbose at INFO level, so for brevity use ERROR everywhere ...
-#logger.zkclient.name = org.I0Itec.zkclient
-#logger.zkclient=WARN

--- a/user-operator/src/test/resources/log4j2-test.properties
+++ b/user-operator/src/test/resources/log4j2-test.properties
@@ -20,11 +20,11 @@ appender.console2.layout.type = PatternLayout
 appender.console2.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [KAFKA] %-5p %c{1}:%L - %m%n
 
 logger.orgkafka.name = org.apache.kafka
-logger.orgkafka.level = WARN
+logger.orgkafka.level = INFO
 logger.orgkafka.additivity = false
 logger.orgkafka.appenderRef.console2.ref = KAFKA
 logger.kafka.name = kafka
-logger.kafka.level = WARN
+logger.kafka.level = INFO
 logger.kafka.additivity = false
 logger.kafka.appenderRef.console2.ref = KAFKA
 
@@ -35,7 +35,7 @@ appender.console3.layout.type = PatternLayout
 appender.console3.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [ZOOKEEPER] %-5p %c{1}:%L - %m%n
 
 logger.zookeeper.name = org.apache.zookeeper
-logger.zookeeper.level = WARN
+logger.zookeeper.level = INFO
 logger.zookeeper.additivity = false
 logger.zookeeper.appenderRef.console3.ref = ZOOKEEPER
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We are facing the issue that the Travis log is too big. And Travis terminates the job when the log is over 4MB. Most of the log file (~2MB) comes from the TO tests. most of it from Kafka used for the tests actually. This PR changes the log levels for KAfka and Zoo in TO and UO tests to WARN instead of INFO. That should safe us about 1,5-1.6MB of logs and give us more space. Additionally, I changed it to use other log patterns for KAfka and Zoo to make it easier to sdistinguish which log is from Kafka, Zoo and from Strimzi it self.