### PR TITLE
[Draft] Introduce tls user with external CA to user operator

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthentication.java
@@ -20,6 +20,7 @@ import java.util.Map;
 @JsonSubTypes({
         @JsonSubTypes.Type(name = KafkaUserTlsClientAuthentication.TYPE_TLS, value = KafkaUserTlsClientAuthentication.class),
         @JsonSubTypes.Type(name = KafkaUserScramSha512ClientAuthentication.TYPE_SCRAM_SHA_512, value = KafkaUserScramSha512ClientAuthentication.class),
+        @JsonSubTypes.Type(name = KafkaUserTlsClientAuthenticationExternalCa.TYPE_TLS, value = KafkaUserTlsClientAuthenticationExternalCa.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthenticationExternalCa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthenticationExternalCa.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+public class KafkaUserTlsClientAuthenticationExternalCa extends KafkaUserAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_TLS = "tls-external-ca";
+    private String name;
+
+    @Description("Must be `" + TYPE_TLS + "`")
+    @Override
+    public String getType() {
+        return TYPE_TLS;
+    }
+
+    @Description("Authentication CN name.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -31,6 +31,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * <p>Abstract assembly creation, update, read, deletion, etc.</p>
@@ -92,7 +93,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
         this.operationTimeoutMs = config.getOperationTimeoutMs();
     }
 
-    protected Future<Boolean> delete(Reconciliation reconciliation) {
+    protected Future<Boolean> delete(Reconciliation reconciliation, Optional<T> resource) {
         return Future.succeededFuture(Boolean.FALSE);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -110,7 +110,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     @Override
-    protected Future<Boolean> delete(Reconciliation reconciliation) {
+    protected Future<Boolean> delete(Reconciliation reconciliation, Optional<T> resource) {
         // When deleting KafkaConnect we need to update the status of all selected KafkaConnector
         return connectorOperator.listAsync(reconciliation.namespace(), Labels.forCluster(reconciliation.name())).compose(connectors -> {
             List<Future> connectorFutures = new ArrayList<>();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1885,8 +1885,8 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [options="header"]
 |====
 |Property               |Description
-|authentication  1.2+<.<|Authentication mechanism enabled for this Kafka user. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512].
-|xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`]
+|authentication  1.2+<.<|Authentication mechanism enabled for this Kafka user. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, tls-external-ca].
+|xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`], xref:type-KafkaUserTlsClientAuthenticationExternalCa-{context}[`KafkaUserTlsClientAuthenticationExternalCa`]
 |authorization   1.2+<.<|Authorization rules for this Kafka user. The type depends on the value of the `authorization.type` property within the given object, which must be one of [simple].
 |xref:type-KafkaUserAuthorizationSimple-{context}[`KafkaUserAuthorizationSimple`]
 |quotas          1.2+<.<|Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
@@ -1899,7 +1899,7 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaUserTlsClientAuthentication` from xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaUserTlsClientAuthentication` from xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`], xref:type-KafkaUserTlsClientAuthenticationExternalCa-{context}[`KafkaUserTlsClientAuthenticationExternalCa`].
 It must have the value `tls` for the type `KafkaUserTlsClientAuthentication`.
 [options="header"]
 |====
@@ -1914,12 +1914,29 @@ It must have the value `tls` for the type `KafkaUserTlsClientAuthentication`.
 Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
 
 
-The `type` property is a discriminator that distinguishes the use of the type `KafkaUserScramSha512ClientAuthentication` from xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`].
+The `type` property is a discriminator that distinguishes the use of the type `KafkaUserScramSha512ClientAuthentication` from xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserTlsClientAuthenticationExternalCa-{context}[`KafkaUserTlsClientAuthenticationExternalCa`].
 It must have the value `scram-sha-512` for the type `KafkaUserScramSha512ClientAuthentication`.
 [options="header"]
 |====
 |Property     |Description
 |type  1.2+<.<|Must be `scram-sha-512`.
+|string
+|====
+
+[id='type-KafkaUserTlsClientAuthenticationExternalCa-{context}']
+### `KafkaUserTlsClientAuthenticationExternalCa` schema reference
+
+Used in: xref:type-KafkaUserSpec-{context}[`KafkaUserSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `KafkaUserTlsClientAuthenticationExternalCa` from xref:type-KafkaUserTlsClientAuthentication-{context}[`KafkaUserTlsClientAuthentication`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`].
+It must have the value `tls-external-ca` for the type `KafkaUserTlsClientAuthenticationExternalCa`.
+[options="header"]
+|====
+|Property     |Description
+|name  1.2+<.<|Authentication CN name.
+|string
+|type  1.2+<.<|Must be `tls-external-ca`.
 |string
 |====
 

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -42,11 +42,14 @@ spec:
             authentication:
               type: object
               properties:
+                name:
+                  type: string
                 type:
                   type: string
                   enum:
                   - tls
                   - scram-sha-512
+                  - tls-external-ca
               required:
               - type
             authorization:

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.KafkaUserAuthorizationSimple;
 import io.strimzi.api.kafka.model.KafkaUserQuotas;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
+import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthenticationExternalCa;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
@@ -44,6 +45,7 @@ public class KafkaUserModel {
     private static final Logger log = LogManager.getLogger(KafkaUserModel.class.getName());
 
     public static final String KEY_PASSWORD = "password";
+    public static final String FINALIZER = "io.strimzi.api.kafka.model.kafka_user";
 
     protected final String namespace;
     protected final String name;
@@ -305,6 +307,26 @@ public class KafkaUserModel {
     }
 
     /**
+     * Generates the name of the User secret based on the username
+     *
+     * @param username The username.
+     * @return The TLS user name.
+     */
+//    public static String getTlsUserName(String username)    {
+//        return "CN=" + username;
+//    }
+
+    /**
+     * Generates the name of the User secret based on the username
+     *
+     * @param username The username.
+     * @return The TLS user name.
+     */
+    public static String getTlsUserName(String username)    {
+        return "CN=" + username;
+    }
+
+    /**
      * Decodes the name of the User secret based on the username
      *
      * @param username The username.
@@ -328,22 +350,28 @@ public class KafkaUserModel {
      * Generates the name of the User secret based on the username
      *
      * @param username The username.
-     * @return The TLS user name.
-     */
-    public static String getTlsUserName(String username)    {
-        return "CN=" + username;
-    }
-
-    /**
-     * Generates the name of the User secret based on the username
-     *
-     * @param username The username.
      * @return The SCRAM user name.
      */
     public static String getScramUserName(String username)    {
         return username;
     }
 
+    /**
+     * Gets the Username
+     *
+     * @param username The username.
+     * @param authentication KafkaUserAuthentication.
+     * @return The user name.
+     */
+    public static String getUserName(String username, KafkaUserAuthentication authentication)    {
+        if (authentication instanceof KafkaUserTlsClientAuthenticationExternalCa) {
+            return ((KafkaUserTlsClientAuthenticationExternalCa) authentication).getName();
+        } else if (authentication instanceof KafkaUserTlsClientAuthentication) {
+            return "CN=" + username;
+        } else {
+            return username;
+        }
+    }
     /**
      * Gets the Username
      *
@@ -357,6 +385,15 @@ public class KafkaUserModel {
         } else {
             return getName();
         }
+    }
+    /**
+     * Generates the name of the User secret based on the username
+     *
+     * @param username The username.
+     * @return The SCRAM user name.
+     */
+    public static String getTlsUserNameFromExeternalCa(String username)    {
+        return username;
     }
 
     /**

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -375,7 +375,7 @@ public class KafkaUserOperatorTest {
         KafkaUserOperator op = new KafkaUserOperator(vertx, mockCertManager, mockCrdOps, Labels.EMPTY, mockSecretOps, scramOps, quotasOps, aclOps, ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME, ResourceUtils.NAMESPACE);
 
         Checkpoint async = context.checkpoint();
-        op.delete(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME)).setHandler(res -> {
+        op.delete(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), Optional.ofNullable(ResourceUtils.createKafkaUserTls())).setHandler(res -> {
             context.verify(() -> assertThat(res.succeeded(), is(true)));
 
             List<String> capturedNames = secretNameCaptor.getAllValues();
@@ -668,7 +668,7 @@ public class KafkaUserOperatorTest {
                 return h;
             }
             @Override
-            public Future<Boolean> delete(Reconciliation reconciliation) {
+            public Future<Boolean> delete(Reconciliation reconciliation, Optional<KafkaUser> resource) {
                 deleted.add(reconciliation.name());
                 async.countDown();
                 return Future.succeededFuture(Boolean.TRUE);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description
This pr is created in regards to #2358; However, the implementation is diff from what we had discussed in the issue since I would like to support a full Tls user name (e.g. `CN=frankie.test.org.com`) in the user cr; 
In order to do so, the user operator should be able to support the following features:
- be able to get the username from the user spec object when creation/update/delete
- be able to get the cr object upon deletion

However, the current deletion interface from `AbstractOperator` is not able to provide the cr object upon deletion as it treats a cr object would be deleted in k8s immediately when the deletion event happened and the operator deems a user cr as deleted based on the k8s cr removed;

#### Therefore, I decided to add more feature to the `AbstractOperator`:
- extend the delete method to accept an `Optional<T>` so as to provide user cr object while other operators who might not care too much could just provide an option empty;
- refactor the reconcile method to support optionally adding a finalizer based on whether a concrete operator has provided the finalizer or not; the finalizer is an `Optional<Stirng>`;
- remove its own finalizer upon deletion operation;

#### Additional Refactors:
- Also adding some small refactoring in `KafkaUserOperator` to try to clean up the code a little bit;
- Add a new type `KafkaUserTlsClientAuthenticationExternalCa` as `KafkaUserAuthentication` to distinguish from the existing two types as the behavior is very different in my opinion; (the name is pretty verbose and not sure if there could be a better name for it);

This pr is a draft but able to run with the new user type; open it for collecting more feedbacks and discussions;

#### an example of the tls user with external ca type could be:
```
apiVersion: kafka.strimzi.io/v1beta1
kind: KafkaUser
metadata:
  name: "my-auth-user"
  labels:
    strimzi.io/cluster: minikube
spec:
  authentication:
    type: tls-external-ca
    name: CN=frankie.test.org.com
  authorization:
    type: simple
    acls:
      - type: allow
        resource:
          type: topic
          name: my-topic
          patternType: prefix
        operation: Read
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

