### PR TITLE
And the new connecotr CRD to the Strimzi Admin role

### DIFF
--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -15,6 +15,7 @@ rules:
   - kafkausers
   - kafkatopics
   - kafkabridges
+  - kafkaconnectors
   verbs:
   - get
   - list


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `strimzi-admin` role should give users access to all Strimzi CRDs. But currently the `kafkaconnectors` is missing and should be added.