### PR TITLE
Add readiness check to the ZK scale-up

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -249,7 +249,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.zkManualRollingUpdate())
                 .compose(state -> state.zookeeperServiceAccount())
                 .compose(state -> state.zkPvcs())
-                .compose(state -> state.zkScaleUpStep())
+                .compose(state -> state.zkScaleUpInSmallSteps())
                 .compose(state -> state.zkScaleDown())
                 .compose(state -> state.zkService())
                 .compose(state -> state.zkHeadlessService())
@@ -353,6 +353,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private ConfigMap zkMetricsAndLogsConfigMap;
         /* test */ ReconcileResult<StatefulSet> zkDiffs;
         private boolean zkAncillaryCmChange;
+        private boolean zkScalingUp = false;
 
         private KafkaCluster kafkaCluster = null;
         /* test */ KafkaStatus kafkaStatus = new KafkaStatus();
@@ -1201,22 +1202,27 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * There is one special case of scaling from standalone (single one) Zookeeper pod.
          * In this case quorum cannot be preserved.
          */
-        Future<ReconciliationState> zkScaleUpStep() {
-            Future<StatefulSet> futsts = zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name));
-            return withVoid(futsts.map(sts -> sts == null ? Integer.valueOf(0) : sts.getSpec().getReplicas())
+        Future<ReconciliationState> zkScaleUpInSmallSteps() {
+            return zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name))
+                    .map(sts -> sts == null ? Integer.valueOf(0) : sts.getSpec().getReplicas())
                     .compose(currentReplicas -> {
                         if (currentReplicas > 0 && zkCluster.getReplicas() > currentReplicas) {
                             zkCluster.setReplicas(currentReplicas + 1);
+                            zkScalingUp = true;
                         }
-                        Future<Integer> result = Future.succeededFuture(zkCluster.getReplicas() + 1);
-                        return result;
-                    }));
+
+                        return Future.succeededFuture(this);
+                    });
         }
 
         Future<ReconciliationState> zkScaleUp() {
-            return zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas())
-                    .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(zkCluster.getReplicas() - 1), 1_000, operationTimeoutMs))
-                    .map(this);
+            if (zkScalingUp) {
+                return zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas())
+                        .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(zkCluster.getReplicas() - 1), 1_000, operationTimeoutMs))
+                        .map(this);
+            } else {
+                return Future.succeededFuture(this);
+            }
         }
 
         Future<ReconciliationState> zkServiceEndpointReadiness() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1214,7 +1214,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkScaleUp() {
-            return withVoid(zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas()));
+            return zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas())
+                    .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(zkCluster.getReplicas() - 1), 1_000, operationTimeoutMs))
+                    .map(this);
         }
 
         Future<ReconciliationState> zkServiceEndpointReadiness() {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Fabric8 `scale(...)` method IIRC used to wait for readiness of the new pods but doesn't do so anymore. I think we fixed that for KAfka pods by adding additional readiness pod. But when scaling up Zookeeper, we currently start the new pod and even before it is ready we start rolling the old pods. That can for sure have some impact on availability because the new pod will not be ready while we take down the first old pod.

This PR adds additional readiness check for the new pod to make sure it is ready before we move to the rolling update of the old pods.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally