### PR TITLE
Add strimzi category to our CRDs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -43,7 +43,7 @@ import static java.util.Collections.singletonList;
 public class Crds {
 
     public static final String CRD_KIND = "CustomResourceDefinition";
-    public static final String CRD_CATEGORY = "strimzi";
+    public static final String STRIMZI_CATEGORY = "strimzi";
 
     @SuppressWarnings("unchecked")
     private static final Class<? extends CustomResource>[] CRDS = new Class[] {

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -43,6 +43,7 @@ import static java.util.Collections.singletonList;
 public class Crds {
 
     public static final String CRD_KIND = "CustomResourceDefinition";
+    public static final String CRD_CATEGORY = "strimzi";
 
     @SuppressWarnings("unchecked")
     private static final Class<? extends CustomResource>[] CRDS = new Class[] {

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = Kafka.RESOURCE_KIND,
                         plural = Kafka.RESOURCE_PLURAL,
                         shortNames = {Kafka.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = Kafka.RESOURCE_GROUP,
                 scope = Kafka.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -37,7 +38,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = Kafka.RESOURCE_KIND,
                         plural = Kafka.RESOURCE_PLURAL,
-                        shortNames = {Kafka.SHORT_NAME}
+                        shortNames = {Kafka.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = Kafka.RESOURCE_GROUP,
                 scope = Kafka.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -37,7 +38,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaBridge.RESOURCE_KIND,
                         plural = KafkaBridge.RESOURCE_PLURAL,
-                        shortNames = {KafkaBridge.SHORT_NAME}
+                        shortNames = {KafkaBridge.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaBridge.RESOURCE_GROUP,
                 scope = KafkaBridge.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaBridge.RESOURCE_KIND,
                         plural = KafkaBridge.RESOURCE_PLURAL,
                         shortNames = {KafkaBridge.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaBridge.RESOURCE_GROUP,
                 scope = KafkaBridge.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -37,7 +38,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaConnect.RESOURCE_KIND,
                         plural = KafkaConnect.RESOURCE_PLURAL,
-                        shortNames = {KafkaConnect.SHORT_NAME}
+                        shortNames = {KafkaConnect.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaConnect.RESOURCE_GROUP,
                 scope = KafkaConnect.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaConnect.RESOURCE_KIND,
                         plural = KafkaConnect.RESOURCE_PLURAL,
                         shortNames = {KafkaConnect.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaConnect.RESOURCE_GROUP,
                 scope = KafkaConnect.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -42,7 +42,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaConnectS2I.RESOURCE_KIND,
                         plural = KafkaConnectS2I.RESOURCE_PLURAL,
                         shortNames = {KafkaConnectS2I.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaConnectS2I.RESOURCE_GROUP,
                 scope = KafkaConnectS2I.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectS2I.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
@@ -40,7 +41,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaConnectS2I.RESOURCE_KIND,
                         plural = KafkaConnectS2I.RESOURCE_PLURAL,
-                        shortNames = {KafkaConnectS2I.SHORT_NAME}
+                        shortNames = {KafkaConnectS2I.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaConnectS2I.RESOURCE_GROUP,
                 scope = KafkaConnectS2I.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -35,7 +35,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaConnector.RESOURCE_KIND,
                         plural = KafkaConnector.RESOURCE_PLURAL,
                         shortNames = {KafkaConnector.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaConnector.RESOURCE_GROUP,
                 scope = KafkaConnector.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -33,7 +34,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaConnector.RESOURCE_KIND,
                         plural = KafkaConnector.RESOURCE_PLURAL,
-                        shortNames = {KafkaConnector.SHORT_NAME}
+                        shortNames = {KafkaConnector.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaConnector.RESOURCE_GROUP,
                 scope = KafkaConnector.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -37,7 +38,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaMirrorMaker.RESOURCE_KIND,
                         plural = KafkaMirrorMaker.RESOURCE_PLURAL,
-                        shortNames = {KafkaMirrorMaker.SHORT_NAME}
+                        shortNames = {KafkaMirrorMaker.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaMirrorMaker.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaMirrorMaker.RESOURCE_KIND,
                         plural = KafkaMirrorMaker.RESOURCE_PLURAL,
                         shortNames = {KafkaMirrorMaker.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaMirrorMaker.RESOURCE_GROUP,
                 scope = KafkaMirrorMaker.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaTopic.RESOURCE_KIND,
                         plural = KafkaTopic.RESOURCE_PLURAL,
                         shortNames = {KafkaTopic.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaTopic.RESOURCE_GROUP,
                 scope = KafkaTopic.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -37,7 +38,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaTopic.RESOURCE_KIND,
                         plural = KafkaTopic.RESOURCE_PLURAL,
-                        shortNames = {KafkaTopic.SHORT_NAME}
+                        shortNames = {KafkaTopic.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaTopic.RESOURCE_GROUP,
                 scope = KafkaTopic.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
+import static io.strimzi.api.kafka.Crds.STRIMZI_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -38,7 +38,7 @@ import static java.util.Collections.unmodifiableList;
                         kind = KafkaUser.RESOURCE_KIND,
                         plural = KafkaUser.RESOURCE_PLURAL,
                         shortNames = {KafkaUser.SHORT_NAME},
-                        categories = {CRD_CATEGORY}
+                        categories = {STRIMZI_CATEGORY}
                 ),
                 group = KafkaUser.RESOURCE_GROUP,
                 scope = KafkaUser.SCOPE,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.api.kafka.Crds.CRD_CATEGORY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -36,7 +37,8 @@ import static java.util.Collections.unmodifiableList;
                 names = @Crd.Spec.Names(
                         kind = KafkaUser.RESOURCE_KIND,
                         plural = KafkaUser.RESOURCE_PLURAL,
-                        shortNames = {KafkaUser.SHORT_NAME}
+                        shortNames = {KafkaUser.SHORT_NAME},
+                        categories = {CRD_CATEGORY}
                 ),
                 group = KafkaUser.RESOURCE_GROUP,
                 scope = KafkaUser.SCOPE,

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -283,6 +283,10 @@ public class CrdGenerator {
         if (names.shortNames().length > 0) {
             result.set("shortNames", stringArray(asList(names.shortNames())));
         }
+
+        if (names.categories().length > 0) {
+            result.set("categories", stringArray(asList(names.categories())));
+        }
         return result;
     }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -69,6 +69,11 @@ public @interface Crd {
              * @return Short names (e.g. "svc" is the short name for the K8S "services" kind).
              */
             String[] shortNames() default {};
+
+            /**
+             * @return A list of grouped resources custom resources belong to.
+             */
+            String[] categories() default {};
         }
 
         /**

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -27,7 +27,8 @@ import java.util.Map;
         group = "crdgenerator.strimzi.io",
         names = @Crd.Spec.Names(
             kind = "Example",
-            plural = "examples"),
+            plural = "examples",
+            categories = {"strimzi"}),
         scope = "Namespaced",
         version = "v1alpha1",
     versions = {

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/TopicCrd.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 
-@Crd(apiVersion = "v1beta1", spec = @Crd.Spec(group = "strimzi.io", names = @Crd.Spec.Names(kind = "Topic", plural = "topics"), scope = "Namespaced", version = "v1alpha1"))
+@Crd(apiVersion = "v1beta1", spec = @Crd.Spec(group = "strimzi.io", names = @Crd.Spec.Names(kind = "Topic", plural = "topics", categories = "strimzi"), scope = "Namespaced", version = "v1alpha1"))
 public class TopicCrd extends CustomResource {
 
     public String name;

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -18,6 +18,8 @@ spec:
     listKind: "ExampleList"
     singular: "example"
     plural: "examples"
+    categories:
+    - "strimzi"
   additionalPrinterColumns:
   - name: "Foo"
     description: "The foo"

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -24,6 +24,8 @@ spec:
     listKind: "ExampleList"
     singular: "example"
     plural: "examples"
+    categories:
+    - "strimzi"
   additionalPrinterColumns:
   - name: "Foo"
     description: "The foo"

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkas
     shortNames:
     - k
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired Kafka replicas
     description: The desired number of Kafka replicas in the cluster

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkaconnects
     shortNames:
     - kc
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Connect replicas

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkaconnects2is
     shortNames:
     - kcs2i
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Connect replicas

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkatopics
     shortNames:
     - kt
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Partitions
     description: The desired number of partitions in the topic

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkausers
     shortNames:
     - ku
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Authentication
     description: How the user is authenticated

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -27,6 +27,8 @@ spec:
     plural: kafkamirrormakers
     shortNames:
     - kmm
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Mirror Maker replicas

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -24,6 +24,8 @@ spec:
     plural: kafkabridges
     shortNames:
     - kb
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Bridge replicas

--- a/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -24,6 +24,8 @@ spec:
     plural: kafkaconnectors
     shortNames:
     - kctr
+    categories:
+    - strimzi
   subresources:
     status: {}
   validation:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkas
     shortNames:
     - k
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired Kafka replicas
     description: The desired number of Kafka replicas in the cluster

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkaconnects
     shortNames:
     - kc
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Connect replicas

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkaconnects2is
     shortNames:
     - kcs2i
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Connect replicas

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkatopics
     shortNames:
     - kt
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Partitions
     description: The desired number of partitions in the topic

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkausers
     shortNames:
     - ku
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Authentication
     description: How the user is authenticated

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkamirrormakers
     shortNames:
     - kmm
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Mirror Maker replicas

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -19,6 +19,8 @@ spec:
     plural: kafkabridges
     shortNames:
     - kb
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Desired replicas
     description: The desired number of Kafka Bridge replicas

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -19,6 +19,8 @@ spec:
     plural: kafkaconnectors
     shortNames:
     - kctr
+    categories:
+    - strimzi
   subresources:
     status: {}
   validation:

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkatopics
     shortNames:
     - kt
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Partitions
     description: The desired number of partitions in the topic

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -22,6 +22,8 @@ spec:
     plural: kafkausers
     shortNames:
     - ku
+    categories:
+    - strimzi
   additionalPrinterColumns:
   - name: Authentication
     description: How the user is authenticated


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2427
We can get all strimzi CRs by `kubectl get strimzi`, for example
```
[sknot@sknot strimzi-kafka-operator]$ kubectl get strimzi
NAME       PARTITIONS   REPLICATION FACTOR
my-topic   1            1

NAME         DESIRED KAFKA REPLICAS   DESIRED ZK REPLICAS
my-cluster   1                        1

NAME      AUTHENTICATION   AUTHORIZATION
my-user   tls              simple

NAME                  AGE
my-source-connector   21s

NAME        DESIRED REPLICAS
my-bridge   1
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

