### PR TITLE
Set NodeAffinity when Rack awareness is enabled

### DIFF
--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinity-STS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinity-STS.yaml
@@ -16,6 +16,9 @@ nodeAffinity:
         values:
         - "e2e-az1"
         - "e2e-az2"
+    - matchExpressions:
+      - key: "failure-domain.beta.kubernetes.io/zone"
+        operator: "Exists"
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndOldAffinity-STS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndOldAffinity-STS.yaml
@@ -16,6 +16,9 @@ nodeAffinity:
         values:
         - "e2e-az1"
         - "e2e-az2"
+    - matchExpressions:
+      - key: "failure-domain.beta.kubernetes.io/zone"
+        operator: "Exists"
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackWithoutAffinity-STS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackWithoutAffinity-STS.yaml
@@ -1,4 +1,10 @@
 ---
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: "failure-domain.beta.kubernetes.io/zone"
+        operator: "Exists"
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When Rack Awareness is enabled, we currently create the pod-anti-affinity rules which spred the pods accross the nodes labeled witht he rack label. However, that does not guarantee that the pods will be scheduled on nodes where such label is set because the rule is only preferred (which it has to be because there might be more pods than zones). And if they end up on the node without the rack label, the pod will be looping in the init container.

This PR sets in addition to the pod-anti-affinity rule also a node-affinity rule whihc targets only nodes with the rack label set. That will ensure that the pods will be either scheduled on nodes witht he label and will work or will not be scheduled at all and will stay as Pending.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally