### PR TITLE
Fix problems with app.kubernetes.io labels in TO and KafkaTopic CRs

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -351,8 +351,6 @@ class TopicOperator {
         }
     }
 
-    protected static final String KAFKA_TOPIC_OPERATOR_NAME = "strimzi-kafka-topic-operator";
-
     public TopicOperator(Vertx vertx, Kafka kafka,
                          K8s k8s,
                          TopicStore topicStore,

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicSerialization.java
@@ -131,12 +131,6 @@ class TopicSerialization {
         ObjectMeta om = topic.getMetadata();
         Map<String, String> lbls = new HashMap<>();
         lbls.putAll(labels.labels());
-        lbls.put(io.strimzi.operator.common.model.Labels.KUBERNETES_NAME_LABEL,
-            io.strimzi.operator.common.model.Labels.KUBERNETES_NAME);
-        lbls.put(io.strimzi.operator.common.model.Labels.KUBERNETES_INSTANCE_LABEL,
-            topic.getTopicName().toString());
-        lbls.put(io.strimzi.operator.common.model.Labels.KUBERNETES_MANAGED_BY_LABEL,
-            TopicOperator.KAFKA_TOPIC_OPERATOR_NAME);
         if (om != null) {
             om.setName(resourceName.toString());
             if (topic.getMetadata().getLabels() != null)

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -287,7 +287,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().get(0).getUid(), is(uid));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getAnnotations().size(), is(1));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getAnnotations().get("iam"), is("groot"));
-        assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().size(), is(5));
+        assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().size(), is(2));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("iam"), is("root"));
 
         // edit kafka topic
@@ -309,7 +309,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         topicResource = TopicSerialization.toTopicResource(topic3, labels);
         createKafkaTopicResource(topicResource);
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getOwnerReferences().get(0).getUid(), is(uid));
-        assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().size(), is(6));
+        assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().size(), is(3));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("stan"), is("lee"));
         assertThat(operation().inNamespace(NAMESPACE).withName(topicName).get().getMetadata().getLabels().get("iam"), is("root"));
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In 0.15.0 we added `app.kubernetes.io` labels to the Topic Operator which applies them on the KafkaTopic custom resources. This seems be causing issues:
* The custom resource in general is expected to belong and to be managed by a user application (the slight exception would be the KafkaTopics created by TO, but we should ignore that at least for the time being). We should let users set their own labels and not overwrite them.
* The labels need to work with all kind of topics - including those with names invalid for labels (e.g. longer than 63 characters, special characters on the beginning and end etc.). We should avoid breaking exceptions like this:
```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://172.20.0.1/apis/kafka.strimzi.io/v1beta1/namespaces/strimzi/kafkatopics/debezium-heartbeat.com.nutmeg.portfolio.cdc-holdings---5094fa1513e34efe64b32dc77449fcca54c5f4c1. Message: KafkaTopic.kafka.strimzi.io "debezium-heartbeat.com.nutmeg.portfolio.cdc-holdings---5094fa1513e34efe64b32dc77449fcca54c5f4c1" is invalid: metadata.labels: Invalid value: "__debezium-heartbeat.com.nutmeg.portfolio.cdc-holdings": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?').
```

To fix this, the PR:
* removes the labels `app.kubernetes.io` set by the 
* Lets users to set their own labels when desired.

While this solution might not be perfect, it seems to be the ost straight forward. It also mirrors our other CRs where we do not set any labels.

This PR addresses the TO only. It does not address the UO or CO.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally