### PR TITLE
Fix KafkaConnector command instructions

### DIFF
--- a/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/kafkaconnectors/proc-deploying-kafkaconnector.adoc
@@ -43,12 +43,12 @@ spec:
 +
 [source,shell,subs="+quotes"]
 ----
-oc apply -f examples/connector/source-connector.yaml
+kubectl apply -f examples/connector/source-connector.yaml
 ----
 
 . Check that the resource was created:
 +
 [source,shell,subs="+quotes"]
 ----
-oc get all --selector strimzi.io/cluster: my-connect-cluster -o name
+kubectl get all --selector strimzi.io/cluster=my-connect-cluster -o name
 ----


### PR DESCRIPTION
Signed-off-by: Simon Woodman <swoodman@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Documentation

### Description

The syntax of the arguments to kubectl was incorrect so I fixed it. Also replaced `oc` with `kubectl`
