### PR TITLE
Fix resource deletion between test classes

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/BaseST.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest;
+
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.jupiter.api.TestInstance;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BaseST {
+
+    protected KubeClusterResource cluster = KubeClusterResource.getInstance();
+    protected static final String CLUSTER_NAME = "my-cluster";
+
+    /**
+     * Prepare environment for cluster operator which includes creation of namespaces, custom resources and operator
+     * specific config files such as ServiceAccount, Roles and CRDs.
+     * @param clientNamespace namespace which will be created and used as default by kube client
+     * @param namespaces list of namespaces which will be created
+     * @param resources list of path to yaml files with resources specifications
+     */
+    protected void prepareEnvForOperator(String clientNamespace, List<String> namespaces, String... resources) {
+        cluster.createNamespaces(clientNamespace, namespaces);
+        cluster.createCustomResources(resources);
+        cluster.applyClusterOperatorInstallFiles();
+    }
+
+    /**
+     * Prepare environment for cluster operator which includes creation of namespaces, custom resources and operator
+     * specific config files such as ServiceAccount, Roles and CRDs.
+     * @param clientNamespace namespace which will be created and used as default by kube client
+     * @param resources list of path to yaml files with resources specifications
+     */
+    protected void prepareEnvForOperator(String clientNamespace, String... resources) {
+        prepareEnvForOperator(clientNamespace, Collections.singletonList(clientNamespace), resources);
+    }
+
+    /**
+     * Prepare environment for cluster operator which includes creation of namespaces, custom resources and operator
+     * specific config files such as ServiceAccount, Roles and CRDs.
+     * @param clientNamespace namespace which will be created and used as default by kube client
+     */
+    protected void prepareEnvForOperator(String clientNamespace) {
+        prepareEnvForOperator(clientNamespace, Collections.singletonList(clientNamespace));
+    }
+
+    /**
+     * Clear cluster from all created namespaces and configurations files for cluster operator.
+     */
+    protected void teardownEnvForOperator() {
+        cluster.deleteCustomResources();
+        cluster.deleteClusterOperatorInstallFiles();
+        cluster.deleteNamespaces();
+    }
+
+    /**
+     * Recreate namespace and CO after test failure
+     * @param coNamespace namespace where CO will be deployed to
+     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
+     */
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_DEFAULT);
+    }
+
+    /**
+     * Recreate namespace and CO after test failure
+     * @param coNamespace namespace where CO will be deployed to
+     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to.
+     * @param operationTimeout timeout for CO operations
+     */
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces, long operationTimeout) {
+        ResourceManager.deleteMethodResources();
+        ResourceManager.deleteClassResources();
+
+        KubeClusterResource.getInstance().deleteCustomResources();
+        KubeClusterResource.getInstance().deleteClusterOperatorInstallFiles();
+        KubeClusterResource.getInstance().deleteNamespaces();
+
+        KubeClusterResource.getInstance().createNamespaces(coNamespace, bindingsNamespaces);
+        KubeClusterResource.getInstance().applyClusterOperatorInstallFiles();
+
+        ResourceManager.setClassResources();
+
+        applyRoleBindings(coNamespace, bindingsNamespaces);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(coNamespace, operationTimeout).done();
+    }
+
+    /**
+     * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
+     * @param namespace namespace where CO will be deployed to
+     * @param bindingsNamespaces list of namespaces where Bindings should be deployed to
+     */
+    public static void applyRoleBindings(String namespace, List<String> bindingsNamespaces) {
+        for (String bindingsNamespace : bindingsNamespaces) {
+            // 020-RoleBinding
+            KubernetesResource.roleBinding("../install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
+            // 021-ClusterRoleBinding
+            KubernetesResource.clusterRoleBinding("../install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
+            // 030-ClusterRoleBinding
+            KubernetesResource.clusterRoleBinding("../install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml", namespace, bindingsNamespace);
+            // 031-RoleBinding
+            KubernetesResource.roleBinding("../install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
+            // 032-RoleBinding
+            KubernetesResource.roleBinding("../install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml", namespace, bindingsNamespace);
+        }
+    }
+
+    /**
+     * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
+     * @param namespace namespace where CO will be deployed to
+     */
+    public static void applyRoleBindings(String namespace) {
+        applyRoleBindings(namespace, Collections.singletonList(namespace));
+    }
+
+    /**
+     * Method for apply Strimzi cluster operator specific Role and ClusterRole bindings for specific namespaces.
+     * @param namespace namespace where CO will be deployed to
+     * @param bindingsNamespaces array of namespaces where Bindings should be deployed to
+     */
+    public static void applyRoleBindings(String namespace, String... bindingsNamespaces) {
+        applyRoleBindings(namespace, Arrays.asList(bindingsNamespaces));
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -51,6 +51,11 @@ public class KafkaConnectResource {
         return deployKafkaConnect(defaultKafkaConnect(kafkaConnect, name, clusterName, kafkaConnectReplicas).build());
     }
 
+    public static KafkaConnectBuilder defaultKafkaConnect(String name, String kafkaClusterName, int kafkaConnectReplicas) {
+        KafkaConnect kafkaConnect = getKafkaConnectFromYaml(PATH_TO_KAFKA_CONNECT_CONFIG);
+        return defaultKafkaConnect(kafkaConnect, name, kafkaClusterName, kafkaConnectReplicas);
+    }
+
     private static KafkaConnectBuilder defaultKafkaConnect(KafkaConnect kafkaConnect, String name, String kafkaClusterName, int kafkaConnectReplicas) {
         return new KafkaConnectBuilder(kafkaConnect)
             .withNewMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -58,7 +58,7 @@ public class KafkaConnectResource {
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withClusterName(kafkaClusterName)
             .endMetadata()
-            .withNewSpec()
+            .editOrNewSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)
                 .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
                 .withReplicas(kafkaConnectReplicas)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
@@ -65,8 +66,11 @@ public class KafkaConnectResource {
             .endMetadata()
             .editOrNewSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)
-                .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
+                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterName))
                 .withReplicas(kafkaConnectReplicas)
+                .withNewTls()
+                    .withTrustedCertificates(new CertSecretSourceBuilder().withNewSecretName(kafkaClusterName + "-cluster-ca-cert").withCertificate("ca.crt").build())
+                .endTls()
             .endSpec();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -47,7 +47,7 @@ public class KafkaConnectS2IResource {
             .endMetadata()
             .editSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)
-                .withBootstrapServers(KafkaResources.plainBootstrapAddress(name))
+                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterName))
                 .withReplicas(kafkaConnectReplicas)
                 // Try it without TLS
                 .withNewTls()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -39,6 +39,16 @@ public class KafkaMirrorMakerResource {
         return deployKafkaMirrorMaker(defaultKafkaMirrorMaker(kafkaMirrorMaker, name, sourceBootstrapServer, targetBootstrapServer, groupId, mirrorMakerReplicas, tlsListener).build());
     }
 
+    public static KafkaMirrorMakerBuilder defaultKafkaMirrorMaker(String name,
+                                                                  String sourceBootstrapServer,
+                                                                  String targetBootstrapServer,
+                                                                  String groupId,
+                                                                  int kafkaMirrorMakerReplicas,
+                                                                  boolean tlsListener) {
+        KafkaMirrorMaker kafkaMirrorMaker = getKafkaMirrorMakerFromYaml(PATH_TO_KAFKA_MIRROR_MAKER_CONFIG);
+        return defaultKafkaMirrorMaker(kafkaMirrorMaker, name, sourceBootstrapServer, targetBootstrapServer, groupId, kafkaMirrorMakerReplicas, tlsListener);
+    }
+
     private static KafkaMirrorMakerBuilder defaultKafkaMirrorMaker(KafkaMirrorMaker kafkaMirrorMaker,
                                                                    String name,
                                                                    String sourceBootstrapServer,

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -83,6 +83,11 @@ public class KafkaResource {
             .build());
     }
 
+    public static KafkaBuilder defaultKafka(String name, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_EPHEMERAL_CONFIG);
+        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas);
+    }
+
     private static KafkaBuilder defaultKafka(Kafka kafka, String name, int kafkaReplicas, int zookeeperReplicas) {
         String tOImage = StUtils.changeOrgAndTag(ResourceManager.getImageValueFromCO("STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE"));
         String uOImage = StUtils.changeOrgAndTag(ResourceManager.getImageValueFromCO("STRIMZI_DEFAULT_USER_OPERATOR_IMAGE"));

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -40,7 +40,7 @@ public class KafkaTopicResource {
         return topic(defaultTopic(clusterName, topicName, partitions, replicas).build());
     }
 
-    private static KafkaTopicBuilder defaultTopic(String clusterName, String topicName, int partitions, int replicas) {
+    public static KafkaTopicBuilder defaultTopic(String clusterName, String topicName, int partitions, int replicas) {
         KafkaTopic kafkaTopic = getKafkaTopicFromYaml(PATH_TO_KAFKA_TOPIC_CONFIG);
         return new KafkaTopicBuilder(kafkaTopic)
             .withNewMetadata()
@@ -61,6 +61,11 @@ public class KafkaTopicResource {
             LOGGER.info("Created KafkaTopic {}", kt.getMetadata().getName());
             return waitFor(deleteLater(kt));
         });
+    }
+
+    public static KafkaTopic topicWithoutWait(KafkaTopic kafkaTopic) {
+        kafkaTopicClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(kafkaTopic);
+        return kafkaTopic;
     }
 
     private static KafkaTopic getKafkaTopicFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -46,7 +46,7 @@ public class KafkaUserResource {
             .build());
     }
 
-    private static KafkaUserBuilder defaultUser(String clusterName, String name) {
+    public static KafkaUserBuilder defaultUser(String clusterName, String name) {
         KafkaUser kafkaUser = getKafkaUserFromYaml(PATH_TO_KAFKA_USER_CONFIG);
         return new KafkaUserBuilder(kafkaUser)
             .withNewMetadata()
@@ -63,6 +63,11 @@ public class KafkaUserResource {
             LOGGER.info("Created KafkaUser {}", ku.getMetadata().getName());
             return waitFor(deleteLater(ku));
         });
+    }
+
+    public static KafkaUser kafkaUserWithoutWait(KafkaUser user) {
+        kafkaUserClient().inNamespace(ResourceManager.kubeClient().getNamespace()).createOrReplace(user);
+        return user;
     }
 
     private static KafkaUser getKafkaUserFromYaml(String yamlPath) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -182,6 +182,7 @@ class AllNamespaceST extends AbstractNamespaceST {
 
     @Override
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        teardownEnvForOperator();
         deployTestSpecificResources();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -36,6 +36,7 @@ import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
@@ -278,5 +279,10 @@ class ConnectS2IST extends MessagingBaseST {
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
         KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT,  Constants.RECONCILIATION_INTERVAL).done();
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
+        super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -100,7 +100,7 @@ class CustomResourceStatusST extends MessagingBaseST {
     void testKafkaUserStatusNotReady() {
         // Simulate NotReady state with userName longer than 64 characters
         String userName = "sasl-use-rabcdefghijklmnopqrstuvxyzabcdefghijklmnopqrstuvxyzabcdef";
-        KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+        KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, userName).build());
 
         String eoPodName = kubeClient().listPods("strimzi.io/name", KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME)).get(0).getMetadata().getName();
         KafkaUserUtils.waitForKafkaUserCreationError(userName, eoPodName);
@@ -215,7 +215,7 @@ class CustomResourceStatusST extends MessagingBaseST {
     @Test
     void testKafkaTopicStatusNotReady() {
         String topicName = "my-topic";
-        KafkaTopicResource.topic(CLUSTER_NAME, topicName, 1, 10).done();
+        KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10).build());
         waitForKafkaTopic("NotReady", topicName);
         assertKafkaTopicStatus(1, topicName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -209,7 +209,8 @@ class CustomResourceStatusST extends MessagingBaseST {
     @Test
     void testKafkaTopicStatus() {
         waitForKafkaTopic("Ready", TOPIC_NAME);
-        assertKafkaTopicStatus(1, TOPIC_NAME);
+        // The reason why we have there Observed Generation = 2 cause Kafka sync message.format.version when topic is created
+        assertKafkaTopicStatus(2, TOPIC_NAME);
     }
 
     @Test
@@ -225,10 +226,6 @@ class CustomResourceStatusST extends MessagingBaseST {
         ResourceManager.setClassResources();
         prepareEnvForOperator(NAMESPACE);
 
-        applyRoleBindings(NAMESPACE);
-        // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
-
         deployTestSpecificResources();
     }
 
@@ -239,6 +236,10 @@ class CustomResourceStatusST extends MessagingBaseST {
     }
 
     void deployTestSpecificResources() {
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
+
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -139,6 +139,6 @@ class RollingUpdateST extends BaseST {
 
         applyRoleBindings(NAMESPACE);
         // 050-Deployment
-        KubernetesResource.clusterOperator(NAMESPACE).done();
+        KubernetesResource.clusterOperator(NAMESPACE, Constants.CO_OPERATION_TIMEOUT_SHORT).done();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -777,7 +777,7 @@ class SecurityST extends MessagingBaseST {
 
         LOGGER.info("Kafka connect without config {} will not connect to {}:9093", "ssl.endpoint.identification.algorithm", ipOfBootstrapService);
 
-        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.kafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
+        KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
                 .editMetadata()
                     .addToLabels("type", "kafka-connect")
                 .endMetadata()
@@ -790,7 +790,7 @@ class SecurityST extends MessagingBaseST {
                     .endTls()
                     .withBootstrapServers(ipOfBootstrapService + ":9093")
                 .endSpec()
-                .done());
+                .build());
 
         PodUtils.waitUntilPodIsPresent(CLUSTER_NAME + "-connect");
 
@@ -835,7 +835,7 @@ class SecurityST extends MessagingBaseST {
         LOGGER.info("Mirror maker without config {} will not connect to consumer with address {}:9093", "ssl.endpoint.identification.algorithm", ipOfSourceBootstrapService);
         LOGGER.info("Mirror maker without config {} will not connect to producer with address {}:9093", "ssl.endpoint.identification.algorithm", ipOfTargetBootstrapService);
 
-        KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerWithoutWait(KafkaMirrorMakerResource.kafkaMirrorMaker(CLUSTER_NAME, sourceKafkaCluster, targetKafkaCluster,
+        KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerWithoutWait(KafkaMirrorMakerResource.defaultKafkaMirrorMaker(CLUSTER_NAME, sourceKafkaCluster, targetKafkaCluster,
                 "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, true)
                 .editMetadata()
                     .addToLabels("type", "kafka-mirror-maker")
@@ -860,7 +860,7 @@ class SecurityST extends MessagingBaseST {
                         .withBootstrapServers(ipOfTargetBootstrapService + ":9093")
                     .endProducer()
                 .endSpec()
-                .done());
+                .build());
 
         PodUtils.waitUntilPodIsPresent(CLUSTER_NAME + "-mirror-maker");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -65,7 +65,12 @@ class UserST extends BaseST {
                 "Ready");
 
         // Create sasl user with long name
-        KafkaUserResource.scramShaUser(CLUSTER_NAME, saslUserWithLongName).done();
+        KafkaUserResource.kafkaUserWithoutWait(KafkaUserResource.defaultUser(CLUSTER_NAME, saslUserWithLongName)
+            .editSpec()
+                .withNewKafkaUserScramSha512ClientAuthentication()
+                .endKafkaUserScramSha512ClientAuthentication()
+            .endSpec()
+            .build());
 
         KafkaUserUtils.waitUntilKafkaUserStatusConditionIsPresent(saslUserWithLongName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -114,12 +114,7 @@ public class SpecificST extends MessagingBaseST {
     @Test
     @Tag(REGRESSION)
     void testDeployUnsupportedKafka() {
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withVersion("6.6.6")
-                .endKafka()
-            .endSpec().done();
+        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1).build());
 
         LOGGER.info("Wait until Zookeeper stateful set is ready");
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -322,7 +322,7 @@ public class TracingST extends MessagingBaseST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -182,11 +182,12 @@ public class TracingST extends MessagingBaseST {
         configOfKafkaConnect.put("value.converter.schemas.enable", "false");
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
-                .editSpec()
+                .withNewSpec()
                     .withConfig(configOfKafkaConnect)
                     .withNewJaegerTracing()
                     .endJaegerTracing()
                     .withBootstrapServers(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
+                    .withReplicas(1)
                     .withNewTemplate()
                         .withNewConnectContainer()
                             .addNewEnv()

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -100,7 +100,7 @@ public class TracingST extends MessagingBaseST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -149,7 +149,7 @@ public class TracingST extends MessagingBaseST {
         configOfKafka.put("transaction.state.log.replication.factor", "1");
         configOfKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .editListeners()
@@ -240,7 +240,7 @@ public class TracingST extends MessagingBaseST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -379,7 +379,7 @@ public class TracingST extends MessagingBaseST {
         configOfSourceKafka.put("transaction.state.log.replication.factor", "1");
         configOfSourceKafka.put("transaction.state.log.min.isr", "1");
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfSourceKafka)
@@ -457,7 +457,7 @@ public class TracingST extends MessagingBaseST {
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfKafka)
@@ -475,7 +475,7 @@ public class TracingST extends MessagingBaseST {
                 .endSpec()
                 .done();
 
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1)
                 .editSpec()
                     .editKafka()
                         .withConfig(configOfKafka)
@@ -575,7 +575,7 @@ public class TracingST extends MessagingBaseST {
         final String kafkaClusterSourceName = CLUSTER_NAME + "-source";
         final String kafkaClusterTargetName = CLUSTER_NAME + "-target";
 
-        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 1, 1).editSpec().editKafka()
+        KafkaResource.kafkaEphemeral(kafkaClusterSourceName, 3, 1).editSpec().editKafka()
                         .editListeners()
                             .withNewKafkaListenerExternalNodePort()
                                 .withTls(false)
@@ -585,7 +585,7 @@ public class TracingST extends MessagingBaseST {
                 .endSpec()
                 .done();
 
-        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 1, 1).editSpec().editKafka()
+        KafkaResource.kafkaEphemeral(kafkaClusterTargetName, 3, 1).editSpec().editKafka()
                         .editListeners()
                             .withNewKafkaListenerExternalNodePort()
                                 .withTls(false)

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -79,7 +79,7 @@ public class TracingST extends MessagingBaseST {
     private static final String JAEGER_CONSUMER_SERVICE = "hello-world-consumer";
     private static final String JAEGER_KAFKA_STREAMS_SERVICE = "hello-world-streams";
     private static final String JAEGER_MIRROR_MAKER_SERVICE = "my-mirror-maker";
-    private static final String JAEGER_KAFKA_CONNECT_SERVICE = "my-target-connect";
+    private static final String JAEGER_KAFKA_CONNECT_SERVICE = "my-connect";
     private static final String JAEGER_KAFKA_CONNECT_S2I_SERVICE = "my-connect-s2i";
     private static final String JAEGER_KAFKA_BRIDGE_SERVICE = "my-kafka-bridge";
     private static final String BRIDGE_EXTERNAL_SERVICE = CLUSTER_NAME + "-bridge-external-service";
@@ -567,6 +567,7 @@ public class TracingST extends MessagingBaseST {
     }
 
     @Test
+    @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerMirrorMakerConnectStreamsService() throws Exception {
         Map<String, Object> configOfKafka = new HashMap<>();
         configOfKafka.put("offsets.topic.replication.factor", "1");
@@ -655,11 +656,12 @@ public class TracingST extends MessagingBaseST {
         configOfKafkaConnect.put("value.converter.schemas.enable", "false");
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
-                .editSpec()
+                .withNewSpec()
                     .withConfig(configOfKafkaConnect)
                     .withNewJaegerTracing()
                     .endJaegerTracing()
                     .withBootstrapServers(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
+                    .withReplicas(1)
                     .withNewTemplate()
                         .withNewConnectContainer()
                             .addNewEnv()

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -144,6 +144,18 @@ public class Exec {
      * @return execution results
      */
     public static ExecResult exec(String input, List<String> command, int timeout, boolean logToOutput) {
+        return exec(input, command, timeout, logToOutput, true);
+    }
+
+    /**
+     * Method executes external command
+     * @param command arguments for command
+     * @param timeout timeout for execution
+     * @param logToOutput log output or not
+     * @param throwErrors look for errors in output and throws exception if true
+     * @return execution results
+     */
+    public static ExecResult exec(String input, List<String> command, int timeout, boolean logToOutput, boolean throwErrors) {
         int ret = 1;
         ExecResult execResult;
         try {
@@ -159,7 +171,7 @@ public class Exec {
 
             execResult = new ExecResult(ret, executor.out(), executor.err());
 
-            if (ret != 0) {
+            if (throwErrors && ret != 0) {
                 String msg = "`" + join(" ", command) + "` got status code " + ret + " and stderr:\n------\n" + executor.stdErr + "\n------\nand stdout:\n------\n" + executor.stdOut + "\n------";
 
                 Matcher matcher = ERROR_PATTERN.matcher(executor.err());

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -95,6 +95,7 @@ public class KubeClusterResource {
     public void applyClusterOperatorInstallFiles() {
         timeMeasuringSystem.setTestName(testClass, testClass);
         timeMeasuringSystem.startOperation(Operation.CO_CREATION);
+        clusterOperatorConfigs.clear();
         Map<File, String> operatorFiles = Arrays.stream(new File(CO_INSTALL_DIR).listFiles()).sorted().filter(file ->
                 !file.getName().matches(".*(Binding|Deployment)-.*")
         ).collect(Collectors.toMap(file -> file, f -> TestUtils.getContent(f, TestUtils::toYamlString), (x, y) -> x, LinkedHashMap::new));
@@ -232,6 +233,7 @@ public class KubeClusterResource {
             cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
         }
         deploymentNamespaces.clear();
+        bindingsNamespaces.clear();
         LOGGER.info("Using namespace {}", testNamespace);
         setNamespace(testNamespace);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -233,7 +233,7 @@ public class KubeClusterResource {
             cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
         }
         deploymentNamespaces.clear();
-        bindingsNamespaces.clear();
+        bindingsNamespaces = null;
         LOGGER.info("Using namespace {}", testNamespace);
         setNamespace(testNamespace);
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -233,8 +233,8 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     @Override
-    public List<String> execInCurrentNamespace(String... commands) {
-        return namespacedCommand(commands);
+    public ExecResult execInCurrentNamespace(String... commands) {
+        return Exec.exec(namespacedCommand(commands));
     }
 
     enum ExType {

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -38,6 +40,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     private static final String CREATE = "create";
     private static final String APPLY = "apply";
     private static final String DELETE = "delete";
+    private static final String REPLACE = "replace";
 
     public static final String STATEFUL_SET = "statefulset";
     public static final String CM = "cm";
@@ -98,9 +101,12 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K create(File... files) {
         try (Context context = defaultContext()) {
-            KubeClusterException error = execRecursive(CREATE, files, Comparator.comparing(File::getName));
-            if (error != null) {
-                throw error;
+            Map<File, ExecResult> execResults = execRecursive(CREATE, files, Comparator.comparing(File::getName).reversed());
+            for (Map.Entry<File, ExecResult> entry : execResults.entrySet()) {
+                if (!entry.getValue().exitStatus()) {
+                    LOGGER.warn("Failed to create {}!", entry.getKey().getAbsolutePath());
+                    LOGGER.debug(entry.getValue().err());
+                }
             }
             return (K) this;
         }
@@ -110,9 +116,12 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K apply(File... files) {
         try (Context context = defaultContext()) {
-            KubeClusterException error = execRecursive(APPLY, files, Comparator.comparing(File::getName));
-            if (error != null) {
-                throw error;
+            Map<File, ExecResult> execResults = execRecursive(APPLY, files, Comparator.comparing(File::getName).reversed());
+            for (Map.Entry<File, ExecResult> entry : execResults.entrySet()) {
+                if (!entry.getValue().exitStatus()) {
+                    LOGGER.warn("Failed to apply {}!", entry.getKey().getAbsolutePath());
+                    LOGGER.debug(entry.getValue().err());
+                }
             }
             return (K) this;
         }
@@ -122,48 +131,48 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K delete(File... files) {
         try (Context context = defaultContext()) {
-            KubeClusterException error = execRecursive(DELETE, files, Comparator.comparing(File::getName).reversed());
-            if (error != null) {
-                throw error;
+            Map<File, ExecResult> execResults = execRecursive(DELETE, files, Comparator.comparing(File::getName).reversed());
+            for (Map.Entry<File, ExecResult> entry : execResults.entrySet()) {
+                if (!entry.getValue().exitStatus()) {
+                    LOGGER.warn("Failed to delete {}!", entry.getKey().getAbsolutePath());
+                    LOGGER.debug(entry.getValue().err());
+                }
             }
             return (K) this;
         }
     }
 
-    private KubeClusterException execRecursive(String subcommand, File[] files, Comparator<File> cmp) {
-        KubeClusterException error = null;
+    private Map<File, ExecResult> execRecursive(String subcommand, File[] files, Comparator<File> cmp) {
+        Map<File, ExecResult> execResults = new HashMap<>(25);
         for (File f : files) {
             if (f.isFile()) {
                 if (f.getName().endsWith(".yaml")) {
-                    try {
-                        Exec.exec(namespacedCommand(subcommand, "-f", f.getAbsolutePath()));
-                    } catch (KubeClusterException e) {
-                        if (error == null) {
-                            error = e;
-                        }
-                    }
+                    execResults.put(f, Exec.exec(null, namespacedCommand(subcommand, "-f", f.getAbsolutePath()), 0, false, false));
                 }
             } else if (f.isDirectory()) {
                 File[] children = f.listFiles();
                 if (children != null) {
                     Arrays.sort(children, cmp);
-                    KubeClusterException e = execRecursive(subcommand, children, cmp);
-                    if (error == null) {
-                        error = e;
-                    }
+                    execResults.putAll(execRecursive(subcommand, children, cmp));
                 }
             } else if (!f.exists()) {
                 throw new RuntimeException(new NoSuchFileException(f.getPath()));
             }
         }
-        return error;
+        return execResults;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public K replace(File... files) {
         try (Context context = defaultContext()) {
-            execRecursive("replace", files, (f1, f2) -> f1.getName().compareTo(f2.getName()));
+            Map<File, ExecResult> execResults = execRecursive(REPLACE, files, Comparator.comparing(File::getName));
+            for (Map.Entry<File, ExecResult> entry : execResults.entrySet()) {
+                if (!entry.getValue().exitStatus()) {
+                    LOGGER.warn("Failed to replace {}!", entry.getKey().getAbsolutePath());
+                    LOGGER.debug(entry.getValue().err());
+                }
+            }
             return (K) this;
         }
     }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -73,7 +73,7 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      */
     ExecResult execInPod(String pod, String... command);
 
-    List<String> execInCurrentNamespace(String... commands);
+    ExecResult execInCurrentNamespace(String... commands);
 
     /**
      * Execute the given {@code command} in the given {@code container} which is deployed in {@code pod}.


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

As part of our refactor, we forget to clear all resources after tests properly, especially in case of test failure. This PR fir this issue. Now, we all resources from previous tests should be properly deleted even during `recreateTestEnv`

### Checklist

- [x] Make sure all tests pass

