### PR TITLE
Push the new Overview book from master builds to the website

### DIFF
--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -10,15 +10,19 @@ ssh-add github_deploy_key
 git clone git@github.com:strimzi/strimzi.github.io.git /tmp/website
 cp -v documentation/htmlnoheader/master.html /tmp/website/docs/master/master.html
 cp -v documentation/html/index.html /tmp/website/docs/master/full.html
+cp -v documentation/htmlnoheader/overview.html /tmp/website/docs/overview/master/master.html
+cp -v documentation/html/overview.html /tmp/website/docs/overview/master/full.html
 cp -v documentation/htmlnoheader/quickstart.html /tmp/website/docs/quickstart/master/master.html
 cp -v documentation/html/quickstart.html /tmp/website/docs/quickstart/master/full.html
 cp -v documentation/htmlnoheader/contributing.html /tmp/website/contributing/guide/contributing.html
 cp -v documentation/html/contributing.html /tmp/website/contributing/guide/full.html
 rm -rf /tmp/website/docs/master/images
+rm -rf /tmp/website/docs/overview/master/images
 rm -rf /tmp/website/docs/quickstart/master/images
 rm -rf /tmp/website/contributing/guide/images
 rm -rf /tmp/website/contributing/guide/templates
 cp -vrL documentation/htmlnoheader/images /tmp/website/docs/master/images
+cp -vrL documentation/htmlnoheader/images /tmp/website/docs/overview/master/images
 cp -vrL documentation/htmlnoheader/images /tmp/website/docs/quickstart/master/images
 cp -vrL documentation/htmlnoheader/images /tmp/website/contributing/guide/images
 cp -vrL documentation/contributing/templates /tmp/website/contributing/guide/templates

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ docu_html: docu_htmlclean docu_versions docu_check
 	mkdir -p documentation/html
 	$(CP) -vrL documentation/shared/images documentation/html/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/using/master.adoc -o documentation/html/index.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/overview/master.adoc -o documentation/html/overview.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/quickstart/master.adoc -o documentation/html/quickstart.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) documentation/contributing/master.adoc -o documentation/html/contributing.html
 
@@ -97,6 +98,7 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_versions docu_check
 	mkdir -p documentation/htmlnoheader
 	$(CP) -vrL documentation/shared/images documentation/htmlnoheader/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/using/master.adoc -o documentation/htmlnoheader/master.html
+	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/overview/master.adoc -o documentation/htmlnoheader/overview.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/quickstart/master.adoc -o documentation/htmlnoheader/quickstart.html
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -a GithubVersion=$(GITHUB_VERSION) -s documentation/contributing/master.adoc -o documentation/htmlnoheader/contributing.html
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The newly added Overview book should be pushed from every master build to the website (as all our outher books are). It also needs to be added to the Makefile to be build during the build.

This should be merged only after the strimzi/strimzi.github.io#116 PR is merged which creates the initial structrues.