### PR TITLE
Fix connector operator when connect runs in a different namespace

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -48,6 +48,17 @@ public class KafkaConnectResources {
     }
 
     /**
+     * Returns qualified name of the service which works across different namespaces.
+     *
+     * @param clusterName   Name of the Connect CR
+     * @param namespace     Namespace of the Connect dpeloyment
+     * @return              quaified namespace in the format "&lt;service-name&gt;.&lt;namespace&gt;.svc"
+     */
+    public static String qualifiedServiceName(String clusterName, String namespace) {
+        return serviceName(clusterName) + "." + namespace + ".svc";
+    }
+
+    /**
      * Returns the URL of the Kafka Connect REST API for a {@code KafkaConnect} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
      * @param namespace The namespace where {@code KafkaConnect} cluster is running.
@@ -55,6 +66,6 @@ public class KafkaConnectResources {
      * @return The base URL of the {@code KafkaConnect} REST API.
      */
     public static String url(String clusterName, String namespace, int port) {
-        return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
+        return "http://" + qualifiedServiceName(clusterName, namespace) + ":" + port;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -30,7 +30,10 @@ public class KafkaConnectResources {
     }
 
     /**
-     * Returns the name of the HTTP REST {@code Service} for a {@code KafkaConnect} cluster of the given name.
+     * Returns the name of the HTTP REST {@code Service} for a {@code KafkaConnect} cluster of the given name. This
+     * returns only the name of the service without any namespace. Therefore it cannot be used to connect to the Connect
+     * REST API. USe the {@code qualifiedServiceName} or {@code url} methods instead.
+     *
      * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
      * @return The name of the corresponding {@code Service}.
      */

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -51,8 +51,8 @@ public class KafkaConnectResources {
      * Returns qualified name of the service which works across different namespaces.
      *
      * @param clusterName   Name of the Connect CR
-     * @param namespace     Namespace of the Connect dpeloyment
-     * @return              quaified namespace in the format "&lt;service-name&gt;.&lt;namespace&gt;.svc"
+     * @param namespace     Namespace of the Connect deployment
+     * @return              qualified namespace in the format "&lt;service-name&gt;.&lt;namespace&gt;.svc"
      */
     public static String qualifiedServiceName(String clusterName, String namespace) {
         return serviceName(clusterName) + "." + namespace + ".svc";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -180,7 +180,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                                 }
                                                 return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
                                                     () -> connectOperator.reconcileConnector(reconciliation,
-                                                                KafkaConnectResources.serviceName(connectName), apiClient,
+                                                                KafkaConnectResources.qualifiedServiceName(connectName, connectNamespace), apiClient,
                                                                 isUseResources(connect),
                                                                 kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
                                                             .compose(reconcileResult -> {
@@ -196,7 +196,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
                                                 return connectS2IOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
                                                     () -> connectS2IOperator.reconcileConnector(reconciliation,
-                                                                KafkaConnectResources.serviceName(connectName), apiClient,
+                                                                KafkaConnectResources.qualifiedServiceName(connectName, connectNamespace), apiClient,
                                                                 isUseResources(connectS2i),
                                                                 kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
                                                             .compose(reconcileResult -> {
@@ -250,7 +250,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect) {
         String connectName = connect.getMetadata().getName();
         String namespace = connect.getMetadata().getNamespace();
-        String host = KafkaConnectResources.serviceName(connectName);
+        String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
         boolean useResources = isUseResources(connect);
         return CompositeFuture.join(apiClient.list(host, KafkaConnectCluster.REST_API_PORT),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -435,15 +435,16 @@ public class ConnectorMockTest {
 
         // triggered twice (creation+status update)
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
                     .withName(connectorName)
+                    .withNamespace(NAMESPACE)
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
@@ -452,9 +453,9 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), set(connectorName));
         
@@ -464,7 +465,7 @@ public class ConnectorMockTest {
             return runningConnectors.isEmpty();
         });
         verify(api).delete(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
@@ -490,9 +491,9 @@ public class ConnectorMockTest {
             "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
 
         verify(api, never()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), emptySet());
 
@@ -509,9 +510,9 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
         // (connect crt, connector status, connect status)
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), set(connectorName));
 
@@ -521,7 +522,7 @@ public class ConnectorMockTest {
             return runningConnectors.isEmpty();
         });
         verify(api).delete(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
         Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
@@ -546,9 +547,9 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         // Create KafkaConnect cluster and wait till it's ready
@@ -564,9 +565,9 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), set(connectorName));
 
@@ -576,7 +577,7 @@ public class ConnectorMockTest {
 
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
         verify(api, never()).delete(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }
 
@@ -600,9 +601,9 @@ public class ConnectorMockTest {
                 "KafkaConnect resource 'cluster' identified by label 'strimzi.io/cluster' does not exist in namespace ns.");
 
         verify(api, never()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), emptySet());
 
@@ -619,9 +620,9 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), set(connectorName));
 
@@ -631,7 +632,7 @@ public class ConnectorMockTest {
 
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
         verify(api, never()).delete(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }
 
@@ -668,6 +669,7 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
                     .withName(connectorName)
+                    .withNamespace(NAMESPACE)
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connect1Name)
                 .endMetadata()
                 .withNewSpec()
@@ -676,15 +678,16 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connect1Name, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connect2Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connect2Name, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).patch(new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName(connectorName)
+                    .withNamespace(NAMESPACE)
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connect2Name)
                 .endMetadata()
                 .withNewSpec()
@@ -694,10 +697,10 @@ public class ConnectorMockTest {
         // Note: The connector does not get deleted immediately from cluster 1, only on the next timed reconciliation
 
         verify(api, never()).delete(
-                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connect1Name, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connect2Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connect2Name, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         CountDownLatch async = new CountDownLatch(1);
@@ -706,7 +709,7 @@ public class ConnectorMockTest {
         });
         async.await(30, TimeUnit.SECONDS);
         verify(api, atLeastOnce()).delete(
-                eq(KafkaConnectResources.serviceName(connect1Name)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connect1Name, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }
 
@@ -733,16 +736,17 @@ public class ConnectorMockTest {
 
         // triggered twice (creation+status update)
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -751,9 +755,9 @@ public class ConnectorMockTest {
                 "ConnectRestException", "GET /foo returned 500 (Internal server error): Bad stuff happened");
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), emptySet());
     }
@@ -778,16 +782,17 @@ public class ConnectorMockTest {
 
         // triggered twice (creation+status update)
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
 
         // Create KafkaConnect cluster and wait till it's ready
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).createNew()
                 .withNewMetadata()
-                .withName(connectorName)
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -796,17 +801,17 @@ public class ConnectorMockTest {
         waitForConnectorState(connectorName, "RUNNING");
 
         verify(api, atLeastOnce()).list(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT));
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, atLeastOnce()).createOrUpdatePutRequest(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertEquals(runningConnectors.keySet(), singleton(connectorName));
 
         verify(api, never()).pause(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
         verify(api, never()).resume(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
@@ -818,10 +823,10 @@ public class ConnectorMockTest {
         waitForConnectorState(connectorName, "PAUSED");
 
         verify(api, atLeastOnce()).pause(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
         verify(api, never()).resume(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit()
@@ -833,10 +838,10 @@ public class ConnectorMockTest {
         waitForConnectorState(connectorName, "RUNNING");
 
         verify(api, atLeastOnce()).pause(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
         verify(api, atLeastOnce()).resume(
-                eq(KafkaConnectResources.serviceName(connectName)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The connector operator is using only the service name to connect to the Kafka Connect REST API. However that is not enough when the operator does not run in the same namespace as the operator. In that case it needs to use the qualified name `<connect-service>.<connect-namespace>.svc`. This PR fixes this and should close the issue #2417.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging