### PR TITLE
Add support for new fields in external services template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for tini
 * When not explicitly configured by the user in `jvmOptions`, `-Xmx` option is calculated from memory requests rather than from memory limits
 * Expose JMX port on Kafka brokers via an internal service
+* Add support for `externalTrafficPolicy` and `loadBalancerSourceRanges` properties on loadbalancer and nodeport type services
 * Add support for user quotas
 * Add support for Istio protocol selection in service port names  
 Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka services and headless services.  

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
@@ -47,10 +47,10 @@ public class ExternalServiceTemplate implements Serializable, UnknownPropertyPre
         this.metadata = metadata;
     }
 
-    @Description("Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. " +
+    @Description("Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. " +
             "`Cluster` may cause a second hop to another node and obscures the client source IP. " +
             "`Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). " +
-            "When not specified, Kubernetes will use `Cluster` as default.")
+            "If unspecified, Kubernetes will use `Cluster` as the default.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ExternalTrafficPolicy getExternalTrafficPolicy() {
         return externalTrafficPolicy;
@@ -60,10 +60,10 @@ public class ExternalServiceTemplate implements Serializable, UnknownPropertyPre
         this.externalTrafficPolicy = externalTrafficPolicy;
     }
 
-    @Description("A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. " +
-            "If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. " +
-            "This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature. " +
-            "For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/")
+    @Description("A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. " +
+            "If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. " +
+            "This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. " +
+            "For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<String> getLoadBalancerSourceRanges() {
         return loadBalancerSourceRanges;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
@@ -27,8 +27,7 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({
-        "metadata"})
+@JsonPropertyOrder({"metadata", "externalTrafficPolicy", "loadBalancerSourceRanges"})
 @EqualsAndHashCode
 public class ExternalServiceTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalServiceTemplate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of a template for Strimzi external services.
+ * It contains additional values applicable to load balancer or node port type services.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "metadata"})
+@EqualsAndHashCode
+public class ExternalServiceTemplate implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private MetadataTemplate metadata;
+    private ExternalTrafficPolicy externalTrafficPolicy;
+    private List<String> loadBalancerSourceRanges = new ArrayList<>(0);
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Metadata which should be applied to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public MetadataTemplate getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(MetadataTemplate metadata) {
+        this.metadata = metadata;
+    }
+
+    @Description("Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. " +
+            "`Cluster` may cause a second hop to another node and obscures the client source IP. " +
+            "`Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). " +
+            "When not specified, Kubernetes will use `Cluster` as default.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ExternalTrafficPolicy getExternalTrafficPolicy() {
+        return externalTrafficPolicy;
+    }
+
+    public void setExternalTrafficPolicy(ExternalTrafficPolicy externalTrafficPolicy) {
+        this.externalTrafficPolicy = externalTrafficPolicy;
+    }
+
+    @Description("A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. " +
+            "If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. " +
+            "This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature. " +
+            "For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getLoadBalancerSourceRanges() {
+        return loadBalancerSourceRanges;
+    }
+
+    public void setLoadBalancerSourceRanges(List<String> loadBalancerSourceRanges) {
+        this.loadBalancerSourceRanges = loadBalancerSourceRanges;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalTrafficPolicy.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ExternalTrafficPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum ExternalTrafficPolicy {
+    LOCAL,
+    CLUSTER;
+
+    @JsonCreator
+    public static ExternalTrafficPolicy forValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "local":
+                return LOCAL;
+            case "cluster":
+                return CLUSTER;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case CLUSTER:
+                return "Cluster";
+            case LOCAL:
+                return "Local";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -36,8 +36,8 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private PodTemplate pod;
     private ResourceTemplate bootstrapService;
     private ResourceTemplate brokersService;
-    private ResourceTemplate externalBootstrapService;
-    private ResourceTemplate perPodService;
+    private ExternalServiceTemplate externalBootstrapService;
+    private ExternalServiceTemplate perPodService;
     private ResourceTemplate externalBootstrapRoute;
     private ResourceTemplate perPodRoute;
     private ResourceTemplate externalBootstrapIngress;
@@ -91,21 +91,21 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     @Description("Template for Kafka external bootstrap `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getExternalBootstrapService() {
+    public ExternalServiceTemplate getExternalBootstrapService() {
         return externalBootstrapService;
     }
 
-    public void setExternalBootstrapService(ResourceTemplate externalBootstrapService) {
+    public void setExternalBootstrapService(ExternalServiceTemplate externalBootstrapService) {
         this.externalBootstrapService = externalBootstrapService;
     }
 
     @Description("Template for Kafka per-pod `Services` used for access from outside of Kubernetes.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getPerPodService() {
+    public ExternalServiceTemplate getPerPodService() {
         return perPodService;
     }
 
-    public void setPerPodService(ResourceTemplate perPodService) {
+    public void setPerPodService(ExternalServiceTemplate perPodService) {
         this.perPodService = perPodService;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -62,6 +62,7 @@ import io.strimzi.api.kafka.model.listener.NodePortListenerBootstrapOverride;
 import io.strimzi.api.kafka.model.listener.NodePortListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.RouteListenerBrokerOverride;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
+import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -86,6 +87,7 @@ import java.util.stream.Collectors;
 import static io.strimzi.test.TestUtils.LINE_SEPARATOR;
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -724,6 +726,8 @@ public class KafkaClusterTest {
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
         assertThat(ext.getSpec().getLoadBalancerIP(), is(nullValue()));
+        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(nullValue()));
+        assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
         checkOwnerReference(kc.createOwnerReference(), ext);
 
         // Check per pod services
@@ -734,7 +738,153 @@ public class KafkaClusterTest {
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
             assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
             assertThat(srv.getSpec().getLoadBalancerIP(), is(nullValue()));
+            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(nullValue()));
+            assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
             checkOwnerReference(kc.createOwnerReference(), srv);
+        }
+    }
+
+    @Test
+    public void testLoadBalancerExternalTrafficPolicyLocal() {
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalLoadBalancer()
+                            .endKafkaListenerExternalLoadBalancer()
+                        .endListeners()
+                        .withNewTemplate()
+                            .withNewExternalBootstrapService()
+                                .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                            .endExternalBootstrapService()
+                            .withNewPerPodService()
+                                .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                            .endPerPodService()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check external bootstrap service
+        Service ext = kc.generateExternalBootstrapService();
+        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
+
+        // Check per pod services
+        for (int i = 0; i < replicas; i++)  {
+            Service srv = kc.generateExternalService(i);
+            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
+        }
+    }
+
+    @Test
+    public void testLoadBalancerExternalTrafficPolicyCluster() {
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalLoadBalancer()
+                            .endKafkaListenerExternalLoadBalancer()
+                        .endListeners()
+                        .withNewTemplate()
+                            .withNewExternalBootstrapService()
+                                .withExternalTrafficPolicy(ExternalTrafficPolicy.CLUSTER)
+                            .endExternalBootstrapService()
+                            .withNewPerPodService()
+                                .withExternalTrafficPolicy(ExternalTrafficPolicy.CLUSTER)
+                            .endPerPodService()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check external bootstrap service
+        Service ext = kc.generateExternalBootstrapService();
+        assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
+
+        // Check per pod services
+        for (int i = 0; i < replicas; i++)  {
+            Service srv = kc.generateExternalService(i);
+            assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
+        }
+    }
+
+    @Test
+    public void testLoadBalancerSourceRange() {
+        List<String> sourceRanges = new ArrayList();
+        sourceRanges.add("10.0.0.0/8");
+        sourceRanges.add("130.211.204.1/32");
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalLoadBalancer()
+                            .endKafkaListenerExternalLoadBalancer()
+                        .endListeners()
+                        .withNewTemplate()
+                            .withNewExternalBootstrapService()
+                                .withLoadBalancerSourceRanges(sourceRanges)
+                            .endExternalBootstrapService()
+                            .withNewPerPodService()
+                                .withLoadBalancerSourceRanges(sourceRanges)
+                            .endPerPodService()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check external bootstrap service
+        Service ext = kc.generateExternalBootstrapService();
+        assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
+
+        // Check per pod services
+        for (int i = 0; i < replicas; i++)  {
+            Service srv = kc.generateExternalService(i);
+            assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
+        }
+    }
+
+    @Test
+    public void testSourceRangeOnNodePort() {
+        List<String> sourceRanges = new ArrayList();
+        sourceRanges.add("10.0.0.0/8");
+        sourceRanges.add("130.211.204.1/32");
+
+        Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
+                image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
+                .editSpec()
+                    .editKafka()
+                        .withNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                        .withNewTemplate()
+                            .withNewExternalBootstrapService()
+                                .withLoadBalancerSourceRanges(sourceRanges)
+                            .endExternalBootstrapService()
+                            .withNewPerPodService()
+                                .withLoadBalancerSourceRanges(sourceRanges)
+                            .endPerPodService()
+                        .endTemplate()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
+
+        // Check external bootstrap service
+        Service ext = kc.generateExternalBootstrapService();
+        assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
+
+        // Check per pod services
+        for (int i = 0; i < replicas; i++)  {
+            Service srv = kc.generateExternalService(i);
+            assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
         }
     }
 
@@ -743,13 +893,13 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
-                    .editKafka()
-                        .withNewListeners()
-                            .withNewKafkaListenerExternalLoadBalancer()
-                                .withTls(false)
-                            .endKafkaListenerExternalLoadBalancer()
-                        .endListeners()
-                    .endKafka()
+                .editKafka()
+                .withNewListeners()
+                .withNewKafkaListenerExternalLoadBalancer()
+                .withTls(false)
+                .endKafkaListenerExternalLoadBalancer()
+                .endListeners()
+                .endKafka()
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
@@ -788,16 +938,16 @@ public class KafkaClusterTest {
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
-                    .editKafka()
-                        .withNewListeners()
-                            .withNewKafkaListenerExternalLoadBalancer()
-                                .withNewOverrides()
-                                    .withBootstrap(bootstrapOverride)
-                                    .withBrokers(brokerOverride0, brokerOverride2)
-                                .endOverrides()
-                            .endKafkaListenerExternalLoadBalancer()
-                        .endListeners()
-                    .endKafka()
+                .editKafka()
+                .withNewListeners()
+                .withNewKafkaListenerExternalLoadBalancer()
+                .withNewOverrides()
+                .withBootstrap(bootstrapOverride)
+                .withBrokers(brokerOverride0, brokerOverride2)
+                .endOverrides()
+                .endKafkaListenerExternalLoadBalancer()
+                .endListeners()
+                .endKafka()
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);

--- a/documentation/assemblies/assembly-customizing-deployments.adoc
+++ b/documentation/assemblies/assembly-customizing-deployments.adoc
@@ -24,6 +24,8 @@ include::../modules/con-customizing-pods.adoc[leveloffset=+1]
 
 include::../modules/con-customizing-containers.adoc[leveloffset=+1]
 
+include::../modules/con-customizing-external-services.adoc[leveloffset=+1]
+
 include::../modules/con-customizing-image-pull-policy.adoc[leveloffset=+1]
 
 include::../modules/con-customizing-pod-disruption-budgets.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -966,9 +966,9 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 |Property                         |Description
 |metadata                  1.2+<.<|Metadata which should be applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|externalTrafficPolicy     1.2+<.<|Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). When not specified, Kubernetes will use `Cluster` as default.
+|externalTrafficPolicy     1.2+<.<|Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
 |string (one of [Local, Cluster])
-|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature. For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services, and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
 |string array
 |====
 
@@ -2369,4 +2369,3 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |====
-

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -869,9 +869,9 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |brokersService            1.2+<.<|Template for Kafka broker `Service`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |externalBootstrapService  1.2+<.<|Template for Kafka external bootstrap `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`]
 |perPodService             1.2+<.<|Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`]
 |externalBootstrapRoute    1.2+<.<|Template for Kafka external bootstrap `Route`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |perPodRoute               1.2+<.<|Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
@@ -908,7 +908,7 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 [id='type-MetadataTemplate-{context}']
 ### `MetadataTemplate` schema reference
 
-Used in: xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+Used in: xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 
 
 [options="header"]
@@ -953,6 +953,23 @@ Used in: xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], x
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core[Toleration] array
+|====
+
+[id='type-ExternalServiceTemplate-{context}']
+### `ExternalServiceTemplate` schema reference
+
+Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
+
+
+[options="header"]
+|====
+|Property                         |Description
+|metadata                  1.2+<.<|Metadata which should be applied to the resource.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|externalTrafficPolicy     1.2+<.<|Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). When not specified, Kubernetes will use `Cluster` as default.
+|string (one of [Local, Cluster])
+|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. This field will be ignored if the cloud-provider does not support the feature. For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+|string array
 |====
 
 [id='type-PodDisruptionBudgetTemplate-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -968,7 +968,7 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |externalTrafficPolicy     1.2+<.<|Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). When not specified, Kubernetes will use `Cluster` as default.
 |string (one of [Local, Cluster])
-|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. This field will be ignored if the cloud-provider does not support the feature. For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners. If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list. This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature. For more info see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
 |string array
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -968,7 +968,7 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |externalTrafficPolicy     1.2+<.<|Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.
 |string (one of [Local, Cluster])
-|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services, and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+|loadBalancerSourceRanges  1.2+<.<|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
 |string array
 |====
 
@@ -2369,3 +2369,4 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
 |====
+

--- a/documentation/modules/con-customizing-external-services.adoc
+++ b/documentation/modules/con-customizing-external-services.adoc
@@ -1,0 +1,51 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-customizing-deployments.adoc
+
+[id='con-customizing-external-services-{context}']
+= Customizing external Services
+
+When exposing Kafka to the outside of Kubernetes using load balancers or node prots, you can in addition to Labels and Annotations customize some more fields .
+These fields are described in the following table and affect how the Service is created.
+
+[table,stripes=none]
+|===
+|Field |Description
+
+|`externalTrafficPolicy`
+|Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
+`Cluster` may cause a second hop to another node and obscures the client source IP.
+`Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure).
+When not specified, Kubernetes will use `Cluster` as default.
+
+|`loadBalancerSourceRanges`
+|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners.
+If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list.
+This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature.
+
+For more info see link:https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/[Configure Your Cloud Provider's Firewalls].
+|===
+
+These fields are available on the `externalBootstrapService` and `perPodService` fields.
+The following example shows these customized fields on a `template` property:
+
+[source,yaml,subs=attributes+]
+----
+# ...
+template:
+  externalBootstrapService:
+    externalTrafficPolicy: Local
+    loadBalancerSourceRanges:
+      - 10.0.0.0/8
+      - 88.208.76.87/32
+  perPodService:
+    externalTrafficPolicy: Local
+    loadBalancerSourceRanges:
+      - 10.0.0.0/8
+      - 88.208.76.87/32
+# ...
+----
+
+.Additional resources
+
+* For more information, see xref:type-ExternalServiceTemplate-reference[].

--- a/documentation/modules/con-customizing-external-services.adoc
+++ b/documentation/modules/con-customizing-external-services.adoc
@@ -5,7 +5,7 @@
 [id='con-customizing-external-services-{context}']
 = Customizing external Services
 
-When exposing Kafka to the outside of Kubernetes using load balancers or node prots, you can in addition to Labels and Annotations customize some more fields .
+When exposing Kafka to the outside of Kubernetes using load balancers or node ports, you can customize some more fields in addition to Labels and Annotations.
 These fields are described in the following table and affect how the Service is created.
 
 [table,stripes=none]

--- a/documentation/modules/con-customizing-external-services.adoc
+++ b/documentation/modules/con-customizing-external-services.adoc
@@ -5,29 +5,29 @@
 [id='con-customizing-external-services-{context}']
 = Customizing external Services
 
-When exposing Kafka to the outside of Kubernetes using load balancers or node ports, you can customize some more fields in addition to Labels and Annotations.
-These fields are described in the following table and affect how the Service is created.
+When exposing Kafka outside of Kubernetes using loadbalancers or node ports, you can use additional customization properties in addition to labels and annotations.
+The properties for external services are described in the following table and affect how a Service is created.
 
 [table,stripes=none]
 |===
 |Field |Description
 
 |`externalTrafficPolicy`
-|Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
+|Specifies whether the service routes external traffic to node-local or cluster-wide endpoints.
 `Cluster` may cause a second hop to another node and obscures the client source IP.
 `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure).
-When not specified, Kubernetes will use `Cluster` as default.
+If unspecified, Kubernetes will use `Cluster` as the default.
 
 |`loadBalancerSourceRanges`
-|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients will be able to connect to load balancer type listeners.
-If supported by the platform, this will restrict traffic through the load balancer to the specified CIDR ranges in this list.
-This field is applicable only for load balancer type services and will be ignored if the cloud-provider does not support the feature.
+|A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners.
+If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges.
+This field is applicable only for loadbalancer type services, and is ignored if the cloud provider does not support the feature.
 
-For more info see link:https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/[Configure Your Cloud Provider's Firewalls].
+For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
 |===
 
-These fields are available on the `externalBootstrapService` and `perPodService` fields.
-The following example shows these customized fields on a `template` property:
+These properties are available for `externalBootstrapService` and `perPodService`.
+The following example shows these customized properties for a `template`:
 
 [source,yaml,subs=attributes+]
 ----

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -1259,6 +1259,15 @@ spec:
                               type: object
                             annotations:
                               type: object
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
                     perPodService:
                       type: object
                       properties:
@@ -1269,6 +1278,15 @@ spec:
                               type: object
                             annotations:
                               type: object
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
                     externalBootstrapRoute:
                       type: object
                       properties:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1254,6 +1254,15 @@ spec:
                               type: object
                             annotations:
                               type: object
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
                     perPodService:
                       type: object
                       properties:
@@ -1264,6 +1273,15 @@ spec:
                               type: object
                             annotations:
                               type: object
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
                     externalBootstrapRoute:
                       type: object
                       properties:

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -104,4 +104,35 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
         assertThat(current.getSpec().getPorts().get(0).getNodePort(), is(desired.getSpec().getPorts().get(1).getNodePort()));
         assertThat(current.getSpec().getPorts().get(1).getNodePort(), is(desired.getSpec().getPorts().get(0).getNodePort()));
     }
+
+    @Test
+    public void testHealthCheckPortPatching()  {
+        KubernetesClient client = mock(KubernetesClient.class);
+
+        Service current = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("Loadbalancer")
+                    .withHealthCheckNodePort(34321)
+                .endSpec()
+                .build();
+
+        Service desired = new ServiceBuilder()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                .withType("Loadbalancer")
+                .endSpec()
+                .build();
+
+        ServiceOperator op = new ServiceOperator(vertx, client);
+        op.patchHealthCheckPorts(current, desired);
+
+        assertThat(current.getSpec().getHealthCheckNodePort(), is(desired.getSpec().getHealthCheckNodePort()));
+    }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases, it might be useful to be able to edit the `externalTrafficPolicy` and `loadBalancerSourceRanges` options of the load balancer or node port services. Their value might be in:
* Propagating the real source IP address into the Kafka brokers (`externalTrafficPolicy`)
* Making sure the routing is more efficient by not routing node port traffic between nodes not hosting the endpoint locally (`externalTrafficPolicy`)
* Configure the cloud provider firewalls to allow connections only from some IPs (`loadBalancerSourceRanges`)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

