### PR TITLE
Fix rolling update of existing pods when scaling up/down

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -378,7 +378,7 @@ public class ModelUtils {
      *
      * @return  True if there is a key which exists in the data sections of both secrets and which changed.
      */
-    public static boolean didAnyCertificateChangedInSecret(Secret current, Secret desired) {
+    public static boolean doExistingCertificatesDiffer(Secret current, Secret desired) {
         Map<String, String> currentData = current.getData();
         Map<String, String> desiredData = desired.getData();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -366,4 +366,31 @@ public class ModelUtils {
     private static byte[] decodeFromSecret(Secret secret, String key) {
         return Base64.getDecoder().decode(secret.getData().get(key));
     }
+
+    /**
+     * Compares two Secrets with certificates and checks whether any value for a key which exists in both Secrets
+     * changed. This method is used to evaluate whether rolling update of existing brokers is needed when secrets with
+     * certificates change. It separates changes for existing certificates with other changes to the secret such as
+     * added or removed certificates (scale-up or scale-down).
+     *
+     * @param current   Existing secret
+     * @param desired   Desired secret
+     *
+     * @return  True if there is a key which exists in the data sections of both secrets and which changed.
+     */
+    public static boolean didAnyCertificateChangedInSecret(Secret current, Secret desired) {
+        Map<String, String> currentData = current.getData();
+        Map<String, String> desiredData = desired.getData();
+
+        for (Map.Entry<String, String> entry : currentData.entrySet()) {
+            String desiredValue = desiredData.get(entry.getKey());
+            if (entry.getValue() != null
+                    && desiredValue != null
+                    && !entry.getValue().equals(desiredValue)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
@@ -176,5 +178,100 @@ public class ModelUtilsTest {
         assertThat(probe.getTcpSocket().getPort().getIntVal(), is(new Integer(1234)));
         assertThat(probe.getInitialDelaySeconds(), is(new Integer(10)));
         assertThat(probe.getTimeoutSeconds(), is(new Integer(20)));
+    }
+
+    @Test
+    public void testCertificateSecretChange()   {
+        Secret defaultSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret sameAsDefaultSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret scaleDownSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .build();
+
+        Secret scaleUpSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .addToData("my-cluster-kafka-3.crt", "Certificate3")
+                .addToData("my-cluster-kafka-3.key", "Key3")
+                .addToData("my-cluster-kafka-4.crt", "Certificate4")
+                .addToData("my-cluster-kafka-4.key", "Key4")
+                .build();
+
+        Secret changedSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "NewKey1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret changedScaleUpSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "NewCertificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .addToData("my-cluster-kafka-3.crt", "Certificate3")
+                .addToData("my-cluster-kafka-3.key", "Key3")
+                .addToData("my-cluster-kafka-4.crt", "Certificate4")
+                .addToData("my-cluster-kafka-4.key", "Key4")
+                .build();
+
+        Secret changedScaleDownSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "NewCertificate0")
+                .addToData("my-cluster-kafka-0.key", "NewKey0")
+                .build();
+
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, defaultSecret), is(false));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, sameAsDefaultSecret), is(false));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, scaleDownSecret), is(false));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, scaleUpSecret), is(false));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedSecret), is(true));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedScaleUpSecret), is(true));
+        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedScaleDownSecret), is(true));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -181,7 +181,7 @@ public class ModelUtilsTest {
     }
 
     @Test
-    public void testCertificateSecretChange()   {
+    public void testExistingCertificatesDiffer()   {
         Secret defaultSecret = new SecretBuilder()
                 .withNewMetadata()
                     .withName("my-secret")
@@ -266,12 +266,12 @@ public class ModelUtilsTest {
                 .addToData("my-cluster-kafka-0.key", "NewKey0")
                 .build();
 
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, defaultSecret), is(false));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, sameAsDefaultSecret), is(false));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, scaleDownSecret), is(false));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, scaleUpSecret), is(false));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedSecret), is(true));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedScaleUpSecret), is(true));
-        assertThat(ModelUtils.didAnyCertificateChangedInSecret(defaultSecret, changedScaleDownSecret), is(true));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, defaultSecret), is(false));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, sameAsDefaultSecret), is(false));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, scaleDownSecret), is(false));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, scaleUpSecret), is(false));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedSecret), is(true));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleUpSecret), is(true));
+        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleDownSecret), is(true));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -519,10 +519,10 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.list(anyString(), any())).thenReturn(
                 secrets
         );
-        // Getting JMX Secret
-        when(mockSecretOps.getAsync(anyString(), eq(kafkaCluster.jmxSecretName(clusterCmName)))).thenReturn(
+        when(mockSecretOps.getAsync(anyString(), any())).thenReturn(
                 Future.succeededFuture(null)
         );
+
         Set<String> createdOrUpdatedSecrets = new HashSet<>();
         when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenAnswer(invocation -> {
             Secret desired = invocation.getArgument(2);
@@ -953,6 +953,18 @@ public class KafkaAssemblyOperatorTest {
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.jmxSecretName(clusterName))).thenReturn(
                 Future.succeededFuture(originalKafkaCluster.generateJmxSecret())
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, ZookeeperCluster.nodesSecretName(clusterName))).thenReturn(
+                Future.succeededFuture()
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.brokersSecretName(clusterName))).thenReturn(
+                Future.succeededFuture()
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, EntityOperator.secretName(clusterName))).thenReturn(
+                Future.succeededFuture()
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, KafkaExporter.secretName(clusterName))).thenReturn(
+                Future.succeededFuture()
         );
 
         // Mock NetworkPolicy get


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When checking the update of the secrets with server certificates for our different STS / Deployments, we trigger unnecessary rolling update when scaling up or down (new records are added to the secret -> the secret changed and we trigger rolling update of all pods.). This PR checks the changes in more details so that it triggers the rolling update only when the certificates which eisted before changed. Thanks to that Kafka doesn't roll when it scales up or down.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally