### PR TITLE
Add initial status to Kafka resources when it is created

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -474,7 +474,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 .withLastTransitionTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(dateSupplier()))
                                 .withType("NotReady")
                                 .withStatus("True")
-                                .withReason("Deploying")
+                                .withReason("Creating")
                                 .withMessage("Kafka cluster is being deployed")
                                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -339,7 +339,7 @@ public class KafkaStatusTest {
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
             assertThat(status.getConditions().get(0).getStatus(), is("True"));
-            assertThat(status.getConditions().get(0).getReason(), is("Deploying"));
+            assertThat(status.getConditions().get(0).getReason(), is("Creating"));
             assertThat(status.getConditions().get(0).getMessage(), is("Kafka cluster is being deployed"));
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -305,6 +306,71 @@ public class KafkaStatusTest {
         });
     }
 
+    @Test
+    public void testInitialStatusOnNewResource() throws ParseException {
+        Kafka kafka = getKafkaCrd();
+        kafka.setStatus(null);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the Kafka Operator
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        MockInitialStatusKafkaAssemblyOperator kao = new MockInitialStatusKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getAllValues().size(), is(2));
+            assertThat(kafkaCaptor.getAllValues().get(0).getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getAllValues().get(0).getStatus();
+
+            assertThat(status.getListeners(), is(nullValue()));
+
+            assertThat(status.getConditions().size(), is(1));
+            assertThat(status.getConditions().get(0).getType(), is("NotReady"));
+            assertThat(status.getConditions().get(0).getStatus(), is("True"));
+            assertThat(status.getConditions().get(0).getReason(), is("Deploying"));
+            assertThat(status.getConditions().get(0).getMessage(), is("Kafka cluster is being deployed"));
+        });
+    }
+
+    @Test
+    public void testInitialStatusOnOldResource() throws ParseException {
+        Kafka kafka = getKafkaCrd();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the Kafka Operator
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        MockInitialStatusKafkaAssemblyOperator kao = new MockInitialStatusKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getAllValues().size(), is(1));
+        });
+    }
+
     // This allows to test the status handling when reconciliation succeeds
     class MockWorkingKafkaAssemblyOperator extends KafkaAssemblyOperator  {
         public MockWorkingKafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, PasswordGenerator passwordGenerator, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
@@ -361,6 +427,19 @@ public class KafkaStatusTest {
             reconcileState.kafkaStatus.setListeners(singletonList(ls));
 
             return Future.failedFuture(exception);
+        }
+    }
+
+    // This allows to test the initial status handling when new resource is created
+    class MockInitialStatusKafkaAssemblyOperator extends KafkaAssemblyOperator  {
+        public MockInitialStatusKafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, PasswordGenerator passwordGenerator, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
+            super(vertx, pfa, certManager, passwordGenerator, supplier, config);
+        }
+
+        @Override
+        Future<Void> reconcile(ReconciliationState reconcileState)  {
+            return reconcileState.initialStatus()
+                    .map((Void) null);
         }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Deploying some resources such as Kafka clusters might take a long time. This PR adds new initial status when a brand new Kafka resource is created. The status looks like this:

```yaml
status:
  conditions:
  - lastTransitionTime: 2019-12-22T20:58:22+0000
    message: Kafka cluster is being deployed
    reason: Deploying
    status: "True"
    type: NotReady
  observedGeneration: 0
```

This should help our users to understand what is going on. This status is applied only when the resource is brand new and has no other status yet. It is not used in any subsequent reconciliations.

This PR implements this only for the Kafka resource. If this is accepted, we should do this to all resources (at least those which might take long to deploy - Connect, MirrorMaker, Bridge etc.)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally