### PR TITLE
Add list of connector plugins to Kafka Connect status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.connect;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation a connector plugin available in the Kafka Connect deployment
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "connectorClass", "type", "version" })
+@EqualsAndHashCode
+public class ConnectorPlugin implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private String connectorClass;
+    private String type;
+    private String version;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("The class of the connector plugin.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @JsonProperty("class")
+    public String getConnectorClass() {
+        return connectorClass;
+    }
+
+    public void setConnectorClass(String connectorClass) {
+        this.connectorClass = connectorClass;
+    }
+
+    @Description("The type of the connector plugin. " +
+            "The available types are `sink` and `source`.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Description("The version of the connector plugin.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}
+

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectS2Istatus.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "buildConfigName" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectorPlugins", "buildConfigName" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectS2Istatus extends KafkaConnectStatus {

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectStatus.java
@@ -6,10 +6,13 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+
+import java.util.List;
 
 /**
  * Represents a status of the Kafka Connect resource
@@ -20,13 +23,14 @@ import lombok.ToString;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectorPlugins" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {
     private static final long serialVersionUID = 1L;
 
     private String url;
+    private List<ConnectorPlugin> connectorPlugins;
 
     @Description("The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.")
     public String getUrl() {
@@ -35,5 +39,15 @@ public class KafkaConnectStatus extends Status {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The list of connector plugins available in this Kafka Connect deployment.")
+    public List<ConnectorPlugin> getConnectorPlugins() {
+        return connectorPlugins;
+    }
+
+    public void setConnectorPlugins(List<ConnectorPlugin> connectorPlugins) {
+        this.connectorPlugins = connectorPlugins;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -27,7 +27,10 @@ import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectorSpec;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.status.HasStatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectS2Istatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -71,7 +74,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyMap;
 
 public abstract class AbstractConnectOperator<C extends KubernetesClient, T extends CustomResource,
-        L extends CustomResourceList<T>, D extends Doneable<T>, R extends Resource<T, D>>
+        L extends CustomResourceList<T>, D extends Doneable<T>, R extends Resource<T, D>, S extends KafkaConnectStatus>
         extends AbstractOperator<T, CrdOperator<C, T, L, D>> {
 
     private static final Logger log = LogManager.getLogger(AbstractConnectOperator.class.getName());
@@ -122,7 +125,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * Create a watch on {@code KafkaConnector} in the given {@code namespace}.
      * The watcher will:
      * <ul>
-     * <li>{@link #reconcileConnectors(Reconciliation, CustomResource)} on the KafkaConnect or KafkaConnectS2I
+     * <li>{@link #reconcileConnectors(Reconciliation, CustomResource, KafkaConnectStatus)} on the KafkaConnect or KafkaConnectS2I
      * identified by {@code KafkaConnector.metadata.labels[strimzi.io/cluster]}.</li>
      * <li>If there is a Connect and ConnectS2I cluster with the given name then the plain Connect one is used
      * (and an error is logged about the ambiguity).</li>
@@ -133,8 +136,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param watchNamespaceOrWildcard The namespace to watch.
      * @return A future which completes when the watch has been set up.
      */
-    public static Future<Void> createConnectorWatch(AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> connectOperator,
-            AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> connectS2IOperator,
+    public static Future<Void> createConnectorWatch(AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>, KafkaConnectStatus> connectOperator,
+            AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>, KafkaConnectS2Istatus> connectS2IOperator,
             String watchNamespaceOrWildcard) {
         return Util.async(connectOperator.vertx, () -> {
             connectOperator.connectorOperator.watch(watchNamespaceOrWildcard, new Watcher<KafkaConnector>() {
@@ -219,18 +222,24 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param connect The connector
      * @return A future, failed if any of the connectors' statuses could not be updated.
      */
-    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect) {
+    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, T connect, S connectStatus) {
         String connectName = connect.getMetadata().getName();
         String namespace = connect.getMetadata().getNamespace();
         String host = KafkaConnectResources.serviceName(connectName);
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
         boolean useResources = isUseResources(connect);
-        return CompositeFuture.join(apiClient.list(host, KafkaConnectCluster.REST_API_PORT),
-                connectorOperator.listAsync(namespace,
-                        Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build()))
+        return CompositeFuture.join(
+                apiClient.list(host, KafkaConnectCluster.REST_API_PORT),
+                connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())),
+                apiClient.listConnectorPlugins(host, KafkaConnectCluster.REST_API_PORT)
         ).compose(cf -> {
             List<String> runningConnectorNames = cf.resultAt(0);
             List<KafkaConnector> desiredConnectors = cf.resultAt(1);
+            List<ConnectorPlugin> connectorPlugins = cf.resultAt(2);
+
+            log.debug("{}: Setting list of connector plugins in Kafka Connect status", reconciliation);
+            connectStatus.setConnectorPlugins(connectorPlugins);
+
             log.debug("{}: {}} cluster: required connectors: {}", reconciliation, kind(), desiredConnectors);
             Set<String> deleteConnectorNames = new HashSet<>(runningConnectorNames);
             deleteConnectorNames.removeAll(desiredConnectors.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.vertx.core.Future;
@@ -19,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -231,7 +231,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             ObjectMapper mapper = new ObjectMapper();
 
                             try {
-                                result.complete(mapper.readValue(buffer.getBytes(), new TypeReference<List<ConnectorPlugin>>() { }));
+                                result.complete(Arrays.asList(mapper.readValue(buffer.getBytes(), ConnectorPlugin[].class)));
                             } catch (IOException e)  {
                                 log.warn("Failed to parse list of connector plugins");
                                 result.fail(e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -42,7 +42,7 @@ import java.util.function.Function;
  *     <li>A Kafka Connect Deployment and related Services</li>
  * </ul>
  */
-public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>> {
+public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, DoneableKafkaConnect, Resource<KafkaConnect, DoneableKafkaConnect>, KafkaConnectStatus> {
 
     private static final Logger log = LogManager.getLogger(KafkaConnectAssemblyOperator.class.getName());
     public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
@@ -109,7 +109,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> deploymentOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()))
                 .compose(i -> deploymentOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                 .compose(i -> deploymentOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
-                .compose(i -> reconcileConnectors(reconciliation, kafkaConnect))
+                .compose(i -> reconcileConnectors(reconciliation, kafkaConnect, kafkaConnectStatus))
                 .setHandler(reconciliationResult -> {
                     StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
                     kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -52,7 +52,7 @@ import java.util.function.Function;
  *     <li>A BuildConfig</li>
  * </ul>
  */
-public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>> {
+public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<OpenShiftClient, KafkaConnectS2I, KafkaConnectS2IList, DoneableKafkaConnectS2I, Resource<KafkaConnectS2I, DoneableKafkaConnectS2I>, KafkaConnectS2Istatus> {
 
     private static final Logger log = LogManager.getLogger(KafkaConnectS2IAssemblyOperator.class.getName());
     public static final String ANNO_STRIMZI_IO_LOGGING = Annotations.STRIMZI_DOMAIN + "/logging";
@@ -125,7 +125,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                     .compose(i -> deploymentConfigOperations.scaleUp(namespace, connect.getName(), connect.getReplicas()))
                     .compose(i -> deploymentConfigOperations.waitForObserved(namespace, connect.getName(), 1_000, operationTimeoutMs))
                     .compose(i -> deploymentConfigOperations.readiness(namespace, connect.getName(), 1_000, operationTimeoutMs))
-                    .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I))
+                    .compose(i -> reconcileConnectors(reconciliation, kafkaConnectS2I, kafkaConnectS2Istatus))
                     .setHandler(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnectS2I, kafkaConnectS2Istatus, reconciliationResult);
                         kafkaConnectS2Istatus.setUrl(KafkaConnectS2IResources.url(connect.getCluster(), namespace, KafkaConnectS2ICluster.REST_API_PORT));
@@ -151,13 +151,13 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
     }
 
     @Override
-    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaConnectS2I connects2i) {
+    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaConnectS2I connects2i, KafkaConnectS2Istatus connects2istatus) {
         return connectOperations.getAsync(connects2i.getMetadata().getNamespace(), connects2i.getMetadata().getName()).compose(connect -> {
             // If there's a non-s2i of the same name then do nothing, since that takes precedence
             if (connect == null) {
                 return Future.succeededFuture();
             } else {
-                return super.reconcileConnectors(reconciliation, connects2i);
+                return super.reconcileConnectors(reconciliation, connects2i, connects2istatus);
             }
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -19,6 +19,8 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
+import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
 import io.strimzi.api.kafka.model.status.HasStatus;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -42,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +105,14 @@ public class ConnectorMockTest {
         runningConnectors = new HashMap<>();
         when(api.list(any(), anyInt())).thenAnswer(i -> {
             return Future.succeededFuture(new ArrayList<>(runningConnectors.keySet()));
+        });
+        when(api.listConnectorPlugins(any(), anyInt())).thenAnswer(i -> {
+            ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                    .withConnectorClass("io.strimzi.MyClass")
+                    .withType("sink")
+                    .withVersion("1.0.0")
+                    .build();
+            return Future.succeededFuture(Collections.singletonList(plugin1));
         });
         when(api.createOrUpdatePutRequest(any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
             String connectorName = invocation.getArgument(2);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -34,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(VertxExtension.class)
@@ -105,12 +106,14 @@ public class KafkaConnectApiTest {
                 ConnectorPlugin fileSink = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSinkConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
                 assertNotNull(fileSink);
                 assertEquals(fileSink.getType(), "sink");
-                assertEquals(fileSink.getVersion(), "2.3.1");
+                assertNotNull(fileSink.getVersion());
+                assertFalse(fileSink.getVersion().isEmpty());
 
                 ConnectorPlugin fileSource = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSourceConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
                 assertNotNull(fileSource);
                 assertEquals(fileSource.getType(), "source");
-                assertEquals(fileSource.getVersion(), "2.3.1");
+                assertNotNull(fileSource.getVersion());
+                assertFalse(fileSource.getVersion().isEmpty());
 
                 return client.list("localhost", PORT);
             })

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.debezium.kafka.KafkaCluster;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -33,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiTest {
@@ -96,7 +98,22 @@ public class KafkaConnectApiTest {
     public void test(VertxTestContext context) throws InterruptedException {
         KafkaConnectApi client = new KafkaConnectApiImpl(vertx);
         CountDownLatch async = new CountDownLatch(1);
-        client.list("localhost", PORT)
+        client.listConnectorPlugins("localhost", PORT)
+            .compose(connectorPlugins -> {
+                assertEquals(connectorPlugins.size(), 2);
+
+                ConnectorPlugin fileSink = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSinkConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
+                assertNotNull(fileSink);
+                assertEquals(fileSink.getType(), "sink");
+                assertEquals(fileSink.getVersion(), "2.3.1");
+
+                ConnectorPlugin fileSource = connectorPlugins.stream().filter(connector -> "org.apache.kafka.connect.file.FileStreamSourceConnector".equals(connector.getConnectorClass())).findFirst().orElse(null);
+                assertNotNull(fileSource);
+                assertEquals(fileSource.getType(), "source");
+                assertEquals(fileSource.getVersion(), "2.3.1");
+
+                return client.list("localhost", PORT);
+            })
             .compose(connectorNames -> {
                 assertEquals(emptyList(), connectorNames);
                 JsonObject o = new JsonObject()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -140,6 +140,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
             .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
         when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         KafkaConnectAssemblyOperator kco = createConnectCluster(context,
                 mock);
         LOGGER.info("Reconciling again -> update");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -15,6 +15,8 @@ import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
+import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -59,6 +61,7 @@ import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -131,6 +134,13 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
+
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
@@ -174,6 +184,10 @@ public class KafkaConnectAssemblyOperatorTest {
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
             async.flag();
         });
     }
@@ -225,6 +239,13 @@ public class KafkaConnectAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -330,6 +351,13 @@ public class KafkaConnectAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -477,6 +505,13 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
+
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
 
@@ -534,6 +569,13 @@ public class KafkaConnectAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -17,6 +17,8 @@ import io.strimzi.api.kafka.model.DoneableKafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectS2I;
 import io.strimzi.api.kafka.model.KafkaConnectS2IResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
+import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -64,6 +66,7 @@ import java.util.concurrent.TimeoutException;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -145,6 +148,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
+
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
 
         ArgumentCaptor<KafkaConnectS2I> connectCaptor = ArgumentCaptor.forClass(KafkaConnectS2I.class);
@@ -207,6 +217,10 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
             context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
+            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
 
             async.flag();
         });
@@ -283,6 +297,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -410,6 +431,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
@@ -602,6 +630,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
+
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
@@ -671,6 +706,13 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
         when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
         KafkaConnectS2IAssemblyOperator ops = new KafkaConnectS2IAssemblyOperator(vertx, pfa,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -341,7 +341,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         });
     }
 
-    @SuppressWarnings("checkstyle:JavaNCSS")
+    @SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     @Test
     public void testUpdateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1706,6 +1706,25 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |integer
 |url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
+|connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
+|xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
+|====
+
+[id='type-ConnectorPlugin-{context}']
+### `ConnectorPlugin` schema reference
+
+Used in: xref:type-KafkaConnectS2Istatus-{context}[`KafkaConnectS2Istatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`]
+
+
+[options="header"]
+|====
+|Property        |Description
+|type     1.2+<.<|The type of the connector plugin. The available types are `sink` and `source`.
+|string
+|version  1.2+<.<|The version of the connector plugin.
+|string
+|class    1.2+<.<|The class of the connector plugin.
+|string
 |====
 
 [id='type-KafkaConnectS2I-{context}']
@@ -1793,6 +1812,8 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |string
 |buildConfigName     1.2+<.<|The name of the build configuration.
 |string
+|connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
+|xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
 |====
 
 [id='type-KafkaTopic-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1810,10 +1810,10 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |integer
 |url                 1.2+<.<|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|buildConfigName     1.2+<.<|The name of the build configuration.
-|string
 |connectorPlugins    1.2+<.<|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
+|buildConfigName     1.2+<.<|The name of the build configuration.
+|string
 |====
 
 [id='type-KafkaTopic-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -896,4 +896,15 @@ spec:
               type: integer
             url:
               type: string
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                  class:
+                    type: string
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -905,8 +905,6 @@ spec:
               type: integer
             url:
               type: string
-            buildConfigName:
-              type: string
             connectorPlugins:
               type: array
               items:
@@ -918,4 +916,6 @@ spec:
                     type: string
                   class:
                     type: string
+            buildConfigName:
+              type: string
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -907,4 +907,15 @@ spec:
               type: string
             buildConfigName:
               type: string
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                  class:
+                    type: string
 {{- end -}}

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -891,3 +891,14 @@ spec:
               type: integer
             url:
               type: string
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                  class:
+                    type: string

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -900,8 +900,6 @@ spec:
               type: integer
             url:
               type: string
-            buildConfigName:
-              type: string
             connectorPlugins:
               type: array
               items:
@@ -913,3 +911,5 @@ spec:
                     type: string
                   class:
                     type: string
+            buildConfigName:
+              type: string

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -902,3 +902,14 @@ spec:
               type: string
             buildConfigName:
               type: string
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                  class:
+                    type: string


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

One of the things user needs to know to manage connectors using the Connector operator is which connectors are available in the Connect deployment. This PR adds list of available plugins to Kafka Connect and Kafka Connect S2I resources.

The status with this change looks something like this:

```
status:
  buildConfigName: my-connect-cluster-connect
  conditions:
  - lastTransitionTime: "2020-01-18T17:43:26.736Z"
    status: "True"
    type: Ready
  connectorPlugins:
  - class: cz.scholz.kafka.connect.echosink.EchoSinkConnector
    type: sink
    version: 1.0.0
  - class: org.apache.kafka.connect.file.FileStreamSinkConnector
    type: sink
    version: 2.4.0
  - class: org.apache.kafka.connect.file.FileStreamSourceConnector
    type: source
    version: 2.4.0
  - class: org.apache.kafka.connect.mirror.MirrorCheckpointConnector
    type: source
    version: "1"
  - class: org.apache.kafka.connect.mirror.MirrorHeartbeatConnector
    type: source
    version: "1"
  - class: org.apache.kafka.connect.mirror.MirrorSourceConnector
    type: source
    version: "1"
  observedGeneration: 1
  url: http://my-connect-cluster-connect-api.myproject.svc:8083
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally