### PR TITLE
Fixing issues with back ticks in the generated docs

### DIFF
--- a/documentation/modules/con-customizing-pod-disruption-budgets.adoc
+++ b/documentation/modules/con-customizing-pod-disruption-budgets.adoc
@@ -6,7 +6,7 @@
 = Customizing Pod Disruption Budgets
 
 {ProductName} creates a pod disruption budget for every new `StatefulSet` or `Deployment`.
-By default, these pod disruption budgets only allow a single pod to be unavailable at a given time by setting the `maxUnavailable` value in the`PodDisruptionBudget.spec` resource to 1.
+By default, these pod disruption budgets only allow a single pod to be unavailable at a given time by setting the `maxUnavailable` value in the `PodDisruptionBudget.spec` resource to 1.
 You can change the amount of unavailable pods allowed by changing the default value of `maxUnavailable` in the pod disruption budget template.
 This template applies to each type of cluster (Kafka and ZooKeeper; Kafka Connect and Kafka Connect with S2I support; and Kafka Mirror Maker).
 

--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -19,10 +19,10 @@ Deploy the example `KafkaConnector` to a Kafka Connect cluster. The example YAML
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: kafka.strimzi.io/v1alpha1
-kind: `KafkaConnector`
+kind: KafkaConnector
 metadata:
   name: my-source-connector <1>
-  labels:   
+  labels:
     strimzi.io/cluster: my-connect-cluster <2>
 spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>

--- a/documentation/modules/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/proc-generating-reassignment-json-files.adoc
@@ -53,10 +53,10 @@ For example if you want to reassign all the partitions of `topic-a` and `topic-b
 ----
 cat _topics.json_ | kubectl exec -c kafka _<BrokerPod>_ -i -- \
   /bin/bash -c \
-  'cat > /tmp/topics.json'  
+  'cat > /tmp/topics.json'
 ----
 
-. Use the `kafka-reassign-partitions.sh`` command to generate the reassignment JSON.
+. Use the `kafka-reassign-partitions.sh` command to generate the reassignment JSON.
 +
 [source,subs=+quotes]
 ----


### PR DESCRIPTION
Signed-off-by: Simon Woodman <swoodman@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix


### Description

Fixes some `back ticks` which were appearing in the generated documentation
### Checklist
