### PR TITLE
Make exception in Quantities class more informative

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -109,7 +109,7 @@ class Quantities {
                 } else if (cpu.substring(i).startsWith(".")) {
                     return (int) (Double.parseDouble(cpu) * 1000L);
                 } else {
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("Failed to parse CPU quantity \"" + cpu + "\"");
                 }
             }
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/QuantitiesTest.java
@@ -111,6 +111,7 @@ public class QuantitiesTest {
 
     @Test
     public void testParse() {
+        assertThat(parseCpuAsMilliCpus("100000"), is(100000000));
         assertThat(parseCpuAsMilliCpus("1"), is(1000));
         assertThat(parseCpuAsMilliCpus("1m"), is(1));
         assertThat(parseCpuAsMilliCpus("0.5"), is(500));


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

When we fail to parse the CPU quantity from resource request or limits, we throw an exception without any error message:

```
2020-01-07 15:06:01 ERROR AbstractOperator:124 - Reconciliation #10(timer) Kafka(rolling-update-cluster-test/my-cluster): createOrUpdate failed
java.lang.IllegalArgumentException: null
	at io.strimzi.operator.cluster.operator.resource.Quantities.parseCpuAsMilliCpus(Quantities.java:112) ~[io.strimzi.cluster-operator-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetDiff.compareMemoryAndCpuResources(StatefulSetDiff.java:129) ~[io.strimzi.cluster-operator-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetDiff.<init>(StatefulSetDiff.java:87) ~[io.strimzi.cluster-operator-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetOperator.internalPatch(StatefulSetOperator.java:284) ~[io.strimzi.cluster-operator-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.resource.StatefulSetOperator.internalPatch(StatefulSetOperator.java:43) ~[io.strimzi.cluster-operator-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.strimzi.operator.common.operator.resource.AbstractResourceOperator.lambda$reconcile$0(AbstractResourceOperator.java:103) ~[io.strimzi.operator-common-0.16.0-SNAPSHOT.jar:0.16.0-SNAPSHOT]
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_232]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_232]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.42.Final.jar:4.1.42.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_232]
```

That looks stupid and doesn't provide us with any information of what was actually the issue. This PR adds a message to the exception to make it easier to understand the issue and also to print the CPU quantity which failed to parse.