### PR TITLE
Fix the NPE when preferred address type is not defined but custom certificates are

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -2296,7 +2296,8 @@ public class KafkaCluster extends AbstractModel {
         if (isExposedWithNodePort()) {
             KafkaListenerExternalNodePort listener = (KafkaListenerExternalNodePort) listeners.getExternal();
 
-            if (listener.getConfiguration() != null) {
+            if (listener.getConfiguration() != null
+                    && listener.getConfiguration().getPreferredAddressType() != null) {
                 return listener.getConfiguration().getPreferredAddressType().toValue();
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `getPreferredNodeAddressType` method in `KafkaCluster` can trigger an NPE when the custm certificates are defined but no address type. This is because a wrong/insufficient null check

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass