### PR TITLE
Fixed JMX KafkaCrdIT test for use on K8s 1.16+

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -50,11 +50,10 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml");
             });
 
-        String expectedString1 = "spec.bootstrapServers in body is required";
-        String expectedString2 = "spec.bootstrapServers: Required value";
-
         assertThat(exception.getMessage(),
-                anyOf(containsStringIgnoringCase(expectedString1), containsStringIgnoringCase(expectedString2)));
+                anyOf(
+                        containsStringIgnoringCase("spec.bootstrapServers in body is required"),
+                        containsStringIgnoringCase("spec.bootstrapServers: Required value")));
     }
 
     @Test
@@ -75,15 +74,13 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml");
             });
 
-        String expectedMsg1a = "spec.authentication.certificateAndKey.certificate in body is required";
-        String expectedMsg1b = "spec.authentication.certificateAndKey.key in body is required";
-
-        String expectedMsg2a = "spec.authentication.certificateAndKey.certificate: Required value";
-        String expectedMsg2b = "spec.authentication.certificateAndKey.key: Required value";
-
         assertThat(exception.getMessage(), anyOf(
-                allOf(containsStringIgnoringCase(expectedMsg1a), containsStringIgnoringCase(expectedMsg1b)),
-                allOf(containsStringIgnoringCase(expectedMsg2a), containsStringIgnoringCase(expectedMsg2b))));
+                allOf(
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate in body is required"),
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key in body is required")),
+                allOf(
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate: Required value"),
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key: Required value"))));
     }
 
     @Test
@@ -109,10 +106,9 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-wrong-tracing-type.yaml");
             });
 
-        String expectedMsg1 = "spec.tracing.type in body should be one of [jaeger]";
-        String expectedMsg2 = "spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\"";
-
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.tracing.type in body should be one of [jaeger]"),
+                containsStringIgnoringCase("spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\"")));
     }
 
     @Test
@@ -123,10 +119,9 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
             });
 
-        String expectedMsg1 = "spec.tracing.type in body is required";
-        String expectedMsg2 = "spec.tracing.type: Required value";
-
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.tracing.type in body is required"),
+                containsStringIgnoringCase("spec.tracing.type: Required value")));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -54,11 +54,10 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml");
             });
 
-        String expectedMsg1 = "spec.bootstrapServers in body is required";
-        String expectedMsg2 = "spec.bootstrapServers: Required value";
 
         assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+                containsStringIgnoringCase("spec.bootstrapServers in body is required"),
+                containsStringIgnoringCase("spec.bootstrapServers: Required value")));
     }
 
     @Test
@@ -91,15 +90,13 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
             });
 
-        String expectedMsg1a = "spec.authentication.certificateAndKey.certificate in body is required";
-        String expectedMsg1b = "spec.authentication.certificateAndKey.key in body is required";
-
-        String expectedMsg2a = "spec.authentication.certificateAndKey.certificate: Required value";
-        String expectedMsg2b = "spec.authentication.certificateAndKey.key: Required value";
-
         assertThat(exception.getMessage(), anyOf(
-                allOf(containsStringIgnoringCase(expectedMsg1a), containsStringIgnoringCase(expectedMsg1b)),
-                allOf(containsStringIgnoringCase(expectedMsg2a), containsStringIgnoringCase(expectedMsg2b))));
+                allOf(
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate in body is required"),
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key in body is required")),
+                allOf(
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate: Required value"),
+                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key: Required value"))));
     }
 
     @Test
@@ -125,11 +122,9 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml");
             });
 
-        String expectedMsg1 = "spec.externalConfiguration.env.valueFrom in body is required";
-        String expectedMsg2 = "spec.externalConfiguration.env.valueFrom: Required value";
-
         assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+                containsStringIgnoringCase("spec.externalConfiguration.env.valueFrom in body is required"),
+                containsStringIgnoringCase("spec.externalConfiguration.env.valueFrom: Required value")));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -155,8 +155,9 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-invalid-jmx-authentication.yaml");
             });
         String expectedMsg1 = "spec.kafka.jmxOptions.authentication.type in body should be one of [password]";
+        String expectedMsg2 = "spec.kafka.jmxOptions.authentication.type: Unsupported value: \"not-right\": supported values: \"password\"";
 
-        assertThat(exception.getMessage(), containsStringIgnoringCase(expectedMsg1));
+        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -56,15 +56,13 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-missing-required-property.yaml");
             });
 
-        String expectedMsg1a = "spec.zookeeper in body is required";
-        String expectedMsg1b = "spec.kafka in body is required";
-
-        String expectedMsg2a = "spec.kafka: Required value";
-        String expectedMsg2b = "spec.zookeeper: Required value";
-
         assertThat(exception.getMessage(), anyOf(
-                allOf(containsStringIgnoringCase(expectedMsg1a), containsStringIgnoringCase(expectedMsg1b)),
-                allOf(containsStringIgnoringCase(expectedMsg2a), containsStringIgnoringCase(expectedMsg2b))));
+                allOf(
+                        containsStringIgnoringCase("spec.zookeeper in body is required"),
+                        containsStringIgnoringCase("spec.kafka in body is required")),
+                allOf(
+                        containsStringIgnoringCase("spec.kafka: Required value"),
+                        containsStringIgnoringCase("spec.zookeeper: Required value"))));
     }
 
     @Test
@@ -85,9 +83,8 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-null-maintenance.yaml");
             });
 
-        String expectedMsg1 = "spec.maintenanceTimeWindows in body must be of type string: \"null\"";
-
-        assertThat(exception.getMessage(), containsStringIgnoringCase(expectedMsg1));
+        assertThat(exception.getMessage(),
+                containsStringIgnoringCase("spec.maintenanceTimeWindows in body must be of type string: \"null\""));
     }
 
     @Test
@@ -108,10 +105,9 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-tls-sidecar-invalid-loglevel.yaml");
             });
 
-        String expectedMsg1 = "spec.kafka.tlsSidecar.logLevel in body should be one of [emerg alert crit err warning notice info debug]";
-        String expectedMsg2 = "spec.kafka.tlsSidecar.logLevel: Unsupported value: \"invalid\": supported values: \"emerg\", \"alert\", \"crit\", \"err\", \"warning\", \"notice\", \"info\", \"debug\"";
-
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.kafka.tlsSidecar.logLevel in body should be one of [emerg alert crit err warning notice info debug]"),
+                containsStringIgnoringCase("spec.kafka.tlsSidecar.logLevel: Unsupported value: \"invalid\": supported values: \"emerg\", \"alert\", \"crit\", \"err\", \"warning\", \"notice\", \"info\", \"debug\"")));
     }
 
     @Test
@@ -127,10 +123,9 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-jbod-storage-on-zookeeper.yaml");
             });
 
-        String expectedMsg1 = "spec.zookeeper.storage.type in body should be one of [ephemeral persistent-claim]";
-        String expectedMsg2 = "spec.zookeeper.storage.type: Unsupported value: \"jbod\": supported values: \"ephemeral\", \"persistent-claim\"";
-
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.zookeeper.storage.type in body should be one of [ephemeral persistent-claim]"),
+                containsStringIgnoringCase("spec.zookeeper.storage.type: Unsupported value: \"jbod\": supported values: \"ephemeral\", \"persistent-claim\"")));
     }
 
     @Test
@@ -141,10 +136,9 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-invalid-storage.yaml");
             });
 
-        String expectedMsg1 = "spec.kafka.storage.type in body should be one of [ephemeral persistent-claim jbod]";
-        String expectedMsg2 = "spec.kafka.storage.type: Unsupported value: \"foobar\": supported values: \"ephemeral\", \"persistent-claim\", \"jbod\"";
-
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.kafka.storage.type in body should be one of [ephemeral persistent-claim jbod]"),
+                containsStringIgnoringCase("spec.kafka.storage.type: Unsupported value: \"foobar\": supported values: \"ephemeral\", \"persistent-claim\", \"jbod\"")));
     }
 
     @Test
@@ -154,10 +148,10 @@ public class KafkaCrdIT extends AbstractCrdIT {
             () -> {
                 createDelete(Kafka.class, "Kafka-with-invalid-jmx-authentication.yaml");
             });
-        String expectedMsg1 = "spec.kafka.jmxOptions.authentication.type in body should be one of [password]";
-        String expectedMsg2 = "spec.kafka.jmxOptions.authentication.type: Unsupported value: \"not-right\": supported values: \"password\"";
 
-        assertThat(exception.getMessage(), anyOf(containsStringIgnoringCase(expectedMsg1), containsStringIgnoringCase(expectedMsg2)));
+        assertThat(exception.getMessage(), anyOf(
+                containsStringIgnoringCase("spec.kafka.jmxOptions.authentication.type in body should be one of [password]"),
+                containsStringIgnoringCase("spec.kafka.jmxOptions.authentication.type: Unsupported value: \"not-right\": supported values: \"password\"")));
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -55,23 +55,15 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
                 createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-missing-required-property.yaml");
             });
 
-        String expectedMsg1a = "spec.consumer.bootstrapServers in body is required";
-        String expectedMsg1b = "spec.producer in body is required";
-        String expectedMsg1c = "spec.whitelist in body is required";
-
-        String expectedMsg2a = "spec.consumer.bootstrapServers: Required value";
-        String expectedMSg2b = "spec.whitelist: Required value";
-        String expectedMsg2c = "spec.producer: Required value";
-
         assertThat(exception.getMessage(), anyOf(
                 allOf(
-                        containsStringIgnoringCase(expectedMsg1a),
-                        containsStringIgnoringCase(expectedMsg1b),
-                        containsStringIgnoringCase(expectedMsg1c)),
+                        containsStringIgnoringCase("spec.consumer.bootstrapServers in body is required"),
+                        containsStringIgnoringCase("spec.producer in body is required"),
+                        containsStringIgnoringCase("spec.whitelist in body is required")),
                 allOf(
-                        containsStringIgnoringCase(expectedMsg2a),
-                        containsStringIgnoringCase(expectedMSg2b),
-                        containsStringIgnoringCase(expectedMsg2c))
+                        containsStringIgnoringCase("spec.consumer.bootstrapServers: Required value"),
+                        containsStringIgnoringCase("spec.whitelist: Required value"),
+                        containsStringIgnoringCase("spec.producer: Required value"))
                 ));
     }
 
@@ -93,21 +85,14 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
                 createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
             });
 
-        String expectedMsg1a = "spec.producer.authentication.certificateAndKey.certificate in body is required";
-        String expectedMsg1b = "spec.producer.authentication.certificateAndKey.key in body is required";
-
-        String expectedMsg2a = "spec.producer.authentication.certificateAndKey.certificate: Required value";
-        String expectedMSg2b = "spec.producer.authentication.certificateAndKey.key: Required value";
-        String expectedMsg2c = "spec.whitelist: Required value";
-
         assertThat(exception.getMessage(), anyOf(
                 allOf(
-                        containsStringIgnoringCase(expectedMsg1a),
-                        containsStringIgnoringCase(expectedMsg1b)),
+                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.certificate in body is required"),
+                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.key in body is required")),
                 allOf(
-                        containsStringIgnoringCase(expectedMsg2a),
-                        containsStringIgnoringCase(expectedMSg2b),
-                        containsStringIgnoringCase(expectedMsg2c))
+                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.certificate: Required value"),
+                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.key: Required value"),
+                        containsStringIgnoringCase("spec.whitelist: Required value"))
         ));
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -54,17 +54,13 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
                 createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml");
             });
 
-        String expectedMsg1a = "spec.partitions in body is required";
-        String expectedMsg1b = "spec.replicas in body is required";
-        String expectedMsg2a = "spec.partitions: Required value";
-        String expectedMsg2b = "spec.replicas: Required value";
         assertThat(exception.getMessage(), anyOf(
                 allOf(
-                        containsStringIgnoringCase(expectedMsg1a),
-                        containsStringIgnoringCase(expectedMsg1b)),
+                        containsStringIgnoringCase("spec.partitions in body is required"),
+                        containsStringIgnoringCase("spec.replicas in body is required")),
                 allOf(
-                        containsStringIgnoringCase(expectedMsg2a),
-                        containsStringIgnoringCase(expectedMsg2b))
+                        containsStringIgnoringCase("spec.partitions: Required value"),
+                        containsStringIgnoringCase("spec.replicas: Required value"))
                 ));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
Fixes the JMX test in the KafkaCrdIT so that it will pass on K8s 1.16 and above.

### Checklist

- [x] Make sure all tests pass

