### PR TITLE
Fixed KafkaBridge CRD test name

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -27,7 +27,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     public static final String NAMESPACE = "kafkabridge-crd-it";
 
     @Test
-    void testKafkaMirrorMakerV1alpha1() {
+    void testKafkaBridgeV1alpha1() {
         assumeKube1_11Plus();
         createDelete(KafkaBridge.class, "KafkaBridgeV1alpha1.yaml");
     }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Refactoring

### Description

To be honest the `testKafkaBridgeV1alpha1` doesn't actually make sense to be there currently, because `KafkaBridge` CRD is still alpha1. It will be needed when the CRD will move to beta1. By the way, I left the test there but at least fixing the name :-)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

