### PR TITLE
[DOC] KafkaConnector resources

### DIFF
--- a/documentation/assemblies/assembly-deployment-configuration-kafka-connect-s2i.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-connect-s2i.adoc
@@ -45,6 +45,8 @@ include::assembly-scheduling.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-external-configuration.adoc[leveloffset=+1]
 
+include::../modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc[leveloffset=+1]
+
 include::../modules/ref-list-of-kafka-connect-s2i-resources.adoc[leveloffset=+1]
 
 include::../modules/proc-using-openshift-builds-create-image.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-deployment-configuration-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration-kafka-connect.adoc
@@ -45,6 +45,8 @@ include::assembly-scheduling.adoc[leveloffset=+1]
 
 include::assembly-kafka-connect-external-configuration.adoc[leveloffset=+1]
 
+include::../modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc[leveloffset=+1]
+
 include::../modules/ref-list-of-kafka-connect-resources.adoc[leveloffset=+1]
 
 // Restore the context to what it was before this assembly.

--- a/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
@@ -11,7 +11,7 @@
 
 = Using external configuration and secrets
 
-Connectors are created, reconfigured, and deleted using an HTTP REST interface unless `KafkaConnectors` are enabled for the Kafka Connect cluster. The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
+Connectors are created, reconfigured, and deleted using an HTTP REST interface unless `KafkaConnectors` are enabled for the Kafka Connect cluster (for more information, see xref:con-creating-managing-connectors-{context}[]). The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
 
 Some parts of the configuration of a connector can be externalized using ConfigMaps or Secrets.
 You can then reference the configuration values in HTTP REST commands (this keeps the configuration separate and more secure, if needed).

--- a/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
@@ -11,13 +11,12 @@
 
 = Using external configuration and secrets
 
-Connectors are created, reconfigured, and deleted using an HTTP REST interface unless `KafkaConnectors` are enabled for the Kafka Connect cluster (for more information, see xref:con-creating-managing-connectors-{context}[]). The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
-
-Some parts of the configuration of a connector can be externalized using ConfigMaps or Secrets.
-You can then reference the configuration values in HTTP REST commands (this keeps the configuration separate and more secure, if needed).
-This method applies especially to confidential data, such as usernames, passwords, or certificates.
+Connectors are created, reconfigured, and deleted using the Kafka Connect HTTP REST interface, or by using `KafkaConnectors`. For more information on these methods, see xref:con-creating-managing-connectors-str[]. The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
 
 ConfigMaps and Secrets are standard Kubernetes resources used for storing configurations and confidential data.
+Whichever method you use to manage connectors, you can use ConfigMaps and Secrets to configure certain elements of a connector.
+You can then reference the configuration values in HTTP REST commands (this keeps the configuration separate and more secure, if needed).
+This method applies especially to confidential data, such as usernames, passwords, or certificates.
 
 include::../modules/con-kafka-connect-external-configuration.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-external-configuration.adoc
@@ -11,14 +11,13 @@
 
 = Using external configuration and secrets
 
-Kafka Connect connectors are configured using an HTTP REST interface.
-The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
+Connectors are created, reconfigured, and deleted using an HTTP REST interface unless `KafkaConnectors` are enabled for the Kafka Connect cluster. The connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
 
-Some parts of the configuration of a Kafka Connect connector can be externalized using ConfigMaps or Secrets.
+Some parts of the configuration of a connector can be externalized using ConfigMaps or Secrets.
 You can then reference the configuration values in HTTP REST commands (this keeps the configuration separate and more secure, if needed).
 This method applies especially to confidential data, such as usernames, passwords, or certificates.
 
-ConfigMaps and Secrets are standard Kubernetes resources used for storing of configurations and confidential data.
+ConfigMaps and Secrets are standard Kubernetes resources used for storing configurations and confidential data.
 
 include::../modules/con-kafka-connect-external-configuration.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect-replicas.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-replicas.adoc
@@ -11,7 +11,7 @@
 
 = Replicas
 
-Kafka Connect clusters can run multiple of nodes.
+Kafka Connect clusters can consist of one or several nodes.
 The number of nodes is defined in the `KafkaConnect` and `KafkaConnectS2I` resources.
 Running a Kafka Connect cluster with multiple nodes can provide better availability and scalability.
 However, when running Kafka Connect on Kubernetes it is not absolutely necessary to run multiple nodes of Kafka Connect for high availability.

--- a/documentation/assemblies/assembly-kafka-connect-replicas.adoc
+++ b/documentation/assemblies/assembly-kafka-connect-replicas.adoc
@@ -11,10 +11,10 @@
 
 = Replicas
 
-Kafka Connect clusters can consist of one or several nodes.
+Kafka Connect clusters can consist of one or more nodes.
 The number of nodes is defined in the `KafkaConnect` and `KafkaConnectS2I` resources.
 Running a Kafka Connect cluster with multiple nodes can provide better availability and scalability.
-However, when running Kafka Connect on Kubernetes it is not absolutely necessary to run multiple nodes of Kafka Connect for high availability.
+However, when running Kafka Connect on Kubernetes it is not necessary to run multiple nodes of Kafka Connect for high availability.
 If a node where Kafka Connect is deployed to crashes, Kubernetes will automatically reschedule the Kafka Connect pod to a different node.
 However, running Kafka Connect with multiple nodes can provide faster failover times, because the other nodes will be up and running already.
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -11,7 +11,7 @@
 
 link:https://kafka.apache.org/documentation/#connect[Kafka Connect^] is a tool for streaming data between Apache Kafka and external systems. It provides a framework for moving large amounts of data into and out of your Kafka cluster while maintaining scalability and reliability. Kafka Connect is typically used to integrate Kafka with external databases and storage and messaging systems.
 
-In Kafka Connect a _source connector_ is a runtime entity that fetches data from an external system and feeds it to Kafka as messages. A _sink connector_ is a runtime entity that fetches messages from Kafka topics and feeds them to an external system. The workload of connectors is divided into _tasks_. Tasks are distributed among nodes, which form a _Connect cluster_. This allows the message flow to be highly scalable and reliable.
+In Kafka Connect a _source connector_ is a runtime entity that fetches data from an external system and feeds it to Kafka as messages. A _sink connector_ is a runtime entity that fetches messages from Kafka topics and feeds them to an external system. The workload of connectors is divided into _tasks_. Tasks are distributed among nodes (also called _workers_), which form a _Connect cluster_. This allows the message flow to be highly scalable and reliable.
 
 Each connector is an instance of a particular _connector class_ that knows how to communicate with the relevant external system in terms of messages. Connectors are available for many external systems, or you can develop your own.
 
@@ -49,7 +49,7 @@ To use other connector classes, you need to prepare connector images by followin
 
 The Cluster Operator can use images that you create to deploy a Kafka Connect cluster to your Kubernetes cluster.
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. Each individual connector's tasks are distributed among the workers in the cluster.
+A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers.
 
 You can create and manage connectors using `KafkaConnector` resources or manually using the Kafka Connect REST API, which is available on port 8083 as the `<connect-cluster-name>-connect-api` service. The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -35,7 +35,7 @@ m¦FileStreamSinkConnector
 
 You can use the Cluster Operator to deploy a Kafka Connect cluster containing the built-in connectors to your Kubernetes cluster. Deploying a Kafka Connect Source-2-Image (S2I) cluster is supported on OpenShift only. For more information, see xref:using-openshift-s2i-create-image-str[].
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api service`. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
+A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -11,11 +11,19 @@
 
 link:https://kafka.apache.org/documentation/#connect[Kafka Connect^] is a tool for streaming data between Apache Kafka and external systems. It provides a framework for moving large amounts of data into and out of your Kafka cluster while maintaining scalability and reliability. Kafka Connect is typically used to integrate Kafka with external databases and storage and messaging systems.
 
-You can use Kafka Connect to:
+In Kafka Connect a _source connector_ is a runtime entity that fetches data from an external system and feeds it to Kafka as messages. A _sink connector_ is a runtime entity that fetches messages from Kafka topics and feeds them to an external system. The workload of connectors is divided into _tasks_. Tasks are distributed among nodes, which form a _Connect cluster_. This allows the message flow to be highly scalable and reliable.
 
-* Build connector plug-ins (as JAR files) for your Kafka cluster
-* Run connectors
-* Create and manage connectors using `KafkaConnector` resources
+Each connector is an instance of a particular _connector class_ that knows how to communicate with the relevant external system in terms of messages. Connectors are available for many external systems, or you can develop your own.
+
+The term _connector_ is used interchangably to mean a connector instance running within a Kafka Connect cluster, or a connector class. This guide uses the term _connector_ when the meaning is clear from the context.
+
+{ProductName} allows you to:
+
+* Create a Kafka Connect image containing the connectors you want
+
+* Deploy and manage a Kafka Connect cluster running within Kubernetes using a `KafkaConnect` resource
+
+* Run connectors within your Kafka Connect cluster, optionally managed using `KafkaConnector` resources
 
 Kafka Connect includes the following built-in connectors for moving file-based data into and out of your Kafka cluster.
 
@@ -33,9 +41,17 @@ m¦FileStreamSinkConnector
 
 |===
 
-You can use the Cluster Operator to deploy a Kafka Connect cluster containing the built-in connectors to your Kubernetes cluster. Deploying a Kafka Connect Source-2-Image (S2I) cluster is supported on OpenShift only. For more information, see xref:using-openshift-s2i-create-image-str[].
+To use other connector classes, you need to prepare connector images by following one of these procedures:
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
+* xref:creating-new-image-from-base-{context}[] 
+
+* xref:using-openshift-s2i-create-image-str[] (OpenShift only)
+
+The Cluster Operator can use images that you create to deploy a Kafka Connect cluster to your Kubernetes cluster.
+
+A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. Each individual connector's tasks are distributed among the workers in the cluster.
+
+You can create and manage connectors using `KafkaConnector` resources or manually using the Kafka Connect REST API, which is available on port 8083 as the `<connect-cluster-name>-connect-api` service. The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -1,6 +1,6 @@
 // This assembly is included in the following assemblies:
 //
-// getting-started.adoc
+// assembly-getting-started.adoc
 
 // Save the context of the assembly that is including this one.
 // This is necessary for including assemblies in assemblies.

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -35,7 +35,7 @@ m¦FileStreamSinkConnector
 
 You can use the Cluster Operator to deploy a Kafka Connect cluster containing the built-in connectors to your Kubernetes cluster. Deploying a Kafka Connect Source-2-Image (S2I) cluster is supported on OpenShift only. For more information, see xref:using-openshift-s2i-create-image-str[].
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api service`. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[^Apache Kafka documentation].
+A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api service`. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -42,3 +42,7 @@ For more information on deploying a Kafka Connect S2I cluster on OpenShift, see 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 
 include::assembly-using-kafka-connect-with-plugins.adoc[leveloffset=+1]
+
+include::../modules/con-creating-managing-connectors.adoc[leveloffset=+1]
+
+include::../modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -11,7 +11,7 @@
 
 link:https://kafka.apache.org/documentation/#connect[Kafka Connect^] is a tool for streaming data between Apache Kafka and external systems. It provides a framework for moving large amounts of data into and out of your Kafka cluster while maintaining scalability and reliability. Kafka Connect is typically used to integrate Kafka with external databases and storage and messaging systems.
 
-In Kafka Connect a _source connector_ is a runtime entity that fetches data from an external system and feeds it to Kafka as messages. A _sink connector_ is a runtime entity that fetches messages from Kafka topics and feeds them to an external system. The workload of connectors is divided into _tasks_. Tasks are distributed among nodes (also called _workers_), which form a _Connect cluster_. This allows the message flow to be highly scalable and reliable.
+In Kafka Connect, a _source connector_ is a runtime entity that fetches data from an external system and feeds it to Kafka as messages. A _sink connector_ is a runtime entity that fetches messages from Kafka topics and feeds them to an external system. The workload of connectors is divided into _tasks_. Tasks are distributed among nodes (also called _workers_), which form a _Connect cluster_. This allows the message flow to be highly scalable and reliable.
 
 Each connector is an instance of a particular _connector class_ that knows how to communicate with the relevant external system in terms of messages. Connectors are available for many external systems, or you can develop your own.
 
@@ -51,7 +51,7 @@ The Cluster Operator can use images that you create to deploy a Kafka Connect cl
 
 A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers.
 
-You can create and manage connectors using `KafkaConnector` resources or manually using the Kafka Connect REST API, which is available on port 8083 as the `<connect-cluster-name>-connect-api` service. The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
+You can xref:con-creating-managing-connectors-{context}[create and manage connectors] using `KafkaConnector` resources or manually using the Kafka Connect REST API, which is available on port 8083 as the `<connect-cluster-name>-connect-api` service. The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-kafka-connect.adoc
+++ b/documentation/assemblies/assembly-kafka-connect.adoc
@@ -15,6 +15,7 @@ You can use Kafka Connect to:
 
 * Build connector plug-ins (as JAR files) for your Kafka cluster
 * Run connectors
+* Create and manage connectors using `KafkaConnector` resources
 
 Kafka Connect includes the following built-in connectors for moving file-based data into and out of your Kafka cluster.
 
@@ -32,12 +33,9 @@ m¦FileStreamSinkConnector
 
 |===
 
-In {ProductName}, you can use the Cluster Operator to deploy a Kafka Connect to your Kubernetes cluster.
-OpenShift also supports Kafka Connect Source-2-Image (S2I) clusters.
+You can use the Cluster Operator to deploy a Kafka Connect cluster containing the built-in connectors to your Kubernetes cluster. Deploying a Kafka Connect Source-2-Image (S2I) cluster is supported on OpenShift only. For more information, see xref:using-openshift-s2i-create-image-str[].
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083, as the `<connect-cluster-name>-connect-api` service.
-
-For more information on deploying a Kafka Connect S2I cluster on OpenShift, see xref:using-openshift-s2i-create-image-str[Creating a container image using OpenShift builds and Source-to-Image].
+A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of workers. The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api service`. For more information about the supported operations, see the link:https://kafka.apache.org/documentation/#connect_rest[^Apache Kafka documentation].
 
 include::../modules/proc-deploying-kafka-connect.adoc[leveloffset=+1]
 

--- a/documentation/modules/con-cluster-operator-watch-options.adoc
+++ b/documentation/modules/con-cluster-operator-watch-options.adoc
@@ -17,11 +17,12 @@ Depending on the deployment, the Cluster Operator can watch Kafka resources from
 
 NOTE: {ProductName} provides example YAML files to make the deployment process easier.
 
-The Cluster Operator watches the following resources:
+The Cluster Operator watches for changes to the following resources:
 
 * `Kafka` for the Kafka cluster.
 * `KafkaConnect` for the Kafka Connect cluster.
 * `KafkaConnectS2I` for the Kafka Connect cluster with Source2Image support.
+* `KafkaConnector` for creating and managing connectors in a Kafka Connect cluster.
 * `KafkaMirrorMaker` for the Kafka Mirror Maker instance.
 * `KafkaBridge` for the Kafka Bridge instance
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -6,7 +6,7 @@
 
 = Creating and managing connectors
 
-Once you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster. You can then configure, monitor, and manage a running connector instance. For example, you can:
+When you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster. You can then configure, monitor, and manage a running connector instance. For example, you can:
 
 * Check the status of a connector instance
 * Increase or decrease the number of tasks
@@ -26,11 +26,13 @@ NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks or pau
 `KafkaConnectors` allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
 Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance. 
 
-You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates (for example, using `kubectl apply`). You remove a connector by deleting its corresponding `KafkaConnector`.
+You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates. You remove a connector by deleting its corresponding `KafkaConnector`.
 
-To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must configure the `KafkaConnect` custom resource to use `KafkaConnectors` for the creation and management of connectors. For instructions, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
+To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource. For instructions, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 
 When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. Like other Kafka resources, the Cluster Operator updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
+
+{ProductName} includes an example `KafkaConnector`, named `examples/connector/source-connector.yaml`, that you can use to create and manage a `FileStreamSourceConnector`.
 
 .Availability of the Kafka Connect REST API
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -19,11 +19,12 @@ Once you have created a container image for your connector plug-in, you need to 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
 
-NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks and pausing and resuming connectors. You need to use the Kafka Connect REST API to perform these tasks.
+NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks or pausing and resuming connectors. You need to use the Kafka Connect REST API to perform those tasks.
 
 .`KafkaConnector` resources
 
-`KafkaConnectors` allow you to create and manage source and sink connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required. Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance. 
+`KafkaConnectors` allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
+Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance. 
 
 You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates (for example, using `kubectl apply`). You remove a connector by deleting its corresponding `KafkaConnector`.
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// ????????.adoc
+
+[id='con-creating-managing-connectors-{context}']
+= Creating and managing connectors
+The standard address space is the default address space in {ProductName}. It consists of an AMQP router network in combination with attachable storage units. Clients connect to a message router, which forwards messages to or from one or more message brokers. This address space type is appropriate when you have many connections and addresses. However, the standard address space has the following limitations:
+
+* No transaction support
+* No message ordering
+* No selectors on queues
+* No browsing on queues
+* No message groups
+
+Clients connect and send and receive messages in this address space using the AMQP or MQTT protocols. Note that MQTT does not support qos2 or retained messages.

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -1,15 +1,40 @@
 // Module included in the following assemblies:
 //
-// ????????.adoc
+// assembly-kafka-connect.adoc
 
 [id='con-creating-managing-connectors-{context}']
+
 = Creating and managing connectors
-The standard address space is the default address space in {ProductName}. It consists of an AMQP router network in combination with attachable storage units. Clients connect to a message router, which forwards messages to or from one or more message brokers. This address space type is appropriate when you have many connections and addresses. However, the standard address space has the following limitations:
 
-* No transaction support
-* No message ordering
-* No selectors on queues
-* No browsing on queues
-* No message groups
+Once you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster. You can then configure, monitor, and manage a running connector instance. For example, you can:
 
-Clients connect and send and receive messages in this address space using the AMQP or MQTT protocols. Note that MQTT does not support qos2 or retained messages.
+* Check the status of a connector instance
+* Increase or decrease the number of tasks
+* Restart failed tasks
+* Pause a connector instance
+* Delete a connector instance
+
+{ProductName} provides two different APIs for creating and managing connectors:
+
+* `KafkaConnector` resources (referred to as `KafkaConnectors`)
+* Kafka Connect REST API
+
+For security reasons, we recommend that you use `KafkaConnectors` rather than the Kafka Connect REST API. `KafkaConnectors` use Kubernetes RBAC controls to secure the Kafka Connect REST API and lock down its resources.
+
+NOTE: You need to use the Kafka Connect REST API for restarting failed tasks and pausing and resuming connectors. Future {ProductName} releases might add this functionality to `KafkaConnectors`.
+
+.`KafkaConnector` resources
+
+`KafkaConnectors` allow you to create and manage source and sink connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required. Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create a corresponding connector instance. 
+
+You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates using `kubectl apply`. You remove a connector by deleting its corresponding `KafkaConnector`.
+
+To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must configure the `KafkaConnect` custom resource to use `KafkaConnectors` for the creation and management of connectors. For instructions, see xref:proc-enabling-kafkaconnectors-{context}[].
+
+When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. Like other Kafka resources, the Cluster Operator updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
+
+.Availability of the Kafka Connect REST API
+
+The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service.
+
+If `KafkaConnectors` are enabled, changes made using the Kafka Connect REST API are reverted by the Cluster Operator. 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -29,7 +29,7 @@ NOTE: You need to use the Kafka Connect REST API for restarting failed tasks and
 
 You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates using `kubectl apply`. You remove a connector by deleting its corresponding `KafkaConnector`.
 
-To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must configure the `KafkaConnect` custom resource to use `KafkaConnectors` for the creation and management of connectors. For instructions, see xref:proc-enabling-kafkaconnectors-{context}[].
+To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must configure the `KafkaConnect` custom resource to use `KafkaConnectors` for the creation and management of connectors. For instructions, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 
 When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. Like other Kafka resources, the Cluster Operator updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -19,7 +19,7 @@ When you have created a container image for your connector plug-in, you need to 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
 
-NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks or pausing and resuming connectors. You need to use the Kafka Connect REST API to perform those tasks.
+NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks. You need to use the Kafka Connect REST API to do this.
 
 .`KafkaConnector` resources
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -9,19 +9,19 @@
 When you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster. You can then configure, monitor, and manage a running connector instance. For example, you can:
 
 * Check the status of a connector instance
-* Increase or decrease the number of tasks
+* Increase or decrease the number of tasks for a connector instance
 * Restart failed tasks
 * Pause a connector instance
 * Delete a connector instance
 
-{ProductName} provides two different APIs for creating and managing connectors:
+{ProductName} provides two APIs for creating and managing connectors:
 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
 
 NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks. You need to use the Kafka Connect REST API to do this.
 
-.`KafkaConnector` resources
+== `KafkaConnector` resources
 
 `KafkaConnectors` allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
 Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance. 
@@ -30,11 +30,11 @@ You manage a running connector instance by updating its corresponding `KafkaConn
 
 To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource. For instructions, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 
-When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. Like other Kafka resources, the Cluster Operator updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
+When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their `KafkaConnectors`.
 
-{ProductName} includes an example `KafkaConnector`, named `examples/connector/source-connector.yaml`, that you can use to create and manage a `FileStreamSourceConnector`.
+{ProductName} includes an example `KafkaConnector`, named `examples/connector/source-connector.yaml`. You can use this example to create and manage a `FileStreamSourceConnector`.
 
-.Availability of the Kafka Connect REST API
+== Availability of the Kafka Connect REST API
 
 The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service.
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -19,15 +19,13 @@ Once you have created a container image for your connector plug-in, you need to 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
 
-For security reasons, we recommend that you use `KafkaConnectors` rather than the Kafka Connect REST API. `KafkaConnectors` use Kubernetes RBAC controls to secure the Kafka Connect REST API and lock down its resources.
-
-NOTE: You need to use the Kafka Connect REST API for restarting failed tasks and pausing and resuming connectors. Future {ProductName} releases might add this functionality to `KafkaConnectors`.
+NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks and pausing and resuming connectors. You need to use the Kafka Connect REST API to perform these tasks.
 
 .`KafkaConnector` resources
 
-`KafkaConnectors` allow you to create and manage source and sink connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required. Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create a corresponding connector instance. 
+`KafkaConnectors` allow you to create and manage source and sink connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required. Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance. 
 
-You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates using `kubectl apply`. You remove a connector by deleting its corresponding `KafkaConnector`.
+You manage a running connector instance by updating its corresponding `KafkaConnector`, and then applying the updates (for example, using `kubectl apply`). You remove a connector by deleting its corresponding `KafkaConnector`.
 
 To ensure compatibility with earlier versions of {ProductName}, `KafkaConnectors` are disabled by default. To enable them for a Kafka Connect cluster, you must configure the `KafkaConnect` custom resource to use `KafkaConnectors` for the creation and management of connectors. For instructions, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 
@@ -37,4 +35,4 @@ When `KafkaConnectors` are enabled, the Cluster Operator begins to watch for the
 
 The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service.
 
-If `KafkaConnectors` are enabled, changes made using the Kafka Connect REST API are reverted by the Cluster Operator. 
+If `KafkaConnectors` are enabled, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator. 

--- a/documentation/modules/con-custom-resources-status.adoc
+++ b/documentation/modules/con-custom-resources-status.adoc
@@ -29,6 +29,10 @@ m¦KafkaConnectS2I
 ¦xref:type-KafkaConnectS2Istatus-reference[]
 ¦The Kafka Connect cluster with Source-to-Image support, if deployed.
 
+m¦KafkaConnector
+¦xref:type-KafkaConnectorStatus-reference[]
+¦`KafkaConnector` resources, if deployed.
+
 m¦KafkaMirrorMaker
 ¦xref:type-KafkaMirrorMakerStatus-reference[]
 ¦The Kafka MirrorMaker tool, if deployed.

--- a/documentation/modules/con-customizing-labels-and-annotations.adoc
+++ b/documentation/modules/con-customizing-labels-and-annotations.adoc
@@ -28,6 +28,6 @@ template:
 The `labels` and `annotations` fields can contain any labels or annotations that do not contain the reserved string `strimzi.io`.
 Labels and annotations containing `strimzi.io` are used internally by {ProductName} and cannot be configured.
 
-For Kafka Connect, annotations on the `KafkaConnect` resource are used to enable the creation and management of connectors using `KafkaConnector` resources. For more information, see xref:proc-enabling-kafkaconnectors-{context}[].
+For Kafka Connect, annotations on the `KafkaConnect` resource are used to enable the creation and management of connectors using `KafkaConnector` resources. For more information, see xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[].
 
 NOTE: The `metadata` property is not applicable to container templates, such as the `kafkaContainer`.

--- a/documentation/modules/con-customizing-labels-and-annotations.adoc
+++ b/documentation/modules/con-customizing-labels-and-annotations.adoc
@@ -28,4 +28,6 @@ template:
 The `labels` and `annotations` fields can contain any labels or annotations that do not contain the reserved string `strimzi.io`.
 Labels and annotations containing `strimzi.io` are used internally by {ProductName} and cannot be configured.
 
+For Kafka Connect, annotations on the `KafkaConnect` resource are used to enable the creation and management of connectors using `KafkaConnector` resources. For more information, see xref:proc-enabling-kafkaconnectors-{context}[].
+
 NOTE: The `metadata` property is not applicable to container templates, such as the `kafkaContainer`.

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -52,9 +52,3 @@ oc apply -f examples/connector/source-connector.yaml
 ----
 oc get all --selector strimzi.io/cluster: my-connect-cluster -o name
 ----
-
-.Additional resources
-
-* xref:type-KafkaConnect-reference[] 
-
-* xref:type-KafkaConnectS2I-reference[] 

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -5,7 +5,7 @@
 [id='proc-deploying-kafkaconnector-{context}']
 = Deploying a `KafkaConnector` resource to Kafka Connect
 
-Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML file is configured to create a `FileStreamSourceConnector` to send each line of the Kafka license file as a message in Kafka.
+Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML will create a `FileStreamSourceConnector` to send each line of the license file to Kafka as a message in a topic named `my-topic`.
 
 .Prerequisites
 
@@ -33,10 +33,10 @@ spec:
     # ...
 ----
 +
-<1> Enter a name for the `KafkaConnector` resource. You can choose any name.
+<1> Enter a name for the `KafkaConnector` resource. This will be used as the name of the connector within Kafka Connect. You can choose any name that is valid for a Kubernetes resource.
 <2> Enter the name of the Kafka Connect cluster in which to create the connector.
-<3> The name or alias of the connector class.
-<4> The maximum number of tasks for the connector.
+<3> The name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
+<4> The maximum number of tasks that the connector can create.
 <5> Configuration settings for the connector. Available configuration options depend on the connector class.
 
 . Create the `KafkaConnector` in your Kubernetes cluster:

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -3,13 +3,13 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying a `KafkaConnector resource to Kafka Connect
+= Deploying a `KafkaConnector` resource to Kafka Connect
 
 Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML file is configured to create a `FileStreamSourceConnector`.
 
 .Prerequisites
 
-* A Kafka Connect deployment in which xref:proc-enabling-kafkaconnectors-{context}[`KafkaConnectors` are enabled]
+* A Kafka Connect deployment in which xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[`KafkaConnectors` are enabled]
 * A running Cluster Operator
 
 .Procedure
@@ -48,11 +48,9 @@ oc apply -f examples/connector/source-connector.yaml
 
 .Additional resources
 
-* xref:proc-enabling-kafkaconnectors-{context}[] 
+* xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[] 
 
 * xref:kafka-connect-{context}[] 
-
-* xref:con-creating-managing-connectors-{context}[]
 
 * xref:type-KafkaConnect-reference[] 
 

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -5,7 +5,7 @@
 [id='proc-deploying-kafkaconnector-{context}']
 = Deploying a `KafkaConnector` resource to Kafka Connect
 
-Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML file is configured to create a `FileStreamSourceConnector`.
+Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML file is configured to create a `FileStreamSourceConnector` to send each line of the Kafka license file as a message in Kafka.
 
 .Prerequisites
 
@@ -27,7 +27,7 @@ metadata:
 spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
   tasksMax: 2 <4>
-  Config: <5>
+  config: <5>
     file: "/opt/kafka/LICENSE"
     topic: my-topic
     # ...

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -3,30 +3,59 @@
 // assembly-kafka-connect.adoc
 
 [id='proc-deploying-kafkaconnector-{context}']
-= Deploying a `KafkaConnector` resource to Kafka Connect
+= Deploying a `KafkaConnector resource to Kafka Connect
 
-Intro
+Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example file is configured to create a `FileStreamSourceConnector`.
+
+Note: `KafkaConnectors` must be xref:proc-enabling-kafkaconnectors-{context}[enabled for the Kafka Connect cluster].
 
 .Prerequisites
 
-* A running Kafka cluster.
-*
-*
+* A Kafka Connect deployment with `KafkaConnectors` enabled
+* A running Cluster Operator
 
 .Procedure
 
-. Step
+. View or edit the `examples/connector/source-connector.yaml` file:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: `KafkaConnector`
+metadata:
+  name: my-source-connector <1>
+  labels:   
+    strimzi.io/cluster: my-connect-cluster <2>
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
+  tasksMax: 2 <4>
+  Config: <5>
+    file: "/opt/kafka/LICENSE"
+    topic: my-topic
+    # ...
+----
++
+<1> The name of the `KafkaConnector` resource. You can enter any name.
+<2> The name of the Kafka Connect cluster in which to create the connector.
+<3> The name or alias of the connector class.
+<4> The maximum number of tasks for the connector.
+<5> Configuration settings for the connector. Available configuration options depend on the connector class.
 
-. Step
-
-. Step
-
-. Step
-
-. Step
-
-. Step
+. Create a `KafkaConnector` in your Kubernetes cluster:
++
+[source,shell,subs="+quotes"]
+----
+oc apply -f examples/connector/source-connector.yaml
+----
 
 .Additional resources
 
-* For more information about, see .
+* xref:proc-enabling-kafkaconnectors-{context}[] 
+
+* xref:kafka-connect-{context}[] 
+
+* xref:con-creating-managing-connectors-{context}[]
+
+* xref:type-KafkaConnect-reference[] 
+
+* xref:type-KafkaConnectS2I-reference[] 

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -46,11 +46,14 @@ spec:
 oc apply -f examples/connector/source-connector.yaml
 ----
 
+. Check that the resource was created:
++
+[source,shell,subs="+quotes"]
+----
+oc get all --selector strimzi.io/cluster: my-connect-cluster -o name
+----
+
 .Additional resources
-
-* xref:proc-enabling-kafkaconnectors-deployment-configuration-kafka-connect[] 
-
-* xref:kafka-connect-{context}[] 
 
 * xref:type-KafkaConnect-reference[] 
 

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -5,18 +5,16 @@
 [id='proc-deploying-kafkaconnector-{context}']
 = Deploying a `KafkaConnector resource to Kafka Connect
 
-Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example file is configured to create a `FileStreamSourceConnector`.
-
-Note: `KafkaConnectors` must be xref:proc-enabling-kafkaconnectors-{context}[enabled for the Kafka Connect cluster].
+Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML file is configured to create a `FileStreamSourceConnector`.
 
 .Prerequisites
 
-* A Kafka Connect deployment with `KafkaConnectors` enabled
+* A Kafka Connect deployment in which xref:proc-enabling-kafkaconnectors-{context}[`KafkaConnectors` are enabled]
 * A running Cluster Operator
 
 .Procedure
 
-. View or edit the `examples/connector/source-connector.yaml` file:
+. Edit the `examples/connector/source-connector.yaml` file:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -35,13 +33,13 @@ spec:
     # ...
 ----
 +
-<1> The name of the `KafkaConnector` resource. You can enter any name.
-<2> The name of the Kafka Connect cluster in which to create the connector.
+<1> Enter a name for the `KafkaConnector` resource. You can choose any name.
+<2> Enter the name of the Kafka Connect cluster in which to create the connector.
 <3> The name or alias of the connector class.
 <4> The maximum number of tasks for the connector.
 <5> Configuration settings for the connector. Available configuration options depend on the connector class.
 
-. Create a `KafkaConnector` in your Kubernetes cluster:
+. Create the `KafkaConnector` in your Kubernetes cluster:
 +
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// assembly-kafka-connect.adoc
+
+[id='proc-deploying-kafkaconnector-{context}']
+= Deploying a `KafkaConnector` resource to Kafka Connect
+
+Intro
+
+.Prerequisites
+
+* A running Kafka cluster.
+*
+*
+
+.Procedure
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+.Additional resources
+
+* For more information about, see .

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// assembly-deployment-configuration-kafka-connect.adoc
+
+[id='proc-enabling-kafkaconnectors-{context}']
+= Enabling `KafkaConnector` resources
+
+Intro
+
+.Prerequisites
+
+* A running Kafka cluster.
+*
+*
+
+.Procedure
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+. Step
+
+.Additional resources
+
+* For more information about, see .

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -5,28 +5,45 @@
 [id='proc-enabling-kafkaconnectors-{context}']
 = Enabling `KafkaConnector` resources
 
-Intro
+To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use-connector-resources` annotation to the `KafkaConnect` or `KafkaConnectS2I` custom resource. When enabled, connectors in the Kafka Connect cluster are created and managed using `KafkaConnectors`.
 
 .Prerequisites
 
-* A running Kafka cluster.
-*
-*
+* A running Cluster Operator
 
 .Procedure
 
-. Step
+. Edit a `KafkaConnect` or `KafkaConnectS2I` custom resource.
 
-. Step
+. Add the `strimzi.io/use-connector-resources` annotation to the custom resource. For example:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+Metadata:
+  name: my-connect-cluster
+  Annotations: 
+    strimzi.io/use-connector-resources: "true"
+Spec:
+  # ...
+----
 
-. Step
-
-. Step
-
-. Step
-
-. Step
+. Create or update the resource using `kubectl apply`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl apply -f kafka-connect.yaml
+----
 
 .Additional resources
 
-* For more information about, see .
+* xref:con-creating-managing-connectors-{context}[]
+
+* xref:proc-deploying-kafkaconnector-{context}[] 
+
+* xref:kafka-connect-{context}[] 
+
+* xref:type-KafkaConnect-reference[] 
+
+* xref:type-KafkaConnectS2I-reference[] 

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -21,11 +21,11 @@ To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use
 ----
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
-Metadata:
+metadata:
   name: my-connect-cluster
-  Annotations: 
+  annotations: 
     strimzi.io/use-connector-resources: "true"
-Spec:
+spec:
   # ...
 ----
 

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -38,12 +38,6 @@ kubectl apply -f kafka-connect.yaml
 
 .Additional resources
 
-* xref:con-creating-managing-connectors-{context}[]
+* xref:con-creating-managing-connectors-str[]
 
-* xref:proc-deploying-kafkaconnector-{context}[] 
-
-* xref:kafka-connect-{context}[] 
-
-* xref:type-KafkaConnect-reference[] 
-
-* xref:type-KafkaConnectS2I-reference[] 
+* xref:proc-deploying-kafkaconnector-str[] 

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -13,9 +13,7 @@ To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use
 
 .Procedure
 
-. Edit a `KafkaConnect` or `KafkaConnectS2I` custom resource.
-
-. Add the `strimzi.io/use-connector-resources` annotation to the custom resource. For example:
+. Edit the `KafkaConnect` or `KafkaConnectS2I` resource. Add the `strimzi.io/use-connector-resources` annotation For example:
 +
 [source,yaml,subs="attributes+"]
 ----

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -13,7 +13,7 @@ To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use
 
 .Procedure
 
-. Edit the `KafkaConnect` or `KafkaConnectS2I` resource. Add the `strimzi.io/use-connector-resources` annotation For example:
+. Edit the `KafkaConnect` or `KafkaConnectS2I` resource. Add the `strimzi.io/use-connector-resources` annotation. For example:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -39,3 +39,7 @@ kubectl apply -f kafka-connect.yaml
 * xref:con-creating-managing-connectors-str[]
 
 * xref:proc-deploying-kafkaconnector-str[] 
+
+* xref:type-KafkaConnect-reference[] 
+
+* xref:type-KafkaConnectS2I-reference[] 

--- a/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
+++ b/documentation/modules/kafkaconnectors/proc-enabling-kafkaconnectors.adoc
@@ -5,7 +5,7 @@
 [id='proc-enabling-kafkaconnectors-{context}']
 = Enabling `KafkaConnector` resources
 
-To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use-connector-resources` annotation to the `KafkaConnect` or `KafkaConnectS2I` custom resource. When enabled, connectors in the Kafka Connect cluster are created and managed using `KafkaConnectors`.
+To enable `KafkaConnectors` for a Kafka Connect cluster, add the `strimzi.io/use-connector-resources` annotation to the `KafkaConnect` or `KafkaConnectS2I` custom resource. 
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change
- Documentation

### Description

This pull request updates _Using Strimzi_ with documentation about using `KafkaConnectors` to create and manage connectors. `KafkaConnectors` were added in #2073 and #2087.

Added a new concept and procedure to  `Getting started with Strimzi / Kafka Connect /`

- "Creating and managing connectors" -- intended to discuss managing connectors using `KafkaConnectors` and the REST API.
- "Deploying a `KafkaConnector` resource to Kafka Connect"

Added a new procedure to `Deployment configuration / Kafka Connect cluster configuration /`. 

- "Enabling `KafkaConnector` resources"

The above procedure is reused in `Deployment configuration / Kafka Connect cluster with Source2Image support /` 

This PR also adds supporting information to a few other places.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

