### PR TITLE
Improved readability of Connector docs

### DIFF
--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -10,7 +10,7 @@ When you have created a container image for your connector plug-in, you need to 
 
 * Check the status of a connector instance
 * Increase or decrease the number of tasks for a connector instance
-* Restart failed tasks
+* Restart failed tasks (not supported by `KafkaConnector` resource)
 * Pause a connector instance
 * Delete a connector instance
 
@@ -18,8 +18,6 @@ When you have created a container image for your connector plug-in, you need to 
 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)
 * Kafka Connect REST API
-
-NOTE: Currently, `KafkaConnectors` do not support restarting failed tasks. You need to use the Kafka Connect REST API to do this.
 
 == `KafkaConnector` resources
 

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -8,6 +8,7 @@
 
 When you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster.
 You can then configure, monitor, and manage a running connector instance.
+
 {ProductName} provides two APIs for creating and managing connectors:
 
 * `KafkaConnector` resources (referred to as `KafkaConnectors`)

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -17,9 +17,11 @@ You can then configure, monitor, and manage a running connector instance.
 Using the APIs, you can:
 
 * Check the status of a connector instance
+* Reconfigure a running connector
 * Increase or decrease the number of tasks for a connector instance
 * Restart failed tasks (not supported by `KafkaConnector` resource)
 * Pause a connector instance
+* Resume a previously paused connector instance
 * Delete a connector instance
 
 == `KafkaConnector` resources

--- a/documentation/modules/con-creating-managing-connectors.adoc
+++ b/documentation/modules/con-creating-managing-connectors.adoc
@@ -6,18 +6,20 @@
 
 = Creating and managing connectors
 
-When you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster. You can then configure, monitor, and manage a running connector instance. For example, you can:
+When you have created a container image for your connector plug-in, you need to create a connector instance in your Kafka Connect cluster.
+You can then configure, monitor, and manage a running connector instance.
+{ProductName} provides two APIs for creating and managing connectors:
+
+* `KafkaConnector` resources (referred to as `KafkaConnectors`)
+* Kafka Connect REST API
+
+Using the APIs, you can:
 
 * Check the status of a connector instance
 * Increase or decrease the number of tasks for a connector instance
 * Restart failed tasks (not supported by `KafkaConnector` resource)
 * Pause a connector instance
 * Delete a connector instance
-
-{ProductName} provides two APIs for creating and managing connectors:
-
-* `KafkaConnector` resources (referred to as `KafkaConnectors`)
-* Kafka Connect REST API
 
 == `KafkaConnector` resources
 


### PR DESCRIPTION
Signed-off-by: Simon Woodman <swoodman@redhat.com>

### Type of change

- Documentation

### Description

Potential improvement to the Connector documentation. The current docs are *correct* but I found them confusing unless you really focus on what they say. In one paragraph they state that restarting failed tasks is supported and in the next they say that the `KafkaConnector` resource doesn't support restarting failed tasks. When you understand the underlying structure and the APIs present this makes sense. However, if you are simply a user I think it is a bit hard to understand especially for new users.

I think that this PR improves things by combining the to mentions. However, it's only a suggestion and am happy to be guided by @laidan6000 and @PaulRMellor 