### PR TITLE
Make sure Kafka Connect S2I is reconciling connectors

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -154,7 +154,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
     protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaConnectS2I connects2i) {
         return connectOperations.getAsync(connects2i.getMetadata().getNamespace(), connects2i.getMetadata().getName()).compose(connect -> {
             // If there's a non-s2i of the same name then do nothing, since that takes precedence
-            if (connect == null) {
+            if (connect != null) {
                 return Future.succeededFuture();
             } else {
                 return super.reconcileConnectors(reconciliation, connects2i);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The idea is that when both KafkaConnect and KafkaConnectS2I with the same name exist, the connector reconciliation will be done only for KAfkaconnect which takes precedence. However, the condition in the Kafka Connect S2I operator  works in a way that when no Kafkaconnect is found, the reconciliation of connector is skipped. And only when KafkaConnect with the same name exists it will be done. This PR fixes it and does it the right way.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally