### PR TITLE
Fix testDeployUnsupportedKafka

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -115,7 +115,13 @@ public class SpecificST extends MessagingBaseST {
     @Tag(REGRESSION)
     void testDeployUnsupportedKafka() {
         String nonExistingVersion = "6.6.6";
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1).editSpec().editKafka().withVersion(nonExistingVersion).endKafka().endSpec().build());
+        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .withVersion(nonExistingVersion)
+                    .endKafka()
+                .endSpec()
+                .build());
 
         LOGGER.info("Wait until Zookeeper stateful set is ready");
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 1);


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
This test was not even setting the non-existen kafka version.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

