### PR TITLE
Added KafkaClusterRebalance CRD and related tests

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -170,6 +170,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaBridge</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnector</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaClusterRebalance</argument>
                             </arguments>
                             <workingDirectory>${pom.basedir}${file.separator}..${file.separator}documentation</workingDirectory>
                         </configuration>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -142,6 +142,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}045-Crd-kafkamirrormaker.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaBridge=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}046-Crd-kafkabridge.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnector=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}047-Crd-kafkaconnector.yaml</argument>
+                                <argument>io.strimzi.api.kafka.model.KafkaClusterRebalance=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}048-Crd-kafkaclusterrebalance.yaml</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -100,6 +100,7 @@ public class Crds {
         return crd(cls, version);
     }
 
+    @SuppressWarnings("checkstyle:JavaNCSS")
     private static CustomResourceDefinition crd(Class<? extends CustomResource> cls, String version) {
         String scope, crdApiVersion, plural, singular, group, kind, listKind;
         CustomResourceSubresourceStatus status = null;

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.DoneableKafkaBridge;
+import io.strimzi.api.kafka.model.DoneableKafkaClusterRebalance;
 import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.DoneableKafkaConnectS2I;
 import io.strimzi.api.kafka.model.DoneableKafkaMirrorMaker;
@@ -25,6 +26,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaClusterRebalance;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
@@ -53,7 +55,8 @@ public class Crds {
         KafkaUser.class,
         KafkaMirrorMaker.class,
         KafkaBridge.class,
-        KafkaConnector.class
+        KafkaConnector.class,
+        KafkaClusterRebalance.class
     };
 
     private Crds() {
@@ -88,6 +91,8 @@ public class Crds {
             version = KafkaBridge.VERSIONS.get(0);
         } else if (cls.equals(KafkaConnector.class)) {
             version = KafkaConnector.VERSIONS.get(0);
+        } else if (cls.equals(KafkaClusterRebalance.class)) {
+            version = KafkaClusterRebalance.VERSIONS.get(0);
         } else {
             throw new RuntimeException();
         }
@@ -194,6 +199,18 @@ public class Crds {
             if (!KafkaConnector.VERSIONS.contains(version)) {
                 throw new RuntimeException();
             }
+        } else if (cls.equals(KafkaClusterRebalance.class)) {
+            scope = KafkaClusterRebalance.SCOPE;
+            crdApiVersion = KafkaClusterRebalance.CRD_API_VERSION;
+            plural = KafkaClusterRebalance.RESOURCE_PLURAL;
+            singular = KafkaClusterRebalance.RESOURCE_SINGULAR;
+            group = KafkaClusterRebalance.RESOURCE_GROUP;
+            kind = KafkaClusterRebalance.RESOURCE_KIND;
+            listKind = KafkaClusterRebalance.RESOURCE_LIST_KIND;
+            status = new CustomResourceSubresourceStatus();
+            if (!KafkaClusterRebalance.VERSIONS.contains(version)) {
+                throw new RuntimeException();
+            }
         } else {
             throw new RuntimeException();
         }
@@ -287,6 +304,14 @@ public class Crds {
 
     public static MixedOperation<KafkaBridge, KafkaBridgeList, DoneableKafkaBridge, Resource<KafkaBridge, DoneableKafkaBridge>> kafkaBridgeOperation(KubernetesClient client) {
         return client.customResources(kafkaBridge(), KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class);
+    }
+
+    public static CustomResourceDefinition kafkaClusterRebalance() {
+        return crd(KafkaClusterRebalance.class);
+    }
+
+    public static MixedOperation<KafkaClusterRebalance, KafkaClusterRebalanceList, DoneableKafkaClusterRebalance, Resource<KafkaClusterRebalance, DoneableKafkaClusterRebalance>> kafkaClusterRebalanceOperation(KubernetesClient client) {
+        return client.customResources(kafkaClusterRebalance(), KafkaClusterRebalance.class, KafkaClusterRebalanceList.class, DoneableKafkaClusterRebalance.class);
     }
 
     public static <T extends CustomResource, L extends CustomResourceList<T>, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>>

--- a/api/src/main/java/io/strimzi/api/kafka/KafkaClusterRebalanceList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/KafkaClusterRebalanceList.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.strimzi.api.kafka.model.KafkaClusterRebalance;
+
+/**
+ * A {@code CustomResourceList<KafkaClusterRebalance>} required for using Fabric8 CRD support.
+ */
+public class KafkaClusterRebalanceList extends CustomResourceList<KafkaClusterRebalance> {
+    private static final long serialVersionUID = 1L;
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalance.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.HasStatus;
+import io.strimzi.api.kafka.model.status.KafkaClusterRebalanceStatus;
+import io.strimzi.crdgenerator.annotations.Crd;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+
+@JsonDeserialize
+@Crd(
+        apiVersion = KafkaClusterRebalance.CRD_API_VERSION,
+        spec = @Crd.Spec(
+                names = @Crd.Spec.Names(
+                        kind = KafkaClusterRebalance.RESOURCE_KIND,
+                        plural = KafkaClusterRebalance.RESOURCE_PLURAL,
+                        shortNames = {KafkaClusterRebalance.SHORT_NAME}
+                ),
+                group = KafkaClusterRebalance.RESOURCE_GROUP,
+                scope = KafkaClusterRebalance.SCOPE,
+                version = KafkaClusterRebalance.V1ALPHA1,
+                versions = {
+                        @Crd.Spec.Version(
+                                name = KafkaClusterRebalance.V1ALPHA1,
+                                served = true,
+                                storage = true
+                        )
+                },
+                subresources = @Crd.Spec.Subresources(
+                        status = @Crd.Spec.Subresources.Status()
+                )
+        )
+)
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@EqualsAndHashCode
+public class KafkaClusterRebalance extends CustomResource implements UnknownPropertyPreserving, HasStatus<KafkaClusterRebalanceStatus> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SCOPE = "Namespaced";
+    public static final String V1ALPHA1 = "v1alpha1";
+    public static final List<String> VERSIONS = unmodifiableList(asList(V1ALPHA1));
+    public static final String RESOURCE_KIND = "KafkaClusterRebalance";
+    public static final String RESOURCE_LIST_KIND = RESOURCE_KIND + "List";
+    public static final String RESOURCE_GROUP = "kafka.strimzi.io";
+    public static final String RESOURCE_PLURAL = "kafkaclusterrebalances";
+    public static final String RESOURCE_SINGULAR = "kafkaclusterrebalance";
+    public static final String CRD_API_VERSION = "apiextensions.k8s.io/v1beta1";
+    public static final String CRD_NAME = RESOURCE_PLURAL + "." + RESOURCE_GROUP;
+    public static final String SHORT_NAME = "kcr";
+    public static final List<String> RESOURCE_SHORTNAMES = singletonList(SHORT_NAME);
+
+    private String apiVersion;
+    private ObjectMeta metadata;
+    private KafkaClusterRebalanceSpec spec;
+    private KafkaClusterRebalanceStatus status;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @JsonProperty("kind")
+    @Override
+    public String getKind() {
+        return RESOURCE_KIND;
+    }
+
+    @Override
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    @Override
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @Override
+    public ObjectMeta getMetadata() {
+        return super.getMetadata();
+    }
+
+    @Override
+    public void setMetadata(ObjectMeta metadata) {
+        super.setMetadata(metadata);
+    }
+
+    @Description("The specification of the Kafka Cluster Rebalance.")
+    public KafkaClusterRebalanceSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(KafkaClusterRebalanceSpec spec) {
+        this.spec = spec;
+    }
+
+    @Override
+    @Description("The status of the Kafka Cluster Rebalance.")
+    public KafkaClusterRebalanceStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(KafkaClusterRebalanceStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        YAMLMapper mapper = new YAMLMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -34,7 +34,9 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("A list of goals to use in generating the proposal and executing it")
+    @Description("A list of goals to use in generating the proposal and executing it. " +
+            "The supported goals are available at https://github.com/linkedin/cruise-control#goals." +
+            "Providing empty goals means to use all of them.")
     public List<String> getGoals() {
         return goals;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "goals", "verbose" })
+@EqualsAndHashCode
+public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> goals;
+    private boolean verbose = false;
+
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("A list of goals to use in generating the proposal and executing it")
+    public List<String> getGoals() {
+        return goals;
+    }
+
+    public void setGoals(List<String> goals) {
+        this.goals = goals;
+    }
+
+    @Description("Enable the verbose mode for the JSON string describing the optimization result in the related status")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        YAMLMapper mapper = new YAMLMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -34,9 +34,9 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("A list of goals to use in generating the proposal and executing it. " +
+    @Description("A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it." +
             "The supported goals are available at https://github.com/linkedin/cruise-control#goals." +
-            "Providing empty goals means to use all of them.")
+            "Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.")
     public List<String> getGoals() {
         return goals;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaClusterRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaClusterRebalanceStatus.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Represents a status of the Kafka Cluster Rebalance resource
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "conditions", "observedGeneration", "optimizationResult" })
+@EqualsAndHashCode
+@ToString(callSuper = true)
+public class KafkaClusterRebalanceStatus extends Status {
+
+    private static final long serialVersionUID = 1L;
+
+    private String optimizationResult;
+
+    @Description("A JSON string describing the optimization result")
+    public String getOptimizationResult() {
+        return optimizationResult;
+    }
+
+    public void setOptimizationResult(String optimizationResult) {
+        this.optimizationResult = optimizationResult;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaClusterRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaClusterRebalanceStatus.java
@@ -11,6 +11,9 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Represents a status of the Kafka Cluster Rebalance resource
  */
@@ -27,14 +30,15 @@ public class KafkaClusterRebalanceStatus extends Status {
 
     private static final long serialVersionUID = 1L;
 
-    private String optimizationResult;
+    private Map<String, Object> optimizationResult = new HashMap<>(0);
 
-    @Description("A JSON string describing the optimization result")
-    public String getOptimizationResult() {
+    @Description("A JSON describing the optimization result")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Object> getOptimizationResult() {
         return optimizationResult;
     }
 
-    public void setOptimizationResult(String optimizationResult) {
+    public void setOptimizationResult(Map<String, Object> optimizationResult) {
         this.optimizationResult = optimizationResult;
     }
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.strimzi.test.TestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The purpose of this test is to confirm that we can create a
+ * resource from the POJOs, serialize it and create the resource in K8S.
+ * I.e. that such instance resources obtained from POJOs are valid according to the schema
+ * validation done by K8S.
+ */
+public class KafkaClusterRebalanceCrdIT extends AbstractCrdIT {
+
+    public static final String NAMESPACE = "kafkaclusterrebalance-crd-it";
+
+    @Test
+    void testKafkaClusterRebalanceMinimal() {
+        createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-minimal.yaml");
+    }
+
+    @Test
+    void testKafkaClusterRebalanceWithGoals() {
+        createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals.yaml");
+    }
+
+    @Test
+    void testKafkaClusterRebalanceWithGoalsVerbose() {
+        createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals-verbose.yaml");
+    }
+
+    @BeforeAll
+    void setupEnvironment() {
+        cluster.createNamespace(NAMESPACE);
+        cluster.createCustomResources(TestUtils.CRD_KAFKA_CLUSTER_REBALANCE);
+    }
+
+    @AfterAll
+    void teardownEnvironment() {
+        cluster.deleteCustomResources();
+        cluster.deleteNamespaces();
+    }
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * The purpose of this test is to ensure:
+ *
+ * 1. we get a correct tree of POJOs when reading a JSON/YAML `KafkaClusterRebalance` resource.
+ */
+public class KafkaClusterRebalanceTest extends AbstractCrdTest<KafkaClusterRebalance> {
+
+    public KafkaClusterRebalanceTest() {
+        super(KafkaClusterRebalance.class);
+    }
+}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-minimal.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-minimal.yaml
@@ -1,0 +1,5 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec: {}

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-verbose.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-verbose.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec:
+  goals:
+    - DiskCapacityGoal
+    - CpuCapacityGoal
+  verbose: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals.yaml
@@ -1,0 +1,8 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec:
+  goals:
+    - DiskCapacityGoal
+    - CpuCapacityGoal

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.out.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: "kafka.strimzi.io/v1alpha1"
+kind: "KafkaClusterRebalance"
+metadata:
+  name: "my-rebalance"
+spec:
+  goals:
+  - "DiskCapacityGoal"
+  - "CpuCapacityGoal"
+  verbose: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec:
+  goals:
+    - DiskCapacityGoal
+    - CpuCapacityGoal
+  verbose: true

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1310,7 +1310,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [id='type-Condition-{context}']
 ### `Condition` schema reference
 
-Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
+Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaClusterRebalanceStatus-{context}[`KafkaClusterRebalanceStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
 
 
 [options="header"]
@@ -2343,5 +2343,50 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
+|====
+
+[id='type-KafkaClusterRebalance-{context}']
+### `KafkaClusterRebalance` schema reference
+
+
+[options="header"]
+|====
+|Property       |Description
+|spec    1.2+<.<|The specification of the Kafka Cluster Rebalance.
+|xref:type-KafkaClusterRebalanceSpec-{context}[`KafkaClusterRebalanceSpec`]
+|status  1.2+<.<|The status of the Kafka Cluster Rebalance.
+|xref:type-KafkaClusterRebalanceStatus-{context}[`KafkaClusterRebalanceStatus`]
+|====
+
+[id='type-KafkaClusterRebalanceSpec-{context}']
+### `KafkaClusterRebalanceSpec` schema reference
+
+Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
+
+
+[options="header"]
+|====
+|Property        |Description
+|goals    1.2+<.<|A list of goals to use in generating the proposal and executing it. The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all of them.
+|string array
+|verbose  1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
+|boolean
+|====
+
+[id='type-KafkaClusterRebalanceStatus-{context}']
+### `KafkaClusterRebalanceStatus` schema reference
+
+Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
+
+
+[options="header"]
+|====
+|Property                   |Description
+|conditions          1.2+<.<|List of status conditions.
+|xref:type-Condition-{context}[`Condition`] array
+|observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
+|integer
+|optimizationResult  1.2+<.<|A JSON describing the optimization result.
+|map
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2367,7 +2367,7 @@ Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
 [options="header"]
 |====
 |Property        |Description
-|goals    1.2+<.<|A list of goals to use in generating the proposal and executing it. The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all of them.
+|goals    1.2+<.<|A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it.The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.
 |string array
 |verbose  1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
 |boolean

--- a/examples/kafka-rebalance/kafka-cluster-rebalance.yaml
+++ b/examples/kafka-rebalance/kafka-cluster-rebalance.yaml
@@ -1,0 +1,8 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec:
+  goals:
+    - DiskCapacityGoal
+    - CpuCapacityGoal

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkaclusterrebalance.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkaclusterrebalance.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaclusterrebalances.kafka.strimzi.io
+  labels:
+    app: '{{ template "strimzi.name" . }}'
+    chart: '{{ template "strimzi.chart" . }}'
+    component: kafkaclusterrebalances.kafka.strimzi.io-crd
+    release: '{{ .Release.Name }}'
+    heritage: '{{ .Release.Service }}'
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaClusterRebalance
+    listKind: KafkaClusterRebalanceList
+    singular: kafkaclusterrebalance
+    plural: kafkaclusterrebalances
+    shortNames:
+    - kcr
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            goals:
+              type: array
+              items:
+                type: string
+            verbose:
+              type: boolean
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
+            optimizationResult:
+              type: object
+{{- end -}}

--- a/install/Makefile
+++ b/install/Makefile
@@ -16,6 +16,7 @@ crd_install:
 	$(CP) ./cluster-operator/045-Crd-kafkamirrormaker.yaml ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
 	$(CP) ./cluster-operator/046-Crd-kafkabridge.yaml ../helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
 	$(CP) ./cluster-operator/047-Crd-kafkaconnector.yaml ../helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+	$(CP) ./cluster-operator/048-Crd-kafkaclusterrebalance.yaml ../helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkaclusterrebalance.yaml
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.app "{{ template \"strimzi.name\" . }}" \; && cd $$oldpath
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.chart "{{ template \"strimzi.chart\" . }}" \; && cd $$oldpath
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml metadata.labels.component "kafkas.kafka.strimzi.io-crd"
@@ -26,6 +27,7 @@ crd_install:
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml metadata.labels.component "kafkamirrormakers.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml metadata.labels.component "kafkabridges.kafka.strimzi.io-crd"
 	yq write -i ../helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml metadata.labels.component "kafkaconnectors.kafka.strimzi.io-crd"
+	yq write -i ../helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkaclusterrebalance.yaml metadata.labels.component "kafkaclusterrebalances.kafka.strimzi.io-crd"
 
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.release "{{ .Release.Name }}" \; && cd $$oldpath
 	oldpath=`pwd` && cd ../helm-charts/strimzi-kafka-operator/templates/ &&  $(FIND) . -type f -name '04*-Crd-*.yaml' -exec yq write -i {} metadata.labels.heritage "{{ .Release.Service }}" \; && cd $$oldpath

--- a/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
@@ -53,3 +53,5 @@ spec:
                     type: string
             observedGeneration:
               type: integer
+            optimizationResult:
+              type: object

--- a/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
@@ -53,5 +53,3 @@ spec:
                     type: string
             observedGeneration:
               type: integer
-            optimizationResult:
-              type: string

--- a/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaclusterrebalances.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaClusterRebalance
+    listKind: KafkaClusterRebalanceList
+    singular: kafkaclusterrebalance
+    plural: kafkaclusterrebalances
+    shortNames:
+    - kcr
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            goals:
+              type: array
+              items:
+                type: string
+            verbose:
+              type: boolean
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              type: integer
+            optimizationResult:
+              type: string

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -75,6 +75,8 @@ public final class TestUtils {
 
     public static final String CRD_KAFKA_BRIDGE = "../install/cluster-operator/046-Crd-kafkabridge.yaml";
 
+    public static final String CRD_KAFKA_CLUSTER_REBALANCE = "../install/cluster-operator/048-Crd-kafkaclusterrebalance.yaml";
+
     private TestUtils() {
         // All static methods
     }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Enhancement / new feature

### Description

This PR is about adding the KafkaClusterRebalance CRD used by the user for asking for a rebalance dry-run first and then executing the actual proposal.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

