### PR TITLE
ST: Improve Kafka cluster rolling tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -143,7 +143,7 @@ public class PodUtils {
     }
 
     public static void waitUntilPodsCountIsPresent(String podNamePrefix, int numberOfPods) {
-        LOGGER.info("Waiting till pods with prefix {} count is present", podNamePrefix);
+        LOGGER.info("Waiting till {} pods with prefix {} are present", numberOfPods, podNamePrefix);
         TestUtils.waitFor("", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
             () -> kubeClient().listPodsByPrefixInName(podNamePrefix).size() == numberOfPods);
         LOGGER.info("Pods with count {} are present", numberOfPods);

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -358,7 +358,6 @@ class RollingUpdateST extends MessagingBaseST {
         zkSnapshot = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), scaleZkTo, zkSnapshot);
         // check the new node is either in leader or follower state
         KafkaUtils.waitForZkMntr(CLUSTER_NAME, ZK_SERVER_STATE, 0, 1, 2, 3, 4, 5, 6);
-        checkZkPodsLog(newZkPodNames);
 
         //Test that CO doesn't have any exceptions in log
         timeMeasuringSystem.stopOperation(timeMeasuringSystem.getOperationID());
@@ -481,16 +480,6 @@ class RollingUpdateST extends MessagingBaseST {
         LOGGER.info("{} pods statutes: {}", stableComponent, statusCount);
 
         assertThat("", statusCount.get("Running"), is(Integer.toUnsignedLong(podStatuses.size())));
-    }
-
-    void checkZkPodsLog(List<String> newZkPodNames) {
-        for (String name : newZkPodNames) {
-            //Test that second pod does not have errors or failures in events
-            LOGGER.info("Checking logs from pod {}", name);
-            String uid = kubeClient().getPodUid(name);
-            List<Event> eventsForSecondPod = kubeClient().listEvents(uid);
-            assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
-        }
     }
 
     void deployTestSpecificResources() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -188,7 +187,6 @@ class RollingUpdateST extends MessagingBaseST {
         assertThat(received, is(sent));
     }
 
-    @Disabled
     @Test
     @Tag(ACCEPTANCE)
     @Tag(NODEPORT_SUPPORTED)
@@ -274,7 +272,6 @@ class RollingUpdateST extends MessagingBaseST {
      * 4. Trigger rolling update for Kafka cluster
      * 5. Rolling update will not be performed, because topic which we created had some replicas on deleted pods - manual fix is needed in that case
      */
-    @Disabled
     @Test
     void testKafkaWontRollUpBecauseTopic() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
@@ -329,7 +326,6 @@ class RollingUpdateST extends MessagingBaseST {
         }
     }
 
-    @Disabled
     @Test
     void testZookeeperScaleUpScaleDown() throws Exception {
         int messageCount = 50;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,6 @@ import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.WAIT_FOR_ROLLING_UPDATE_TIMEOUT;
 import static io.strimzi.systemtest.k8s.Events.Created;
 import static io.strimzi.systemtest.k8s.Events.Killing;
 import static io.strimzi.systemtest.k8s.Events.Pulled;
@@ -188,6 +188,7 @@ class RollingUpdateST extends MessagingBaseST {
         assertThat(received, is(sent));
     }
 
+    @Disabled
     @Test
     @Tag(ACCEPTANCE)
     @Tag(NODEPORT_SUPPORTED)
@@ -273,6 +274,7 @@ class RollingUpdateST extends MessagingBaseST {
      * 4. Trigger rolling update for Kafka cluster
      * 5. Rolling update will not be performed, because topic which we created had some replicas on deleted pods - manual fix is needed in that case
      */
+    @Disabled
     @Test
     void testKafkaWontRollUpBecauseTopic() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
@@ -327,6 +329,7 @@ class RollingUpdateST extends MessagingBaseST {
         }
     }
 
+    @Disabled
     @Test
     void testZookeeperScaleUpScaleDown() throws Exception {
         int messageCount = 50;
@@ -429,7 +432,7 @@ class RollingUpdateST extends MessagingBaseST {
                 .getMetadata().getAnnotations().get("strimzi.io/manual-rolling-update")), is(true));
 
         // wait when annotation will be removed
-        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, WAIT_FOR_ROLLING_UPDATE_TIMEOUT,
+        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getStatefulSet(kafkaName).getMetadata().getAnnotations() == null
                     || !kubeClient().getStatefulSet(kafkaName).getMetadata().getAnnotations().containsKey("strimzi.io/manual-rolling-update"));
 
@@ -451,7 +454,7 @@ class RollingUpdateST extends MessagingBaseST {
                 .getMetadata().getAnnotations().get("strimzi.io/manual-rolling-update")), is(true));
 
         // wait when annotation will be removed
-        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, WAIT_FOR_ROLLING_UPDATE_TIMEOUT,
+        TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
             () -> kubeClient().getStatefulSet(zkName).getMetadata().getAnnotations() == null
                     || !kubeClient().getStatefulSet(zkName).getMetadata().getAnnotations().containsKey("strimzi.io/manual-rolling-update"));
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR add tests, which check behaviour of Kafka Cluster when manual CB is needed:

1. Deploy kafka cluster with 3 pods
2. Create topic with 4 replicas
3. Scale kafka cluster to 7 replicas and wait, until all pods are ready
4. Scale down kafka cluster to 3 replicas
5. Trigger rolling update for Kafka cluster
6. Rolling update will not be performed, because topic which we created had some replicas on deleted pods - manual intervention is needed in that case

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
