### PR TITLE
Fix NPE when secret does not contain given crt

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -57,6 +57,7 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.EntityTopicOperator;
 import io.strimzi.operator.cluster.model.EntityUserOperator;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaExporter;
@@ -1971,10 +1972,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 if (certSecret != null) {
                                     if (!certSecret.getData().containsKey(customCertSecret.getCertificate())) {
                                         log.warn("{}: Secret {} does not contain certificate under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getCertificate());
-                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain certificate under the key " + customCertSecret.getCertificate() + ".");
+                                        thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " does not contain certificate under the key " + customCertSecret.getCertificate() + "."));
                                     } else if (!certSecret.getData().containsKey(customCertSecret.getKey())) {
                                         log.warn("{}: Secret {} does not contain custom certificate private key under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getKey());
-                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain custom certificate private key under the key " + customCertSecret.getKey() + ".");
+                                        thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " does not contain custom certificate private key under the key " + customCertSecret.getKey() + "."));
                                     } else
                                         try {
                                             X509Certificate cert = Ca.cert(certSecret, customCertSecret.getCertificate());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1971,8 +1971,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 if (certSecret != null) {
                                     try {
                                         X509Certificate cert = Ca.cert(certSecret, customCertSecret.getCertificate());
-                                        byte[] signature = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
-                                        thumbprintPromise.complete(Base64.getEncoder().encodeToString(signature));
+                                        if (cert != null) {
+                                            byte[] signature = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
+                                            thumbprintPromise.complete(Base64.getEncoder().encodeToString(signature));
+                                        } else {
+                                            thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain custom TLS certificate " + customCertSecret.getCertificate() + ".");
+                                        }
                                     } catch (CertificateEncodingException | NoSuchAlgorithmException e) {
                                         log.warn("{}: Failed to get certificate signature of {} from Secret {}.", reconciliation, customCertSecret.getCertificate(), customCertSecret.getSecretName());
                                         thumbprintPromise.fail(new RuntimeException("Failed to get certificate signature of " + customCertSecret.getCertificate() + " from Secret " + certSecret.getMetadata().getName(), e));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -65,6 +65,7 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeUtils;
+import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
@@ -1986,7 +1987,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                     thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " with custom TLS certificate does not exist."));
                                 }
                             } else {
-                                thumbprintPromise.fail("Failed to get secret " + customCertSecret.getSecretName() + " with custom TLS certificate.");
+                                thumbprintPromise.fail(new NoSuchResourceException("Failed to get secret " + customCertSecret.getSecretName() + " with custom TLS certificate."));
                             }
                         });
             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1971,10 +1971,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                                 if (certSecret != null) {
                                     if (!certSecret.getData().containsKey(customCertSecret.getCertificate())) {
-                                        log.warn("{}: Secret {} does not contain certificate under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getCertificate());
                                         thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " does not contain certificate under the key " + customCertSecret.getCertificate() + "."));
                                     } else if (!certSecret.getData().containsKey(customCertSecret.getKey())) {
-                                        log.warn("{}: Secret {} does not contain custom certificate private key under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getKey());
                                         thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " does not contain custom certificate private key under the key " + customCertSecret.getKey() + "."));
                                     } else
                                         try {
@@ -1982,15 +1980,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             byte[] signature = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
                                             thumbprintPromise.complete(Base64.getEncoder().encodeToString(signature));
                                         } catch (CertificateEncodingException | NoSuchAlgorithmException e) {
-                                            log.warn("{}: Failed to get certificate signature of {} from Secret {}.", reconciliation, customCertSecret.getCertificate(), customCertSecret.getSecretName());
                                             thumbprintPromise.fail(new RuntimeException("Failed to get certificate signature of " + customCertSecret.getCertificate() + " from Secret " + certSecret.getMetadata().getName(), e));
                                         }
                                 } else {
-                                    log.warn("{}: Secret {} with custom TLS certificate does not exist.", reconciliation, customCertSecret.getSecretName());
                                     thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " with custom TLS certificate does not exist.");
                                 }
                             } else {
-                                log.warn("{}: Failed to get secret {} with custom TLS certificate.", reconciliation, customCertSecret.getSecretName());
                                 thumbprintPromise.fail("Failed to get secret " + customCertSecret.getSecretName() + " with custom TLS certificate.");
                             }
                         });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1970,10 +1970,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                                 if (certSecret != null) {
                                     if (!certSecret.getData().containsKey(customCertSecret.getCertificate())) {
-                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain certificate " + customCertSecret.getCertificate() + ".");
+                                        log.warn("{}: Secret {} does not contain certificate under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getCertificate());
+                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain certificate under the key " + customCertSecret.getCertificate() + ".");
                                     } else if (!certSecret.getData().containsKey(customCertSecret.getKey())) {
-                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain key " + customCertSecret.getKey() + ".");
-                                    } else try {
+                                        log.warn("{}: Secret {} does not contain custom certificate private key under the key {}.", reconciliation, customCertSecret.getSecretName(), customCertSecret.getKey());
+                                        thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " does not contain custom certificate private key under the key " + customCertSecret.getKey() + ".");
+                                    } else
+                                        try {
                                             X509Certificate cert = Ca.cert(certSecret, customCertSecret.getCertificate());
                                             byte[] signature = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
                                             thumbprintPromise.complete(Base64.getEncoder().encodeToString(signature));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1983,7 +1983,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             thumbprintPromise.fail(new RuntimeException("Failed to get certificate signature of " + customCertSecret.getCertificate() + " from Secret " + certSecret.getMetadata().getName(), e));
                                         }
                                 } else {
-                                    thumbprintPromise.fail("Secret " + customCertSecret.getSecretName() + " with custom TLS certificate does not exist.");
+                                    thumbprintPromise.fail(new InvalidResourceException("Secret " + customCertSecret.getSecretName() + " with custom TLS certificate does not exist."));
                                 }
                             } else {
                                 thumbprintPromise.fail("Failed to get secret " + customCertSecret.getSecretName() + " with custom TLS certificate.");


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
When the secret with custom crts does not contain given crt, NPE appears in the CO logs.

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

