### PR TITLE
ST: Apply some fixes for some negative test cases

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/api/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/api/VerifiableClient.java
@@ -62,13 +62,13 @@ public class VerifiableClient {
      */
     public void setArguments(ClientArgumentMap args) {
         arguments.clear();
-        String test;
+        String argument;
         for (ClientArgument arg : args.getArguments()) {
             if (validateArgument(arg)) {
                 for (String value : args.getValues(arg)) {
                     if (arg.equals(ClientArgument.USER)) {
-                        test = String.format("%s=%s", arg.command(), value);
-                        arguments.add(test);
+                        argument = String.format("%s=%s", arg.command(), value);
+                        arguments.add(argument);
                     } else {
                         arguments.add(arg.command());
                         if (!value.isEmpty()) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -38,6 +38,11 @@ public class KafkaConnectS2IResource {
         return deployKafkaConnectS2I(defaultKafkaConnectS2I(kafkaConnectS2I, name, clusterName, kafkaConnectS2IReplicas).build());
     }
 
+    public static KafkaConnectS2IBuilder defaultKafkaConnectS2I(String name, String kafkaClusterName, int kafkaConnectReplicas) {
+        KafkaConnectS2I kafkaConnectS2I = getKafkaConnectS2IFromYaml(PATH_TO_KAFKA_CONNECT_S2I_CONFIG);
+        return defaultKafkaConnectS2I(kafkaConnectS2I, name, kafkaClusterName, kafkaConnectReplicas);
+    }
+
     public static KafkaConnectS2IBuilder defaultKafkaConnectS2I(KafkaConnectS2I kafkaConnectS2I, String name, String kafkaClusterName, int kafkaConnectReplicas) {
         return new KafkaConnectS2IBuilder(kafkaConnectS2I)
             .withNewMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -157,23 +157,23 @@ public class StUtils {
 
     /**
      * Get a Map of properties from an environment variable in json.
-     * @param containerName name of the container
+     * @param containerIndex name of the container
      * @param json The json from which to extract properties
      * @param envVar The environment variable name
      * @return The properties which the variable contains
      */
-    public static Map<String, Object> getPropertiesFromJson(String containerName, String json, String envVar) {
-        List<String> array = JsonPath.parse(json).read(globalVariableJsonPathBuilder(containerName, envVar));
+    public static Map<String, Object> getPropertiesFromJson(int containerIndex, String json, String envVar) {
+        List<String> array = JsonPath.parse(json).read(globalVariableJsonPathBuilder(containerIndex, envVar));
         return StUtils.loadProperties(array.get(0));
     }
 
     /**
      * Get a jsonPath which can be used to extract envariable variables from a spec
-     * @param containerName name of the container
+     * @param containerIndex index of the container
      * @param envVar The environment variable name
      * @return The json path
      */
-    public static String globalVariableJsonPathBuilder(String containerName, String envVar) {
-        return "$.spec.containers[" + containerName + "].env[?(@.name=='" + envVar + "')].value";
+    public static String globalVariableJsonPathBuilder(int containerIndex, String envVar) {
+        return "$.spec.containers[" + containerIndex + "].env[?(@.name=='" + envVar + "')].value";
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -25,7 +25,7 @@ public class KafkaConnectS2IUtils {
      */
     public static void waitForConnectS2IStatus(String name, String status) {
         LOGGER.info("Waiting for Kafka Connect S2I {} state: {}", name, status);
-        TestUtils.waitFor("Test " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("Kafka Connect S2I " + name + " state: " + status, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> Crds.kafkaConnectS2iOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(status));
         LOGGER.info("Kafka Connect S2I {} is in desired state: {}", name, status);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -213,7 +213,7 @@ class ConnectS2IST extends MessagingBaseST {
         Map<String, String> jvmOptionsXX = new HashMap<>();
         jvmOptionsXX.put("UseG1GC", "true");
 
-        KafkaConnectS2I kafkaConnectS2i = KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.kafkaConnectS2I(kafkaConnectS2IName, CLUSTER_NAME, 1)
+        KafkaConnectS2I kafkaConnectS2i = KafkaConnectS2IResource.kafkaConnectS2IWithoutWait(KafkaConnectS2IResource.defaultKafkaConnectS2I(kafkaConnectS2IName, CLUSTER_NAME, 1)
             .editMetadata()
                 .addToLabels("type", "kafka-connect")
             .endMetadata()
@@ -236,7 +236,7 @@ class ConnectS2IST extends MessagingBaseST {
                     .withServer(true)
                     .withXx(jvmOptionsXX)
                 .endJvmOptions()
-            .endSpec().done());
+            .endSpec().build());
 
         KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2IName, "NotReady");
 
@@ -254,7 +254,7 @@ class ConnectS2IST extends MessagingBaseST {
                     .build());
         });
 
-        TestUtils.waitFor("Test", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+        TestUtils.waitFor("Kafka Connect CR change", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getClient().adapt(OpenShiftClient.class).buildConfigs().inNamespace(NAMESPACE).withName(kafkaConnectS2IName + "-connect").get().getSpec().getResources().getRequests().get("cpu").equals(new Quantity("1")));
 
         cmdKubeClient().exec("oc", "start-build", KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName), "-n", NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -87,9 +87,9 @@ class ConnectST extends MessagingBaseST {
         String podName = PodUtils.getPodNameByPrefix(KafkaConnectResources.deploymentName(CLUSTER_NAME));
         String kafkaPodJson = TestUtils.toJsonString(kubeClient().getPod(podName));
 
-        assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder("kafka", "KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
-                hasItem(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))));
-        assertThat(StUtils.getPropertiesFromJson("kafka", kafkaPodJson, "KAFKA_CONNECT_CONFIGURATION"), is(exceptedConfig));
+        assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0,"KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
+                hasItem(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))));
+        assertThat(StUtils.getPropertiesFromJson(0, kafkaPodJson, "KAFKA_CONNECT_CONFIGURATION"), is(exceptedConfig));
         testDockerImagesForKafkaConnect();
 
         verifyLabelsOnPods(CLUSTER_NAME, "connect", null, "KafkaConnect");

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -87,7 +87,7 @@ class ConnectST extends MessagingBaseST {
         String podName = PodUtils.getPodNameByPrefix(KafkaConnectResources.deploymentName(CLUSTER_NAME));
         String kafkaPodJson = TestUtils.toJsonString(kubeClient().getPod(podName));
 
-        assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0,"KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
+        assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0, "KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
                 hasItem(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))));
         assertThat(StUtils.getPropertiesFromJson(0, kafkaPodJson, "KAFKA_CONNECT_CONFIGURATION"), is(exceptedConfig));
         testDockerImagesForKafkaConnect();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -250,8 +250,8 @@ class ConnectST extends MessagingBaseST {
         final int scaleTo = initialReplicas + 1;
 
         LOGGER.info("Scaling up to {}", scaleTo);
-        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, c -> c.getSpec().setReplicas(initialReplicas + 1));
-        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(CLUSTER_NAME), initialReplicas + 1);
+        KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, c -> c.getSpec().setReplicas(scaleTo));
+        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(CLUSTER_NAME), scaleTo);
         connectPods = kubeClient().listPodNames("strimzi.io/kind", "KafkaConnect");
         assertThat(connectPods.size(), is(scaleTo));
         for (String pod : connectPods) {
@@ -264,9 +264,7 @@ class ConnectST extends MessagingBaseST {
 
         LOGGER.info("Scaling down to {}", initialReplicas);
         KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, c -> c.getSpec().setReplicas(initialReplicas));
-        while (kubeClient().listPods("strimzi.io/kind", "KafkaConnect").size() == scaleTo) {
-            LOGGER.info("Waiting for connect pod deletion");
-        }
+        DeploymentUtils.waitForDeploymentReady(KafkaConnectResources.deploymentName(CLUSTER_NAME), initialReplicas);
         connectPods = kubeClient().listPodNames("strimzi.io/kind", "KafkaConnect");
         assertThat(connectPods.size(), is(initialReplicas));
         for (String pod : connectPods) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -950,11 +950,11 @@ class KafkaST extends MessagingBaseST {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3).done();
 
         // Creating topic without any label
-        KafkaTopicResource.topic(CLUSTER_NAME, "topic-without-labels")
+        KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, "topic-without-labels", 1, 1, 1)
             .editMetadata()
                 .withLabels(null)
             .endMetadata()
-            .done();
+            .build());
 
         // Checking that resource was created
         assertThat(cmdKubeClient().list("kafkatopic"), hasItems("topic-without-labels"));
@@ -1192,6 +1192,7 @@ class KafkaST extends MessagingBaseST {
         ArrayList pvcs = new ArrayList();
 
         kubeClient().listPersistentVolumeClaims().stream()
+                .filter(pvc -> pvc.getMetadata().getName().contains("kafka"))
                 .forEach(volume -> {
                     String volumeName = volume.getMetadata().getName();
                     pvcs.add(volumeName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -431,7 +431,7 @@ class SecurityST extends MessagingBaseST {
 
     private void createClusterWithExternalRoute() {
         LOGGER.info("Creating a cluster");
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)
                 .editSpec()
                     .editKafka()
                         .editListeners()
@@ -445,7 +445,6 @@ class SecurityST extends MessagingBaseST {
                         .endPersistentClaimStorage()
                     .endKafka()
                     .editZookeeper()
-                        .withReplicas(3)
                         .withNewPersistentClaimStorage()
                             .withSize("2Gi")
                             .withDeleteClaim(true)
@@ -566,7 +565,7 @@ class SecurityST extends MessagingBaseST {
 
         String maintenanceWindowCron = "* " + windowStartMin + "-" + windowStopMin + " * * * ? *";
         LOGGER.info("Maintenance window is: {}", maintenanceWindowCron);
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 1)
                 .editSpec()
                 .editKafka()
                 .editListeners()
@@ -608,7 +607,7 @@ class SecurityST extends MessagingBaseST {
     @Tag(NODEPORT_SUPPORTED)
     void testCertRegeneratedAfterInternalCAisDeleted() throws Exception {
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 1)
                 .editSpec()
                     .editKafka()
                         .editListeners()

--- a/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
@@ -45,7 +45,8 @@ public class TopicST extends MessagingBaseST {
         int topicPartitions = 5;
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
-        KafkaTopic kafkaTopic =  KafkaTopicResource.topic(CLUSTER_NAME, topicName, topicPartitions, topicReplicationFactor).done();
+        KafkaTopic kafkaTopic =
+                KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, "topic-without-labels", topicPartitions, topicReplicationFactor, 1).build());
 
         assertThat("Topic exists in Kafka CR (Kubernetes)", hasTopicInCRK8s(kafkaTopic, topicName));
         assertThat("Topic doesn't exists in Kafka itself", !hasTopicInKafka(topicName));

--- a/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
@@ -46,7 +46,7 @@ public class TopicST extends MessagingBaseST {
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
         KafkaTopic kafkaTopic =
-                KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, "topic-without-labels", topicPartitions, topicReplicationFactor, 1).build());
+                KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, topicPartitions, topicReplicationFactor, 1).build());
 
         assertThat("Topic exists in Kafka CR (Kubernetes)", hasTopicInCRK8s(kafkaTopic, topicName));
         assertThat("Topic doesn't exists in Kafka itself", !hasTopicInKafka(topicName));


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>


- Bugfix

### Description

After CO fix in https://github.com/strimzi/strimzi-kafka-operator/pull/2312 and major tests fixes in https://github.com/strimzi/strimzi-kafka-operator/pull/2293 we were able to find some other failures caused by refactor. This PR apply fixes for all these failures.

For example:

- test for unsupported kafka version
- all tests which use wrong configuration for topics (expected failures)
- all tests which performs rolling update now use persistent kafka
- tests which checks PVC for kafka doesn't check zookeeper PVC (don't need in that tests)

I also rename few variables in tests for better understanding.

### Checklist

- [ ] Make sure all tests pass

