### PR TITLE
Non-connector connects should not delete connectors

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -249,6 +249,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             if (useResources) {
                 log.debug("{}: {}} cluster: deleting connector: {}", reconciliation, kind(), connectorName);
                 return apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connectorName);
+            } else {
+                return Future.succeededFuture();
             }
         } else {
             log.debug("{}: {}} cluster: creating/updating connector: {}", reconciliation, kind(), connectorName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -246,8 +246,10 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
     private Future<Void> reconcileConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, boolean useResources, String connectorName, KafkaConnector connector) {
         if (connector == null) {
-            log.debug("{}: {}} cluster: deleting connector: {}", reconciliation, kind(), connectorName);
-            return apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connectorName);
+            if (useResources) {
+                log.debug("{}: {}} cluster: deleting connector: {}", reconciliation, kind(), connectorName);
+                return apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connectorName);
+            }
         } else {
             log.debug("{}: {}} cluster: creating/updating connector: {}", reconciliation, kind(), connectorName);
             if (connector.getSpec() == null) {


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

This PR fixes a bug where a `KafkaConnect` without the `strimzi.io/use-connector-resources` annotation incorrectly deletes connectors.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

