### PR TITLE
Remove dependency duplicity from mockube pom

### DIFF
--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -76,11 +76,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2359

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

