### PR TITLE
SystemTest: wait for s2i cluster to be rebalanced

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -29,4 +29,15 @@ public class KafkaConnectS2IUtils {
             () -> Crds.kafkaConnectS2iOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace()).withName(name).get().getStatus().getConditions().get(0).getType().equals(status));
         LOGGER.info("Kafka Connect S2I {} is in desired state: {}", name, status);
     }
+
+    public static void waitForRebalancingDone(String name) {
+        LOGGER.info("Waiting for Kafka Connect S2I {} to rebalance", name);
+        TestUtils.waitFor("Kafka Connect S2I rebalancing", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
+            () -> {
+                String connect = kubeClient().listPodNames("strimzi.io/kind", "KafkaConnectS2I").get(0);
+                String log = kubeClient().logs(connect);
+                return (log.length() - log.replace("Finished starting connectors and tasks", "").length()) / "Finished starting connectors and tasks".length() == 2;
+            });
+        LOGGER.info("Kafka Connect S2I {} rebalanced", name);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectS2IUtils.java
@@ -36,6 +36,7 @@ public class KafkaConnectS2IUtils {
             () -> {
                 String connect = kubeClient().listPodNames("strimzi.io/kind", "KafkaConnectS2I").get(0);
                 String log = kubeClient().logs(connect);
+                // wait for second occurrence of message about finished rebalancing
                 return (log.length() - log.replace("Finished starting connectors and tasks", "").length()) / "Finished starting connectors and tasks".length() == 2;
             });
         LOGGER.info("Kafka Connect S2I {} rebalanced", name);

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -86,8 +86,7 @@ class ConnectS2IST extends BaseST {
         KafkaConnectS2IUtils.waitForConnectS2IStatus(kafkaConnectS2IName, "Ready");
 
         // Make sure that Connenct API is ready
-        // TODO remove this sleep when ENTMQST-1613 will be fixed
-        Thread.sleep(10_000);
+        KafkaConnectS2IUtils.waitForRebalancingDone(kafkaConnectS2IName);
 
         checkConnectorInStatus(NAMESPACE, kafkaConnectS2IName);
 
@@ -109,8 +108,7 @@ class ConnectS2IST extends BaseST {
         String podForExecName = deployConnectS2IWithMongoDb(kafkaConnectS2IName);
 
         // Make sure that Connenct API is ready
-        // TODO remove this sleep when ENTMQST-1613 will be fixed
-        Thread.sleep(10_000);
+        KafkaConnectS2IUtils.waitForRebalancingDone(kafkaConnectS2IName);
 
         KafkaConnectorResource.kafkaConnector(kafkaConnectS2IName)
             .withNewSpec()


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
In the test, we are waiting for the rolling update of Connect S2I cluster. There is a small time window when the leader is lost and the follower tries to connect to it, what obviously fails. After some discussion with @scholzj we decided not to check whole cluster status in operator but rather adjust the tests.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

