### PR TITLE
When advertised host overrides are used with node port external listener, use tham in status

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1688,7 +1688,17 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             Set<ListenerAddress> statusAddresses = new HashSet<>();
 
                             for (Pod broker : pods) {
-                                if (broker.getStatus() != null && broker.getStatus().getHostIP() != null) {
+                                String podName = broker.getMetadata().getName();
+                                Integer podIndex = Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
+
+                                if (kafkaCluster.getExternalServiceAdvertisedHostOverride(podIndex) != null)    {
+                                    ListenerAddress address = new ListenerAddressBuilder()
+                                            .withHost(kafkaCluster.getExternalServiceAdvertisedHostOverride(podIndex))
+                                            .withPort(externalBootstrapNodePort)
+                                            .build();
+
+                                    statusAddresses.add(address);
+                                } else if (broker.getStatus() != null && broker.getStatus().getHostIP() != null) {
                                     String hostIP = broker.getStatus().getHostIP();
                                     Node podNode = nodes.stream().filter(node -> {
                                         if (node.getStatus() != null && node.getStatus().getAddresses() != null)    {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

In th eprevious PR I added the address to the KAfkaStatus for node prot external listener. The address was based on the actual node address. However, it would probably make sense to use the advertised address from the overrides if specified and use the node address only if it is used as advertised in the broker. This is implemented in the PR.

Note: This is different for the port, since we do not have override for the advertised bootstrap port, because the ports for the shared bootstrap service are not advertised anywhere.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally