### PR TITLE
Fix certificate renewal when the initial renewal breaks in the middle

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -115,7 +115,7 @@ public class ClusterCa extends Ca {
         return kafkaExporterSecret;
     }
 
-    public Map<String, CertAndKey> generateZkCerts(Kafka kafka) throws IOException {
+    public Map<String, CertAndKey> generateZkCerts(Kafka kafka, boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
         String cluster = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
         Function<Integer, Subject> subjectFn = i -> {
@@ -139,10 +139,12 @@ public class ClusterCa extends Ca {
             kafka.getSpec().getZookeeper().getReplicas(),
             subjectFn,
             zkNodesSecret,
-            podNum -> ZookeeperCluster.zookeeperPodName(cluster, podNum));
+            podNum -> ZookeeperCluster.zookeeperPodName(cluster, podNum),
+            isMaintenanceTimeWindowsSatisfied);
     }
 
-    public Map<String, CertAndKey> generateBrokerCerts(Kafka kafka, Set<String> externalBootstrapAddresses, Map<Integer, Set<String>> externalAddresses) throws IOException {
+    public Map<String, CertAndKey> generateBrokerCerts(Kafka kafka, Set<String> externalBootstrapAddresses,
+            Map<Integer, Set<String>> externalAddresses, boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
         String cluster = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
         Function<Integer, Subject> subjectFn = i -> {
@@ -191,7 +193,8 @@ public class ClusterCa extends Ca {
             kafka.getSpec().getKafka().getReplicas(),
             subjectFn,
             brokersSecret,
-            podNum -> KafkaCluster.kafkaPodName(cluster, podNum));
+            podNum -> KafkaCluster.kafkaPodName(cluster, podNum),
+            isMaintenanceTimeWindowsSatisfied);
     }
 
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -302,14 +302,17 @@ public class EntityOperator extends AbstractModel {
      * It also contains the related Entity Operator private key.
      *
      * @param clusterCa The cluster CA.
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateSecret(ClusterCa clusterCa) {
+    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         if (!isDeployed()) {
             return null;
         }
         Secret secret = clusterCa.entityOperatorSecret();
-        return ModelUtils.buildSecret(clusterCa, secret, namespace, EntityOperator.secretName(cluster), name, "entity-operator", labels, createOwnerReference());
+        return ModelUtils.buildSecret(clusterCa, secret, namespace, EntityOperator.secretName(cluster), name,
+                "entity-operator", labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -657,12 +657,15 @@ public class KafkaCluster extends AbstractModel {
      * @param clusterCa                The CA for cluster certificates
      * @param externalBootstrapDnsName The set of DNS names for bootstrap service (should be appended to every broker certificate)
      * @param externalDnsNames         The list of DNS names for broker pods (should be appended only to specific certificates for given broker)
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
      */
-    public void generateCertificates(Kafka kafka, ClusterCa clusterCa, Set<String> externalBootstrapDnsName, Map<Integer, Set<String>> externalDnsNames) {
+    public void generateCertificates(Kafka kafka, ClusterCa clusterCa, Set<String> externalBootstrapDnsName,
+            Map<Integer, Set<String>> externalDnsNames, boolean isMaintenanceTimeWindowsSatisfied) {
         log.debug("Generating certificates");
 
         try {
-            brokerCerts = clusterCa.generateBrokerCerts(kafka, externalBootstrapDnsName, externalDnsNames);
+            brokerCerts = clusterCa.generateBrokerCerts(kafka, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             log.warn("Error while generating certificates", e);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -328,13 +328,16 @@ public class KafkaExporter extends AbstractModel {
      * It also contains the related Kafka Exporter private key.
      *
      * @param clusterCa The cluster CA.
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateSecret(ClusterCa clusterCa) {
+    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         if (!isDeployed()) {
             return null;
         }
         Secret secret = clusterCa.kafkaExporterSecret();
-        return ModelUtils.buildSecret(clusterCa, secret, namespace, KafkaExporter.secretName(cluster), name, "kafka-exporter", labels, createOwnerReference());
+        return ModelUtils.buildSecret(clusterCa, secret, namespace, KafkaExporter.secretName(cluster), name,
+                "kafka-exporter", labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -200,8 +199,7 @@ public class ModelUtils {
             reasons.add("certificate doesn't exist yet");
             shouldBeRegenerated = true;
         } else {
-            X509Certificate currentCert = clusterCa.getAsX509Certificate(secret, keyCertName + ".crt");
-            if (clusterCa.certRenewed() || (clusterCa.certNeedsRenewal(currentCert) && isMaintenanceTimeWindowsSatisfied)) {
+            if (clusterCa.certRenewed() || (clusterCa.isExpiring(secret, keyCertName + ".crt") && isMaintenanceTimeWindowsSatisfied)) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -188,25 +189,39 @@ public class ModelUtils {
                         tlsSidecar.getLogLevel() : TlsSidecarLogLevel.NOTICE).toValue());
     }
 
-    public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName, String commonName, String keyCertName, Labels labels, OwnerReference ownerReference) {
+    public static Secret buildSecret(ClusterCa clusterCa, Secret secret, String namespace, String secretName,
+            String commonName, String keyCertName, Labels labels, OwnerReference ownerReference, boolean isMaintenanceTimeWindowsSatisfied) {
         Map<String, String> data = new HashMap<>();
         CertAndKey certAndKey = null;
-        if (secret == null || clusterCa.certRenewed()) {
-            log.debug("Generating certificates");
+        boolean shouldBeRegenerated = false;
+        List<String> reasons = new ArrayList<>(2);
+
+        if (secret == null) {
+            reasons.add("certificate doesn't exist yet");
+            shouldBeRegenerated = true;
+        } else {
+            X509Certificate currentCert = clusterCa.getAsX509Certificate(secret, keyCertName + ".crt");
+            if (clusterCa.certRenewed() || (clusterCa.certNeedsRenewal(currentCert) && isMaintenanceTimeWindowsSatisfied)) {
+                reasons.add("certificate needs to be renewed");
+                shouldBeRegenerated = true;
+            }
+        }
+
+        if (shouldBeRegenerated) {
+            log.debug("Certificate for pod {} need to be regenerated because:", keyCertName, String.join(", ", reasons));
+
             try {
-                log.debug(keyCertName + " certificate to generate");
                 certAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
             } catch (IOException e) {
                 log.warn("Error while generating certificates", e);
             }
+
             log.debug("End generating certificates");
         } else {
-
             if (secret.getData().get(keyCertName + ".p12") != null &&
                     !secret.getData().get(keyCertName + ".p12").isEmpty() &&
                     secret.getData().get(keyCertName + ".password") != null &&
                     !secret.getData().get(keyCertName + ".password").isEmpty()) {
-
                 certAndKey = new CertAndKey(
                         decodeFromSecret(secret, keyCertName + ".key"),
                         decodeFromSecret(secret, keyCertName + ".crt"),
@@ -225,12 +240,14 @@ public class ModelUtils {
                 }
             }
         }
+
         if (certAndKey != null) {
             data.put(keyCertName + ".key", certAndKey.keyAsBase64String());
             data.put(keyCertName + ".crt", certAndKey.certAsBase64String());
             data.put(keyCertName + ".p12", certAndKey.keyStoreAsBase64String());
             data.put(keyCertName + ".password", certAndKey.storePasswordAsBase64String());
         }
+
         return createSecret(secretName, namespace, labels, ownerReference, data);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -399,12 +399,15 @@ public class TopicOperator extends AbstractModel {
      * Generate the Secret containing CA self-signed certificates for internal communication
      * It also contains the private key-certificate (signed by internal CA) for communicating with Zookeeper and Kafka
      * @param clusterCa The cluster CA
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
      * @return The generated Secret
      */
-    public Secret generateSecret(ClusterCa clusterCa) {
+    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret topicOperatorSecret = clusterCa.topicOperatorSecret();
         // TO is using the keyCertName as "entity-operator". This is not typo.
-        return ModelUtils.buildSecret(clusterCa, topicOperatorSecret, namespace, TopicOperator.secretName(cluster), name, "entity-operator", labels, createOwnerReference());
+        return ModelUtils.buildSecret(clusterCa, topicOperatorSecret, namespace, TopicOperator.secretName(cluster), name,
+                "entity-operator", labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 
     protected void setTlsSidecar(TlsSidecar tlsSidecar) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -450,9 +450,11 @@ public class ZookeeperCluster extends AbstractModel {
      *
      * @param clusterCa The cluster CA.
      * @param kafka The Kafka resource.
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka) {
+    public Secret generateNodesSecret(ClusterCa clusterCa, Kafka kafka, boolean isMaintenanceTimeWindowsSatisfied) {
 
         Map<String, String> data = new HashMap<>();
 
@@ -460,7 +462,7 @@ public class ZookeeperCluster extends AbstractModel {
         Map<String, CertAndKey> certs;
         try {
             log.debug("Cluster communication certificates");
-            certs = clusterCa.generateZkCerts(kafka);
+            certs = clusterCa.generateZkCerts(kafka, isMaintenanceTimeWindowsSatisfied);
             log.debug("End generating certificates");
             for (int i = 0; i < replicas; i++) {
                 CertAndKey cert = certs.get(ZookeeperCluster.zookeeperPodName(cluster, i));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2586,20 +2586,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityOperatorSecret(Supplier<Date> dateSupplier) {
-            Promise<ReconciliationState> resultPromise = Promise.promise();
-
-            secretOperations.reconcile(namespace, EntityOperator.secretName(name),
+            return secretOperations.reconcile(namespace, EntityOperator.secretName(name),
                     entityOperator == null ? null : entityOperator.generateSecret(clusterCa, isMaintenanceTimeWindowsSatisfied(dateSupplier)))
-                    .setHandler(res -> {
-                        if (res.succeeded()) {
-                            isEntityOperatorCertsChanged = res.result() instanceof ReconcileResult.Patched;
-                            resultPromise.complete(this);
-                        } else {
-                            resultPromise.fail(res.cause());
-                        }
+                    .map(res -> {
+                        isEntityOperatorCertsChanged = res instanceof ReconcileResult.Patched;
+                        return this;
                     });
-
-            return resultPromise.future();
         }
 
         private boolean isPodUpToDate(StatefulSet sts, Pod pod) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.Subject;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class CaRenewalTest {
+    @Test
+    public void renewalOfStatefulSetCertificatesWithNullSecret() throws IOException {
+        Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
+            private AtomicInteger invocationCount = new AtomicInteger(0);
+
+            @Override
+            public boolean certRenewed() {
+                return false;
+            }
+
+            @Override
+            public boolean certNeedsRenewal(X509Certificate cert) {
+                return false;
+            }
+
+            @Override
+            protected CertAndKey generateSignedCert(Subject subject,
+                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
+                int index = invocationCount.getAndIncrement();
+
+                return new CertAndKey(
+                        ("new-key" + index).getBytes(),
+                        ("new-cert" + index).getBytes(),
+                        ("new-truststore" + index).getBytes(),
+                        ("new-keystore" + index).getBytes(),
+                        "new-password" + index
+                );
+            }
+        };
+
+        int replicas = 3;
+        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, String> podNameFn = i -> "pod" + i;
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(replicas,
+                subjectFn,
+                null,
+                podNameFn,
+                isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
+        assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
+        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
+        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
+
+        assertThat(new String(newCerts.get("pod1").cert()), is("new-cert1"));
+        assertThat(new String(newCerts.get("pod1").key()), is("new-key1"));
+        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
+        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
+
+        assertThat(new String(newCerts.get("pod2").cert()), is("new-cert2"));
+        assertThat(new String(newCerts.get("pod2").key()), is("new-key2"));
+        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
+        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
+    }
+
+    @Test
+    public void renewalOfStatefulSetCertificatesWithCaRenewal() throws IOException {
+        Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
+            private AtomicInteger invocationCount = new AtomicInteger(0);
+
+            @Override
+            public boolean certRenewed() {
+                return true;
+            }
+
+            @Override
+            public boolean certNeedsRenewal(X509Certificate cert) {
+                return false;
+            }
+
+            @Override
+            protected CertAndKey generateSignedCert(Subject subject,
+                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
+                int index = invocationCount.getAndIncrement();
+
+                return new CertAndKey(
+                        ("new-key" + index).getBytes(),
+                        ("new-cert" + index).getBytes(),
+                        ("new-truststore" + index).getBytes(),
+                        ("new-keystore" + index).getBytes(),
+                        "new-password" + index
+                );
+            }
+        };
+
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withNewName("test-secret")
+                .endMetadata()
+                .addToData("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        int replicas = 3;
+        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, String> podNameFn = i -> "pod" + i;
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(replicas,
+                subjectFn,
+                initialSecret,
+                podNameFn,
+                isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
+        assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
+        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
+        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
+
+        assertThat(new String(newCerts.get("pod1").cert()), is("new-cert1"));
+        assertThat(new String(newCerts.get("pod1").key()), is("new-key1"));
+        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
+        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
+
+        assertThat(new String(newCerts.get("pod2").cert()), is("new-cert2"));
+        assertThat(new String(newCerts.get("pod2").key()), is("new-key2"));
+        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
+        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
+    }
+
+    @Test
+    public void renewalOfStatefulSetCertificatesDelayedRenewalInWindow() throws IOException {
+        Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
+            private AtomicInteger invocationCount = new AtomicInteger(0);
+
+            @Override
+            public boolean certRenewed() {
+                return false;
+            }
+
+            @Override
+            public boolean certNeedsRenewal(X509Certificate cert) {
+                return true;
+            }
+
+            @Override
+            protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
+                return false;
+            }
+
+            @Override
+            public X509Certificate getAsX509Certificate(Secret secret, String key)    {
+                return null;
+            }
+
+            @Override
+            protected CertAndKey generateSignedCert(Subject subject,
+                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
+                int index = invocationCount.getAndIncrement();
+
+                return new CertAndKey(
+                        ("new-key" + index).getBytes(),
+                        ("new-cert" + index).getBytes(),
+                        ("new-truststore" + index).getBytes(),
+                        ("new-keystore" + index).getBytes(),
+                        "new-password" + index
+                );
+            }
+        };
+
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withNewName("test-secret")
+                .endMetadata()
+                .addToData("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        int replicas = 3;
+        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, String> podNameFn = i -> "pod" + i;
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(replicas,
+                subjectFn,
+                initialSecret,
+                podNameFn,
+                isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
+        assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
+        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
+        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
+
+        assertThat(new String(newCerts.get("pod1").cert()), is("new-cert1"));
+        assertThat(new String(newCerts.get("pod1").key()), is("new-key1"));
+        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
+        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
+
+        assertThat(new String(newCerts.get("pod2").cert()), is("new-cert2"));
+        assertThat(new String(newCerts.get("pod2").key()), is("new-key2"));
+        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
+        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
+    }
+
+    @Test
+    public void renewalOfStatefulSetCertificatesDelayedRenewalOutsideWindow() throws IOException {
+        Ca mockedCa = new Ca(null, null, null, null, null, null, null, 2, 1, true, null) {
+            private AtomicInteger invocationCount = new AtomicInteger(0);
+
+            @Override
+            public boolean certRenewed() {
+                return false;
+            }
+
+            @Override
+            public boolean certNeedsRenewal(X509Certificate cert) {
+                return true;
+            }
+
+            @Override
+            protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
+                return false;
+            }
+
+            @Override
+            public X509Certificate getAsX509Certificate(Secret secret, String key)    {
+                return null;
+            }
+
+            @Override
+            protected CertAndKey generateSignedCert(Subject subject,
+                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
+                int index = invocationCount.getAndIncrement();
+
+                return new CertAndKey(
+                        ("new-key" + index).getBytes(),
+                        ("new-cert" + index).getBytes(),
+                        ("new-truststore" + index).getBytes(),
+                        ("new-keystore" + index).getBytes(),
+                        "new-password" + index
+                );
+            }
+        };
+
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withNewName("test-secret")
+                .endMetadata()
+                .addToData("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .addToData("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        int replicas = 3;
+        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, String> podNameFn = i -> "pod" + i;
+        boolean isMaintenanceTimeWindowsSatisfied = false;
+
+        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(replicas,
+                subjectFn,
+                initialSecret,
+                podNameFn,
+                isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
+        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
+        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
+
+        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
+        assertThat(new String(newCerts.get("pod1").keyStore()), is("old-keystore"));
+        assertThat(newCerts.get("pod1").storePassword(), is("old-password"));
+
+        assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
+        assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
+        assertThat(new String(newCerts.get("pod2").keyStore()), is("old-keystore"));
+        assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -36,7 +36,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean isExpiring(Secret secret, String podName)  {
+            public boolean isExpiring(Secret secret, String certKey)  {
                 return false;
             }
 
@@ -93,7 +93,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean isExpiring(Secret secret, String podName)  {
+            public boolean isExpiring(Secret secret, String certKey)  {
                 return false;
             }
 
@@ -168,7 +168,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean isExpiring(Secret secret, String podName)  {
+            public boolean isExpiring(Secret secret, String certKey)  {
                 return true;
             }
 
@@ -253,7 +253,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean isExpiring(Secret secret, String podName)  {
+            public boolean isExpiring(Secret secret, String certKey)  {
                 return true;
             }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -36,7 +36,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean certNeedsRenewal(X509Certificate cert) {
+            public boolean isExpiring(Secret secret, String podName)  {
                 return false;
             }
 
@@ -93,7 +93,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean certNeedsRenewal(X509Certificate cert) {
+            public boolean isExpiring(Secret secret, String podName)  {
                 return false;
             }
 
@@ -168,7 +168,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean certNeedsRenewal(X509Certificate cert) {
+            public boolean isExpiring(Secret secret, String podName)  {
                 return true;
             }
 
@@ -253,7 +253,7 @@ public class CaRenewalTest {
             }
 
             @Override
-            public boolean certNeedsRenewal(X509Certificate cert) {
+            public boolean isExpiring(Secret secret, String podName)  {
                 return true;
             }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1192,7 +1192,7 @@ public class KafkaClusterTest {
         ClusterCa clusterCa = new ClusterCa(new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), null, true);
 
-        kc.generateCertificates(kafkaAssembly, clusterCa, externalBootstrapAddress, externalAddresses);
+        kc.generateCertificates(kafkaAssembly, clusterCa, externalBootstrapAddress, externalAddresses, true);
         return kc.generateBrokersSecret();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -286,7 +286,7 @@ public class KafkaExporterTest {
 
         assertThat(ke.generateDeployment(true, null, null), is(nullValue()));
         assertThat(ke.generateService(), is(nullValue()));
-        assertThat(ke.generateSecret(null), is(nullValue()));
+        assertThat(ke.generateSecret(null, true), is(nullValue()));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -338,7 +338,7 @@ public class ZookeeperClusterTest {
         ClusterCa clusterCa = new ClusterCa(new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), null, true);
 
-        Secret secret = zc.generateNodesSecret(clusterCa, ka);
+        Secret secret = zc.generateNodesSecret(clusterCa, ka, true);
         assertThat(secret.getData().keySet(), is(set(
                 "foo-zookeeper-0.crt",  "foo-zookeeper-0.key", "foo-zookeeper-0.p12", "foo-zookeeper-0.password",
                 "foo-zookeeper-1.crt", "foo-zookeeper-1.key", "foo-zookeeper-1.p12", "foo-zookeeper-1.password",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -1114,13 +1114,6 @@ public class CertificateRenewalTest {
 
     @Test
     public void renewalOfDeploymentCertificatesWithNullSecret() throws IOException {
-        /*Secret initialSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withNewName("test-secret")
-                .endMetadata()
-                .withData(emptyMap())
-                .build();*/
-
         CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
@@ -1156,7 +1149,8 @@ public class CertificateRenewalTest {
         CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(true);
-        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.isExpiring(any(), any())).thenReturn(false);
+        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";
@@ -1190,8 +1184,9 @@ public class CertificateRenewalTest {
         CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(false);
-        when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
-        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.isExpiring(any(), any())).thenReturn(true);
+        //when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
+        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";
@@ -1225,8 +1220,9 @@ public class CertificateRenewalTest {
         CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(false);
-        when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
-        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.isExpiring(any(), any())).thenReturn(true);
+        //when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
+        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -1150,7 +1150,6 @@ public class CertificateRenewalTest {
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(true);
         when(clusterCaMock.isExpiring(any(), any())).thenReturn(false);
-        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";
@@ -1185,8 +1184,6 @@ public class CertificateRenewalTest {
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(false);
         when(clusterCaMock.isExpiring(any(), any())).thenReturn(true);
-        //when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
-        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";
@@ -1221,8 +1218,6 @@ public class CertificateRenewalTest {
         ClusterCa clusterCaMock = mock(ClusterCa.class);
         when(clusterCaMock.certRenewed()).thenReturn(false);
         when(clusterCaMock.isExpiring(any(), any())).thenReturn(true);
-        //when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
-        //when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
         when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
         String namespace = "my-namespace";
         String secretName = "my-secret";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -4,7 +4,9 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.CertificateAuthorityBuilder;
@@ -17,6 +19,7 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.KubernetesVersion;
@@ -74,6 +77,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -1106,5 +1110,138 @@ public class CertificateRenewalTest {
 
         ArgumentCaptor<Secret> c = reconcileCa(context, certificateAuthority, certificateAuthority);
         assertThat(c.getAllValues().size(), is(0));
+    }
+
+    @Test
+    public void renewalOfDeploymentCertificatesWithNullSecret() throws IOException {
+        /*Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withNewName("test-secret")
+                .endMetadata()
+                .withData(emptyMap())
+                .build();*/
+
+        CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
+        ClusterCa clusterCaMock = mock(ClusterCa.class);
+        when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
+        String namespace = "my-namespace";
+        String secretName = "my-secret";
+        String commonName = "deployment";
+        String keyCertName = "deployment";
+        Labels labels = Labels.forCluster("my-cluster");
+        OwnerReference ownerReference = new OwnerReference();
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Secret newSecret = ModelUtils.buildSecret(clusterCaMock, null, namespace, secretName, commonName,
+                keyCertName, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(newSecret.getData().get("deployment.crt"), is(newCertAndKey.certAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.key"), is(newCertAndKey.keyAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.p12"), is(newCertAndKey.keyStoreAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.password"), is(newCertAndKey.storePasswordAsBase64String()));
+    }
+
+    @Test
+    public void renewalOfDeploymentCertificatesWithRenewingCa() throws IOException {
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withNewName("test-secret")
+                .endMetadata()
+                .addToData("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("deployment.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("deployment.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("deployment.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
+        ClusterCa clusterCaMock = mock(ClusterCa.class);
+        when(clusterCaMock.certRenewed()).thenReturn(true);
+        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
+        String namespace = "my-namespace";
+        String secretName = "my-secret";
+        String commonName = "deployment";
+        String keyCertName = "deployment";
+        Labels labels = Labels.forCluster("my-cluster");
+        OwnerReference ownerReference = new OwnerReference();
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Secret newSecret = ModelUtils.buildSecret(clusterCaMock, initialSecret, namespace, secretName, commonName,
+                keyCertName, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(newSecret.getData().get("deployment.crt"), is(newCertAndKey.certAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.key"), is(newCertAndKey.keyAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.p12"), is(newCertAndKey.keyStoreAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.password"), is(newCertAndKey.storePasswordAsBase64String()));
+    }
+
+    @Test
+    public void renewalOfDeploymentCertificatesDelayedRenewal() throws IOException {
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withNewName("test-secret")
+                .endMetadata()
+                .addToData("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("deployment.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("deployment.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("deployment.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
+        ClusterCa clusterCaMock = mock(ClusterCa.class);
+        when(clusterCaMock.certRenewed()).thenReturn(false);
+        when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
+        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
+        String namespace = "my-namespace";
+        String secretName = "my-secret";
+        String commonName = "deployment";
+        String keyCertName = "deployment";
+        Labels labels = Labels.forCluster("my-cluster");
+        OwnerReference ownerReference = new OwnerReference();
+        boolean isMaintenanceTimeWindowsSatisfied = true;
+
+        Secret newSecret = ModelUtils.buildSecret(clusterCaMock, initialSecret, namespace, secretName, commonName,
+                keyCertName, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(newSecret.getData().get("deployment.crt"), is(newCertAndKey.certAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.key"), is(newCertAndKey.keyAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.p12"), is(newCertAndKey.keyStoreAsBase64String()));
+        assertThat(newSecret.getData().get("deployment.password"), is(newCertAndKey.storePasswordAsBase64String()));
+    }
+
+    @Test
+    public void renewalOfDeploymentCertificatesDelayedRenewalOutsideOfMaintenanceWindow() throws IOException {
+        Secret initialSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withNewName("test-secret")
+                .endMetadata()
+                .addToData("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()))
+                .addToData("deployment.key", Base64.getEncoder().encodeToString("old-key".getBytes()))
+                .addToData("deployment.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()))
+                .addToData("deployment.password", Base64.getEncoder().encodeToString("old-password".getBytes()))
+                .build();
+
+        CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
+        ClusterCa clusterCaMock = mock(ClusterCa.class);
+        when(clusterCaMock.certRenewed()).thenReturn(false);
+        when(clusterCaMock.certNeedsRenewal(any())).thenReturn(true);
+        when(clusterCaMock.getAsX509Certificate(any(), any())).thenReturn(null);
+        when(clusterCaMock.generateSignedCert(anyString(), anyString())).thenReturn(newCertAndKey);
+        String namespace = "my-namespace";
+        String secretName = "my-secret";
+        String commonName = "deployment";
+        String keyCertName = "deployment";
+        Labels labels = Labels.forCluster("my-cluster");
+        OwnerReference ownerReference = new OwnerReference();
+        boolean isMaintenanceTimeWindowsSatisfied = false;
+
+        Secret newSecret = ModelUtils.buildSecret(clusterCaMock, initialSecret, namespace, secretName, commonName,
+                keyCertName, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
+
+        assertThat(newSecret.getData().get("deployment.crt"), is(Base64.getEncoder().encodeToString("old-cert".getBytes())));
+        assertThat(newSecret.getData().get("deployment.key"), is(Base64.getEncoder().encodeToString("old-key".getBytes())));
+        assertThat(newSecret.getData().get("deployment.p12"), is(Base64.getEncoder().encodeToString("old-keystore".getBytes())));
+        assertThat(newSecret.getData().get("deployment.password"), is(Base64.getEncoder().encodeToString("old-password".getBytes())));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -26,7 +26,6 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
-import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -45,6 +44,7 @@ import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Vertx;
@@ -259,7 +259,7 @@ public class KafkaAssemblyOperatorMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         ResourceOperatorSupplier supplier = supplierWithMocks();
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, pfa, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), supplier, config);
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"), supplier, config);
 
         LOGGER.info("Reconciling initially -> create");
         CountDownLatch createAsync = new CountDownLatch(1);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -26,6 +26,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -44,7 +45,6 @@ import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Vertx;
@@ -259,7 +259,7 @@ public class KafkaAssemblyOperatorMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         ResourceOperatorSupplier supplier = supplierWithMocks();
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
-        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"), supplier, config);
+        KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, pfa, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), supplier, config);
 
         LOGGER.info("Reconciling initially -> create");
         CountDownLatch createAsync = new CountDownLatch(1);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -385,7 +385,7 @@ public abstract class Ca {
                 shouldBeRegenerated = true;
             }
 
-            if (isExpiring(secret, podName) && isMaintenanceTimeWindowsSatisfied)  {
+            if (isExpiring(secret, podName + ".crt") && isMaintenanceTimeWindowsSatisfied)  {
                 reasons.add("certificate is expiring");
                 shouldBeRegenerated = true;
             }
@@ -424,14 +424,14 @@ public abstract class Ca {
      * Returns whether the certificate is expiring or not
      *
      * @param secret  Secret with the certificate
-     * @param podName   Key under which is the certificate stored
+     * @param certKey   Key under which is the certificate stored
      * @return  True when the certificate should be renewed. False otherwise.
      */
-    public boolean isExpiring(Secret secret, String podName)  {
+    public boolean isExpiring(Secret secret, String certKey)  {
         boolean isExpiring = false;
 
         try {
-            X509Certificate currentCert = cert(secret, podName + ".crt");
+            X509Certificate currentCert = cert(secret, certKey);
             isExpiring = certNeedsRenewal(currentCert);
         } catch (RuntimeException e) {
             // TODO: We should mock the certificates properly so that this doesn't fail in tests (not now => long term :-o)

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -168,16 +168,6 @@ public abstract class Ca {
             public String postDescription(String keySecretName, String certSecretName) {
                 return "CA key (in " + keySecretName + ") replaced";
             }
-        },
-        REGENERATED_CERT() {
-            @Override
-            public String preDescription(String keySecretName, String certSecretName) {
-                return "CA (in " + keySecretName + ") needs to be changed";
-            }
-            @Override
-            public String postDescription(String keySecretName, String certSecretName) {
-                return "CA (in " + keySecretName + ") replaced";
-            }
         };
 
         RenewalType() {
@@ -662,9 +652,6 @@ public abstract class Ca {
             case NOOP:
                 log.debug("{}: The CA certificate in secret {} already exists and does not need renewing", this, caCertSecretName);
                 break;
-            case REGENERATED_CERT:
-                log.debug("{}: The CA certificate in secret {} already exists however it does need update metadata", this, caCertSecretName);
-                break;
         }
         if (!generateCa) {
             if (renewalType == RenewalType.RENEW_CERT) {
@@ -742,15 +729,7 @@ public abstract class Ca {
      * @return Whether the certificate was renewed.
      */
     public boolean certRenewed() {
-        return renewalType == RenewalType.RENEW_CERT || renewalType == RenewalType.REPLACE_KEY || certChanged();
-    }
-
-    /**
-     * True if the certificate data has changed
-     * @return Whether the certificate metadata has changed.
-     */
-    public boolean certChanged() {
-        return  renewalType == RenewalType.REGENERATED_CERT;
+        return renewalType == RenewalType.RENEW_CERT || renewalType == RenewalType.REPLACE_KEY;
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -377,26 +377,22 @@ public abstract class Ca {
                         Base64.getDecoder().decode(secret.getData().get(podName + ".crt")));
             }
 
-            boolean shouldBeRegenerated = false;
             List<String> reasons = new ArrayList<>(2);
 
             if (certSubjectChanged(certAndKey, subject, podName))   {
                 reasons.add("DNS names changed");
-                shouldBeRegenerated = true;
             }
 
             if (isExpiring(secret, podName + ".crt") && isMaintenanceTimeWindowsSatisfied)  {
                 reasons.add("certificate is expiring");
-                shouldBeRegenerated = true;
             }
 
-            if (shouldBeRegenerated)  {
+            if (!reasons.isEmpty())  {
                 log.debug("Certificate for pod {} need to be regenerated because:", podName, String.join(", ", reasons));
 
                 CertAndKey newCertAndKey = generateSignedCert(subject, brokerCsrFile, brokerKeyFile, brokerCertFile, brokerKeyStoreFile);
                 certs.put(podName, newCertAndKey);
             }   else {
-
                 certs.put(podName, certAndKey);
             }
         }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -405,8 +405,6 @@ public abstract class Ca {
 
                 CertAndKey newCertAndKey = generateSignedCert(subject, brokerCsrFile, brokerKeyFile, brokerCertFile, brokerKeyStoreFile);
                 certs.put(podName, newCertAndKey);
-
-                this.renewalType = RenewalType.REGENERATED_CERT;
             }   else {
 
                 certs.put(podName, certAndKey);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The renewal of the certificates for the different components happens while reconciling their own secrets, not during the initial renewal. Currently the renewal is based on the certRenewed() from the Ca method. But this returns true only during the reconciliation which renewed the cluster CA. If the initial reconciliation fails, a new instance will be created and it will not return as renewed anymore. The reason for this could be anything from operation timeout, CO crash / restart etc.

So in addition to checking this flag, we need to check the actual expiration of the certificates for the different components. And since this can happen decoupled from the initial CA renewal, this should also check the maintenance window.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally