### PR TITLE
Add discovery labels and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Add support for Istio protocol selection in service port names  
 Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka services and headless services.  
 (e.g clientstls -> tcp-clientstls)
+* Add service discovery labels and annotations
+* Add possibility to specify custom server certificates to TLS based listeners
 
 ## 0.15.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -244,7 +244,7 @@ public abstract class AbstractModel {
      * @return The selector labels.
      */
     public Map<String, String> getSelectorLabels() {
-        return labels.withName(name).strimziLabels().toMap();
+        return labels.withName(name).strimziSelectorLabels().toMap();
     }
 
     protected Map<String, String> getLabelsWithName() {
@@ -255,13 +255,20 @@ public abstract class AbstractModel {
         return getLabelsWithName(name, userLabels);
     }
 
-
     protected Map<String, String> getLabelsWithName(String name) {
         return labels.withName(name).toMap();
     }
 
     protected Map<String, String> getLabelsWithName(String name, Map<String, String> userLabels) {
         return labels.withName(name).withUserLabels(userLabels).toMap();
+    }
+
+    protected Map<String, String> getLabelsWithNameAndDiscovery(String name, String discoveryProtocol) {
+        return labels.withName(name).withDiscovery(discoveryProtocol).toMap();
+    }
+
+    protected Map<String, String> getLabelsWithNameAndDiscovery(String name, Map<String, String> userLabels, String discoveryProtocol) {
+        return labels.withName(name).withDiscovery(discoveryProtocol).withUserLabels(userLabels).toMap();
     }
 
     /**
@@ -722,8 +729,16 @@ public abstract class AbstractModel {
         return createService(serviceName, type, ports, getLabelsWithName(serviceName, templateServiceLabels), getSelectorLabels(), annotations);
     }
 
+    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> annotations, String discoveryProtocol) {
+        return createService(serviceName, type, ports, getLabelsWithNameAndDiscovery(serviceName, templateServiceLabels, discoveryProtocol), getSelectorLabels(), annotations);
+    }
+
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
         return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithName(serviceName), templateServiceLabels, labels), getSelectorLabels(), annotations);
+    }
+
+    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations, String discoveryProtocol) {
+        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithNameAndDiscovery(serviceName, discoveryProtocol), templateServiceLabels, labels), getSelectorLabels(), annotations);
     }
 
     protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -263,12 +263,12 @@ public abstract class AbstractModel {
         return labels.withName(name).withUserLabels(userLabels).toMap();
     }
 
-    protected Map<String, String> getLabelsWithNameAndDiscovery(String name, String discoveryProtocol) {
-        return labels.withName(name).withDiscovery(discoveryProtocol).toMap();
+    protected Map<String, String> getLabelsWithNameAndDiscovery(String name) {
+        return labels.withName(name).withDiscovery().toMap();
     }
 
-    protected Map<String, String> getLabelsWithNameAndDiscovery(String name, Map<String, String> userLabels, String discoveryProtocol) {
-        return labels.withName(name).withDiscovery(discoveryProtocol).withUserLabels(userLabels).toMap();
+    protected Map<String, String> getLabelsWithNameAndDiscovery(String name, Map<String, String> userLabels) {
+        return labels.withName(name).withDiscovery().withUserLabels(userLabels).toMap();
     }
 
     /**
@@ -729,16 +729,16 @@ public abstract class AbstractModel {
         return createService(serviceName, type, ports, getLabelsWithName(serviceName, templateServiceLabels), getSelectorLabels(), annotations);
     }
 
-    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> annotations, String discoveryProtocol) {
-        return createService(serviceName, type, ports, getLabelsWithNameAndDiscovery(serviceName, templateServiceLabels, discoveryProtocol), getSelectorLabels(), annotations);
+    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> annotations) {
+        return createService(serviceName, type, ports, getLabelsWithNameAndDiscovery(serviceName, templateServiceLabels), getSelectorLabels(), annotations);
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
         return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithName(serviceName), templateServiceLabels, labels), getSelectorLabels(), annotations);
     }
 
-    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations, String discoveryProtocol) {
-        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithNameAndDiscovery(serviceName, discoveryProtocol), templateServiceLabels, labels), getSelectorLabels(), annotations);
+    protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
+        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithNameAndDiscovery(serviceName), templateServiceLabels, labels), getSelectorLabels(), annotations);
     }
 
     protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -221,7 +221,7 @@ public class KafkaBridgeCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createDiscoverableService("ClusterIP", ports, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_LABELS), mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)), "http");
+        return createDiscoverableService("ClusterIP", ports, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_LABELS), mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)));
     }
 
     /**
@@ -234,6 +234,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         discovery.put("port", port);
         discovery.put("tls", false);
         discovery.put("auth", "none");
+        discovery.put("protocol", "http");
 
         JsonArray anno = new JsonArray();
         anno.add(discovery);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -35,6 +35,8 @@ import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Labels;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -219,7 +221,24 @@ public class KafkaBridgeCluster extends AbstractModel {
             ports.add(createServicePort(METRICS_PORT_NAME, METRICS_PORT, METRICS_PORT, "TCP"));
         }
 
-        return createService("ClusterIP", ports, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_LABELS), mergeLabelsOrAnnotations(templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)));
+        return createDiscoverableService("ClusterIP", ports, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_LABELS), mergeLabelsOrAnnotations(getDiscoveryAnnotation(port), templateServiceAnnotations, ModelUtils.getCustomLabelsOrAnnotations(CO_ENV_VAR_CUSTOM_ANNOTATIONS)), "http");
+    }
+
+    /**
+     * Generates a JSON String with the discovery annotation for the bridge service
+     *
+     * @return  JSON with discovery annotation
+     */
+    /*test*/ Map<String, String> getDiscoveryAnnotation(int port) {
+        JsonObject discovery = new JsonObject();
+        discovery.put("port", port);
+        discovery.put("tls", false);
+        discovery.put("auth", "none");
+
+        JsonArray anno = new JsonArray();
+        anno.add(discovery);
+
+        return Collections.singletonMap(Labels.STRIMZI_DISCOVERY_LABEL, anno.encodePrettily());
     }
 
     protected List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -739,34 +739,36 @@ public class KafkaCluster extends AbstractModel {
     /*test*/ Map<String, String> getInternalDiscoveryAnnotation() {
         JsonArray anno = new JsonArray();
 
-        if (listeners.getPlain() != null)   {
-            JsonObject discovery = new JsonObject();
-            discovery.put("port", 9092);
-            discovery.put("tls", false);
-            discovery.put("protocol", "kafka");
+        if (listeners != null) {
+            if (listeners.getPlain() != null) {
+                JsonObject discovery = new JsonObject();
+                discovery.put("port", 9092);
+                discovery.put("tls", false);
+                discovery.put("protocol", "kafka");
 
-            if (listeners.getPlain().getAuth() != null) {
-                discovery.put("auth", listeners.getPlain().getAuth().getType());
-            } else {
-                discovery.put("auth", "none");
+                if (listeners.getPlain().getAuth() != null) {
+                    discovery.put("auth", listeners.getPlain().getAuth().getType());
+                } else {
+                    discovery.put("auth", "none");
+                }
+
+                anno.add(discovery);
             }
 
-            anno.add(discovery);
-        }
+            if (listeners.getTls() != null) {
+                JsonObject discovery = new JsonObject();
+                discovery.put("port", 9093);
+                discovery.put("tls", true);
+                discovery.put("protocol", "kafka");
 
-        if (listeners.getTls() != null)   {
-            JsonObject discovery = new JsonObject();
-            discovery.put("port", 9093);
-            discovery.put("tls", true);
-            discovery.put("protocol", "kafka");
+                if (listeners.getTls().getAuth() != null) {
+                    discovery.put("auth", listeners.getTls().getAuth().getType());
+                } else {
+                    discovery.put("auth", "none");
+                }
 
-            if (listeners.getTls().getAuth() != null) {
-                discovery.put("auth", listeners.getTls().getAuth().getType());
-            } else {
-                discovery.put("auth", "none");
+                anno.add(discovery);
             }
-
-            anno.add(discovery);
         }
 
         return Collections.singletonMap(Labels.STRIMZI_DISCOVERY_LABEL, anno.encodePrettily());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -728,7 +728,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The generated Service
      */
     public Service generateService() {
-        return createDiscoverableService("ClusterIP", getServicePorts(), mergeLabelsOrAnnotations(getInternalDiscoveryAnnotation(), getPrometheusAnnotations(), templateServiceAnnotations), "kafka");
+        return createDiscoverableService("ClusterIP", getServicePorts(), mergeLabelsOrAnnotations(getInternalDiscoveryAnnotation(), getPrometheusAnnotations(), templateServiceAnnotations));
     }
 
     /**
@@ -743,6 +743,7 @@ public class KafkaCluster extends AbstractModel {
             JsonObject discovery = new JsonObject();
             discovery.put("port", 9092);
             discovery.put("tls", false);
+            discovery.put("protocol", "kafka");
 
             if (listeners.getPlain().getAuth() != null) {
                 discovery.put("auth", listeners.getPlain().getAuth().getType());
@@ -757,6 +758,7 @@ public class KafkaCluster extends AbstractModel {
             JsonObject discovery = new JsonObject();
             discovery.put("port", 9093);
             discovery.put("tls", true);
+            discovery.put("protocol", "kafka");
 
             if (listeners.getTls().getAuth() != null) {
                 discovery.put("auth", listeners.getTls().getAuth().getType());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -96,8 +96,15 @@ public class KafkaBridgeClusterTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
+    private Map<String, String> expectedServiceLabels(String name)    {
+        Map<String, String> serviceLabels = expectedLabels(name);
+        serviceLabels.put(Labels.STRIMZI_DISCOVERY_LABEL, "http");
+
+        return serviceLabels;
+    }
+
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {
@@ -152,13 +159,15 @@ public class KafkaBridgeClusterTest {
         Service svc = kbc.generateService();
 
         assertThat(svc.getSpec().getType(), is("ClusterIP"));
-        assertThat(svc.getMetadata().getLabels(), is(expectedLabels(kbc.getServiceName())));
+        assertThat(svc.getMetadata().getLabels(), is(expectedServiceLabels(kbc.getServiceName())));
         assertThat(svc.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(svc.getSpec().getPorts().size(), is(2));
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(new Integer(KafkaBridgeCluster.DEFAULT_REST_API_PORT)));
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaBridgeCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(svc.getMetadata().getAnnotations(), is(emptyMap()));
+
+        assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(KafkaBridgeCluster.DEFAULT_REST_API_PORT)));
+
         checkOwnerReference(kbc.createOwnerReference(), svc);
     }
 
@@ -892,12 +901,12 @@ public class KafkaBridgeClusterTest {
         Service svc = kb.generateService();
 
         assertThat(svc.getSpec().getType(), is("ClusterIP"));
-        assertThat(svc.getMetadata().getLabels(), is(expectedLabels(kb.getServiceName())));
+        assertThat(svc.getMetadata().getLabels(), is(expectedServiceLabels(kb.getServiceName())));
         assertThat(svc.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(new Integer(1874)));
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaBridgeCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(svc.getMetadata().getAnnotations(), is(emptyMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(1874)));
         checkOwnerReference(kbc.createOwnerReference(), svc);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -98,7 +98,7 @@ public class KafkaBridgeClusterTest {
 
     private Map<String, String> expectedServiceLabels(String name)    {
         Map<String, String> serviceLabels = expectedLabels(name);
-        serviceLabels.put(Labels.STRIMZI_DISCOVERY_LABEL, "http");
+        serviceLabels.put(Labels.STRIMZI_DISCOVERY_LABEL, "true");
 
         return serviceLabels;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -185,7 +185,7 @@ public class KafkaClusterTest {
         assertThat(headful.getMetadata().getAnnotations(), is(AbstractModel.mergeLabelsOrAnnotations(kc.getInternalDiscoveryAnnotation(), kc.getPrometheusAnnotations())));
 
         assertThat(headful.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
-        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("kafka"));
+        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
         checkOwnerReference(kc.createOwnerReference(), headful);
     }
@@ -220,7 +220,7 @@ public class KafkaClusterTest {
         assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
 
         assertThat(headful.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
-        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("kafka"));
+        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
         checkOwnerReference(kc.createOwnerReference(), headful);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -159,7 +159,7 @@ public class KafkaClusterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     @Test
@@ -181,7 +181,11 @@ public class KafkaClusterTest {
         assertThat(headful.getSpec().getPorts().get(3).getName(), is(AbstractModel.METRICS_PORT_NAME));
         assertThat(headful.getSpec().getPorts().get(3).getPort(), is(new Integer(KafkaCluster.METRICS_PORT)));
         assertThat(headful.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
-        assertThat(headful.getMetadata().getAnnotations(), is(kc.getPrometheusAnnotations()));
+
+        assertThat(headful.getMetadata().getAnnotations(), is(AbstractModel.mergeLabelsOrAnnotations(kc.getInternalDiscoveryAnnotation(), kc.getPrometheusAnnotations())));
+
+        assertThat(headful.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
+        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("kafka"));
 
         checkOwnerReference(kc.createOwnerReference(), headful);
     }
@@ -215,6 +219,9 @@ public class KafkaClusterTest {
         assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"), is(false));
         assertThat(headful.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
 
+        assertThat(headful.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(true));
+        assertThat(headful.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("kafka"));
+
         checkOwnerReference(kc.createOwnerReference(), headful);
     }
 
@@ -246,6 +253,8 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getPorts().get(3).getPort(), is(new Integer(KafkaCluster.JMX_PORT)));
         assertThat(headless.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
 
+        assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
+
         checkOwnerReference(kc.createOwnerReference(), headless);
     }
 
@@ -271,6 +280,8 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getPorts().get(2).getName(), is(KafkaCluster.CLIENT_TLS_PORT_NAME));
         assertThat(headless.getSpec().getPorts().get(2).getPort(), is(new Integer(KafkaCluster.CLIENT_TLS_PORT)));
         assertThat(headless.getSpec().getPorts().get(2).getProtocol(), is("TCP"));
+
+        assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -119,7 +119,7 @@ public class KafkaConnectClusterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -124,7 +124,7 @@ public class KafkaConnectS2IClusterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -102,7 +102,7 @@ public class KafkaExporterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -124,7 +124,7 @@ public class KafkaMirrorMakerClusterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -122,7 +122,7 @@ public class ZookeeperClusterTest {
     }
 
     private Map<String, String> expectedSelectorLabels()    {
-        return Labels.fromMap(expectedLabels()).strimziLabels().toMap();
+        return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
 
     private Map<String, String> expectedLabels()    {

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -279,12 +279,11 @@ public class Labels {
     }
 
     /**
-     * The same labels as this instance, but with the given {@code protocol} for the {@code strimzi.io/discovery} key.
-     * @param protocol The name of the protocol
+     * The same labels as this instance, but with "true" for the {@code strimzi.io/discovery} key.
      * @return A new instance with the given name added.
      */
-    public Labels withDiscovery(String protocol) {
-        return with(STRIMZI_DISCOVERY_LABEL, protocol);
+    public Labels withDiscovery() {
+        return with(STRIMZI_DISCOVERY_LABEL, "true");
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -54,6 +54,14 @@ public class Labels {
      */
     public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "name";
 
+    /**
+     * The name of the label used for Strimzi discovery.
+     * This label should be set by Strimzi on services which are user interfaces when users are expected to connect.
+     * Applications using Strimzi can use this label to find the services and connect to Strimzi created clusters.
+     * This label should be used for example on the Kafka bootstrap service.
+     */
+    public static final String STRIMZI_DISCOVERY_LABEL = STRIMZI_DOMAIN + "discovery";
+
     public static final String KUBERNETES_NAME_LABEL = KUBERNETES_DOMAIN + "name";
     public static final String KUBERNETES_INSTANCE_LABEL = KUBERNETES_DOMAIN + "instance";
     public static final String KUBERNETES_MANAGED_BY_LABEL = KUBERNETES_DOMAIN + "managed-by";
@@ -271,6 +279,15 @@ public class Labels {
     }
 
     /**
+     * The same labels as this instance, but with the given {@code protocol} for the {@code strimzi.io/discovery} key.
+     * @param protocol The name of the protocol
+     * @return A new instance with the given name added.
+     */
+    public Labels withDiscovery(String protocol) {
+        return with(STRIMZI_DISCOVERY_LABEL, protocol);
+    }
+
+    /**
      * The same labels as this instance, but with the given {@code name} for the {@code statefulset.kubernetes.io/pod-name} key.
      * @param name The pod name to add
      * @return A new instance with the given pod name added.
@@ -305,11 +322,11 @@ public class Labels {
     /**
      * @return An instances containing just the strimzi.io labels present in this instance.
      */
-    public Labels strimziLabels() {
+    public Labels strimziSelectorLabels() {
         Map<String, String> newLabels = new HashMap<>(3);
 
         for (Map.Entry<String, String> entry : labels.entrySet()) {
-            if (entry.getKey().startsWith(STRIMZI_DOMAIN)) {
+            if (entry.getKey().startsWith(STRIMZI_DOMAIN) && !entry.getKey().equals(STRIMZI_DISCOVERY_LABEL)) {
                 newLabels.put(entry.getKey(), entry.getValue());
             }
         }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -86,7 +86,7 @@ public class LabelsTest {
         sourceMap.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
         sourceMap.put("key2", "value2");
         sourceMap.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
-        sourceMap.put(Labels.STRIMZI_DISCOVERY_LABEL, "kafka");
+        sourceMap.put(Labels.STRIMZI_DISCOVERY_LABEL, "true");
         Labels labels = Labels.fromMap(sourceMap);
 
         Map expected = new HashMap<String, String>(2);

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -79,13 +79,14 @@ public class LabelsTest {
     }
 
     @Test
-    public void testStrimziLabels()   {
+    public void testStrimziSelectorLabels()   {
         Map sourceMap = new HashMap<String, String>(5);
         sourceMap.put(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster");
         sourceMap.put("key1", "value1");
         sourceMap.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
         sourceMap.put("key2", "value2");
         sourceMap.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
+        sourceMap.put(Labels.STRIMZI_DISCOVERY_LABEL, "kafka");
         Labels labels = Labels.fromMap(sourceMap);
 
         Map expected = new HashMap<String, String>(2);
@@ -93,7 +94,7 @@ public class LabelsTest {
         expected.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
         expected.put(Labels.STRIMZI_NAME_LABEL, "my-cluster-kafka");
 
-        assertThat(labels.strimziLabels().toMap(), is(expected));
+        assertThat(labels.strimziSelectorLabels().toMap(), is(expected));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds discovery labels and annotations as descirbed in #504:
* It adds a labels `strimzi.io/discovery: true` to the Kafka internal bootstrap service and to the HTTP Bridge service
* Adds annotation `strimzi.io/discovery` with additional details. E.g.:

```yaml
    strimzi.io/discovery: |-
      [ {
        "port" : 9092,
        "tls" : false,
        "protocol" : "kafka",
        "auth" : "scram-sha-512"
      }, {
        "port" : 9093,
        "tls" : true,
        "protocol" : "kafka",
        "auth" : "tls"
      } ]
```

or

```yaml
    strimzi.io/discovery: |-
      [ {
        "port" : 8080,
        "tls" : false,
        "auth" : "none",
        "protocol" : "http"
      } ]
```

The services can be discovered using `kubectl get service -l strimzi.io/discovery=true` or the corresponding API call.

This should fix the issue #504.

This PR also adds the CHANGELOG.md record for the custom TLS certificates. I hope this is ok - separate PR would just cause conflicts etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

