### PR TITLE
Make Kafka container wait till the TLS sidecar is ready

### DIFF
--- a/docker-images/kafka/scripts/kafka_pre_start.sh
+++ b/docker-images/kafka/scripts/kafka_pre_start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Waiting for the TLS sidecar to get ready"
+
+while true; do
+  netstat -ntl | grep -q :2181
+  RESULT=$?
+
+  if [ "$RESULT" -eq "0" ]; then
+    break
+  fi
+
+  echo "TLS sidecar is not ready yet, waiting for another 1 second"
+
+  sleep 1
+done
+
+exit 0

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set +x
 
+# Wait for the TLS sidecar to be ready and listen on port 2181
+./kafka_pre_start.sh
+
 export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')
 echo "KAFKA_BROKER_ID=$KAFKA_BROKER_ID"
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Sometimes on a slow internet, the images for the two containers in the same pod take time. As a result, Kafka container often starts before the TLS sidecar pod is running. It cannot connect to Zoo and restarts. This can cause confusion that there is some actual problem and it kind of _looks bad_. 

This PR adds the `pre_start_check.sh` which checks whether the TLS sidecar is already listening on port 2181 and if it is not, it will wait. That should make sure that the Kafka container doesn't restart just because the TLS sidecar is slow to pull image.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally