### PR TITLE
Use an actual node address in KafkaStatus for NodePorts

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -45,6 +45,7 @@ if [ -n "$CHANGED_DERIVED" ] || [ -n "$GENERATED_FILES" ] ; then
   echo "Run the following to add up-to-date resources:"
   echo "  mvn clean verify -DskipTests -DskipITs \\"
   echo "    && make crd_install \\"
+  echo "    && make helm_install \\"
   echo "    && git add install/ helm-charts/ documentation/modules/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles"
   echo "    && git commit -s -m 'Update derived resources'"
   exit 1

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -243,14 +243,14 @@ public abstract class AbstractModel {
      * @return The selector labels as an instance of the Labels object.
      */
     public Labels getSelectorLabels() {
-        return labels.withName(name).strimziLabels();
+        return labels.withName(name).strimziSelectorLabels();
     }
 
     /**
      * @return The selector labels as Map.
      */
     public Map<String, String> getSelectorLabelsAsMap() {
-        return labels.withName(name).strimziLabels().toMap();
+        return getSelectorLabels().toMap();
     }
 
     protected Map<String, String> getLabelsWithName() {
@@ -736,7 +736,7 @@ public abstract class AbstractModel {
     }
 
     protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> annotations) {
-        return createService(serviceName, type, ports, getLabelsWithNameAndDiscovery(serviceName, templateServiceLabels), getSelectorLabels(), annotations);
+        return createService(serviceName, type, ports, getLabelsWithNameAndDiscovery(serviceName, templateServiceLabels), getSelectorLabelsAsMap(), annotations);
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
@@ -744,7 +744,7 @@ public abstract class AbstractModel {
     }
 
     protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
-        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithNameAndDiscovery(serviceName), templateServiceLabels, labels), getSelectorLabels(), annotations);
+        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithNameAndDiscovery(serviceName), templateServiceLabels, labels), getSelectorLabelsAsMap(), annotations);
     }
 
     protected Service createService(String name, String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> selector, Map<String, String> annotations) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -239,12 +239,18 @@ public abstract class AbstractModel {
         return headlessServiceName;
     }
 
+    /**
+     * @return The selector labels as an instance of the Labels object.
+     */
+    public Labels getSelectorLabels() {
+        return labels.withName(name).strimziLabels();
+    }
 
     /**
-     * @return The selector labels.
+     * @return The selector labels as Map.
      */
-    public Map<String, String> getSelectorLabels() {
-        return labels.withName(name).strimziSelectorLabels().toMap();
+    public Map<String, String> getSelectorLabelsAsMap() {
+        return labels.withName(name).strimziLabels().toMap();
     }
 
     protected Map<String, String> getLabelsWithName() {
@@ -726,7 +732,7 @@ public abstract class AbstractModel {
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> annotations) {
-        return createService(serviceName, type, ports, getLabelsWithName(serviceName, templateServiceLabels), getSelectorLabels(), annotations);
+        return createService(serviceName, type, ports, getLabelsWithName(serviceName, templateServiceLabels), getSelectorLabelsAsMap(), annotations);
     }
 
     protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> annotations) {
@@ -734,7 +740,7 @@ public abstract class AbstractModel {
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
-        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithName(serviceName), templateServiceLabels, labels), getSelectorLabels(), annotations);
+        return createService(serviceName, type, ports, mergeLabelsOrAnnotations(getLabelsWithName(serviceName), templateServiceLabels, labels), getSelectorLabelsAsMap(), annotations);
     }
 
     protected Service createDiscoverableService(String type, List<ServicePort> ports, Map<String, String> labels, Map<String, String> annotations) {
@@ -778,7 +784,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withType("ClusterIP")
                     .withClusterIP("None")
-                    .withSelector(getSelectorLabels())
+                    .withSelector(getSelectorLabelsAsMap())
                     .withPorts(ports)
                     .withPublishNotReadyAddresses(true)
                 .endSpec()
@@ -818,7 +824,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withPodManagementPolicy("Parallel")
                     .withUpdateStrategy(new StatefulSetUpdateStrategyBuilder().withType("OnDelete").build())
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels()).build())
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabelsAsMap()).build())
                     .withServiceName(headlessServiceName)
                     .withReplicas(replicas)
                     .withNewTemplate()
@@ -869,7 +875,7 @@ public abstract class AbstractModel {
                 .withNewSpec()
                     .withStrategy(updateStrategy)
                     .withReplicas(replicas)
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels()).build())
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabelsAsMap()).build())
                     .withNewTemplate()
                         .withNewMetadata()
                             .withLabels(getLabelsWithName(templatePodLabels))
@@ -1114,7 +1120,7 @@ public abstract class AbstractModel {
                 .endMetadata()
                 .withNewSpec()
                     .withNewMaxUnavailable(templatePodDisruptionBudgetMaxUnavailable)
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels()).build())
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabelsAsMap()).build())
                 .endSpec()
                 .build();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -867,7 +867,7 @@ public class KafkaCluster extends AbstractModel {
 
             Service service = createService(externalBootstrapServiceName, getExternalServiceType(), ports,
                 getLabelsWithName(externalBootstrapServiceName, templateExternalBootstrapServiceLabels),
-                getSelectorLabels(),
+                getSelectorLabelsAsMap(),
                 mergeLabelsOrAnnotations(dnsAnnotations, templateExternalBootstrapServiceAnnotations), loadBalancerIP);
 
             if (isExposedWithLoadBalancer()) {
@@ -947,7 +947,7 @@ public class KafkaCluster extends AbstractModel {
                 }
             }
 
-            Labels selector = Labels.fromMap(getSelectorLabels()).withStatefulSetPod(kafkaPodName(cluster, pod));
+            Labels selector = Labels.fromMap(getSelectorLabelsAsMap()).withStatefulSetPod(kafkaPodName(cluster, pod));
 
             Service service = createService(perPodServiceName, getExternalServiceType(), ports,
                     getLabelsWithName(perPodServiceName, templatePerPodServiceLabels), selector.toMap(),
@@ -2354,5 +2354,22 @@ public class KafkaCluster extends AbstractModel {
 
     public void setJmxAuthenticated(boolean jmxAuthenticated) {
         isJmxAuthenticated = jmxAuthenticated;
+    }
+
+    /**
+     * Returns the preferred node address type is configured by the user. Returns null otherwise.
+     *
+     * @return Preferred node address type as selected by the user
+     */
+    public String getPreferredNodeAddressType()    {
+        if (isExposedWithNodePort())    {
+            KafkaListenerExternalNodePort listener = (KafkaListenerExternalNodePort) listeners.getExternal();
+
+            if (listener.getConfiguration() != null)    {
+                return listener.getConfiguration().getPreferredAddressType().toValue();
+            }
+        }
+
+        return null;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -2357,7 +2357,7 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Returns the preferred node address type is configured by the user. Returns null otherwise.
+     * Returns the preferred node address type if configured by the user. Returns null otherwise.
      *
      * @return Preferred node address type as selected by the user
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -127,7 +127,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(replicas)
-                    .withSelector(getSelectorLabels())
+                    .withSelector(getSelectorLabelsAsMap())
                     .withNewTemplate()
                         .withNewMetadata()
                             .withAnnotations(mergeLabelsOrAnnotations(annotations, templatePodAnnotations))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -34,6 +34,7 @@ import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
@@ -74,6 +75,7 @@ public class ResourceOperatorSupplier {
     public final BuildConfigOperator buildConfigOperations;
     public final DeploymentConfigOperator deploymentConfigOperations;
     public final StorageClassOperator storageClassOperations;
+    public final NodeOperator nodeOperator;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client,
@@ -111,7 +113,8 @@ public class ResourceOperatorSupplier {
                 new CrdOperator<>(vertx, client, KafkaMirrorMaker.class, KafkaMirrorMakerList.class, DoneableKafkaMirrorMaker.class),
                 new CrdOperator<>(vertx, client, KafkaBridge.class, KafkaBridgeList.class, DoneableKafkaBridge.class),
                 new CrdOperator<>(vertx, client, KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class),
-                new StorageClassOperator(vertx, client, operationTimeoutMs));
+                new StorageClassOperator(vertx, client, operationTimeoutMs),
+                new NodeOperator(vertx, client, operationTimeoutMs));
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
@@ -138,7 +141,8 @@ public class ResourceOperatorSupplier {
                                     CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, DoneableKafkaMirrorMaker> mirrorMakerOperator,
                                     CrdOperator<KubernetesClient, KafkaBridge, KafkaBridgeList, DoneableKafkaBridge> kafkaBridgeOperator,
                                     CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> kafkaConnectorOperator,
-                                    StorageClassOperator storageClassOperator) {
+                                    StorageClassOperator storageClassOperator,
+                                    NodeOperator nodeOperator) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
@@ -164,5 +168,6 @@ public class ResourceOperatorSupplier {
         this.kafkaBridgeOperator = kafkaBridgeOperator;
         this.storageClassOperations = storageClassOperator;
         this.kafkaConnectorOperator = kafkaConnectorOperator;
+        this.nodeOperator = nodeOperator;
     }
 }

--- a/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -22,3 +22,9 @@ rules:
   - storageclasses
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -68,6 +68,7 @@ import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
@@ -622,7 +623,7 @@ public class ResourceUtils {
                 mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
                 mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
                 mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(StorageClassOperator.class));
+                mock(StorageClassOperator.class), mock(NodeOperator.class));
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -606,7 +606,7 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapService();
         assertThat(ext.getMetadata().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
         assertThat(ext.getSpec().getType(), is("ClusterIP"));
-        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
+        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabelsAsMap()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
         checkOwnerReference(kc.createOwnerReference(), ext);
 
@@ -735,7 +735,7 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapService();
         assertThat(ext.getMetadata().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
         assertThat(ext.getSpec().getType(), is("LoadBalancer"));
-        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
+        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabelsAsMap()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
         assertThat(ext.getSpec().getLoadBalancerIP(), is(nullValue()));
         assertThat(ext.getSpec().getExternalTrafficPolicy(), is(nullValue()));
@@ -1091,7 +1091,7 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapService();
         assertThat(ext.getMetadata().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
         assertThat(ext.getSpec().getType(), is("NodePort"));
-        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
+        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabelsAsMap()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
         checkOwnerReference(kc.createOwnerReference(), ext);
 
@@ -1178,7 +1178,7 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapService();
         assertThat(ext.getMetadata().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
         assertThat(ext.getSpec().getType(), is("NodePort"));
-        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
+        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabelsAsMap()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, 32001, "TCP"))));
         checkOwnerReference(kc.createOwnerReference(), ext);
 
@@ -2485,7 +2485,7 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapService();
         assertThat(ext.getMetadata().getName(), is(KafkaCluster.externalBootstrapServiceName(cluster)));
         assertThat(ext.getSpec().getType(), is("ClusterIP"));
-        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels()));
+        assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabelsAsMap()));
         assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, KafkaCluster.EXTERNAL_PORT, "TCP"))));
         checkOwnerReference(kc.createOwnerReference(), ext);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -79,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -67,6 +67,7 @@ import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
@@ -397,6 +398,7 @@ public class KafkaAssemblyOperatorTest {
         NetworkPolicyOperator mockPolicyOps = supplier.networkPolicyOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         RouteOperator mockRotueOps = supplier.routeOperations;
+        NodeOperator mockNodeOps = supplier.nodeOperator;
 
         // Create a CM
         String clusterCmName = clusterCm.getMetadata().getName();
@@ -425,6 +427,10 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock pod readiness
         when(mockPodOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.listAsync(anyString(), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock node ops
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         Map<String, PersistentVolumeClaim> zkPvcs = createPvcs(clusterCmNamespace, zookeeperCluster.getStorage(), zookeeperCluster.getReplicas(),
             (replica, storageId) -> AbstractModel.VOLUME_NAME + "-" + ZookeeperCluster.zookeeperPodName(clusterCmName, replica));
@@ -832,6 +838,7 @@ public class KafkaAssemblyOperatorTest {
         RoleBindingOperator mockRbo = supplier.roleBindingOperations;
         ClusterRoleBindingOperator mockCrbo = supplier.clusterRoleBindingOperator;
         RouteOperator mockRouteOps = supplier.routeOperations;
+        NodeOperator mockNodeOps = supplier.nodeOperator;
 
         String clusterName = updatedAssembly.getMetadata().getName();
         String clusterNamespace = updatedAssembly.getMetadata().getNamespace();
@@ -927,8 +934,12 @@ public class KafkaAssemblyOperatorTest {
                 .build();
         when(mockCmOps.get(clusterNamespace, ZookeeperCluster.zookeeperMetricAndLogConfigsName(clusterName))).thenReturn(zklogsCm);
 
-        // Mock pod readiness
+        // Mock pod ops
         when(mockPodOps.readiness(anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.listAsync(anyString(), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock node ops
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock Service gets
         when(mockServiceOps.get(clusterNamespace, KafkaCluster.kafkaClusterName(clusterName))).thenReturn(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -4,10 +4,17 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
@@ -16,18 +23,28 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.KubernetesVersion;
+import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.NodeOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.text.ParseException;
@@ -40,14 +57,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(VertxExtension.class)
 public class KafkaStatusTest {
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_11;
     private final MockCertManager certManager = new MockCertManager();
     private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
-    private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig();
+    private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "testns";
     private final String clusterName = "testkafka";
@@ -98,7 +117,7 @@ public class KafkaStatusTest {
     }
 
     @Test
-    public void testStatusAfterSuccessfulReconciliationWithPreviousFailure() throws ParseException {
+    public void testStatusAfterSuccessfulReconciliationWithPreviousFailure(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -116,6 +135,7 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
+        Checkpoint async = context.checkpoint();
         kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
             assertThat(res.succeeded(), is(true));
 
@@ -136,11 +156,13 @@ public class KafkaStatusTest {
             assertThat(status.getConditions().get(0).getStatus(), is("True"));
 
             assertThat(status.getObservedGeneration(), is(2L));
+
+            async.flag();
         });
     }
 
     @Test
-    public void testStatusAfterSuccessfulReconciliationWithPreviousSuccess() throws ParseException {
+    public void testStatusAfterSuccessfulReconciliationWithPreviousSuccess(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -181,24 +203,27 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
+        Checkpoint async = context.checkpoint();
         kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
             assertThat(res.succeeded(), is(true));
             // The status should not change => we test that updateStatusAsync was not called
             assertThat(kafkaCaptor.getAllValues().size(), is(0));
+
+            async.flag();
         });
     }
 
     @Test
-    public void testStatusAfterFailedReconciliationWithPreviousFailure() throws ParseException {
-        testStatusAfterFailedReconciliationWithPreviousFailure(new RuntimeException("Something went wrong"));
+    public void testStatusAfterFailedReconciliationWithPreviousFailure(VertxTestContext context) throws ParseException {
+        testStatusAfterFailedReconciliationWithPreviousFailure(context, new RuntimeException("Something went wrong"));
     }
 
     @Test
-    public void testStatusAfterFailedReconciliationWithPreviousFailure_NPE() throws ParseException {
-        testStatusAfterFailedReconciliationWithPreviousFailure(new NullPointerException());
+    public void testStatusAfterFailedReconciliationWithPreviousFailure_NPE(VertxTestContext context) throws ParseException {
+        testStatusAfterFailedReconciliationWithPreviousFailure(context, new NullPointerException());
     }
 
-    public void testStatusAfterFailedReconciliationWithPreviousFailure(Throwable exception) throws ParseException {
+    public void testStatusAfterFailedReconciliationWithPreviousFailure(VertxTestContext context, Throwable exception) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -218,6 +243,7 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
+        Checkpoint async = context.checkpoint();
         kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
             assertThat(res.succeeded(), is(false));
 
@@ -237,11 +263,13 @@ public class KafkaStatusTest {
             assertThat(status.getConditions().get(0).getMessage(), is(exception.getMessage()));
 
             assertThat(status.getObservedGeneration(), is(2L));
+
+            async.flag();
         });
     }
 
     @Test
-    public void testStatusAfterFailedReconciliationWithPreviousSuccess() throws ParseException {
+    public void testStatusAfterFailedReconciliationWithPreviousSuccess(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -284,6 +312,7 @@ public class KafkaStatusTest {
                 supplier,
                 config);
 
+        Checkpoint async = context.checkpoint();
         kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
             assertThat(res.succeeded(), is(false));
 
@@ -303,6 +332,446 @@ public class KafkaStatusTest {
             assertThat(status.getConditions().get(0).getMessage(), is("Something went wrong"));
 
             assertThat(status.getObservedGeneration(), is(2L));
+
+            async.flag();
+        });
+    }
+
+    private List<Node> getClusterNodes()    {
+        Node node0 = new NodeBuilder()
+                .withNewMetadata()
+                    .withName("node-0")
+                .endMetadata()
+                .withNewStatus()
+                    .withAddresses(new NodeAddress("50.35.18.119", "ExternalIP"),
+                            new NodeAddress("node-0.my-kube", "InternalDNS"),
+                            new NodeAddress("10.0.0.1", "InternalIP"),
+                            new NodeAddress("nocde-0", "Hostname"))
+                .endStatus()
+                .build();
+
+        Node node1 = new NodeBuilder()
+                .withNewMetadata()
+                    .withName("node-1")
+                .endMetadata()
+                .withNewStatus()
+                    .withAddresses(new NodeAddress("55.36.78.115", "ExternalIP"),
+                            new NodeAddress("node-1.my-kube", "InternalDNS"),
+                            new NodeAddress("10.0.0.25", "InternalIP"),
+                            new NodeAddress("node-1", "Hostname"))
+                .endStatus()
+                .build();
+
+        Node node2 = new NodeBuilder()
+                .withNewMetadata()
+                    .withName("node-2")
+                .endMetadata()
+                .withNewStatus()
+                    .withAddresses(new NodeAddress("35.15.152.9", "ExternalIP"),
+                            new NodeAddress("node-2.my-kube", "InternalDNS"),
+                            new NodeAddress("10.0.0.16", "InternalIP"),
+                            new NodeAddress("node-2", "Hostname"))
+                .endStatus()
+                .build();
+
+        Node node3 = new NodeBuilder()
+                .withNewMetadata()
+                    .withName("node-3")
+                .endMetadata()
+                .withNewStatus()
+                    .withAddresses(new NodeAddress("5.124.16.8", "ExternalIP"),
+                            new NodeAddress("node-3.my-kube", "InternalDNS"),
+                            new NodeAddress("10.0.0.13", "InternalIP"),
+                            new NodeAddress("node-3", "Hostname"))
+                .endStatus()
+                .build();
+
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(node0);
+        nodes.add(node1);
+        nodes.add(node2);
+        nodes.add(node3);
+
+        return nodes;
+    }
+
+    @Test
+    public void testKafkaListenerNodePortAddressInStatus(VertxTestContext context) throws ParseException {
+        Kafka kafka = new KafkaBuilder(getKafkaCrd())
+                .editOrNewSpec()
+                    .editOrNewKafka()
+                        .editOrNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSetOperator
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.get(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(kafkaCluster.generateStatefulSet(false, null, null));
+
+        // Mock the ConfigMapOperator
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.get(eq(namespace), eq(clusterName))).thenReturn(kafkaCluster.generateMetricsAndLogConfigMap(null));
+
+        // Mock Pods Operator
+        Pod pod0 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 0)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.1")
+                .endStatus()
+                .build();
+
+        Pod pod1 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 1)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.25")
+                .endStatus()
+                .build();
+
+        Pod pod2 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 2)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.13")
+                .endStatus()
+                .build();
+
+        List<Pod> pods = new ArrayList<>();
+        pods.add(pod0);
+        pods.add(pod1);
+        pods.add(pod2);
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(namespace), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
+
+        // Mock Node operator
+        NodeOperator mockNodeOps = supplier.nodeOperator;
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(getClusterNodes()));
+
+        MockNodePortStatusKafkaAssemblyOperator kao = new MockNodePortStatusKafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getValue().getStatus();
+
+            assertThat(status.getListeners().size(), is(1));
+            assertThat(status.getListeners().get(0).getType(), is("external"));
+
+            List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
+            assertThat(addresses.size(), is(3));
+
+            List<ListenerAddress> expected = new ArrayList<>();
+            expected.add(new ListenerAddressBuilder().withHost("50.35.18.119").withPort(31234).build());
+            expected.add(new ListenerAddressBuilder().withHost("55.36.78.115").withPort(31234).build());
+            expected.add(new ListenerAddressBuilder().withHost("5.124.16.8").withPort(31234).build());
+
+            async.flag();
+        });
+    }
+
+    @Test
+    public void testKafkaListenerNodePortAddressWithPreferred(VertxTestContext context) throws ParseException {
+        Kafka kafka = new KafkaBuilder(getKafkaCrd())
+                .editOrNewSpec()
+                    .editOrNewKafka()
+                        .editOrNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                                .withNewConfiguration()
+                                    .withPreferredAddressType(NodeAddressType.INTERNAL_DNS)
+                                .endConfiguration()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSetOperator
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.get(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(kafkaCluster.generateStatefulSet(false, null, null));
+
+        // Mock the ConfigMapOperator
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.get(eq(namespace), eq(clusterName))).thenReturn(kafkaCluster.generateMetricsAndLogConfigMap(null));
+
+        // Mock Pods Operator
+        Pod pod0 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 0)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.1")
+                .endStatus()
+                .build();
+
+        Pod pod1 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 1)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.25")
+                .endStatus()
+                .build();
+
+        Pod pod2 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 2)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.13")
+                .endStatus()
+                .build();
+
+        List<Pod> pods = new ArrayList<>();
+        pods.add(pod0);
+        pods.add(pod1);
+        pods.add(pod2);
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(namespace), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
+
+        // Mock Node operator
+        NodeOperator mockNodeOps = supplier.nodeOperator;
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(getClusterNodes()));
+
+        MockNodePortStatusKafkaAssemblyOperator kao = new MockNodePortStatusKafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getValue().getStatus();
+
+            assertThat(status.getListeners().size(), is(1));
+            assertThat(status.getListeners().get(0).getType(), is("external"));
+
+            List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
+            assertThat(addresses.size(), is(3));
+
+            List<ListenerAddress> expected = new ArrayList<>();
+            expected.add(new ListenerAddressBuilder().withHost("node-0.my-kube").withPort(31234).build());
+            expected.add(new ListenerAddressBuilder().withHost("node-1.my-kube").withPort(31234).build());
+            expected.add(new ListenerAddressBuilder().withHost("node-3.my-kube").withPort(31234).build());
+
+            async.flag();
+        });
+    }
+
+    @Test
+    public void testKafkaListenerNodePortAddressSameNode(VertxTestContext context) throws ParseException {
+        Kafka kafka = new KafkaBuilder(getKafkaCrd())
+                .editOrNewSpec()
+                    .editOrNewKafka()
+                        .editOrNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSetOperator
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.get(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(kafkaCluster.generateStatefulSet(false, null, null));
+
+        // Mock the ConfigMapOperator
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.get(eq(namespace), eq(clusterName))).thenReturn(kafkaCluster.generateMetricsAndLogConfigMap(null));
+
+        // Mock Pods Operator
+        Pod pod0 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 0)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.1")
+                .endStatus()
+                .build();
+
+        Pod pod1 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 1)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.1")
+                .endStatus()
+                .build();
+
+        Pod pod2 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 2)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.1")
+                .endStatus()
+                .build();
+
+        List<Pod> pods = new ArrayList<>();
+        pods.add(pod0);
+        pods.add(pod1);
+        pods.add(pod2);
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(namespace), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
+
+        // Mock Node operator
+        NodeOperator mockNodeOps = supplier.nodeOperator;
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(getClusterNodes()));
+
+        MockNodePortStatusKafkaAssemblyOperator kao = new MockNodePortStatusKafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getValue().getStatus();
+
+            assertThat(status.getListeners().size(), is(1));
+            assertThat(status.getListeners().get(0).getType(), is("external"));
+
+            List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
+            assertThat(addresses.size(), is(1));
+
+            List<ListenerAddress> expected = new ArrayList<>();
+            expected.add(new ListenerAddressBuilder().withHost("50.35.18.119").withPort(31234).build());
+
+            async.flag();
+        });
+    }
+
+    @Test
+    public void testKafkaListenerNodePortAddressMissingNodes(VertxTestContext context) throws ParseException {
+        Kafka kafka = new KafkaBuilder(getKafkaCrd())
+                .editOrNewSpec()
+                    .editOrNewKafka()
+                        .withReplicas(1)
+                        .editOrNewListeners()
+                            .withNewKafkaListenerExternalNodePort()
+                            .endKafkaListenerExternalNodePort()
+                        .endListeners()
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the CRD Operator for Kafka resources
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafka));
+
+        ArgumentCaptor<Kafka> kafkaCaptor = ArgumentCaptor.forClass(Kafka.class);
+        when(mockKafkaOps.updateStatusAsync(kafkaCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSetOperator
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.get(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(kafkaCluster.generateStatefulSet(false, null, null));
+
+        // Mock the ConfigMapOperator
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.get(eq(namespace), eq(clusterName))).thenReturn(kafkaCluster.generateMetricsAndLogConfigMap(null));
+
+        // Mock Pods Operator
+        Pod pod0 = new PodBuilder()
+                .withNewMetadata()
+                    .withNewName(clusterName + "-kafka-" + 0)
+                .endMetadata()
+                .withNewStatus()
+                    .withNewHostIP("10.0.0.5")
+                .endStatus()
+                .build();
+
+        List<Pod> pods = new ArrayList<>();
+        pods.add(pod0);
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(namespace), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
+
+        // Mock Node operator
+        NodeOperator mockNodeOps = supplier.nodeOperator;
+        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(getClusterNodes()));
+
+        MockNodePortStatusKafkaAssemblyOperator kao = new MockNodePortStatusKafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            assertThat(kafkaCaptor.getValue(), is(notNullValue()));
+            assertThat(kafkaCaptor.getValue().getStatus(), is(notNullValue()));
+            KafkaStatus status = kafkaCaptor.getValue().getStatus();
+
+            assertThat(status.getListeners().size(), is(1));
+            assertThat(status.getListeners().get(0).getType(), is("external"));
+
+            assertThat(status.getListeners().get(0).getAddresses(), is(nullValue()));
+
+            async.flag();
         });
     }
 
@@ -439,6 +908,21 @@ public class KafkaStatusTest {
         @Override
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             return reconcileState.initialStatus()
+                    .map((Void) null);
+        }
+    }
+
+    class MockNodePortStatusKafkaAssemblyOperator extends KafkaAssemblyOperator  {
+        public MockNodePortStatusKafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, PasswordGenerator passwordGenerator, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
+            super(vertx, pfa, certManager, passwordGenerator, supplier, config);
+        }
+
+        @Override
+        Future<Void> reconcile(ReconciliationState reconcileState)  {
+            reconcileState.externalBootstrapNodePort = 31234;
+
+            return reconcileState.getKafkaClusterDescription()
+                    .compose(state -> state.kafkaNodePortExternalListenerStatus())
                     .map((Void) null);
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -57,7 +57,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -124,7 +124,8 @@ public class KafkaUpdateTest {
     private List<StatefulSet> upgrade(VertxTestContext context, Map<String, String> versionMap,
                                       Kafka initialKafka, StatefulSet initialSs, Kafka updatedKafka,
                                       Consumer<Integer> reconcileExceptions, Consumer<Integer> rollExceptions) {
-        KafkaSetOperator kso = mock(KafkaSetOperator.class);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        KafkaSetOperator kso = supplier.kafkaSetOperations;
 
         StatefulSet kafkaSts = initialSs != null ? initialSs : KafkaCluster.fromCrd(initialKafka, VERSIONS).generateStatefulSet(false, null, null);
 
@@ -147,9 +148,7 @@ public class KafkaUpdateTest {
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_9),
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"),
-                new ResourceOperatorSupplier(null, null, null,
-                        kso, null, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null, null, null, null, null),
+                supplier,
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 

--- a/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -29,4 +29,12 @@ rules:
   - storageclasses
   verbs:
    - get
+# The listing of nodes is needed to find the node addresses when the NodePort access is configured and set the proper
+# addresses in the status
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - list
 {{- end -}}

--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -22,3 +22,9 @@ rules:
   - storageclasses
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -19,6 +19,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>operator-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/InitWriter.java
@@ -7,6 +7,8 @@ package io.strimzi.kafka.init;
 import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.Arrays;
+
+import io.strimzi.operator.cluster.model.NodeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -61,7 +63,7 @@ public class InitWriter {
 
         List<NodeAddress> addresses = client.nodes().withName(config.getNodeName()).get().getStatus().getAddresses();
         log.info("NodeLabels = {}", addresses);
-        String externalAddress = findAddress(addresses);
+        String externalAddress = NodeUtils.findAddress(addresses, config.getAddressType());
 
         if (externalAddress == null) {
             log.error("External address not found");

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.when;
@@ -121,55 +120,6 @@ public class InitWriterTest {
 
         InitWriter writer = new InitWriter(client, config);
         assertThat(writer.writeRack(), is(false));
-    }
-
-    @Test
-    public void testFindAddressWithType()   {
-        Map<String, String> envs = new HashMap<>(envVars);
-        envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE, "InternalDNS");
-        InitWriterConfig config = InitWriterConfig.fromMap(envs);
-        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
-        InitWriter writer = new InitWriter(client, config);
-        String address = writer.findAddress(addresses);
-
-        assertThat(address, is("my.internal.address"));
-    }
-
-    @Test
-    public void testFindAddress()   {
-        InitWriterConfig config = InitWriterConfig.fromMap(envVars);
-        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
-        InitWriter writer = new InitWriter(client, config);
-        String address = writer.findAddress(addresses);
-
-        assertThat(address, is("my.external.address"));
-    }
-
-    @Test
-    public void testFindAddressNotFound()   {
-        List<NodeAddress> addresses = new ArrayList<>(3);
-        addresses.add(new NodeAddressBuilder().withType("SomeAddress").withAddress("my.external.address").build());
-        addresses.add(new NodeAddressBuilder().withType("SomeOtherAddress").withAddress("my.internal.address").build());
-        addresses.add(new NodeAddressBuilder().withType("YetAnotherAddress").withAddress("192.168.2.94").build());
-
-        InitWriterConfig config = InitWriterConfig.fromMap(envVars);
-        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
-        InitWriter writer = new InitWriter(client, config);
-        String address = writer.findAddress(addresses);
-
-        assertThat(address, is(nullValue()));
-    }
-
-    @Test
-    public void testFindAddressesNull()   {
-        List<NodeAddress> addresses = null;
-
-        InitWriterConfig config = InitWriterConfig.fromMap(envVars);
-        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels, addresses);
-        InitWriter writer = new InitWriter(client, config);
-        String address = writer.findAddress(addresses);
-
-        assertThat(address, is(nullValue()));
     }
 
     @Test

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/NodeUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/NodeUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.NodeAddress;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class NodeUtils {
+    /**
+     * Tries to find the right address of the node. The different addresses has different prioprities:
+     *      1. ExternalDNS
+     *      2. ExternalIP
+     *      3. Hostname
+     *      4. InternalDNS
+     *      5. InternalIP
+     *
+     * @param addresses List of addresses which are assigned to our node
+     * @param preferredAddressType Name of the address which is preferred by the user. Null if not specified.
+     *
+     * @return  Address of the node
+     */
+    public static String findAddress(List<NodeAddress> addresses, String preferredAddressType)   {
+        if (addresses == null)  {
+            return null;
+        }
+
+        Map<String, String> addressMap = addresses.stream().collect(Collectors.toMap(NodeAddress::getType, NodeAddress::getAddress));
+
+        // If user set preferred address type, we should check it first
+        if (preferredAddressType != null && addressMap.containsKey(preferredAddressType)) {
+            return addressMap.get(preferredAddressType);
+        }
+
+        if (addressMap.containsKey("ExternalDNS"))  {
+            return addressMap.get("ExternalDNS");
+        } else if (addressMap.containsKey("ExternalIP"))  {
+            return addressMap.get("ExternalIP");
+        } else if (addressMap.containsKey("InternalDNS"))  {
+            return addressMap.get("InternalDNS");
+        } else if (addressMap.containsKey("InternalIP"))  {
+            return addressMap.get("InternalIP");
+        } else if (addressMap.containsKey("Hostname")) {
+            return addressMap.get("Hostname");
+        }
+
+        return null;
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NodeOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NodeOperator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.DoneableNode;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+public class NodeOperator extends AbstractNonNamespacedResourceOperator<KubernetesClient,
+        Node, NodeList, DoneableNode, Resource<Node, DoneableNode>> {
+
+    /**
+     * Constructor.
+     * @param vertx The Vertx instance.
+     * @param client The Kubernetes client.
+     * @param operationTimeoutMs The timeout in milliseconds.
+     */
+
+    public NodeOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
+        super(vertx, client, "ClusterRoleBinding", operationTimeoutMs);
+    }
+
+    @Override
+    protected NonNamespaceOperation<Node, NodeList, DoneableNode, Resource<Node, DoneableNode>> operation() {
+        return client.nodes();
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NodeOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NodeOperator.java
@@ -21,7 +21,6 @@ public class NodeOperator extends AbstractNonNamespacedResourceOperator<Kubernet
      * @param client The Kubernetes client.
      * @param operationTimeoutMs The timeout in milliseconds.
      */
-
     public NodeOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
         super(vertx, client, "ClusterRoleBinding", operationTimeoutMs);
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/NodeUtilsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/NodeUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.model;
+
+import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.NodeAddressBuilder;
+import io.strimzi.operator.cluster.model.NodeUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class NodeUtilsTest {
+    private static List<NodeAddress> addresses = new ArrayList<>(3);
+
+    static {
+        addresses.add(new NodeAddressBuilder().withType("ExternalDNS").withAddress("my.external.address").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalDNS").withAddress("my.internal.address").build());
+        addresses.add(new NodeAddressBuilder().withType("InternalIP").withAddress("192.168.2.94").build());
+    }
+
+    @Test
+    public void testFindAddressWithType()   {
+        String address = NodeUtils.findAddress(addresses, "InternalDNS");
+
+        assertThat(address, is("my.internal.address"));
+    }
+
+    @Test
+    public void testFindAddress()   {
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is("my.external.address"));
+    }
+
+    @Test
+    public void testFindAddressNotFound()   {
+        List<NodeAddress> addresses = new ArrayList<>(3);
+        addresses.add(new NodeAddressBuilder().withType("SomeAddress").withAddress("my.external.address").build());
+        addresses.add(new NodeAddressBuilder().withType("SomeOtherAddress").withAddress("my.internal.address").build());
+        addresses.add(new NodeAddressBuilder().withType("YetAnotherAddress").withAddress("192.168.2.94").build());
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is(nullValue()));
+    }
+
+    @Test
+    public void testFindAddressesNull()   {
+        List<NodeAddress> addresses = null;
+
+        String address = NodeUtils.findAddress(addresses, null);
+
+        assertThat(address, is(nullValue()));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.DoneableNode;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeBuilder;
 import io.fabric8.kubernetes.api.model.NodeList;
-import io.fabric8.kubernetes.api.model.TaintBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.junit5.VertxExtension;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
@@ -53,7 +53,6 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
                 .endMetadata()
                 .withNewSpec()
                     .withNewUnschedulable(true)
-                    .withTaints(new TaintBuilder().withKey("key").withValue("value").withEffect("NoSchedule").build())
                 .endSpec()
                 .build();
     }
@@ -63,6 +62,5 @@ public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<Kube
         context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
         context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
         context.verify(() -> assertThat(actual.getSpec().getUnschedulable(), is(expected.getSpec().getUnschedulable())));
-        context.verify(() -> assertThat(actual.getSpec().getTaints().size(), is(expected.getSpec().getTaints().size())));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.DoneableNode;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.api.model.TaintBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class NodeOperatorIT extends AbstractNonNamespacedResourceOperatorIT<KubernetesClient,
+        Node, NodeList, DoneableNode,
+        Resource<Node, DoneableNode>> {
+
+    @Override
+    protected AbstractNonNamespacedResourceOperator<KubernetesClient,
+            Node, NodeList, DoneableNode,
+            Resource<Node, DoneableNode>> operator() {
+        return new NodeOperator(vertx, client, 10_000);
+    }
+
+    @Override
+    protected Node getOriginal()  {
+        return new NodeBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewUnschedulable(true)
+                .endSpec()
+                .build();
+    }
+
+    @Override
+    protected Node getModified()  {
+        return new NodeBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withLabels(singletonMap("bar", "foo"))
+                .endMetadata()
+                .withNewSpec()
+                    .withNewUnschedulable(true)
+                    .withTaints(new TaintBuilder().withKey("key").withValue("value").withEffect("NoSchedule").build())
+                .endSpec()
+                .build();
+    }
+
+    @Override
+    protected void assertResources(VertxTestContext context, Node expected, Node actual)   {
+        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
+        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
+        context.verify(() -> assertThat(actual.getSpec().getUnschedulable(), is(expected.getSpec().getUnschedulable())));
+        context.verify(() -> assertThat(actual.getSpec().getTaints().size(), is(expected.getSpec().getTaints().size())));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/NodeOperatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.DoneableNode;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.when;
+
+public class NodeOperatorTest extends AbstractNonNamespacedResourceOperatorTest<KubernetesClient,
+        Node, NodeList, DoneableNode,
+        Resource<Node, DoneableNode>> {
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        when(mockClient.nodes()).thenReturn(op);
+    }
+
+    @Override
+    protected AbstractNonNamespacedResourceOperator<KubernetesClient, Node, NodeList,
+            DoneableNode, Resource<Node, DoneableNode>> createResourceOperations(
+                    Vertx vertx, KubernetesClient mockClient) {
+        return new NodeOperator(vertx, mockClient, 100);
+    }
+
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<? extends Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Node resource() {
+        return new NodeBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .build();
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When node ports are being used to expose the Kafka cluster, we currently dom't list a proper address for the cluster's external listener in the Kafka status. We just list a placeholder. This PR fixes this issue and lists addresses of the nodes hosting the broker in the status instead of the placeholder. That should allow users to use the address form the status to connect to the broker.

It is a bit questionable which nodes should be listed in the Status for node ports. In theory the node ports could work with all nodes. But should it be all nodes? All nodes without master? Only some nodes based on selector? For the time being, I decided to implement this based on the nodes where the Kafka pods were scheduled. That will guarantee the most efficient way for the communication (less forwarding between nodes) since these nodes have a Kafka pod locally. It also means we do not need to bother with detecting the masters etc. right now. If we receive feedback to include also other nodes int he future, we can extend it to include also other addresses.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally