### PR TITLE
Fixed JavaDoc and log messages

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -356,11 +356,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         }
                     }
                 } else {
-                    log.error("{}: Current {} resource not found", reconciliation, resource.getClass().getTypeName());
-                    updateStatusPromise.fail("Current " + resource.getClass().getTypeName() + " resource not found");
+                    log.error("{}: Current {} resource not found", reconciliation, resource.getKind());
+                    updateStatusPromise.fail("Current " + resource.getKind() + " resource not found");
                 }
             } else {
-                log.error("{}: Failed to get the current {} resource and its status", reconciliation, resource.getClass().getTypeName(), getRes.cause());
+                log.error("{}: Failed to get the current {} resource and its status", reconciliation, resource.getKind(), getRes.cause());
                 updateStatusPromise.fail(getRes.cause());
             }
         });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -306,12 +306,12 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     /**
-     * Updates the Status field of the KafkaConnect CR. It diffs the desired status against the current status and calls
+     * Updates the Status field of the KafkaConnect or KafkaConnector CR. It diffs the desired status against the current status and calls
      * the update only when there is any difference in non-timestamp fields.
      *
-     * @param resource The CR of KafkaConnect
+     * @param resource The CR of KafkaConnect or KafkaConnector
      * @param reconciliation Reconciliation information
-     * @param desiredStatus The KafkaConnectStatus which should be set
+     * @param desiredStatus The KafkaConnectStatus or KafkaConnectorStatus which should be set
      *
      * @return
      */
@@ -356,11 +356,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         }
                     }
                 } else {
-                    log.error("{}: Current Kafka Connect resource not found", reconciliation);
-                    updateStatusPromise.fail("Current Kafka Connect resource not found");
+                    log.error("{}: Current {} resource not found", reconciliation, resource.getClass().getTypeName());
+                    updateStatusPromise.fail("Current " + resource.getClass().getTypeName() + " resource not found");
                 }
             } else {
-                log.error("{}: Failed to get the current Kafka Connect resource and its status", reconciliation, getRes.cause());
+                log.error("{}: Failed to get the current {} resource and its status", reconciliation, resource.getClass().getTypeName(), getRes.cause());
                 updateStatusPromise.fail(getRes.cause());
             }
         });


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

This trivial PR fixes Javadoc and log messages around updating status for KafkaConnect and KafkaConnector resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

