### PR TITLE
ST: Improve Connect tests with Connector resource and check values set by…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -19,6 +19,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.ResourceManager;
 
+import java.util.function.Consumer;
+
 public class KafkaConnectorResource {
     private static final Logger LOGGER = LogManager.getLogger(KafkaConnectorResource.class);
 
@@ -89,4 +91,7 @@ public class KafkaConnectorResource {
         return ResourceManager.deleteLater(kafkaConnectorClient(), kafkaConnector);
     }
 
+    public static void replaceKafkaConnectorResource(String resourceName, Consumer<KafkaConnector> editor) {
+        ResourceManager.replaceCrdResource(KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class, resourceName, editor);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -30,28 +30,27 @@ public class KafkaConnectorResource {
         return Crds.kafkaConnectorOperation(ResourceManager.kubeClient().getClient());
     }
 
-    public static DoneableKafkaConnector kafkaConnector(String name, String topicName) {
-        return kafkaConnector(name, name, topicName, 2);
+    public static DoneableKafkaConnector kafkaConnector(String name) {
+        return kafkaConnector(name, name, 2);
     }
 
-    public static DoneableKafkaConnector kafkaConnector(String name, String topicName, int maxTasks) {
-        return kafkaConnector(name, name, topicName, maxTasks);
+    public static DoneableKafkaConnector kafkaConnector(String name, int maxTasks) {
+        return kafkaConnector(name, name, maxTasks);
     }
 
-    public static DoneableKafkaConnector kafkaConnector(String name, String clusterName, String topicName, int maxTasks) {
+    public static DoneableKafkaConnector kafkaConnector(String name, String clusterName, int maxTasks) {
         KafkaConnector kafkaConnector = getKafkaConnectorFromYaml(PATH_TO_KAFKA_CONNECTOR_CONFIG);
-        return deployKafkaConnector(defaultKafkaConnector(kafkaConnector, name, clusterName, topicName, maxTasks).build());
+        return deployKafkaConnector(defaultKafkaConnector(kafkaConnector, name, clusterName, maxTasks).build());
     }
 
-    private static KafkaConnectorBuilder defaultKafkaConnector(KafkaConnector kafkaConnector, String name, String kafkaClusterName, String topicName, int maxTasks) {
+    private static KafkaConnectorBuilder defaultKafkaConnector(KafkaConnector kafkaConnector, String name, String kafkaConnectClusterName, int maxTasks) {
         return new KafkaConnectorBuilder(kafkaConnector)
             .editOrNewMetadata()
                 .withName(name)
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
-                .addToLabels("strimzi.io/cluster", kafkaClusterName)
+                .addToLabels("strimzi.io/cluster", kafkaConnectClusterName)
             .endMetadata()
             .editOrNewSpec()
-                .addToConfig("topic", topicName)
                 .withTasksMax(maxTasks)
             .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -47,7 +47,7 @@ public class StUtils {
     public static void waitForReconciliation(String testClass, String testName, String namespace) {
         LOGGER.info("Waiting for reconciliation");
         String reconciliation = timeMeasuringSystem.startOperation(Operation.NEXT_RECONCILIATION);
-        TestUtils.waitFor("Wait till another rolling update starts", Constants.CO_OPERATION_TIMEOUT_POLL, Constants.RECONCILIATION_INTERVAL + 20000,
+        TestUtils.waitFor("Wait till another rolling update starts", Constants.CO_OPERATION_TIMEOUT_POLL, Constants.RECONCILIATION_INTERVAL + 30000,
             () -> !cmdKubeClient().searchInLog("deploy", "strimzi-cluster-operator",
                 timeMeasuringSystem.getCurrentDuration(testClass, testName, reconciliation),
                 "'Triggering periodic reconciliation for namespace " + namespace + "'").isEmpty());

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
+import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectS2IUtils;
@@ -57,31 +58,66 @@ class ConnectS2IST extends MessagingBaseST {
     private static final String CONNECT_S2I_TOPIC_NAME = "connect-s2i-topic-example";
 
     @Test
-    void testDeployS2IWithMongoDBPlugin() {
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
-
+    void testDeployS2IWithMongoDBPlugin() throws InterruptedException {
         final String kafkaConnectS2IName = "kafka-connect-s2i-name-1";
+        // Calls to Connect API are executed from kafka-0 pod
+        String podForExecName = deployConnectS2IWithMongoDb(kafkaConnectS2IName);
 
-        KafkaConnectS2IResource.kafkaConnectS2I(kafkaConnectS2IName, CLUSTER_NAME, 1)
-            .editMetadata()
-                .addToLabels("type", "kafka-connect-s2i")
-            .endMetadata()
-            .done();
+        String mongoDbConfig = "{" +
+                "\"name\": \"" + kafkaConnectS2IName + "\"," +
+                "\"config\": {" +
+                "   \"connector.class\" : \"io.debezium.connector.mongodb.MongoDbConnector\"," +
+                "   \"tasks.max\" : \"1\"," +
+                "   \"mongodb.hosts\" : \"debezium/localhost:27017\"," +
+                "   \"mongodb.name\" : \"dbserver1\"," +
+                "   \"mongodb.user\" : \"debezium\"," +
+                "   \"mongodb.password\" : \"dbz\"," +
+                "   \"database.history.kafka.bootstrap.servers\" : \"localhost:9092\"}" +
+                "}";
 
-        Map<String, String> connectSnapshot = DeploymentUtils.depConfigSnapshot(KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName));
+        KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2IName, "Ready");
 
-        File dir = FileUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.7.5/debezium-connector-mongodb-0.7.5-plugin.zip");
+        // Make sure that Connenct API is ready
+        // TODO remove this sleep when ENTMQST-1613 will be fixed
+        Thread.sleep(10_000);
 
-        // Start a new image build using the plugins directory
-        cmdKubeClient().execInCurrentNamespace("start-build", KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName), "--from-dir", dir.getAbsolutePath());
-        // Wait for rolling update connect pods
-        DeploymentUtils.waitTillDepConfigHasRolled(kafkaConnectS2IName, connectSnapshot);
-        String connectS2IPodName = kubeClient().listPods("type", "kafka-connect-s2i").get(0).getMetadata().getName();
-        LOGGER.info("Collect plugins information from connect s2i pod");
-        String plugins = cmdKubeClient().execInPod(connectS2IPodName, "curl", "-X", "GET", "http://localhost:8083/connector-plugins").out();
+        String createConnectorOutput = cmdKubeClient().execInPod(podForExecName, "curl", "-X", "POST", "-H", "Accept:application/json", "-H", "Content-Type:application/json",
+                "http://" + KafkaConnectS2IResources.serviceName(kafkaConnectS2IName) + ":8083/connectors/", "-d", mongoDbConfig).out();
+        LOGGER.info("Create Connector result: {}", createConnectorOutput);
 
-        assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));
-        assertThat(kubeClient().getClient().adapt(OpenShiftClient.class).builds().inNamespace(NAMESPACE).list().getItems().size(), is(2));
+        // Make sure that connector is really created
+        Thread.sleep(10_000);
+
+        String connectorStatus = cmdKubeClient().execInPod(podForExecName, "curl", "-X", "GET", "http://" + KafkaConnectS2IResources.serviceName(kafkaConnectS2IName) + ":8083/connectors/" + kafkaConnectS2IName + "/status").out();
+        assertThat(connectorStatus, containsString("RUNNING"));
+    }
+
+    @Test
+    void testDeployS2IAndKafkaConnectorWithMongoDBPlugin() throws InterruptedException {
+        final String kafkaConnectS2IName = "kafka-connect-s2i-name-11";
+        // Calls to Connect API are executed from kafka-0 pod
+        String podForExecName = deployConnectS2IWithMongoDb(kafkaConnectS2IName);
+
+        // Make sure that Connenct API is ready
+        // TODO remove this sleep when ENTMQST-1613 will be fixed
+        Thread.sleep(10_000);
+
+        KafkaConnectorResource.kafkaConnector(kafkaConnectS2IName)
+            .withNewSpec()
+                .withClassName("io.debezium.connector.mongodb.MongoDbConnector")
+                .withTasksMax(2)
+                .addToConfig("mongodb.hosts", "debezium/localhost:27017")
+                .addToConfig("mongodb.name", "dbserver1")
+                .addToConfig("mongodb.user", "debezium")
+                .addToConfig("mongodb.password", "dbz")
+                .addToConfig("database.history.kafka.bootstrap.servers", "localhost:9092")
+            .endSpec().done();
+
+        StUtils.waitForReconciliation(testClass, testName, NAMESPACE);
+        KafkaConnectUtils.waitForConnectorReady(kafkaConnectS2IName);
+
+        String connectorStatus = cmdKubeClient().execInPod(podForExecName, "curl", "-X", "GET", "http://" + KafkaConnectS2IResources.serviceName(kafkaConnectS2IName) + ":8083/connectors/" + kafkaConnectS2IName + "/status").out();
+        assertThat(connectorStatus, containsString("RUNNING"));
     }
 
     @Test
@@ -269,6 +305,35 @@ class ConnectS2IST extends MessagingBaseST {
                 "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
 
         KafkaConnectS2IResource.deleteKafkaConnectS2IWithoutWait(kafkaConnectS2i);
+    }
+
+    private String deployConnectS2IWithMongoDb(String kafkaConnectS2IName) {
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1).done();
+
+        KafkaConnectS2IResource.kafkaConnectS2I(kafkaConnectS2IName, CLUSTER_NAME, 1)
+            .editMetadata()
+                .addToLabels("type", "kafka-connect-s2i")
+                .addToAnnotations("strimzi.io/use-connector-resources", "true")
+            .endMetadata()
+            .done();
+
+        Map<String, String> connectSnapshot = DeploymentUtils.depConfigSnapshot(KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName));
+
+        File dir = FileUtils.downloadAndUnzip("https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/0.7.5/debezium-connector-mongodb-0.7.5-plugin.zip");
+
+        // Start a new image build using the plugins directory
+        cmdKubeClient().execInCurrentNamespace("start-build", KafkaConnectS2IResources.deploymentName(kafkaConnectS2IName), "--from-dir", dir.getAbsolutePath());
+        // Wait for rolling update connect pods
+        DeploymentUtils.waitTillDepConfigHasRolled(kafkaConnectS2IName, connectSnapshot);
+        String podForExecName = KafkaResources.kafkaPodName(CLUSTER_NAME, 0);
+        LOGGER.info("Collect plugins information from connect s2i pod");
+
+        String plugins = cmdKubeClient().execInPod(podForExecName, "curl", "-X", "GET", "http://" + KafkaConnectS2IResources.serviceName(kafkaConnectS2IName) + ":8083/connector-plugins").out();
+
+        assertThat(plugins, containsString("io.debezium.connector.mongodb.MongoDbConnector"));
+        assertThat(kubeClient().getClient().adapt(OpenShiftClient.class).builds().inNamespace(NAMESPACE).list().getItems().size(), is(2));
+
+        return podForExecName;
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -185,7 +185,10 @@ class ConnectST extends MessagingBaseST {
 
         String connectorName = "license-source";
         String topicName = "my-topic";
-        KafkaConnectorResource.kafkaConnector(connectorName, CLUSTER_NAME, topicName, 2).done();
+        KafkaConnectorResource.kafkaConnector(connectorName, CLUSTER_NAME, 2)
+            .editSpec()
+                .addToConfig("topic", topicName)
+            .endSpec().done();
 
         // consume from the topic (we don't really care about the contents)
         try (KafkaClient testClient = new KafkaClient()) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -194,6 +194,13 @@ class ConnectST extends MessagingBaseST {
             assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), greaterThanOrEqualTo(messageCount));
         }
 
+        String kafkaConnectPodName = kubeClient().listPods("type", "kafka-connect").get(0).getMetadata().getName();
+        String output = cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl http://localhost:8083/connectors/" + connectorName).out();
+        assertThat(output, containsString("\"name\":\"license-source\""));
+        assertThat(output, containsString("\"connector.class\":\"org.apache.kafka.connect.file.FileStreamSourceConnector\""));
+        assertThat(output, containsString("\"tasks.max\":\"2\""));
+        assertThat(output, containsString("\"topic\":\"" + topicName + "\""));
+
         LOGGER.info("Deleting connector {} CR", connectorName);
         cmdKubeClient().deleteByName("kafkaconnector", connectorName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -187,15 +187,16 @@ class CustomResourceStatusST extends MessagingBaseST {
                 .build()));
         waitForKafkaConnectStatus("NotReady");
 
-        KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
-            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
-        waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
-
         KafkaConnectResource.replaceKafkaConnectResource(CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
                 .addToRequests("cpu", new Quantity("10m"))
                 .build()));
         waitForKafkaConnectStatus("Ready");
         assertKafkaConnectStatus(3, connectUrl);
+
+        KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
+                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
+        waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
+
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
@@ -219,15 +220,16 @@ class CustomResourceStatusST extends MessagingBaseST {
                 .build()));
         waitForKafkaConnectS2IStatus("NotReady");
 
-        KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
-            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
-        waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "NotReady");
-
         KafkaConnectS2IResource.replaceConnectS2IResource(CONNECTS2I_CLUSTER_NAME, kb -> kb.getSpec().setResources(new ResourceRequirementsBuilder()
                 .addToRequests("cpu", new Quantity("10m"))
                 .build()));
         waitForKafkaConnectS2IStatus("Ready");
         assertKafkaConnectS2IStatus(3, connectS2IUrl, connectS2IDeploymentConfigName);
+
+        KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
+                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
+        waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "NotReady");
+
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CONNECTS2I_CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "Ready");

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -194,7 +194,7 @@ class CustomResourceStatusST extends MessagingBaseST {
         assertKafkaConnectStatus(3, connectUrl);
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
-                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
+            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
@@ -227,7 +227,7 @@ class CustomResourceStatusST extends MessagingBaseST {
         assertKafkaConnectS2IStatus(3, connectS2IUrl, connectS2IDeploymentConfigName);
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
-                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
+            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "NotReady");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -214,7 +214,7 @@ class CustomResourceStatusST extends MessagingBaseST {
             });
 
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
-        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(2));
+        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(3L));
     }
 
     @Test
@@ -254,7 +254,7 @@ class CustomResourceStatusST extends MessagingBaseST {
             });
 
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "Ready");
-        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(1));
+        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CONNECTS2I_CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(3L));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -23,7 +23,16 @@ import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
+import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
@@ -32,15 +41,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
-import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
-import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
-import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
-import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -200,6 +200,16 @@ class CustomResourceStatusST extends MessagingBaseST {
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
+
+        KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
+                kc -> kc.getSpec().setClassName("non-existing-class"));
+        waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
+
+        KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
+                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
+        waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
+
+        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(2));
     }
 
     @Test
@@ -233,6 +243,7 @@ class CustomResourceStatusST extends MessagingBaseST {
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CONNECTS2I_CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "Ready");
+        assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(1));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -202,11 +202,11 @@ class CustomResourceStatusST extends MessagingBaseST {
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
-                kc -> kc.getSpec().setClassName("non-existing-class"));
+            kc -> kc.getSpec().setClassName("non-existing-class"));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
-                kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
+            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
 
         assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(2));

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -201,14 +201,19 @@ class CustomResourceStatusST extends MessagingBaseST {
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
 
+        String defaultClass = KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getSpec().getClassName();
+
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
             kc -> kc.getSpec().setClassName("non-existing-class"));
         waitForKafkaConnectorStatus(CLUSTER_NAME, "NotReady");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CLUSTER_NAME,
-            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME)));
-        waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
+            kc -> {
+                kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CLUSTER_NAME));
+                kc.getSpec().setClassName(defaultClass);
+            });
 
+        waitForKafkaConnectorStatus(CLUSTER_NAME, "Ready");
         assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(2));
     }
 
@@ -236,12 +241,18 @@ class CustomResourceStatusST extends MessagingBaseST {
         waitForKafkaConnectS2IStatus("Ready");
         assertKafkaConnectS2IStatus(3, connectS2IUrl, connectS2IDeploymentConfigName);
 
+        String defaultClass = KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CONNECTS2I_CLUSTER_NAME).get().getSpec().getClassName();
+
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
             kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", "non-existing-connect-cluster")));
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "NotReady");
 
         KafkaConnectorResource.replaceKafkaConnectorResource(CONNECTS2I_CLUSTER_NAME,
-            kc -> kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CONNECTS2I_CLUSTER_NAME)));
+            kc -> {
+                kc.getMetadata().setLabels(Collections.singletonMap("strimzi.io/cluster", CONNECTS2I_CLUSTER_NAME));
+                kc.getSpec().setClassName(defaultClass);
+            });
+
         waitForKafkaConnectorStatus(CONNECTS2I_CLUSTER_NAME, "Ready");
         assertThat(KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CLUSTER_NAME).get().getStatus().getObservedGeneration(), is(1));
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR extends original system test for Kafka Connector CR. 

Connector CR Status is tested as part of `testKafkaConnectS2IStatus` and `testKafkaConnectStatus` tests to save time for regression suite (to avoid duplicity test case which takes 6-8 minutes).

https://github.com/strimzi/strimzi-kafka-operator/issues/2354 is not tested as part of this PR. I suggest to create new with enhancement for current tests when it's fixed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

