### PR TITLE
[Enhancement] Support for Mirror Maker message handlers

### DIFF
--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -91,6 +91,14 @@ if [ -n "$KAFKA_MIRRORMAKER_ABORT_ON_SEND_FAILURE" ]; then
     abort_on_send_failure="--abort.on.send.failure $KAFKA_MIRRORMAKER_ABORT_ON_SEND_FAILURE"
 fi
 
+if [ -n "$KAFKA_MIRRORMAKER_MESSAGE_HANDLER" ]; then
+    message_handler="--message.handler $KAFKA_MIRRORMAKER_MESSAGE_HANDLER"
+fi
+
+if [ -n "$KAFKA_MIRRORMAKER_MESSAGE_HANDLER_ARGS" ]; then
+    message_handler_args="--message.handler.args \""${$KAFKA_MIRRORMAKER_MESSAGE_HANDLER_ARGS}"\""
+fi
+
 . ./set_kafka_gc_options.sh
 
 # starting Kafka Mirror Maker with final configuration
@@ -100,4 +108,6 @@ exec $KAFKA_HOME/bin/kafka-mirror-maker.sh \
 $whitelist \
 $numstreams \
 $offset_commit_interval \
-$abort_on_send_failure
+$abort_on_send_failure \
+$message_handler \
+$message_handler_args


### PR DESCRIPTION
Adds support for message.handler and message.handler.args to Mirror Maker image.

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Adds ability to pass in `--message.handler` and `--message.handler.args` to Mirror Maker.
This PR fixes #2407 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

