### PR TITLE
Fix Cluster Operator metrics tests on jenkins

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -54,7 +54,7 @@ public class ClusterOperator extends AbstractVerticle {
 
     private static final int HEALTH_SERVER_PORT = 8080;
 
-    private static final PrometheusMeterRegistry METRICS_REGISTRY = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
+    private final PrometheusMeterRegistry metrics;
 
     private final KubernetesClient client;
     private final String namespace;
@@ -86,6 +86,8 @@ public class ClusterOperator extends AbstractVerticle {
         this.kafkaConnectS2IAssemblyOperator = kafkaConnectS2IAssemblyOperator;
         this.kafkaMirrorMakerAssemblyOperator = kafkaMirrorMakerAssemblyOperator;
         this.kafkaBridgeAssemblyOperator = kafkaBridgeAssemblyOperator;
+
+        metrics = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
         setupMetrics();
     }
 
@@ -170,7 +172,7 @@ public class ClusterOperator extends AbstractVerticle {
                         request.response().setStatusCode(200).end();
                     } else if (request.path().equals("/metrics")) {
                         request.response().setStatusCode(200)
-                                .end(METRICS_REGISTRY.scrape());
+                                .end(metrics.scrape());
                     }
                 })
                 .listen(HEALTH_SERVER_PORT, ar -> {
@@ -185,11 +187,11 @@ public class ClusterOperator extends AbstractVerticle {
     }
 
     private void setupMetrics() {
-        new ClassLoaderMetrics().bindTo(METRICS_REGISTRY);
-        new JvmMemoryMetrics().bindTo(METRICS_REGISTRY);
-        new ProcessorMetrics().bindTo(METRICS_REGISTRY);
-        new JvmThreadMetrics().bindTo(METRICS_REGISTRY);
-        new JvmGcMetrics().bindTo(METRICS_REGISTRY);
+        new ClassLoaderMetrics().bindTo(metrics);
+        new JvmMemoryMetrics().bindTo(metrics);
+        new ProcessorMetrics().bindTo(metrics);
+        new JvmThreadMetrics().bindTo(metrics);
+        new JvmGcMetrics().bindTo(metrics);
     }
 
     public static String secretName(String cluster) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -26,7 +26,9 @@ import io.vertx.micrometer.VertxPrometheusOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,8 +56,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class ClusterOperatorTest {
-
-    private Vertx vertx;
+    private static Vertx vertx;
 
     private static Map<String, String> buildEnv(String namespaces) {
         Map<String, String> env = new HashMap<>();
@@ -68,8 +69,8 @@ public class ClusterOperatorTest {
         return env;
     }
 
-    @BeforeEach
-    public void createClient() {
+    @BeforeAll
+    public static void createClient() {
         vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
@@ -77,8 +78,8 @@ public class ClusterOperatorTest {
         ));
     }
 
-    @AfterEach
-    public void closeClient() {
+    @AfterAll
+    public static void closeClient() {
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -27,9 +27,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The tests for the Cluster Operator seem to be failing on Jenkins (passing locally and on Travis). This PR tries to make them work on Jenkins as well. It seems that Vert.x is initializing the Metrics registry when it is being created. And that is causing issues when Vert.x is initialized and closed after and before each tests. Initializing Vert.x only once seems to help. Also since it is initialized by Vert.x, it does not seem to make sense to have the metrics registry static.