### PR TITLE
Fixed OAuth artifact version

### DIFF
--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -39,7 +39,7 @@
 
 //OAuth attributes and links
 :oauth2-site: link:https://oauth.net/2/[{oauth} site^]
-:oauth-artifact-version: 0.1.0.redhat-00002
+:oauth-artifact-version: 0.2.0
 
 // External links
 :docs-okd: link:https://docs.okd.io/3.9/dev_guide/builds/index.html[builds^]


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

This PR fixes the `0.1.0.redhat-00002` used as version of the OAuth client artifact updating it to the upstream 0.2.0 release and with no reference to "redhat" stuff.
Even if it fixes the usage of an upstream release, I was wondering if we could avoid specifying a release to use in the doc leaving to the user to use the last one otherwise it means that we should update the `:oauth-artifact-version:` attribute (as I have done) for every new release.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

