### PR TITLE
Fix correct complition of compose patterns in case of failure

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -115,7 +115,10 @@ public class ClusterOperator extends AbstractVerticle {
                 .compose(i -> {
                     ((Promise<Void>) start).complete(i);
                     return start;
-                });
+                }, error -> {
+                        ((Promise<Void>) start).fail(error);
+                        return start;
+                    });
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -112,13 +112,7 @@ public class ClusterOperator extends AbstractVerticle {
                     });
                     return startHealthServer().map((Void) null);
                 })
-                .compose(i -> {
-                    ((Promise<Void>) start).complete(i);
-                    return start;
-                }, error -> {
-                        ((Promise<Void>) start).fail(error);
-                        return start;
-                    });
+                .setHandler(start);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -316,15 +316,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.kafkaExporterService())
                 .compose(state -> state.kafkaExporterReady())
 
-                .compose(state -> Future.succeededFuture())
-                .setHandler(result -> {
-                    if (result.succeeded()) {
-                        chainPromise.complete();
-                    } else {
-                        chainPromise.fail(result.cause());
-                    }
-                });
-
+                .map((Void) null)
+                .setHandler(chainPromise);
 
         return chainPromise.future();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -319,7 +319,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> {
                     chainPromise.complete();
                     return chainPromise.future();
-                });
+                }, error -> {
+                        chainPromise.fail(error);
+                        return chainPromise.future();
+                    });
 
         return chainPromise.future();
     }
@@ -327,8 +330,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     ReconciliationState createReconciliationState(Reconciliation reconciliation, Kafka kafkaAssembly) {
         return new ReconciliationState(reconciliation, kafkaAssembly);
     }
-
-
 
     /**
      * Hold the mutable state during a reconciliation

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -316,13 +316,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.kafkaExporterService())
                 .compose(state -> state.kafkaExporterReady())
 
-                .compose(state -> {
-                    chainPromise.complete();
-                    return chainPromise.future();
-                }, error -> {
-                        chainPromise.fail(error);
-                        return chainPromise.future();
-                    });
+                .compose(state -> Future.succeededFuture())
+                .setHandler(result -> {
+                    if (result.succeeded()) {
+                        chainPromise.complete();
+                    } else {
+                        chainPromise.fail(result.cause());
+                    }
+                });
+
 
         return chainPromise.future();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -94,7 +94,6 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(bridge.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Bridge cluster", reconciliation, name, namespace);
-        Promise<Void> chainPromise = Promise.promise();
         kafkaBridgeServiceAccount(namespace, bridge)
             .compose(i -> deploymentOperations.scaleDown(namespace, bridge.getName(), bridge.getReplicas()))
             .compose(scale -> serviceOperations.reconcile(namespace, bridge.getServiceName(), bridge.generateService()))
@@ -104,13 +103,6 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
             .compose(i -> deploymentOperations.scaleUp(namespace, bridge.getName(), bridge.getReplicas()))
             .compose(i -> deploymentOperations.waitForObserved(namespace, bridge.getName(), 1_000, operationTimeoutMs))
             .compose(i -> deploymentOperations.readiness(namespace, bridge.getName(), 1_000, operationTimeoutMs))
-            .compose(i -> {
-                chainPromise.complete();
-                return chainPromise.future();
-            }, error -> {
-                    chainPromise.fail(error);
-                    return chainPromise.future();
-                })
             .setHandler(reconciliationResult -> {
                 StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaBridgeStatus, reconciliationResult.mapEmpty());
                 int port = KafkaBridgeCluster.DEFAULT_REST_API_PORT;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -107,7 +107,10 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
             .compose(i -> {
                 chainPromise.complete();
                 return chainPromise.future();
-            })
+            }, error -> {
+                    chainPromise.fail(error);
+                    return chainPromise.future();
+                })
             .setHandler(reconciliationResult -> {
                 StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaBridgeStatus, reconciliationResult.mapEmpty());
                 int port = KafkaBridgeCluster.DEFAULT_REST_API_PORT;
@@ -128,6 +131,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
                     }
                 });
             });
+
         return createOrUpdatePromise.future();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -100,7 +100,6 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Connect cluster", reconciliation, name, namespace);
-        Promise<Void> chainPromise = Promise.promise();
         connectServiceAccount(namespace, connect)
                 .compose(i -> deploymentOperations.scaleDown(namespace, connect.getName(), connect.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))
@@ -111,13 +110,6 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> deploymentOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> deploymentOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> reconcileConnectors(reconciliation, kafkaConnect))
-                .compose(i -> {
-                    chainPromise.complete();
-                    return chainPromise.future();
-                }, error -> {
-                        chainPromise.fail(error);
-                        return chainPromise.future();
-                    })
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
                     kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -114,7 +114,10 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> {
                     chainPromise.complete();
                     return chainPromise.future();
-                })
+                }, error -> {
+                        chainPromise.fail(error);
+                        return chainPromise.future();
+                    })
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
                     kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -113,7 +113,6 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
 
             HashMap<String, String> annotations = new HashMap<>();
             annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(connect.ANCILLARY_CM_KEY_LOG_CONFIG));
-            Promise<Void> chainPromise = Promise.promise();
             connectServiceAccount(namespace, connect)
                     .compose(i -> deploymentConfigOperations.scaleDown(namespace, connect.getName(), connect.getReplicas()))
                     .compose(scale -> serviceOperations.reconcile(namespace, connect.getServiceName(), connect.generateService()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -127,13 +127,6 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     .compose(i -> deploymentConfigOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                     .compose(i -> deploymentConfigOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
                     .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I))
-                    .compose(i -> {
-                        chainPromise.complete();
-                        return chainPromise.future();
-                    }, error -> {
-                            chainPromise.fail(error);
-                            return chainPromise.future();
-                        })
                     .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
                         kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -130,7 +130,10 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     .compose(i -> {
                         chainPromise.complete();
                         return chainPromise.future();
-                    })
+                    }, error -> {
+                            chainPromise.fail(error);
+                            return chainPromise.future();
+                        })
                     .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
                         kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -110,7 +110,10 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> {
                     chainPromise.complete();
                     return chainPromise.future();
-                })
+                }, error -> {
+                        chainPromise.fail(error);
+                        return chainPromise.future();
+                    })
                 .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -97,7 +97,6 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
         annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(mirror.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka Mirror Maker cluster", reconciliation, name, namespace);
-        Promise<Void> chainPromise = Promise.promise();
         mirrorMakerServiceAccount(namespace, mirror)
                 .compose(i -> deploymentOperations.scaleDown(namespace, mirror.getName(), mirror.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, KafkaMirrorMakerResources.serviceName(mirror.getCluster()), mirror.generateService()))
@@ -107,13 +106,6 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> deploymentOperations.scaleUp(namespace, mirror.getName(), mirror.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, mirror.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> deploymentOperations.readiness(namespace, mirror.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> {
-                    chainPromise.complete();
-                    return chainPromise.future();
-                }, error -> {
-                        chainPromise.fail(error);
-                        return chainPromise.future();
-                    })
                 .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -256,13 +256,8 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
         crt.compose(res -> readiness(namespace, desired.getMetadata().getName(), 1_000, operationTimeoutMs).map(res))
         // ... then wait for all the pods to be ready
             .compose(res -> podReadiness(namespace, desired, 1_000, operationTimeoutMs).map(res))
-            .compose(res -> {
-                result.complete(res);
-                return result.future();
-            }, error -> {
-                    result.fail(error);
-                    return result.future();
-                });
+            .setHandler(result);
+
         return result.future();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -259,7 +259,10 @@ public abstract class StatefulSetOperator extends AbstractScalableResourceOperat
             .compose(res -> {
                 result.complete(res);
                 return result.future();
-            });
+            }, error -> {
+                    result.fail(error);
+                    return result.future();
+                });
         return result.future();
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -57,7 +57,10 @@ public class PlatformFeaturesAvailability {
             pfa.setImages(supported);
             pfaPromise.complete(pfa);
             return pfaPromise.future();
-        });
+        }, error -> {
+                pfaPromise.fail(error);
+                return pfaPromise.future();
+            });
 
         return pfaPromise.future();
     }

--- a/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
+++ b/operator-common/src/main/java/io/strimzi/operator/PlatformFeaturesAvailability.java
@@ -55,12 +55,9 @@ public class PlatformFeaturesAvailability {
             return checkApiAvailability(vertx, httpClient, client.getMasterUrl().toString(), "image.openshift.io", "v1");
         }).compose(supported -> {
             pfa.setImages(supported);
-            pfaPromise.complete(pfa);
-            return pfaPromise.future();
-        }, error -> {
-                pfaPromise.fail(error);
-                return pfaPromise.future();
-            });
+            return Future.succeededFuture(pfa);
+        })
+        .setHandler(pfaPromise);
 
         return pfaPromise.future();
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -121,7 +121,7 @@ public abstract class AbstractOperator<
                 validate(cr);
                 log.info("{}: {} {} should be created or updated", reconciliation, kind, name);
                 return createOrUpdate(reconciliation, cr).recover(createResult -> {
-                    log.debug("{}: createOrUpdate failed", reconciliation, createResult);
+                    log.error("{}: createOrUpdate failed", reconciliation, createResult);
                     return Future.failedFuture(createResult);
                 });
             } else {
@@ -134,7 +134,7 @@ public abstract class AbstractOperator<
                     }
                     return (Void) null;
                 }).recover(deleteResult -> {
-                    log.debug("{}: Deletion of {} {} failed", reconciliation, kind, name, deleteResult);
+                    log.error("{}: Deletion of {} {} failed", reconciliation, kind, name, deleteResult);
                     return Future.failedFuture(deleteResult);
                 });
             }
@@ -263,9 +263,9 @@ public abstract class AbstractOperator<
         } else {
             Throwable cause = result.cause();
             if (cause instanceof InvalidConfigParameterException) {
-                log.error("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
+                log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
             } else if (!(cause instanceof UnableToAcquireLockException)) {
-                log.error("{}: Failed to reconcile", reconciliation, cause);
+                log.warn("{}: Failed to reconcile", reconciliation, cause);
             }
         }
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -121,7 +121,7 @@ public abstract class AbstractOperator<
                 validate(cr);
                 log.info("{}: {} {} should be created or updated", reconciliation, kind, name);
                 return createOrUpdate(reconciliation, cr).recover(createResult -> {
-                    log.error("{}: createOrUpdate failed", reconciliation, createResult);
+                    log.debug("{}: createOrUpdate failed", reconciliation, createResult);
                     return Future.failedFuture(createResult);
                 });
             } else {
@@ -134,7 +134,7 @@ public abstract class AbstractOperator<
                     }
                     return (Void) null;
                 }).recover(deleteResult -> {
-                    log.error("{}: Deletion of {} {} failed", reconciliation, kind, name, deleteResult);
+                    log.debug("{}: Deletion of {} {} failed", reconciliation, kind, name, deleteResult);
                     return Future.failedFuture(deleteResult);
                 });
             }
@@ -263,9 +263,9 @@ public abstract class AbstractOperator<
         } else {
             Throwable cause = result.cause();
             if (cause instanceof InvalidConfigParameterException) {
-                log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
+                log.error("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
             } else if (!(cause instanceof UnableToAcquireLockException)) {
-                log.warn("{}: Failed to reconcile", reconciliation, cause);
+                log.error("{}: Failed to reconcile", reconciliation, cause);
             }
         }
     }

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -67,7 +67,10 @@ public class UserOperator extends AbstractVerticle {
             }).compose(i -> {
                 ((Promise<Void>) start).complete(i);
                 return start;
-            });
+            }, error -> {
+                    ((Promise<Void>) start).fail(error);
+                    return start;
+                });
     }
 
     @Override

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -64,13 +64,8 @@ public class UserOperator extends AbstractVerticle {
                 });
 
                 return startHealthServer().map((Void) null);
-            }).compose(i -> {
-                ((Promise<Void>) start).complete(i);
-                return start;
-            }, error -> {
-                    ((Promise<Void>) start).fail(error);
-                    return start;
-                });
+            })
+            .setHandler(start);
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the upgrade to Vert.x 3.8 broker (#2282) broke the `.compose` patterns used in our operators to do sequential composition. As a result the future / promise never completes and the lock is never released. Easy way to reproduce the original problem is for example to deploy something with large number of resources requested for a pod which cannot be fulfilled. In such case the operator fails waiting for the pods to be ready. But the failure is not propagated and triggered up the chain. So the reocnciliation never ends and the lock is locked forever so the user cannot really fix the problem (without restarting the CO pod).

It also seems that the `AbstractOperator` logs the errors twice on WARN and ERROR levels. That seems to be unnecessary. I modified the code to log once on ERROR and moved the other log message to DEBUG for only more detailed logging level.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally