### PR TITLE
Improve Kafka Roller logging

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3072,7 +3072,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         /**
          * @param sts Stateful set to which pod belongs
          * @param pod Pod to restart
-         * @param cas cas
+         * @param cas Certificate authorities to be checked for changes
          * @return null or empty if the restart is not needed, reason String otherwise
          */
         private String getReasonsToRestartPod(StatefulSet sts, Pod pod,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1057,8 +1057,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         }
 
                         return kafkaSetOperations.maybeRollingUpdate(newSts, pod -> {
-                            log.info("{}: Upgrade: Maybe patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
-                            return "Upgrade: Maybe patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
+                            log.info("{}: Upgrade: Patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
+                            return "Upgrade phase 1 of " + (twoPhase ? 2 : 1) + ": Patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
                         }).map(resultSts);
                     })
                     .compose(ss2 -> {
@@ -1115,8 +1115,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             log.info("{}: Upgrade: Patch + rolling update of {}", reconciliation, stsName);
             return CompositeFuture.join(kafkaSetOperations.reconcile(namespace, stsName, newSts), configMapOperations.reconcile(namespace, cmName, newCm))
                     .compose(ignored -> kafkaSetOperations.maybeRollingUpdate(sts, pod -> {
-                        log.info("{}: Upgrade: Maybe patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
-                        return "Upgrade: Maybe patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
+                        log.info("{}: Upgrade: Patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
+                        return "Upgrade: Patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
                     }))
                     .compose(ignored -> {
                         log.info("{}: {}, phase 2 of 2 completed", reconciliation, upgrade);
@@ -1213,8 +1213,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         }
 
                         return kafkaSetOperations.maybeRollingUpdate(sts, pod -> {
-                            log.info("{}: Downgrade: Maybe patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
-                            return "Downgrade: Patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
+                            log.info("{}: Downgrade: Patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
+                            return "Downgrade phase 1 of " + phases + ": Patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
                         }).map(resultSts);
                     })
                     .compose(ss2 -> {
@@ -1270,8 +1270,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             log.info("{}: Upgrade: Patch + rolling update of {}", reconciliation, stsName);
             return CompositeFuture.join(kafkaSetOperations.reconcile(namespace, stsName, newSts), configMapOperations.reconcile(namespace, cmName, newCm))
                     .compose(ignored -> kafkaSetOperations.maybeRollingUpdate(sts, pod -> {
-                        log.info("{}: Upgrade: Maybe patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
-                        return "Upgrade: Maybe patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
+                        log.info("{}: Upgrade: Patch + rolling update of {}: Pod {}", reconciliation, stsName, pod.getMetadata().getName());
+                        return "Upgrade phase 2 of 2: Patch + rolling update of " + name + ": Pod " + pod.getMetadata().getName();
                     }))
                     .compose(ignored -> {
                         log.info("{}: {}, phase 2 of 2 completed", reconciliation, versionChange);
@@ -3073,7 +3073,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @param sts Stateful set to which pod belongs
          * @param pod Pod to restart
          * @param cas cas
-         * @return null if the restart is not needed, reason String otherwise
+         * @return null or empty if the restart is not needed, reason String otherwise
          */
         private String getReasonsToRestartPod(StatefulSet sts, Pod pod,
                                        boolean nodeCertsChange,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -15,7 +15,7 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 /**
  * Specialization of {@link StatefulSetOperator} for StatefulSets of Kafka brokers
@@ -66,7 +66,7 @@ public class KafkaSetOperator extends StatefulSetOperator {
     }
 
     @Override
-    public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart,
+    public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart,
                                            Secret clusterCaCertSecret, Secret coKeySecret) {
         return new KafkaRoller(vertx, podOperations, 1_000, operationTimeoutMs,
             () -> new BackOff(250, 2, 10), sts, clusterCaCertSecret, coKeySecret, adminClientProvider)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 
 /**
@@ -67,7 +67,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
     }
 
     @Override
-    public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
+    public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
         String namespace = sts.getMetadata().getNamespace();
         String name = sts.getMetadata().getName();
         final int replicas = sts.getSpec().getReplicas();
@@ -78,7 +78,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         String cluster = sts.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         for (int i = 0; i < replicas; i++) {
             Pod pod = podOperations.get(sts.getMetadata().getNamespace(), KafkaResources.zookeeperPodName(cluster, i));
-            zkRoll |= podRestart.test(pod);
+            zkRoll |= podRestart.apply(pod) != null && !podRestart.apply(pod).isEmpty();
             pods.add(pod);
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -78,7 +78,8 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         String cluster = sts.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         for (int i = 0; i < replicas; i++) {
             Pod pod = podOperations.get(sts.getMetadata().getNamespace(), KafkaResources.zookeeperPodName(cluster, i));
-            zkRoll |= podRestart.apply(pod) != null && !podRestart.apply(pod).isEmpty();
+            String zkPodRestart = podRestart.apply(pod);
+            zkRoll |= zkPodRestart != null && !zkPodRestart.isEmpty();
             pods.add(pod);
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Base64;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -173,8 +173,8 @@ public class KafkaAssemblyOperatorCustomCertTest {
         });
 
         ArgumentCaptor<StatefulSet> maybeRollingUpdateStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
-        ArgumentCaptor<Predicate<Pod>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Predicate.class);
-        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartPredicateCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Function<Pod, String>> isPodToRestartFunctionCaptor = ArgumentCaptor.forClass(Function.class);
+        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartFunctionCaptor.capture())).thenReturn(Future.succeededFuture());
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -204,10 +204,10 @@ public class KafkaAssemblyOperatorCustomCertTest {
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_TLS_LISTENER, ""), is(getTlsThumbprint()));
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_EXTERNAL_LISTENER, ""), is(getExternalThumbprint()));
 
-            assertThat(isPodToRestartPredicateCaptor.getAllValues().size(), is(1));
+            assertThat(isPodToRestartFunctionCaptor.getAllValues().size(), is(1));
 
-            Predicate<Pod> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
-            assertThat(isPodToRestart.test(getPod(reconcileSts)), is(false));
+            Function<Pod, String> isPodToRestart = isPodToRestartFunctionCaptor.getValue();
+            assertThat(isPodToRestart.apply(getPod(reconcileSts)), is(nullValue()));
 
             async.flag();
         });
@@ -234,8 +234,8 @@ public class KafkaAssemblyOperatorCustomCertTest {
         });
 
         ArgumentCaptor<StatefulSet> maybeRollingUpdateStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
-        ArgumentCaptor<Predicate<Pod>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Predicate.class);
-        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartPredicateCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Function<Pod, String>> isPodToRestartFunctionCaptor = ArgumentCaptor.forClass(Function.class);
+        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartFunctionCaptor.capture())).thenReturn(Future.succeededFuture());
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -265,13 +265,13 @@ public class KafkaAssemblyOperatorCustomCertTest {
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_TLS_LISTENER, ""), is(getTlsThumbprint()));
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_EXTERNAL_LISTENER, ""), is(getExternalThumbprint()));
 
-            assertThat(isPodToRestartPredicateCaptor.getAllValues().size(), is(1));
+            assertThat(isPodToRestartFunctionCaptor.getAllValues().size(), is(1));
 
             Pod pod = getPod(reconcileSts);
             pod.getMetadata().getAnnotations().put(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_TLS_LISTENER, Base64.getEncoder().encodeToString("Not the right one!".getBytes()));
 
-            Predicate<Pod> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
-            assertThat(isPodToRestart.test(pod), is(true));
+            Function<Pod, String> isPodToRestart = isPodToRestartFunctionCaptor.getValue();
+            assertThat(isPodToRestart.apply(pod), is("custom certificate on the TLS listener changes"));
 
             async.flag();
         });
@@ -298,8 +298,8 @@ public class KafkaAssemblyOperatorCustomCertTest {
         });
 
         ArgumentCaptor<StatefulSet> maybeRollingUpdateStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
-        ArgumentCaptor<Predicate<Pod>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Predicate.class);
-        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartPredicateCaptor.capture())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<Function<Pod, String>> isPodToRestartFunctionCaptor = ArgumentCaptor.forClass(Function.class);
+        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartFunctionCaptor.capture())).thenReturn(Future.succeededFuture());
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -329,13 +329,13 @@ public class KafkaAssemblyOperatorCustomCertTest {
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_TLS_LISTENER, ""), is(getTlsThumbprint()));
             assertThat(reconcileSts.getSpec().getTemplate().getMetadata().getAnnotations().getOrDefault(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_EXTERNAL_LISTENER, ""), is(getExternalThumbprint()));
 
-            assertThat(isPodToRestartPredicateCaptor.getAllValues().size(), is(1));
+            assertThat(isPodToRestartFunctionCaptor.getAllValues().size(), is(1));
 
             Pod pod = getPod(reconcileSts);
             pod.getMetadata().getAnnotations().put(KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_EXTERNAL_LISTENER, Base64.getEncoder().encodeToString("Not the right one!".getBytes()));
 
-            Predicate<Pod> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
-            assertThat(isPodToRestart.test(pod), is(true));
+            Function<Pod, String> isPodToRestart = isPodToRestartFunctionCaptor.getValue();
+            assertThat(isPodToRestart.apply(pod), is("custom certificate on the external listener changes"));
 
             async.flag();
         });
@@ -373,7 +373,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
         });
 
         ArgumentCaptor<StatefulSet> maybeRollingUpdateStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
-        ArgumentCaptor<Predicate<Pod>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Predicate.class);
+        ArgumentCaptor<Function<Pod, String>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Function.class);
         when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartPredicateCaptor.capture())).thenReturn(Future.succeededFuture());
 
         // Mock the ConfigMapOperator
@@ -406,8 +406,8 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
             assertThat(isPodToRestartPredicateCaptor.getAllValues().size(), is(1));
 
-            Predicate<Pod> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
-            assertThat(isPodToRestart.test(getPod(reconcileSts)), is(false));
+            Function<Pod, String> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
+            assertThat(isPodToRestart.apply(getPod(reconcileSts)), is(nullValue()));
 
             async.flag();
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -109,7 +109,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.function.Predicate;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.strimzi.test.TestUtils.set;
@@ -452,11 +452,11 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<StatefulSet> ssCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockZsOps.reconcile(anyString(), anyString(), ssCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new StatefulSet())));
         when(mockZsOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockZsOps.maybeRollingUpdate(any(), any(Predicate.class))).thenReturn(Future.succeededFuture());
+        when(mockZsOps.maybeRollingUpdate(any(), any(Function.class))).thenReturn(Future.succeededFuture());
         when(mockZsOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockKsOps.reconcile(anyString(), anyString(), ssCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new StatefulSet())));
         when(mockKsOps.scaleDown(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockKsOps.maybeRollingUpdate(any(), any(Predicate.class))).thenReturn(Future.succeededFuture());
+        when(mockKsOps.maybeRollingUpdate(any(), any(Function.class))).thenReturn(Future.succeededFuture());
         when(mockKsOps.scaleUp(anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockPolicyOps.reconcile(anyString(), anyString(), policyCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
         when(mockZsOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture());
@@ -1122,8 +1122,8 @@ public class KafkaAssemblyOperatorTest {
             StatefulSet sts = invocation.getArgument(2);
             return Future.succeededFuture(ReconcileResult.patched(sts));
         });
-        when(mockZsOps.maybeRollingUpdate(any(), any(Predicate.class))).thenReturn(Future.succeededFuture());
-        when(mockKsOps.maybeRollingUpdate(any(), any(Predicate.class))).thenReturn(Future.succeededFuture());
+        when(mockZsOps.maybeRollingUpdate(any(), any(Function.class))).thenReturn(Future.succeededFuture());
+        when(mockKsOps.maybeRollingUpdate(any(), any(Function.class))).thenReturn(Future.succeededFuture());
 
         when(mockZsOps.getAsync(clusterNamespace, ZookeeperCluster.zookeeperClusterName(clusterName))).thenReturn(
                 Future.succeededFuture(originalZookeeperCluster.generateStatefulSet(openShift, null, null))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -352,7 +352,13 @@ public class KafkaRollerTest {
                                     Collection<Integer> podsToRestart,
                                     List<Integer> expected) {
         Checkpoint async = testContext.checkpoint();
-        kafkaRoller.rollingRestart(pod -> podsToRestart.contains(podName2Number(pod.getMetadata().getName())))
+        kafkaRoller.rollingRestart(pod -> {
+            if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
+                return "roll";
+            } else {
+                return null;
+            }
+        })
             .setHandler(testContext.succeeding(v -> {
                 testContext.verify(() -> assertThat(restarted(), is(expected)));
                 assertNoUnclosedAdminClient(testContext, kafkaRoller);
@@ -373,7 +379,13 @@ public class KafkaRollerTest {
                                  Class<? extends Throwable> exception, String message,
                                  List<Integer> expectedRestart) throws InterruptedException {
         CountDownLatch async = new CountDownLatch(1);
-        kafkaRoller.rollingRestart(pod -> podsToRestart.contains(podName2Number(pod.getMetadata().getName())))
+        kafkaRoller.rollingRestart(pod -> {
+            if (podsToRestart.contains(podName2Number(pod.getMetadata().getName()))) {
+                return "roll";
+            } else {
+                return null;
+            }
+        })
             .setHandler(testContext.failing(e -> testContext.verify(() -> {
                 assertThat(e.getClass() + " is not a subclass of " + exception.getName(), e, instanceOf(exception));
                 assertThat("The exception message was not as expected", e.getMessage(), is(message));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -97,7 +97,7 @@ public class StatefulSetOperatorTest
     protected StatefulSetOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new StatefulSetOperator(vertx, mockClient, 60_000L) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -112,7 +112,7 @@ public class StatefulSetOperatorTest
     protected StatefulSetOperator createResourceOperationsWithMockedReadiness(Vertx vertx, KubernetesClient mockClient) {
         return new StatefulSetOperator(vertx, mockClient, 60_000L) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -169,7 +169,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -180,7 +180,7 @@ public class StatefulSetOperatorTest
         };
 
         Checkpoint a = context.checkpoint();
-        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
             .setHandler(context.succeeding(v -> a.flag()));
     }
 
@@ -220,7 +220,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -231,7 +231,7 @@ public class StatefulSetOperatorTest
         };
 
         Checkpoint a = context.checkpoint();
-        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
             .setHandler(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(TimeoutException.class));
                 a.flag();
@@ -268,7 +268,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
             @Override
@@ -278,7 +278,7 @@ public class StatefulSetOperatorTest
         };
 
         Checkpoint a = context.checkpoint();
-        op.maybeRestartPod(resource, "my-pod-0", pod -> true).setHandler(context.failing(e -> context.verify(() -> {
+        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll").setHandler(context.failing(e -> context.verify(() -> {
             assertThat(e, instanceOf(TimeoutException.class));
             a.flag();
         })));
@@ -313,7 +313,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
             @Override
@@ -323,7 +323,7 @@ public class StatefulSetOperatorTest
         };
 
         Checkpoint a = context.checkpoint();
-        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+        op.maybeRestartPod(resource, "my-pod-0", pod -> "roll")
             .setHandler(context.failing(e -> context.verify(() -> {
                 assertThat(e.getMessage(), is("reconcile failed"));
                 a.flag();
@@ -409,7 +409,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -458,7 +458,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -502,7 +502,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -542,7 +542,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 
@@ -582,7 +582,7 @@ public class StatefulSetOperatorTest
 
         StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator, pvcOperator) {
             @Override
-            public Future<Void> maybeRollingUpdate(StatefulSet sts, Predicate<Pod> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
+            public Future<Void> maybeRollingUpdate(StatefulSet sts, Function<Pod, String> podNeedsRestart, Secret clusterCaSecret, Secret coKeySecret) {
                 return Future.succeededFuture();
             }
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement / new feature

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2264

The KafkaRoller class seems to log most of its messages on the DEBUG level. That is seemingly ok if everything works as expected and there are no delays. But in case of some issues, it might get stuck for a possibly long time in some timeouts. All this time there is no message printed on the INFO level or above, so the user does not know what is going on.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

