### PR TITLE
ST: add upgrade chain test

### DIFF
--- a/systemtest/src/main/resources/StrimziUpgradeST.json
+++ b/systemtest/src/main/resources/StrimziUpgradeST.json
@@ -27,8 +27,9 @@
       "logMessageVersion": "2.1"
     },
     "client": {
-      "beforeKafkaUpdate": "strimzi/test-client:0.8.2-kafka-2.0.0",
-      "afterKafkaUpdate": "strimzi/test-client:0.11.4-kafka-2.1.0"
+      "beforeKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
+      "afterKafkaUpdate": "strimzi/test-client:0.12.1-kafka-2.1.0",
+      "reason": "0.8.2 and 0.11.4 test clients images are not compatible with current client execution mechanism in system tests"
     },
     "supportedK8sVersion": {
       "version": "1.11",

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -118,7 +118,7 @@ public class StrimziUpgradeST extends MessagingBaseST {
     }
 
     @Test
-    void strimziChainUpgrade() throws Exception {
+    void testChainUpgrade() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream inputStream = classLoader.getResourceAsStream("StrimziUpgradeST.json");
         JsonReader jsonReader = Json.createReader(inputStream);

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -209,6 +209,8 @@ public class StrimziUpgradeST extends MessagingBaseST {
 
         // Wait until user will be created
         SecretUtils.waitForSecretReady(userName);
+        TestUtils.waitFor("Kafka User " + userName + "availability", 10_000L, 120_000L,
+            () -> !cmdKubeClient().getResourceAsYaml("kafkauser", userName).equals(""));
 
         // Deploy clients and exchange messages
         KafkaUser kafkaUser = TestUtils.fromYamlString(cmdKubeClient().getResourceAsYaml("kafkauser", userName), KafkaUser.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/StrimziUpgradeST.java
@@ -11,6 +11,9 @@ import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.logs.LogCollector;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -22,12 +25,18 @@ import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import net.joshka.junit.json.params.JsonFileSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
 import java.io.File;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -58,6 +67,11 @@ public class StrimziUpgradeST extends MessagingBaseST {
     private Map<String, String> kafkaPods;
     private Map<String, String> eoPods;
 
+    private File coDir = null;
+    private File kafkaEphemeralYaml = null;
+    private File kafkaTopicYaml = null;
+    private File kafkaUserYaml = null;
+
     @ParameterizedTest()
     @JsonFileSource(resources = "/StrimziUpgradeST.json")
     void upgradeStrimziVersion(JsonObject parameters) throws Exception {
@@ -66,10 +80,7 @@ public class StrimziUpgradeST extends MessagingBaseST {
 
         LOGGER.info("Going to test upgrade of Cluster Operator from version {} to version {}", parameters.getString("fromVersion"), parameters.getString("toVersion"));
         cluster.setNamespace(NAMESPACE);
-        File coDir = null;
-        File kafkaEphemeralYaml = null;
-        File kafkaTopicYaml = null;
-        File kafkaUserYaml = null;
+
         String kafkaClusterName = "my-cluster";
         String topicName = "my-topic";
         String userName = "my-user";
@@ -185,6 +196,106 @@ public class StrimziUpgradeST extends MessagingBaseST {
         }
     }
 
+    @Test
+    void strimziChainUpgrade() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        InputStream inputStream = classLoader.getResourceAsStream("StrimziUpgradeST.json");
+        JsonReader jsonReader = Json.createReader(inputStream);
+        JsonArray parameters = jsonReader.readArray();
+
+        try {
+            for (JsonValue testParameters : parameters) {
+                if (StUtils.isAllowedOnCurrentK8sVersion(testParameters.asJsonObject().getJsonObject("supportedK8sVersion").getString("version"))) {
+                    performUpgrade(testParameters.asJsonObject());
+                } else {
+                    LOGGER.info("Upgrade of Cluster Operator from version {} to version {} is not allowed on this K8S version!", testParameters.asJsonObject().getString("fromVersion"), testParameters.asJsonObject().getString("toVersion"));
+                }
+            }
+        } catch (KubeClusterException e) {
+            if (kafkaEphemeralYaml != null) {
+                cmdKubeClient().delete(kafkaEphemeralYaml);
+            }
+            if (coDir != null) {
+                cmdKubeClient().delete(coDir);
+            }
+            e.printStackTrace();
+            throw e;
+        } finally {
+            // Get current date to create a unique folder
+            String currentDate = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime());
+            String logDir = Environment.TEST_LOG_DIR + testClass + currentDate;
+
+            LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
+            logCollector.collectEvents();
+            logCollector.collectConfigMaps();
+            logCollector.collectLogsFromPods();
+
+            deleteInstalledYamls(coDir);
+        }
+    }
+
+    private void performUpgrade(JsonObject testParameters) {
+        LOGGER.info("Going to test upgrade of Cluster Operator from version {} to version {}", testParameters.getString("fromVersion"), testParameters.getString("toVersion"));
+        cluster.setNamespace(NAMESPACE);
+
+        String url = testParameters.getString("urlFrom");
+        File dir = FileUtils.downloadAndUnzip(url);
+
+        coDir = new File(dir, testParameters.getString("fromExamples") + "/install/cluster-operator/");
+
+        // Modify + apply installation files
+        copyModifyApply(coDir);
+
+        LOGGER.info("Waiting for CO deployment");
+        DeploymentUtils.waitForDeploymentReady("strimzi-cluster-operator", 1);
+        LOGGER.info("CO ready");
+
+        // Deploy a Kafka cluster
+        kafkaEphemeralYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/kafka/kafka-persistent.yaml");
+        if (KafkaResource.kafkaClient().inNamespace(NAMESPACE).withName("my-cluster").get() != null) {
+            cmdKubeClient().create(kafkaEphemeralYaml);
+            // Wait for readiness
+            waitForClusterReadiness();
+        }
+        if (KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName("my-user").get() != null) {
+            kafkaUserYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/user/kafka-user.yaml");
+            cmdKubeClient().create(kafkaUserYaml);
+        }
+        if (KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName("my-topic").get() != null) {
+            kafkaTopicYaml = new File(dir, testParameters.getString("fromExamples") + "/examples/topic/kafka-topic.yaml");
+            cmdKubeClient().create(kafkaTopicYaml);
+        }
+
+        makeSnapshots();
+        logPodImages();
+        // Execution of required procedures before upgrading CO
+        changeKafkaAndLogFormatVersion(testParameters.getJsonObject("proceduresBefore"));
+
+        // Upgrade the CO
+        // Modify + apply installation files
+        if ("HEAD".equals(testParameters.getString("toVersion"))) {
+            LOGGER.info("Updating");
+            coDir = new File("../install/cluster-operator");
+            upgradeClusterOperator(coDir, testParameters.getJsonObject("imagesBeforeKafkaUpdate"));
+        } else {
+            url = testParameters.getString("urlTo");
+            dir = FileUtils.downloadAndUnzip(url);
+            coDir = new File(dir, testParameters.getString("toExamples") + "/install/cluster-operator/");
+            upgradeClusterOperator(coDir, testParameters.getJsonObject("imagesBeforeKafkaUpdate"));
+        }
+
+        // Make snapshots of all pods
+        makeSnapshots();
+        logPodImages();
+        //  Upgrade kafka
+        changeKafkaAndLogFormatVersion(testParameters.getJsonObject("proceduresAfter"));
+        logPodImages();
+        checkAllImages(testParameters.getJsonObject("imagesAfterKafkaUpdate"));
+
+        // Check errors in CO log
+        assertNoCoErrorsLogged(0);
+    }
+
     private void upgradeClusterOperator(File coInstallDir, JsonObject images) {
         copyModifyApply(coInstallDir);
         LOGGER.info("Waiting for CO upgrade");
@@ -218,6 +329,15 @@ public class StrimziUpgradeST extends MessagingBaseST {
                     LOGGER.warn("Failed to delete resources: {}", f.getName());
                 }
             });
+        }
+        if (kafkaTopicYaml != null) {
+            cmdKubeClient().delete(kafkaTopicYaml);
+        }
+        if (kafkaTopicYaml != null) {
+            cmdKubeClient().delete(kafkaTopicYaml);
+        }
+        if (kafkaEphemeralYaml != null) {
+            cmdKubeClient().delete(kafkaEphemeralYaml);
         }
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add upgrade chain to upgrade tests. This new test case perform all upgrade scenarios specified in `StrimziUpgrade.json` without any cleaning between each scenario. Kafka, KafkaUser and KafkaTopic are deployed during first non-skip scenario and all upgrades for these resources are done with replace specific configuration in CR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

