### PR TITLE
KafkaConnector: Support connector pause/resume and status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -32,6 +32,7 @@ public class KafkaConnectorSpec implements Serializable, UnknownPropertyPreservi
 
     private String className;
     private Integer tasksMax;
+    private Boolean pause;
     private Map<String, Object> config = new HashMap<>(0);
     private Map<String, Object> additionalProperties;
 
@@ -62,6 +63,15 @@ public class KafkaConnectorSpec implements Serializable, UnknownPropertyPreservi
     }
     public void setConfig(Map<String, Object> config) {
         this.config = config;
+    }
+
+    @Description("Whether the connector should be paused. Defaults to false.")
+    public Boolean getPause() {
+        return pause;
+    }
+
+    public void setPause(Boolean pause) {
+        this.pause = pause;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
@@ -6,9 +6,12 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+
+import java.util.Map;
 
 /**
  * Represents a status of the KafkaConnector resource
@@ -25,4 +28,15 @@ import lombok.ToString;
 public class KafkaConnectorStatus extends Status {
     private static final long serialVersionUID = 1L;
 
+    private Map<String, Object> connectorStatus;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The connector status, as reported by the Kafka Connect REST API.")
+    public Map<String, Object> getConnectorStatus() {
+        return connectorStatus;
+    }
+
+    public void setConnectorStatus(Map<String, Object> connectorStatus) {
+        this.connectorStatus = connectorStatus;
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
@@ -11,3 +11,18 @@ spec:
   config:
     file: "/home/source/test.source.txt"
     topic: "test.topic"
+status:
+  observedGeneration: 0
+  connectorStatus:
+    name: "hdfs-sink-connector"
+    connector:
+      state: "RUNNING"
+      worker_id: "whatever:8083"
+    tasks:
+    - id: 0
+      state: "FAILED"
+      worker_id: "whatever:8083"
+      trace: "org.apache.kafka.common.errors.RecordTooLargeException\n"
+    - id: 1
+      state: "PAUSED"
+      worker_id: "whatever:8083"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
@@ -11,3 +11,19 @@ spec:
   config:
     file: "/home/source/test.source.txt"
     topic: "test.topic"
+status:
+  observedGeneration: 0
+  connectorStatus:
+    name: "hdfs-sink-connector"
+    connector:
+      state: "RUNNING"
+      worker_id: "whatever:8083"
+    tasks:
+    - id: 0
+      state: "FAILED"
+      worker_id: "whatever:8083"
+      trace: "org.apache.kafka.common.errors.RecordTooLargeException\n"
+    - id: 1
+      state: "PAUSED"
+      worker_id: "whatever:8083"
+

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -49,6 +49,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Future<Map<String, Object>> createOrUpdatePutRequest(
             String host, int port,
             String connectorName, JsonObject configJson) {
@@ -65,7 +66,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         response.bodyHandler(buffer -> {
                             ObjectMapper mapper = new ObjectMapper();
                             try {
-                                result.complete(mapper.readValue(buffer.getBytes(), new TypeReference<Map<String, Object>>() { }));
+                                result.complete(mapper.readValue(buffer.getBytes(), Map.class));
                             } catch (IOException e) {
                                 result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
                             }
@@ -114,6 +115,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Future<Map<String, Object>> status(String host, int port, String connectorName) {
         Future<Map<String, Object>> result = Future.future();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
@@ -124,7 +126,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         response.bodyHandler(buffer -> {
                             ObjectMapper mapper = new ObjectMapper();
                             try {
-                                result.complete(mapper.readValue(buffer.getBytes(), new TypeReference<Map<String, Object>>() { }));
+                                result.complete(mapper.readValue(buffer.getBytes(), Map.class));
                             } catch (IOException e) {
                                 result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -4,27 +4,38 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public interface KafkaConnectApi {
-    Future<JsonObject> createOrUpdatePutRequest(String host, int port, String connectorName, JsonObject configJson);
+    Future<Map<String, Object>> createOrUpdatePutRequest(String host, int port, String connectorName, JsonObject configJson);
     Future<Void> delete(String host, int port, String connectorName);
+    Future<Map<String, Object>> status(String host, int port, String connectorName);
+    Future<Void> pause(String host, int port, String connectorName);
+    Future<Void> resume(String host, int port, String connectorName);
     Future<List<String>> list(String host, int port);
 }
 
 class ConnectRestException extends RuntimeException {
-    public ConnectRestException(String message) {
-        super(message);
+    ConnectRestException(String method, String path, int statusCode, String statusMessage, String message) {
+        super(method + " " + path + " returned " + statusCode + " (" + statusMessage + "): " + message);
+    }
+    public ConnectRestException(HttpClientResponse response, String message) {
+        this(response.request().method().toString(), response.request().path(), response.statusCode(), response.statusMessage(), message);
     }
 }
 
@@ -38,11 +49,10 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<JsonObject> createOrUpdatePutRequest(
+    public Future<Map<String, Object>> createOrUpdatePutRequest(
             String host, int port,
-            String connectorName,
-                                                       JsonObject configJson) {
-        Future<JsonObject> result = Future.future();
+            String connectorName, JsonObject configJson) {
+        Future<Map<String, Object>> result = Future.future();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         Buffer data = configJson.toBuffer();
         String path = "/connectors/" + connectorName + "/config";
@@ -53,19 +63,22 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                     });
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
                         response.bodyHandler(buffer -> {
-                            result.complete(buffer.toJsonObject());
+                            ObjectMapper mapper = new ObjectMapper();
+                            try {
+                                result.complete(mapper.readValue(buffer.getBytes(), new TypeReference<Map<String, Object>>() { }));
+                            } catch (IOException e) {
+                                result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
+                            }
                         });
                     } else {
                         // TODO Handle 409 (Conflict) indicating a rebalance in progress
                         response.bodyHandler(buffer -> {
                             JsonObject x = buffer.toJsonObject();
-                            result.fail(new ConnectRestException(x.getString("message")));
+                            result.fail(new ConnectRestException(response, x.getString("message")));
                         });
                     }
                 })
-                .exceptionHandler(error -> {
-                    result.fail(error);
-                })
+                .exceptionHandler(result::fail)
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .putHeader("Content-Type", "application/json")
@@ -88,14 +101,78 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         // TODO Handle 409 (Conflict) indicating a rebalance in progress
                         response.bodyHandler(buffer -> {
                             JsonObject x = buffer.toJsonObject();
-                            result.fail(new ConnectRestException(x.getString("message")));
+                            result.fail(new ConnectRestException(response, x.getString("message")));
                         });
                     }
                 })
+                .exceptionHandler(result::fail)
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .putHeader("Content-Type", "application/json")
-                //.write(configJson.toBuffer())
+                .end();
+        return result;
+    }
+
+    @Override
+    public Future<Map<String, Object>> status(String host, int port, String connectorName) {
+        Future<Map<String, Object>> result = Future.future();
+        HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
+        String path = "/connectors/" + connectorName + "/status";
+        vertx.createHttpClient(options)
+                .get(port, host, path, response -> {
+                    if (response.statusCode() == 200) {
+                        response.bodyHandler(buffer -> {
+                            ObjectMapper mapper = new ObjectMapper();
+                            try {
+                                result.complete(mapper.readValue(buffer.getBytes(), new TypeReference<Map<String, Object>>() { }));
+                            } catch (IOException e) {
+                                result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
+                            }
+                        });
+                    } else {
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        response.bodyHandler(buffer -> {
+                            JsonObject x = buffer.toJsonObject();
+                            result.fail(new ConnectRestException(response, x.getString("message")));
+                        });
+                    }
+                })
+                .exceptionHandler(result::fail)
+                .setFollowRedirects(true)
+                .putHeader("Accept", "application/json")
+                .putHeader("Content-Type", "application/json")
+                .end();
+        return result;
+    }
+
+    @Override
+    public Future<Void> pause(String host, int port, String connectorName) {
+        return pauseResume(host, port, "/connectors/" + connectorName + "/pause");
+    }
+
+    @Override
+    public Future<Void> resume(String host, int port, String connectorName) {
+        return pauseResume(host, port, "/connectors/" + connectorName + "/resume");
+    }
+
+    private Future<Void> pauseResume(String host, int port, String path) {
+        Future<Void> result = Future.future();
+        HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
+        vertx.createHttpClient(options)
+                .put(port, host, path, response -> {
+                    response.exceptionHandler(error -> {
+                        result.fail(error);
+                    });
+                    if (response.statusCode() == 202) {
+                        result.complete();
+                    } else {
+                        result.fail("Unexpected status code " + response.statusCode()
+                                + " for GET request to " + host + ":" + port + path);
+                    }
+                })
+                .exceptionHandler(result::fail)
+                .setFollowRedirects(true)
+                .putHeader("Accept", "application/json")
                 .end();
         return result;
     }
@@ -110,7 +187,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                     response.exceptionHandler(error -> {
                         result.fail(error);
                     });
-                    if (response.statusCode() == 200 || response.statusCode() == 201) {
+                    if (response.statusCode() == 200) {
                         response.bodyHandler(buffer -> {
                             JsonArray objects = buffer.toJsonArray();
                             List<String> list = new ArrayList<>(objects.size());
@@ -128,13 +205,10 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 + " for GET request to " + host + ":" + port + path);
                     }
                 })
-                .exceptionHandler(error -> {
-                    result.fail(error);
-                })
+                .exceptionHandler(result::fail)
                 .setFollowRedirects(true)
                 .putHeader("Accept", "application/json")
                 .end();
         return result;
-
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -34,7 +34,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterEach;
@@ -44,6 +43,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -53,7 +54,10 @@ import java.util.function.Predicate;
 import static io.strimzi.test.TestUtils.map;
 import static io.strimzi.test.TestUtils.set;
 import static io.strimzi.test.TestUtils.waitFor;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -75,7 +79,7 @@ public class ConnectorMockTest {
     private Vertx vertx;
     private KubernetesClient client;
     private KafkaConnectApi api;
-    private HashMap<String, JsonObject> runningConnectors;
+    private HashMap<String, Boolean> runningConnectors;
     private KafkaConnectS2IAssemblyOperator kafkaConnectS2iOperator;
     private KafkaConnectAssemblyOperator kafkaConnectOperator;
 
@@ -101,14 +105,55 @@ public class ConnectorMockTest {
         });
         when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
             String connectorName = invocation.getArgument(2);
-            runningConnectors.put(connectorName, invocation.getArgument(3));
+            runningConnectors.putIfAbsent(connectorName, false);
             return Future.succeededFuture();
         });
         when(api.delete(any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String connectorName = invocation.getArgument(2);
-            JsonObject remove = runningConnectors.remove(connectorName);
+            Boolean remove = runningConnectors.remove(connectorName);
             return remove != null ? Future.succeededFuture() : Future.failedFuture("No such connector " + connectorName);
         });
+        when(api.status(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String connectorName = invocation.getArgument(2);
+            Boolean paused = runningConnectors.get(connectorName);
+            Map<String, Object> statusNode = new HashMap<>();
+            statusNode.put("name", connectorName);
+            Map<String, Object> connector = new HashMap<>();
+            statusNode.put("connector", connector);
+            connector.put("state", paused ? "PAUSED" : "RUNNING");
+            connector.put("worker_id", "somehost0:8083");
+            Map<String, Object> task = new HashMap<>();
+            task.put("id", 0);
+            task.put("state", paused ? "PAUSED" : "RUNNING");
+            task.put("worker_id", "somehost2:8083");
+            List<Map> tasks = singletonList(task);
+            statusNode.put("tasks", tasks);
+
+            return paused != null ? Future.succeededFuture(statusNode) : Future.failedFuture("No such connector " + connectorName);
+        });
+        when(api.pause(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String connectorName = invocation.getArgument(2);
+            Boolean paused = runningConnectors.get(connectorName);
+            if (paused == null) {
+                return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
+            }
+            if (!paused) {
+                runningConnectors.put(connectorName, true);
+            }
+            return Future.succeededFuture();
+        });
+        when(api.resume(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String connectorName = invocation.getArgument(2);
+            Boolean paused = runningConnectors.get(connectorName);
+            if (paused == null) {
+                return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
+            }
+            if (paused) {
+                runningConnectors.put(connectorName, false);
+            }
+            return Future.succeededFuture();
+        });
+
 
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client, pfa, 10_000);
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
@@ -229,6 +274,22 @@ public class ConnectorMockTest {
                 .inNamespace(NAMESPACE)
                 .withName(connectorName);
         waitForStatus(resource, connectorName, ready());
+    }
+
+    public void waitForConnectorState(String connectorName, String state) {
+        Resource<KafkaConnector, DoneableKafkaConnector> resource = Crds.kafkaConnectorOperation(client)
+                .inNamespace(NAMESPACE)
+                .withName(connectorName);
+        waitForStatus(resource, connectorName, s -> {
+            Map<String, Object> connector = s.getStatus().getConnectorStatus();
+            if (connector != null) {
+                Object connectorState = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
+                return connectorState instanceof String
+                    && state.equals(connectorState);
+            } else {
+                return false;
+            }
+        });
     }
 
     public void waitForConnectorNotReady(String connectorName, String reason, String message) {
@@ -647,7 +708,7 @@ public class ConnectorMockTest {
     @Test
     public void testExceptionFromRestApi() {
         when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
-            return Future.failedFuture(new ConnectRestException("Bad stuff happened"));
+            return Future.failedFuture(new ConnectRestException("GET", "/foo", 500, "Internal server error", "Bad stuff happened"));
         });
         String connectName = "cluster";
         String connectorName = "connector";
@@ -681,7 +742,7 @@ public class ConnectorMockTest {
                 .endSpec()
                 .done();
         waitForConnectorNotReady(connectorName,
-                "ConnectRestException", "Bad stuff happened");
+                "ConnectRestException", "GET /foo returned 500 (Internal server error): Bad stuff happened");
 
         verify(api, atLeastOnce()).list(
                 eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
@@ -689,6 +750,88 @@ public class ConnectorMockTest {
                 eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), emptySet());
+    }
+
+    /** Create connect, create connector, delete connector, delete connect */
+    @Test
+    public void testPauseResume() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .addToAnnotations("strimzi.io/use-connector-resources", "true")
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectReady(connectName);
+
+        // triggered twice (creation+status update)
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
+                .withNewMetadata()
+                .withName(connectorName)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .done();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, atLeastOnce()).list(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, atLeastOnce()).createOrUpdatePutRequest(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertEquals(runningConnectors.keySet(), singleton(connectorName));
+
+        verify(api, never()).pause(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
+            .editSpec()
+                .withPause(true)
+            .endSpec()
+        .done();
+
+        waitForConnectorState(connectorName, "PAUSED");
+
+        verify(api, atLeastOnce()).pause(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
+                .editSpec()
+                .withPause(false)
+                .endSpec()
+                .done();
+
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, atLeastOnce()).pause(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, atLeastOnce()).resume(
+                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
     }
 
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2375,6 +2375,8 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |integer
 |config    1.2+<.<|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
+|pause     1.2+<.<|Whether the connector should be paused. Defaults to false.
+|boolean
 |====
 
 [id='type-KafkaConnectorStatus-{context}']
@@ -2390,5 +2392,7 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<|The generation of the CRD that was last reconciled by the operator.
 |integer
+|connectorStatus     1.2+<.<|The connector status, as reported by the Kafka Connect REST API.
+|map
 |====
 

--- a/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -39,6 +39,8 @@ spec:
               minimum: 1
             config:
               type: object
+            pause:
+              type: boolean
         status:
           type: object
           properties:
@@ -59,4 +61,6 @@ spec:
                     type: string
             observedGeneration:
               type: integer
+            connectorStatus:
+              type: object
 {{- end -}}

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -34,6 +34,8 @@ spec:
               minimum: 1
             config:
               type: object
+            pause:
+              type: boolean
         status:
           type: object
           properties:
@@ -54,3 +56,5 @@ spec:
                     type: string
             observedGeneration:
               type: integer
+            connectorStatus:
+              type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

* Add a `pause` property to the `KafkaConnector.spec` to control pause/resume
* Add a `connector` property to the `KafkaConnector.status` to expose
  connector status. This is the JSON result of the
  GET /connectors/<connector>/status endpoint. With this change a
  typical status looks like like this:
    ```
      status:
        conditions:
        - lastTransitionTime: "2020-01-06T13:44:20.031Z"
          status: "True"
          type: Ready
        connector:
          connector:
            state: PAUSED
            worker_id: 172.17.0.11:8083
          name: my-source-connector
          tasks:
          - id: 0
            state: RUNNING
            worker_id: 172.17.0.11:8083
          type: source
        observedGeneration: 2
    ```

* Note that the REST API calls to /pause and /resume are asynchronous and the
  operator doesn't poll waiting for all tasks to stop. This means the
  status example above (with a PAUSED connector and a RUNNING task) would
  exist until the next reconciliation (when the status would be updated to
  show a PAUSED task--assuming the task had indeed stopped) even though the
  task was actually paused much sooner than that.
* Some minor changes were needed to the CrdGenerator and DocGenerator to support a `JsonNode` typed property in the API. 

Signed-off-by: Tom Bentley <tbentley@redhat.com>
