### PR TITLE
Allow overriding docker command (e.g. use podman), except travis

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -92,15 +92,20 @@ To configure the `docker_tag` and `docker_push` targets you can set following en
 
 When building the Docker images you can use an alternative JRE or use an alternate base image.
 
-#### Alternate Docker image JRE
+#### Alternative Docker image JRE
 
-The docker images can be built with an alternate java version by setting the environment variable `JAVA_VERSION`.  For example, to build docker images that have the java 11 JRE installed use `JAVA_VERSION=11 make docker_build`.  If not present, JAVA_VERSION is defaulted to **1.8.0**.
+The docker images can be built with an alternative java version by setting the environment variable `JAVA_VERSION`.  For example, to build docker images that have the java 11 JRE installed use `JAVA_VERSION=11 make docker_build`.  If not present, JAVA_VERSION is defaulted to **1.8.0**.
 
 If `JAVA_VERSION` environment variable is set, a profile in the parent pom.xml will set the `maven.compiler.source` and `maven.compiler.target` properties.
 
-#### Alternate Docker base image
+#### Alternative `docker` command
 
-The docker images can be built with an alternate container OS version by adding the environment variable `ALTERNATE_BASE`.  When this environment variable is set, for each component the build will look for a Dockerfile in the subdirectory named by `ALTERNATE_BASE`.  For example, to build docker images based on alpine, use `ALTERNATE_BASE=alpine make docker_build`.  Alternate docker images are an experimental feature not supported by the core Strimzi team.
+The build assumes the `docker` command is available on your `$PATH`. You can set the `DOCKER_CMD` environment variable to use a different `docker` binary or an alternative implementation such as [`podman`](https://podman.io/).
+
+#### Alternative Docker base image
+
+The docker images can be built with an alternative container OS version by adding the environment variable `ALTERNATE_BASE`.  When this environment variable is set, for each component the build will look for a Dockerfile in the subdirectory named by `ALTERNATE_BASE`.  For example, to build docker images based on alpine, use `ALTERNATE_BASE=alpine make docker_build`.  Alternative docker images are an experimental feature not supported by the core Strimzi team.
+
 
 ## Building Strimzi
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GITHUB_VERSION ?= master
 RELEASE_VERSION ?= latest
 CHART_PATH ?= ./helm-charts/strimzi-kafka-operator/
 CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
-DOCKER ?= docker
+DOCKER_CMD ?= docker
 
 ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GITHUB_VERSION ?= master
 RELEASE_VERSION ?= latest
 CHART_PATH ?= ./helm-charts/strimzi-kafka-operator/
 CHART_SEMANTIC_RELEASE_VERSION ?= $(shell cat ./release.version | tr A-Z a-z)
+DOCKER ?= docker
 
 ifneq ($(RELEASE_VERSION),latest)
   GITHUB_VERSION = $(RELEASE_VERSION)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -7,6 +7,7 @@
 # the registry where the image will be pushed (default is Docker Hub).
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 DOCKERFILE_DIR     ?= ./
+DOCKER             ?= docker
 DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
@@ -17,20 +18,20 @@ all: docker_build docker_push
 
 docker_build_default:
 	# Build Docker image ...
-	docker build $(DOCKER_BUILD_ARGS) --build-arg strimzi_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	$(DOCKER) build $(DOCKER_BUILD_ARGS) --build-arg strimzi_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
 #   But because we generate Kafka images for different versions we also need to tag with something
 #   including the kafka version number. This BUILD_TAG is used by the docker_tag target.
 	# Also tag with $(BUILD_TAG)
-	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+	$(DOCKER) tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
 
 docker_tag_default:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
-	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	$(DOCKER) tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_push_default: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
-	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_%: docker_%_default
 	@  true

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -7,7 +7,7 @@
 # the registry where the image will be pushed (default is Docker Hub).
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 DOCKERFILE_DIR     ?= ./
-DOCKER             ?= docker
+DOCKER_CMD         ?= docker
 DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
@@ -18,20 +18,20 @@ all: docker_build docker_push
 
 docker_build_default:
 	# Build Docker image ...
-	$(DOCKER) build $(DOCKER_BUILD_ARGS) --build-arg strimzi_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	$(DOCKER_CMD) build $(DOCKER_BUILD_ARGS) --build-arg strimzi_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
 #   But because we generate Kafka images for different versions we also need to tag with something
 #   including the kafka version number. This BUILD_TAG is used by the docker_tag target.
 	# Also tag with $(BUILD_TAG)
-	$(DOCKER) tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+	$(DOCKER_CMD) tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
 
 docker_tag_default:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
-	$(DOCKER) tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	$(DOCKER_CMD) tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_push_default: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
-	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	$(DOCKER_CMD) push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_%: docker_%_default
 	@  true

--- a/docker-images/find-classpath-collision.sh
+++ b/docker-images/find-classpath-collision.sh
@@ -2,14 +2,14 @@
 image=$1 #strimzi/kafka:latest-kafka-2.2.1
 image_jar_dir=$2 #/opt/kafka/libs
 whilelist_file=$3
-DOCKER=${DOCKER:-docker}
+DOCKER_CMD=${DOCKER_CMD:-docker}
 
 jars_dir=`mktemp -d`
 trap "[ -e $jars_dir ] && rm -rf $jars_dir" EXIT
 
-${DOCKER} run --name temp-container-name "$image" /bin/true || exit 2
-${DOCKER} cp "temp-container-name:$image_jar_dir" "$jars_dir"
-${DOCKER} rm temp-container-name > /dev/null
+${DOCKER_CMD} run --name temp-container-name "$image" /bin/true || exit 2
+${DOCKER_CMD} cp "temp-container-name:$image_jar_dir" "$jars_dir"
+${DOCKER_CMD} rm temp-container-name > /dev/null
 
 classes_root=`mktemp -d`
 trap "[ -e $classes_root ] && rm -rf $classes_root" EXIT

--- a/docker-images/find-classpath-collision.sh
+++ b/docker-images/find-classpath-collision.sh
@@ -2,13 +2,14 @@
 image=$1 #strimzi/kafka:latest-kafka-2.2.1
 image_jar_dir=$2 #/opt/kafka/libs
 whilelist_file=$3
+DOCKER=${DOCKER:-docker}
 
 jars_dir=`mktemp -d`
 trap "[ -e $jars_dir ] && rm -rf $jars_dir" EXIT
 
-docker run --name temp-container-name "$image" /bin/true || exit 2
-docker cp "temp-container-name:$image_jar_dir" "$jars_dir"
-docker rm temp-container-name > /dev/null
+${DOCKER} run --name temp-container-name "$image" /bin/true || exit 2
+${DOCKER} cp "temp-container-name:$image_jar_dir" "$jars_dir"
+${DOCKER} rm temp-container-name > /dev/null
 
 classes_root=`mktemp -d`
 trap "[ -e $classes_root ] && rm -rf $classes_root" EXIT


### PR DESCRIPTION
### Type of change

- Build

### Description

This PR allows people building strimzi to use a different `docker` than the one on their path, or to use something which supports the same CLI interface (e.g. `podman`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

