### PR TITLE
Allow exclude tags in jenkins PR pipeline

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -11,6 +11,7 @@ pipeline {
     parameters {
         string(name: 'TEST_CASE', defaultValue: '*ST', description: 'maven parameter for executing specific tests')
         string(name: 'TEST_PROFILE', defaultValue: 'acceptance', description: 'maven parameter for executing specific test profile')
+        string(name: 'EXCLUDE', defaultValue: 'networkpolicies', description: 'maven parameter for exclude specific test tag')
     }
     options {
         timeout(time: 22, unit: 'HOURS')
@@ -39,12 +40,18 @@ pipeline {
                     echo "Comment body: ${env.ghprbCommentBody}"
                     env.TEST_CASE = params.TEST_CASE
                     env.TEST_PROFILE = params.TEST_PROFILE
+                    env.EXCLUDE_GROUPS = params.EXCLUDE
                     if (env.ghprbCommentBody.contains('testcase=')) {
                         env.TEST_CASE = env.ghprbCommentBody.split('testcase=')[1].split(/\s/)[0]
                     }
                     echo "TEST_CASE: ${env.TEST_CASE}"
                     if (env.ghprbCommentBody.contains('profile=')) {
                         env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
+                    }
+                    echo "EXCLUDE_GROUPS: ${env.EXCLUDE_GROUPS}"
+                    if (env.ghprbCommentBody.contains('exclude=')) {
+                        env.EXCLUDE_GROUPS = env.ghprbCommentBody.split('exclude=')[1].split(/\s/)[0]
+                        env.EXCLUDE_GROUPS = env.EXCLUDE_GROUPS + ",networkpolicies"
                     }
                     echo "TEST_PROFILE: ${env.TEST_PROFILE}"
                     if (env.ghprbCommentBody.contains('test_only')) {
@@ -98,7 +105,7 @@ pipeline {
             steps {
                 script {
                     catchError {
-                        lib.runSystemTests(env.WORKSPACE, env.TEST_CASE, env.TEST_PROFILE)
+                        lib.runSystemTests(env.WORKSPACE, env.TEST_CASE, env.TEST_PROFILE, env.EXCLUDE_GROUPS)
                     }
                 }
             }

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -101,9 +101,9 @@ def buildStrimziImages() {
     sh "make docker_tag"
 }
 
-def runSystemTests(String workspace, String testCases, String testProfile) {
+def runSystemTests(String workspace, String testCases, String testProfile, String excludeGroups) {
     withMaven(mavenOpts: '-Djansi.force=true') {
-        sh "mvn -f ${workspace}/systemtest/pom.xml -P all verify -Dgroups=${testProfile} -Dit.test=${testCases} -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false -Dstyle.color=always --no-transfer-progress"
+        sh "mvn -f ${workspace}/systemtest/pom.xml -P all verify -Dgroups=${testProfile} -DexcludedGroups=${excludeGroups} -Dit.test=${testCases} -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false -Dstyle.color=always --no-transfer-progress"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: David Kornel <kornys@outlook.com>

### Type of change

- Enhancement

### Description

Allow exclude test tags from PR trigger command in jenkins PR pipeline

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

