### PR TITLE
Add all doc books to release archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ pushtonexus:
 
 release_docu: docu_html docu_htmlnoheader
 	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/using.html
+	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/quickstart.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ pushtonexus:
 
 release_docu: docu_html docu_htmlnoheader
 	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/using.html
 	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/quickstart.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,9 @@ pushtonexus:
 
 release_docu: docu_html docu_htmlnoheader
 	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	$(CP) -rv documentation/html/*.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/overview.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/quickstart.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/
 
 docu_clean: docu_htmlclean docu_htmlnoheaderclean

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ pushtonexus:
 
 release_docu: docu_html docu_htmlnoheader
 	mkdir -p strimzi-$(RELEASE_VERSION)/docs
-	$(CP) -rv documentation/html/index.html strimzi-$(RELEASE_VERSION)/docs/
+	$(CP) -rv documentation/html/*.html strimzi-$(RELEASE_VERSION)/docs/
 	$(CP) -rv documentation/html/images/ strimzi-$(RELEASE_VERSION)/docs/images/
 
 docu_clean: docu_htmlclean docu_htmlnoheaderclean


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The release archives right now doesn't contain all our documentation books just the using guide. We should add also the Quickstart guide and Overview guide.

This should be cherry-picked into 0.16.0 branch.