### PR TITLE
Fix namespace in resource watch when watching all namesapces

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
@@ -31,6 +31,7 @@ class OperatorWatcher<T extends HasMetadata> implements Watcher<T> {
     @Override
     public void eventReceived(Action action, T resource) {
         String name = resource.getMetadata().getName();
+        String namespace = resource.getMetadata().getNamespace();
         switch (action) {
             case ADDED:
             case DELETED:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There seems to be a bug in the Cluster Operator in 0.15.0. When the operator is deployed to watch all namespaces, it doesn't properly handle the virtual namespace in the watch `*` and call a reconciliation for it:

```
2019-12-09 15:03:09 INFO Main:125 - Cluster Operator verticle started in namespace *
2019-12-09 15:03:22 INFO OperatorWatcher:39 - Reconciliation #0(watch) Kafka(*/my-cluster): Kafka my-cluster in namespace * was ADDED
2019-12-09 15:03:22 WARN VersionUsageUtils:60 - The client is using resource type 'kafkas' with unstable version 'v1beta1'
2019-12-09 15:03:22 INFO AbstractOperator:135 - Reconciliation #0(watch) Kafka(*/my-cluster): Kafka my-cluster should be deleted
2019-12-09 15:03:22 INFO AbstractOperator:141 - Reconciliation #0(watch) Kafka(*/my-cluster): Assembly my-cluster should be deleted by garbage collection
2019-12-09 15:03:22 INFO AbstractOperator:248 - Reconciliation #0(watch) Kafka(*/my-cluster): reconciled
```

Only the next timed reconciliation will actually start a proper reconciliation. This does apply to all changes when the operator is deployed as cluster wide. Not just to added clusters.

While the timer based reconciliation always handles it eventually, this seems like fairly serious bug. Should we do 0.15.1 with it?

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally