### PR TITLE
Improve logging of the connector operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -140,56 +140,83 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             connectOperator.connectorOperator.watch(watchNamespaceOrWildcard, new Watcher<KafkaConnector>() {
                 @Override
                 public void eventReceived(Action action, KafkaConnector kafkaConnector) {
-                    String connectName = kafkaConnector.getMetadata().getLabels() == null ? null : kafkaConnector.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+                    String connectorName = kafkaConnector.getMetadata().getName();
                     String connectorNamespace = kafkaConnector.getMetadata().getNamespace();
+                    String connectorKind = kafkaConnector.getKind();
+                    String connectName = kafkaConnector.getMetadata().getLabels() == null ? null : kafkaConnector.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
                     String connectNamespace = connectorNamespace;
-                    Future<Void> f;
-                    if (connectName != null) {
-                        // Check whether a KafkaConnect/S2I exists
-                        CompositeFuture.join(connectOperator.resourceOperator.getAsync(connectNamespace, connectName),
-                                             connectOperator.pfa.supportsS2I() ?
-                                                     connectS2IOperator.resourceOperator.getAsync(connectNamespace, connectName) :
-                                                     Future.succeededFuture())
-                                .compose(cf -> {
-                                    KafkaConnect connect = cf.resultAt(0);
-                                    KafkaConnectS2I connectS2i = cf.resultAt(1);
-                                    KafkaConnectApi apiClient = connectOperator.connectClientProvider.apply(connectOperator.vertx);
-                                    if (connect == null && connectS2i == null) {
-                                        updateStatus(noConnectCluster(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
-                                        return Future.succeededFuture();
-                                    } else if (connect != null) {
-                                        // grab the lock and call reconcileConnectors()
-                                        // (i.e. short circuit doing a whole KafkaConnect reconciliation).
-                                        Reconciliation reconciliation = new Reconciliation("connector-watch", connectOperator.kind(),
-                                                kafkaConnector.getMetadata().getNamespace(), connectName);
-                                        if (connectS2i != null) {
-                                            log.warn("{}: There is both a KafkaConnect resource and a KafkaConnectS2I resource named {}. " +
-                                                            "The KafkaConnect takes precedence for the connector {}",
-                                                    reconciliation, connectName, connect.getMetadata().getName());
-                                        }
-                                        return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
-                                            () -> connectOperator.reconcileConnector(reconciliation,
-                                                    KafkaConnectResources.serviceName(connectName), apiClient,
-                                                    isUseResources(connect),
-                                                    kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector));
-                                    } else {
-                                        // grab the lock and call reconcileConnectors()
-                                        // (i.e. short circuit doing a whole KafkaConnect reconciliation).
-                                        Reconciliation r = new Reconciliation("connector-watch", connectS2IOperator.kind(),
-                                                kafkaConnector.getMetadata().getNamespace(), connectName);
-                                        return connectS2IOperator.withLock(r, LOCK_TIMEOUT_MS,
-                                            () -> connectS2IOperator.reconcileConnector(r,
-                                                    KafkaConnectResources.serviceName(connectName), apiClient,
-                                                    isUseResources(connectS2i),
-                                                    kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector));
-                                    }
-                                }
-                            );
-                    } else {
-                        updateStatus(new InvalidResourceException("Resource lacks label '"
-                                        + Labels.STRIMZI_CLUSTER_LABEL
-                                        + "': No connect cluster in which to create this connector."),
-                                kafkaConnector, connectOperator.connectorOperator);
+
+                    switch (action) {
+                        case ADDED:
+                        case DELETED:
+                        case MODIFIED:
+                            Future<Void> f;
+                            if (connectName != null) {
+                                // Check whether a KafkaConnect/S2I exists
+                                CompositeFuture.join(connectOperator.resourceOperator.getAsync(connectNamespace, connectName),
+                                        connectOperator.pfa.supportsS2I() ?
+                                                connectS2IOperator.resourceOperator.getAsync(connectNamespace, connectName) :
+                                                Future.succeededFuture())
+                                        .compose(cf -> {
+                                            KafkaConnect connect = cf.resultAt(0);
+                                            KafkaConnectS2I connectS2i = cf.resultAt(1);
+                                            KafkaConnectApi apiClient = connectOperator.connectClientProvider.apply(connectOperator.vertx);
+                                            if (connect == null && connectS2i == null) {
+                                                log.info("{} {} in namespace {} was {}, but Connect cluster {} does not exist", connectorKind, connectorName, connectorNamespace, action, connectName);
+                                                updateStatus(noConnectCluster(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
+                                                return Future.succeededFuture();
+                                            } else if (connect != null) {
+                                                // grab the lock and call reconcileConnectors()
+                                                // (i.e. short circuit doing a whole KafkaConnect reconciliation).
+                                                Reconciliation reconciliation = new Reconciliation("connector-watch", connectOperator.kind(),
+                                                        kafkaConnector.getMetadata().getNamespace(), connectName);
+                                                log.info("{}: {} {} in namespace {} was {}", reconciliation, connectorKind, connectorName, connectorNamespace, action);
+
+                                                if (connectS2i != null) {
+                                                    log.warn("{}: There is both a KafkaConnect resource and a KafkaConnectS2I resource named {}. " +
+                                                                    "The KafkaConnect takes precedence for the connector {}",
+                                                            reconciliation, connectName, connect.getMetadata().getName());
+                                                }
+                                                return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
+                                                    () -> connectOperator.reconcileConnector(reconciliation,
+                                                                KafkaConnectResources.serviceName(connectName), apiClient,
+                                                                isUseResources(connect),
+                                                                kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
+                                                            .compose(reconcileResult -> {
+                                                                log.info("{}: reconciled", reconciliation);
+                                                                return Future.succeededFuture(reconcileResult);
+                                                            }));
+                                            } else {
+                                                // grab the lock and call reconcileConnectors()
+                                                // (i.e. short circuit doing a whole KafkaConnect reconciliation).
+                                                Reconciliation reconciliation = new Reconciliation("connector-watch", connectS2IOperator.kind(),
+                                                        kafkaConnector.getMetadata().getNamespace(), connectName);
+                                                log.info("{}: {} {} in namespace {} was {}", reconciliation, connectorKind, connectorName, connectorNamespace, action);
+
+                                                return connectS2IOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
+                                                    () -> connectS2IOperator.reconcileConnector(reconciliation,
+                                                                KafkaConnectResources.serviceName(connectName), apiClient,
+                                                                isUseResources(connectS2i),
+                                                                kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
+                                                            .compose(reconcileResult -> {
+                                                                log.info("{}: reconciled", reconciliation);
+                                                                return Future.succeededFuture(reconcileResult);
+                                                            }));
+                                            }
+                                        });
+                            } else {
+                                updateStatus(new InvalidResourceException("Resource lacks label '"
+                                                + Labels.STRIMZI_CLUSTER_LABEL
+                                                + "': No connect cluster in which to create this connector."),
+                                        kafkaConnector, connectOperator.connectorOperator);
+                            }
+
+                            break;
+                        case ERROR:
+                            log.error("Failed {} {} in namespace {} ", connectorKind, connectorName, connectorNamespace);
+                            break;
+                        default:
+                            log.error("Unknown action: {} {} in namespace {}", connectorKind, connectorName, connectorNamespace);
                     }
                 }
 
@@ -231,10 +258,10 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         ).compose(cf -> {
             List<String> runningConnectorNames = cf.resultAt(0);
             List<KafkaConnector> desiredConnectors = cf.resultAt(1);
-            log.debug("{}: {}} cluster: required connectors: {}", reconciliation, kind(), desiredConnectors);
+            log.debug("{}: {} cluster: required connectors: {}", reconciliation, kind(), desiredConnectors);
             Set<String> deleteConnectorNames = new HashSet<>(runningConnectorNames);
             deleteConnectorNames.removeAll(desiredConnectors.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));
-            log.debug("{}: {}} cluster: delete connectors: {}", reconciliation, kind(), deleteConnectorNames);
+            log.debug("{}: {} cluster: delete connectors: {}", reconciliation, kind(), deleteConnectorNames);
             Stream<Future<Void>> deletionFutures = deleteConnectorNames.stream().map(connectorName ->
                 reconcileConnector(reconciliation, host, apiClient, useResources, connectorName, null)
             );
@@ -247,13 +274,13 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     private Future<Void> reconcileConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, boolean useResources, String connectorName, KafkaConnector connector) {
         if (connector == null) {
             if (useResources) {
-                log.debug("{}: {}} cluster: deleting connector: {}", reconciliation, kind(), connectorName);
+                log.info("{}: deleting connector: {}", reconciliation, connectorName);
                 return apiClient.delete(host, KafkaConnectCluster.REST_API_PORT, connectorName);
             } else {
                 return Future.succeededFuture();
             }
         } else {
-            log.debug("{}: {}} cluster: creating/updating connector: {}", reconciliation, kind(), connectorName);
+            log.info("{}: creating/updating connector: {}", reconciliation, connectorName);
             if (connector.getSpec() == null) {
                 return maybeUpdateConnectorStatus(reconciliation, connector, null,
                         new InvalidResourceException("spec property is required"));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The connector operator does currently almost no logging at the INFO log level. This is confusing because all our other operator do log some basic information. This PR improves the logigng for the connector operator. When the KafkaConnector CR is created/changed/deleted, it now logs somehting like this:

```

2020-01-17 21:04:28 INFO  AbstractConnectOperator:173 - Reconciliation #5(connector-watch) KafkaConnect(myproject/my-connect-cluster): KafkaConnector my-source-connector in namespace myproject was MODIFIED
2020-01-17 21:04:29 INFO  AbstractConnectOperator:283 - Reconciliation #5(connector-watch) KafkaConnect(myproject/my-connect-cluster): creating/updating connector: my-source-connector
2020-01-17 21:04:29 INFO  AbstractConnectOperator:186 - Reconciliation #5(connector-watch) KafkaConnect(myproject/my-connect-cluster): reconciled
```

And during timer reconciliation something like this:

```
2020-01-17 21:14:22 INFO  AbstractOperator:122 - Reconciliation #15(timer) KafkaConnect(myproject/my-connect-cluster): KafkaConnect my-connect-cluster should be created or updated
2020-01-17 21:14:23 INFO  AbstractConnectOperator:283 - Reconciliation #15(timer) KafkaConnect(myproject/my-connect-cluster): creating/updating connector: my-other-source-connector
2020-01-17 21:14:23 INFO  AbstractConnectOperator:283 - Reconciliation #15(timer) KafkaConnect(myproject/my-connect-cluster): creating/updating connector: my-source-connector
2020-01-17 21:14:23 INFO  AbstractOperator:262 - Reconciliation #15(timer) KafkaConnect(myproject/my-connect-cluster): reconciled
```

This corresponds to what the other operators are logging.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally