### PR TITLE
Convert storage size before considering resizing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -81,8 +81,8 @@ public class StorageDiff extends AbstractResourceDiff {
                     PersistentClaimStorage persistentCurrent = (PersistentClaimStorage) current;
                     PersistentClaimStorage persistentDesired = (PersistentClaimStorage) desired;
 
-                    long currentSize = parseMemory(persistentCurrent.getSize());
-                    long desiredSize = parseMemory(persistentDesired.getSize());
+                    long currentSize = StorageUtils.parseMemory(persistentCurrent.getSize());
+                    long desiredSize = StorageUtils.parseMemory(persistentDesired.getSize());
 
                     if (currentSize > desiredSize) {
                         shrinkSize = true;
@@ -135,86 +135,5 @@ public class StorageDiff extends AbstractResourceDiff {
      */
     public boolean shrinkSize() {
         return shrinkSize;
-    }
-
-    /**
-     * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
-     * into the equivalent number of bytes represented as a long.
-     *
-     * @param size The String representation of the volume size.
-     * @return The equivalent number of bytes.
-     */
-    public static long parseMemory(String size) {
-        boolean seenE = false;
-        long factor = 1L;
-        int end = size.length();
-        for (int i = 0; i < size.length(); i++) {
-            char ch = size.charAt(i);
-            if (ch == 'e') {
-                seenE = true;
-            } else if (ch < '0' || '9' < ch) {
-                end = i;
-                factor = memoryFactor(size.substring(i));
-                break;
-            }
-        }
-        long result;
-        if (seenE) {
-            result = (long) Double.parseDouble(size);
-        } else {
-            result = Long.parseLong(size.substring(0, end)) * factor;
-        }
-        return result;
-    }
-
-    /**
-     * Returns the factor which can be used to convert different units to bytes.
-     *
-     * @param suffix    The Unit which should be converted
-     * @return          The factor corresponding to the suffix unit
-     */
-    private static long memoryFactor(String suffix) {
-        long factor;
-        switch (suffix) {
-            case "E":
-                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L * 1_000L;
-                break;
-            case "P":
-                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L;
-                break;
-            case "T":
-                factor = 1_000L * 1_000L * 1_000L * 1_000;
-                break;
-            case "G":
-                factor = 1_000L * 1_000L * 1_000L;
-                break;
-            case "M":
-                factor = 1_000L * 1_000L;
-                break;
-            case "K":
-                factor = 1_000L;
-                break;
-            case "Ei":
-                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
-                break;
-            case "Pi":
-                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
-                break;
-            case "Ti":
-                factor = 1_024L * 1_024L * 1_024L * 1_024L;
-                break;
-            case "Gi":
-                factor = 1_024L * 1_024L * 1_024L;
-                break;
-            case "Mi":
-                factor = 1_024L * 1_024L;
-                break;
-            case "Ki":
-                factor = 1_024L;
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid memory suffix: " + suffix);
-        }
-        return factor;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+
+/**
+ * Shared methods for working with Storage - for example comparing volume sizes
+ */
+public class StorageUtils {
+    /**
+     * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
+     * into the equivalent number of bytes represented as a long.
+     *
+     * @param size The String representation of the volume size.
+     * @return The equivalent number of bytes.
+     */
+    public static long parseMemory(Quantity size) {
+        String amount = size.getAmount();
+        String format = size.getFormat();
+
+        if (format != null) {
+            return parseMemory(amount + format);
+        } else  {
+            return parseMemory(amount);
+        }
+    }
+
+    /**
+     * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
+     * into the equivalent number of bytes represented as a long.
+     *
+     * @param size The String representation of the volume size.
+     * @return The equivalent number of bytes.
+     */
+    public static long parseMemory(String size) {
+        boolean seenE = false;
+        long factor = 1L;
+        int end = size.length();
+        for (int i = 0; i < size.length(); i++) {
+            char ch = size.charAt(i);
+            if (ch == 'e') {
+                seenE = true;
+            } else if (ch < '0' || '9' < ch) {
+                end = i;
+                factor = memoryFactor(size.substring(i));
+                break;
+            }
+        }
+        long result;
+        if (seenE) {
+            result = (long) Double.parseDouble(size);
+        } else {
+            result = Long.parseLong(size.substring(0, end)) * factor;
+        }
+        return result;
+    }
+
+    /**
+     * Returns the factor which can be used to convert different units to bytes.
+     *
+     * @param suffix    The Unit which should be converted
+     * @return          The factor corresponding to the suffix unit
+     */
+    private static long memoryFactor(String suffix) {
+        long factor;
+        switch (suffix) {
+            case "E":
+                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L * 1_000L;
+                break;
+            case "P":
+                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L;
+                break;
+            case "T":
+                factor = 1_000L * 1_000L * 1_000L * 1_000;
+                break;
+            case "G":
+                factor = 1_000L * 1_000L * 1_000L;
+                break;
+            case "M":
+                factor = 1_000L * 1_000L;
+                break;
+            case "K":
+                factor = 1_000L;
+                break;
+            case "Ei":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Pi":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Ti":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Gi":
+                factor = 1_024L * 1_024L * 1_024L;
+                break;
+            case "Mi":
+                factor = 1_024L * 1_024L;
+                break;
+            case "Ki":
+                factor = 1_024L;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid memory suffix: " + suffix);
+        }
+        return factor;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
@@ -62,6 +61,7 @@ import io.strimzi.operator.cluster.model.KafkaUpgrade;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.StatusDiff;
+import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -1769,10 +1769,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             result.complete();
                         } else {
                             // The PVC is Bound and resizing is not in progress => We should check if the SC supports resizing and check if size changed
-                            Quantity currentSize = currentPvc.getSpec().getResources().getRequests().get("storage");
-                            Quantity desiredSize = desiredPvc.getSpec().getResources().getRequests().get("storage");
+                            Long currentSize = StorageUtils.parseMemory(currentPvc.getSpec().getResources().getRequests().get("storage"));
+                            Long desiredSize = StorageUtils.parseMemory(desiredPvc.getSpec().getResources().getRequests().get("storage"));
 
-                            if (!desiredSize.equals(currentSize))   {
+                            if (!currentSize.equals(desiredSize))   {
                                 // The sizes are different => we should resize (shrinking will be handled in StorageDiff, so we do not need to check that)
                                 resizePvc(currentPvc, desiredPvc).setHandler(result);
                             } else  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -237,21 +237,4 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(jbod, jbod2).shrinkSize(), is(false));
         assertThat(new StorageDiff(jbod, jbod3).shrinkSize(), is(true));
     }
-
-    @Test
-    public void testSizeConversion() {
-        assertThat(StorageDiff.parseMemory("100Gi"), is(100L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageDiff.parseMemory("100G"), is(100L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageDiff.parseMemory("100000Mi"), is(100_000L * 1_024L * 1_024L));
-        assertThat(StorageDiff.parseMemory("100000M"), is(100L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageDiff.parseMemory("100Ti"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageDiff.parseMemory("100T"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageDiff.parseMemory("100Pi"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageDiff.parseMemory("100P"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
-
-        assertThat(StorageDiff.parseMemory("100Gi") == StorageDiff.parseMemory("100Gi"), is(true));
-        assertThat(StorageDiff.parseMemory("1000Gi") > StorageDiff.parseMemory("100Gi"), is(true));
-        assertThat(StorageDiff.parseMemory("1000000Mi") > StorageDiff.parseMemory("100Gi"), is(true));
-        assertThat(StorageDiff.parseMemory("100Pi") > StorageDiff.parseMemory("100Gi"), is(true));
-    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StorageUtilsTest {
+    @Test
+    public void testSizeConversion() {
+        assertThat(StorageUtils.parseMemory("100Gi"), is(100L * 1_024L * 1_024L * 1_024L));
+        assertThat(StorageUtils.parseMemory("100G"), is(100L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.parseMemory("100000Mi"), is(100_000L * 1_024L * 1_024L));
+        assertThat(StorageUtils.parseMemory("100000M"), is(100L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.parseMemory("100Ti"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L));
+        assertThat(StorageUtils.parseMemory("100T"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.parseMemory("100Pi"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L));
+        assertThat(StorageUtils.parseMemory("100P"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
+
+        assertThat(StorageUtils.parseMemory("100Gi") == StorageUtils.parseMemory("100Gi"), is(true));
+        assertThat(StorageUtils.parseMemory("1000Gi") > StorageUtils.parseMemory("100Gi"), is(true));
+        assertThat(StorageUtils.parseMemory("1000000Mi") > StorageUtils.parseMemory("100Gi"), is(true));
+        assertThat(StorageUtils.parseMemory("100Pi") > StorageUtils.parseMemory("100Gi"), is(true));
+        assertThat(StorageUtils.parseMemory("1000G") == StorageUtils.parseMemory("1T"), is(true));
+    }
+
+    @Test
+    public void testQuantityConversion()    {
+        assertThat(StorageUtils.parseMemory(new Quantity("1000G")), is(1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.parseMemory(new Quantity("100Gi")), is(100L * 1_024L * 1_024L * 1_024L));
+
+        Quantity size = new Quantity("100", "Gi");
+        assertThat(StorageUtils.parseMemory(size), is(100L * 1_024L * 1_024L * 1_024L));
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Sometime, the requested size in the PVC is not the same as we entered there because Kubernetes convert the units. For example storage configuration of `1000G` in out custom resource can result into requested size `1T`. We currently compare the sizes basically only as a string when considering storage resizing. So we see that `1000G` are not equal to `1T` and start resizing. Because in reality there are the same numbers, no resizing really happens. But this can produce confusing log messages which suggest that we are resizing the storage.

This PR first converts the storage size to bytes (just a Long) before comparing them. This helps us to avoid this situation while still resizing the storage when needed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally