### PR TITLE
Use exponential backoff when getting connector status

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -40,6 +40,7 @@ import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AbstractOperator;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
@@ -265,7 +266,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 Promise<Void> promise = Promise.promise();
                 apiClient.createOrUpdatePutRequest(host, KafkaConnectCluster.REST_API_PORT,
                         connectorName, asJson(connector.getSpec()))
-                        .compose(ignored -> apiClient.status(host, KafkaConnectCluster.REST_API_PORT,
+                        .compose(ignored -> apiClient.statusWithBackOff(new BackOff(200L, 2, 6), host, KafkaConnectCluster.REST_API_PORT,
                                 connectorName))
                         .compose(status -> {
                             Object path = ((Map) status.getOrDefault("connector", emptyMap())).get("state");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -5,7 +5,10 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.strimzi.operator.common.BackOff;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
@@ -24,17 +27,26 @@ public interface KafkaConnectApi {
     Future<Map<String, Object>> createOrUpdatePutRequest(String host, int port, String connectorName, JsonObject configJson);
     Future<Void> delete(String host, int port, String connectorName);
     Future<Map<String, Object>> status(String host, int port, String connectorName);
+    Future<Map<String, Object>> statusWithBackOff(BackOff backOff, String host, int port, String connectorName);
     Future<Void> pause(String host, int port, String connectorName);
     Future<Void> resume(String host, int port, String connectorName);
     Future<List<String>> list(String host, int port);
 }
 
 class ConnectRestException extends RuntimeException {
+    private final int statusCode;
+
     ConnectRestException(String method, String path, int statusCode, String statusMessage, String message) {
         super(method + " " + path + " returned " + statusCode + " (" + statusMessage + "): " + message);
+        this.statusCode = statusCode;
     }
+
     public ConnectRestException(HttpClientResponse response, String message) {
         this(response.request().method().toString(), response.request().path(), response.statusCode(), response.statusMessage(), message);
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 }
 
@@ -111,6 +123,58 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 .putHeader("Content-Type", "application/json")
                 .end();
         return result;
+    }
+
+    @Override
+    public Future<Map<String, Object>> statusWithBackOff(BackOff backOff, String host, int port, String connectorName) {
+        Promise<Map<String, Object>> result = Promise.promise();
+
+        Handler<Long> handler = new Handler<Long>() {
+            @Override
+            public void handle(Long tid) {
+                status(host, port, connectorName).setHandler(connectorStatus -> {
+                    if (connectorStatus.succeeded()) {
+                        result.complete(connectorStatus.result());
+                    } else {
+                        Throwable cause = connectorStatus.cause();
+                        if (cause != null
+                                && cause instanceof ConnectRestException
+                                && ((ConnectRestException) cause).getStatusCode() == 404) {
+                            if (backOff.done()) {
+                                log.debug("Connector {} status returned HTTP 404 and we run out of back off time", connectorName);
+                                result.fail(cause);
+                            } else {
+                                log.debug("Connector {} status returned HTTP 404 - backing off", connectorName);
+                                rescheduleOrComplete(tid);
+                            }
+                        } else {
+                            result.fail(cause);
+                        }
+                    }
+                });
+            }
+
+            void rescheduleOrComplete(Long tid) {
+                if (backOff.done()) {
+                    log.warn("Giving up waiting for status of connector {} after {} attempts taking {}ms",
+                            connectorName,  backOff.maxAttempts(), backOff.totalDelayMs());
+                } else {
+                    // Schedule ourselves to run again
+                    long delay = backOff.delayMs();
+                    log.debug("Status for connector {} not found; " +
+                                    "backing off for {}ms (cumulative {}ms)",
+                            connectorName, delay, backOff.cumulativeDelayMs());
+                    if (delay < 1) {
+                        this.handle(tid);
+                    } else {
+                        vertx.setTimer(delay, this);
+                    }
+                }
+            }
+        };
+
+        handler.handle(null);
+        return result.future();
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.operator.common.BackOff;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaConnectApiMockTest {
+    private Vertx vertx = Vertx.vertx();
+    private BackOff backOff = new BackOff(1L, 2, 3);
+
+    @Test
+    public void testStatusWithBackOffSuccedingImmediatelly(VertxTestContext context) {
+        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
+        statusResults.add(Future.succeededFuture(Collections.emptyMap()));
+
+        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
+        Checkpoint async = context.checkpoint();
+
+        api.statusWithBackOff(backOff, "some-host", 8083, "some-connector").setHandler(res -> {
+            if (res.succeeded()) {
+                async.flag();
+            } else {
+                context.failNow(res.cause());
+            }
+        });
+    }
+
+    @Test
+    public void testStatusWithBackOffSuccedingLater(VertxTestContext context) {
+        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(3);
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+        statusResults.add(Future.succeededFuture(Collections.emptyMap()));
+
+        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
+        Checkpoint async = context.checkpoint();
+
+        api.statusWithBackOff(backOff, "some-host", 8083, "some-connector").setHandler(res -> {
+            if (res.succeeded()) {
+                async.flag();
+            } else {
+                context.failNow(res.cause());
+            }
+        });
+    }
+
+    @Test
+    public void testStatusWithBackOffFailingAfterBackOff(VertxTestContext context) {
+        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(4);
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+
+        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
+        Checkpoint async = context.checkpoint();
+
+        api.statusWithBackOff(backOff, "some-host", 8083, "some-connector").setHandler(res -> {
+            if (res.succeeded()) {
+                context.failNow(new Throwable("Was expected to fail"));
+            } else {
+                async.flag();
+            }
+        });
+    }
+
+    @Test
+    public void testStatusWithBackOffAnotherError(VertxTestContext context) {
+        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
+        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 500, null, null)));
+
+        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
+        Checkpoint async = context.checkpoint();
+
+        api.statusWithBackOff(backOff, "some-host", 8083, "some-connector").setHandler(res -> {
+            if (res.succeeded()) {
+                context.failNow(new Throwable("Was expected to fail"));
+            } else {
+                async.flag();
+            }
+        });
+    }
+
+    class MockKafkaConnectApi extends KafkaConnectApiImpl   {
+        private final Queue<Future<Map<String, Object>>> statusResults;
+
+        public MockKafkaConnectApi(Vertx vertx, Queue<Future<Map<String, Object>>> statusResults) {
+            super(vertx);
+            this.statusResults = statusResults;
+        }
+
+        @Override
+        public Future<Map<String, Object>> status(String host, int port, String connectorName) {
+            return statusResults.remove();
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Sometimes, when the connector operator creates the connector and checks its status, the status is not yet ready and does return HTTP 404:

```
2020-01-17 19:35:05 WARN  AbstractConnectOperator:324 - Reconciliation #21(connector-watch) KafkaConnect(myproject/my-connect-cluster): Error reconciling connector my-source-connector
io.strimzi.operator.cluster.operator.assembly.ConnectRestException: GET /connectors/my-source-connector/status returned 404 (Not Found): No status found for connector my-source-connector
	at io.strimzi.operator.cluster.operator.assembly.KafkaConnectApiImpl.lambda$null$7(KafkaConnectApi.java:137) ~[io.strimzi.cluster-operator-0.17.0-SNAPSHOT.jar:0.17.0-SNAPSHOT]
	at io.vertx.core.http.impl.HttpClientResponseImpl$BodyHandler.notifyHandler(HttpClientResponseImpl.java:292) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.HttpClientResponseImpl.lambda$bodyHandler$0(HttpClientResponseImpl.java:193) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleEnd(HttpClientResponseImpl.java:248) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.lambda$beginResponse$0(Http1xClientConnection.java:480) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:237) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:127) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.endResponse(Http1xClientConnection.java:499) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.access$000(Http1xClientConnection.java:237) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseEnd(Http1xClientConnection.java:634) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection.handleHttpMessage(Http1xClientConnection.java:584) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.http.impl.Http1xClientConnection.handleMessage(Http1xClientConnection.java:566) ~[io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:369) [io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43) [io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:232) [io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:173) [io.vertx.vertx-core-3.8.4.jar:3.8.4]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:438) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:328) [io.netty.netty-codec-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:302) [io.netty.netty-codec-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:253) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:241) [io.netty.netty-handler-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1422) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:931) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:700) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:635) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:552) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:514) [io.netty.netty-transport-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$6.run(SingleThreadEventExecutor.java:1044) [io.netty.netty-common-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.42.Final.jar:4.1.42.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.42.Final.jar:4.1.42.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_232]
```

This is later fixed when the status is set. But it looks bad to have the exception in the log because user might not understand it. This PR adds additional status check with exponential back off which backs off when HTTP 404 is returned. That solves the exception and makes the experience better for the user.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally