### PR TITLE
Let user choose which node address should be used as advertised host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 0.16.0
 
+* Let user choose which node address will be used as advertised host (`ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` or `Hostname`)
 * Add support for tini
 * When not explicitly configured by the user in `jvmOptions`, `-Xmx` option is calculated from memory requests rather than from memory limits
 * Expose JMX port on Kafka brokers via an internal service

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
@@ -36,7 +36,7 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     private boolean tls = true;
     private List<NetworkPolicyPeer> networkPolicyPeers;
     private NodePortListenerOverride overrides;
-    private KafkaListenerExternalConfiguration configuration;
+    private NodePortListenerConfiguration configuration;
 
     @Description("Must be `" + TYPE_NODEPORT + "`")
     @Override
@@ -85,11 +85,11 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     }
 
     @Description("External listener configuration")
-    public KafkaListenerExternalConfiguration getConfiguration() {
+    public NodePortListenerConfiguration getConfiguration() {
         return configuration;
     }
 
-    public void setConfiguration(KafkaListenerExternalConfiguration configuration) {
+    public void setConfiguration(NodePortListenerConfiguration configuration) {
         this.configuration = configuration;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodeAddressType.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodeAddressType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.listener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum NodeAddressType {
+    EXTERNAL_IP,
+    EXTERNAL_DNS,
+    INTERNAL_IP,
+    INTERNAL_DNS,
+    HOSTNAME;
+
+    @JsonCreator
+    public static NodeAddressType forValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "externalip":
+                return EXTERNAL_IP;
+            case "externaldns":
+                return EXTERNAL_DNS;
+            case "internalip":
+                return INTERNAL_IP;
+            case "internaldns":
+                return INTERNAL_DNS;
+            case "hostname":
+                return HOSTNAME;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case EXTERNAL_IP:
+                return "ExternalIP";
+            case EXTERNAL_DNS:
+                return "ExternalDNS";
+            case INTERNAL_IP:
+                return "InternalIP";
+            case INTERNAL_DNS:
+                return "InternalDNS";
+            case HOSTNAME:
+                return "Hostname";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.listener;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Configures External node port listeners
+ */
+
+@JsonPropertyOrder({"brokerCertChainAndKey", "addressType"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(
+    editableEnabled = false,
+    generateBuilderPackage = false,
+    builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@EqualsAndHashCode
+public class NodePortListenerConfiguration extends KafkaListenerExternalConfiguration {
+    private static final long serialVersionUID = 1L;
+
+    private NodeAddressType preferredAddressType;
+
+    @Description("Defines which address type should be used as the node address. " +
+            "Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. " +
+            "By default, the addresses will be used in the following order (the first one found will be used):\n" +
+            "* `ExternalDNS`\n" +
+            "* `ExternalIP`\n" +
+            "* `InternalDNS`\n" +
+            "* `InternalIP`\n" +
+            "* `Hostname`\n" +
+            "\n" +
+            "This field can be used to select the address type which will be used as the preferred type and checked first. " +
+            "In case no address will be found for this address type, the other types will be used in the default order.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public NodeAddressType getPreferredAddressType() {
+        return preferredAddressType;
+    }
+
+    public void setPreferredAddressType(NodeAddressType preferredAddressType) {
+        this.preferredAddressType = preferredAddressType;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
@@ -14,7 +14,7 @@ import lombok.EqualsAndHashCode;
  * Configures External node port listeners
  */
 
-@JsonPropertyOrder({"brokerCertChainAndKey", "addressType"})
+@JsonPropertyOrder({"brokerCertChainAndKey", "preferredAddressType"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/NodePortListenerConfiguration.java
@@ -21,7 +21,7 @@ import lombok.EqualsAndHashCode;
     generateBuilderPackage = false,
     builderPackage = "io.fabric8.kubernetes.api.builder"
 )
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class NodePortListenerConfiguration extends KafkaListenerExternalConfiguration {
     private static final long serialVersionUID = 1L;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -111,6 +111,8 @@ public class KafkaCluster extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
     protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS = "EXTERNAL_ADDRESS";
     protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADVERTISED_ADDRESSES = "EXTERNAL_ADVERTISED_ADDRESSES";
+    protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS_TYPE = "EXTERNAL_ADDRESS_TYPE";
+
     /**
      * {@code TRUE} when the CLIENT listener (PLAIN transport) should be enabled
      */
@@ -1440,6 +1442,12 @@ public class KafkaCluster extends AbstractModel {
         if (isExposedWithNodePort()) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS, "TRUE"));
             varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_EXTERNAL_ADVERTISED_ADDRESSES, String.join(" ", externalAddresses)));
+
+            KafkaListenerExternalNodePort listener = (KafkaListenerExternalNodePort) listeners.getExternal();
+
+            if (listener.getConfiguration() != null && listener.getConfiguration().getPreferredAddressType() != null)    {
+                varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS_TYPE, listener.getConfiguration().getPreferredAddressType().toValue()));
+            }
         }
 
         addContainerEnvsToExistingEnvs(varList, templateInitContainerEnvVars);

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -342,7 +342,7 @@ Used in: xref:type-KafkaListenerTls-{context}[`KafkaListenerTls`]
 [id='type-CertAndKeySecretSource-{context}']
 ### `CertAndKeySecretSource` schema reference
 
-Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`], xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaListenerExternalConfiguration-{context}[`KafkaListenerExternalConfiguration`], xref:type-TlsListenerConfiguration-{context}[`TlsListenerConfiguration`]
+Used in: xref:type-IngressListenerConfiguration-{context}[`IngressListenerConfiguration`], xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaListenerExternalConfiguration-{context}[`KafkaListenerExternalConfiguration`], xref:type-NodePortListenerConfiguration-{context}[`NodePortListenerConfiguration`], xref:type-TlsListenerConfiguration-{context}[`TlsListenerConfiguration`]
 
 
 [options="header"]
@@ -433,7 +433,7 @@ Used in: xref:type-RouteListenerOverride-{context}[`RouteListenerOverride`]
 [id='type-KafkaListenerExternalConfiguration-{context}']
 ### `KafkaListenerExternalConfiguration` schema reference
 
-Used in: xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`]
+Used in: xref:type-KafkaListenerExternalLoadBalancer-{context}[`KafkaListenerExternalLoadBalancer`], xref:type-KafkaListenerExternalRoute-{context}[`KafkaListenerExternalRoute`]
 
 
 [options="header"]
@@ -541,7 +541,7 @@ It must have the value `nodeport` for the type `KafkaListenerExternalNodePort`.
 |overrides           1.2+<.<|Overrides for external bootstrap and broker services and externally advertised addresses.
 |xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`]
 |configuration       1.2+<.<|External listener configuration.
-|xref:type-KafkaListenerExternalConfiguration-{context}[`KafkaListenerExternalConfiguration`]
+|xref:type-NodePortListenerConfiguration-{context}[`NodePortListenerConfiguration`]
 |networkPolicyPeers  1.2+<.<|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list. See external documentation of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#networkpolicypeer-v1-networking-k8s-io[networking.k8s.io/v1 networkpolicypeer].
 
 
@@ -601,6 +601,28 @@ Used in: xref:type-NodePortListenerOverride-{context}[`NodePortListenerOverride`
 |integer
 |dnsAnnotations  1.2+<.<|Annotations that will be added to the `Service` resources for individual brokers. You can use this field to configure DNS providers such as External DNS.
 |map
+|====
+
+[id='type-NodePortListenerConfiguration-{context}']
+### `NodePortListenerConfiguration` schema reference
+
+Used in: xref:type-KafkaListenerExternalNodePort-{context}[`KafkaListenerExternalNodePort`]
+
+
+[options="header"]
+|====
+|Property                      |Description
+|brokerCertChainAndKey  1.2+<.<|Reference to the `Secret` which holds the certificate and private key pair. The certificate can optionally contain the whole chain.
+|xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
+|preferredAddressType   1.2+<.<|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+* `ExternalDNS`
+* `ExternalIP`
+* `InternalDNS`
+* `InternalIP`
+* `Hostname`
+
+This field can be used to select the address type which will be used as the preferred type and checked first. In case no address will be found for this address type, the other types will be used in the default order..
+|string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
 |====
 
 [id='type-KafkaListenerExternalIngress-{context}']

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -144,6 +144,11 @@ public class InitWriter {
 
         Map<String, String> addressMap = addresses.stream().collect(Collectors.toMap(NodeAddress::getType, NodeAddress::getAddress));
 
+        // If user set preferred address type, we should check it first
+        if (config.getAddressType() != null && addressMap.containsKey(config.getAddressType())) {
+            return addressMap.get(config.getAddressType());
+        }
+
         if (addressMap.containsKey("ExternalDNS"))  {
             return addressMap.get("ExternalDNS");
         } else if (addressMap.containsKey("ExternalIP"))  {

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriterConfig.java
@@ -15,6 +15,7 @@ public class InitWriterConfig {
     public static final String RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
     public static final String NODE_NAME = "NODE_NAME";
     public static final String EXTERNAL_ADDRESS = "EXTERNAL_ADDRESS";
+    public static final String EXTERNAL_ADDRESS_TYPE = "EXTERNAL_ADDRESS_TYPE";
     public static final String EXTERNAL_ADVERTISED_ADDRESSES = "EXTERNAL_ADVERTISED_ADDRESSES";
 
     public static final String DEFAULT_INIT_FOLDER = "/opt/kafka/init";
@@ -22,6 +23,7 @@ public class InitWriterConfig {
     private String nodeName;
     private String rackTopologyKey;
     private boolean externalAddress;
+    private String addressType;
     private String initFolder;
     private String externalAdvertisedAddresses;
 
@@ -50,15 +52,18 @@ public class InitWriterConfig {
 
         String externalAdvertisedAddressesEnvVar = map.get(InitWriterConfig.EXTERNAL_ADVERTISED_ADDRESSES);
 
-        return new InitWriterConfig(nodeName, rackTopologyKey, externalAddress, initFolder, externalAdvertisedAddressesEnvVar);
+        String externalAddressType = map.get(InitWriterConfig.EXTERNAL_ADDRESS_TYPE);
+
+        return new InitWriterConfig(nodeName, rackTopologyKey, externalAddress, initFolder, externalAdvertisedAddressesEnvVar, externalAddressType);
     }
 
-    public InitWriterConfig(String nodeName, String rackTopologyKey, boolean externalAddress, String initFolder, String externalAdvertisedHost) {
+    public InitWriterConfig(String nodeName, String rackTopologyKey, boolean externalAddress, String initFolder, String externalAdvertisedHost, String externalAddressType) {
         this.nodeName = nodeName;
         this.rackTopologyKey = rackTopologyKey;
         this.externalAddress = externalAddress;
         this.initFolder = initFolder;
         this.externalAdvertisedAddresses = externalAdvertisedHost;
+        this.addressType = externalAddressType;
     }
 
     /**
@@ -96,6 +101,13 @@ public class InitWriterConfig {
         return externalAdvertisedAddresses;
     }
 
+    /**
+     * @return The address type which should be preferred in the selection
+     */
+    public String getAddressType() {
+        return addressType;
+    }
+
     @Override
     public String toString() {
         return "InitWriterConfig(" +
@@ -104,6 +116,7 @@ public class InitWriterConfig {
                 ",externalAddress=" + externalAddress +
                 ",initFolder=" + initFolder +
                 ",externalAdvertisedAddresses=" + externalAdvertisedAddresses +
+                ",addressType=" + addressType +
                 ")";
     }
 }

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.init;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -31,6 +32,16 @@ public class InitWriterConfigTest {
         assertThat(config.getNodeName(), is("localhost"));
         assertThat(config.getRackTopologyKey(), is("failure-domain.beta.kubernetes.io/zone"));
         assertThat(config.isExternalAddress(), is(true));
+        assertThat(config.getAddressType(), is(nullValue()));
+    }
+
+    @Test
+    public void testEnvVarsWithAddressType() {
+        Map<String, String> envs = new HashMap<>(envVars);
+        envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE, "InternalDNS");
+
+        InitWriterConfig config = InitWriterConfig.fromMap(envs);
+        assertThat(config.getAddressType(), is("InternalDNS"));
     }
 
     @Test

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
@@ -124,6 +124,18 @@ public class InitWriterTest {
     }
 
     @Test
+    public void testFindAddressWithType()   {
+        Map<String, String> envs = new HashMap<>(envVars);
+        envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE, "InternalDNS");
+        InitWriterConfig config = InitWriterConfig.fromMap(envs);
+        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
+        InitWriter writer = new InitWriter(client, config);
+        String address = writer.findAddress(addresses);
+
+        assertThat(address, is("my.internal.address"));
+    }
+
+    @Test
     public void testFindAddress()   {
         InitWriterConfig config = InitWriterConfig.fromMap(envVars);
         KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When users are using node ports to expose Kafka clusters to the outside world, we use the address of the Kubernetes node on which the Kafka broker pod gets scheduled as the advertised hostname. However, the nodes often have multiple addresses. We currently take them in the following priority:
* `ExternalDNS`
* `ExternalIP`
* `InternalDNS`
* `InternalIP`
* `Hostname`

When this priority doesn't match the user needs they would need to use the manual overrides - but these do not work well with scaling or when the pods are rescheduled to another node. And there are many reasons why to use different priority. For example because missing DNS support or because the user want to expose the broker only internally with internal DNS or IPs.

This PR lets the user specify which address type should be used as preferred. We will check this address first and if it exists use it. If it doesn't exist we will follow the default priority order to find at least something.

This should close issue #2109.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md

