### PR TITLE
[DOC] New doc assembly to describe Oauth 2.0 authorization

### DIFF
--- a/documentation/assemblies/assembly-access-configuration-kafka-mirror-maker.adoc
+++ b/documentation/assemblies/assembly-access-configuration-kafka-mirror-maker.adoc
@@ -11,7 +11,7 @@ Configure Kafka Mirror Maker encryption and authentication using supported mecha
 * Authentication:
 ** TLS client authentication
 ** SASL SCRAM-SHA-512 and PLAIN authentication
-** xref:assembly-oauth-str[{oauth} token-based authentication]
+** xref:assembly-oauth-authentication_str[{oauth} token-based authentication]
 +
 For more information on the TLS and SASL authentication mechanisms, see xref:con-kafka-mirror-maker-authentication-{context}[Authentication].
 

--- a/documentation/assemblies/assembly-configuring-kafka-listeners.adoc
+++ b/documentation/assemblies/assembly-configuring-kafka-listeners.adoc
@@ -18,7 +18,7 @@ The following types of listeners are supported:
 
 .{oauth}
 If you are using {oauth} token-based authentication, you can configure the listeners to connect to your authorization server.
-For more information, see xref:assembly-oauth-str[Using {oauth} token-based authentication].
+For more information, see xref:assembly-oauth-authentication_str[Using {oauth} token-based authentication].
 
 .Listener certificates
 You can provide your own server certificates, called _Kafka listener certificates_, for TLS listeners or external listeners which have TLS encryption enabled. 

--- a/documentation/assemblies/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration.adoc
@@ -18,6 +18,7 @@ This chapter describes how to configure different aspects of the supported deplo
 * Kafka Mirror Maker
 * Kafka Bridge
 * {oauth} token-based authentication
+* {oauth} token-based authorization
 
 include::assembly-deployment-configuration-kafka.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/assembly-deployment-configuration.adoc
@@ -29,7 +29,9 @@ include::assembly-deployment-configuration-kafka-mirror-maker.adoc[leveloffset=+
 
 include::assembly-deployment-configuration-kafka-bridge.adoc[leveloffset=+1]
 
-include::oauth/assembly-oauth.adoc[leveloffset=+1]
+include::oauth/assembly-oauth-authentication.adoc[leveloffset=+1]
+
+include::oauth/assembly-oauth-authorization.adoc[leveloffset=+1]
 
 include::assembly-customizing-deployments.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
@@ -2,15 +2,15 @@
 //
 // assembly-deployment-configuration.adoc
 
-[id='assembly-oauth-{context}']
+[id='assembly-oauth-authentication_{context}']
 = Using {oauth} token-based authentication
 
 {ProductName} supports the use of {oauth} authentication using the _SASL OAUTHBEARER_ mechanism.
 
 {oauth} enables standardized token-based authentication and authorization between applications, using a central authorization server to issue tokens that grant limited access to resources.
 
-In {ProductName}, {oauth} is currently only supported for authentication, with no authorization support.
-However, {oauth} authentication can be used in conjunction with xref:simple-acl-using-uo[ACL-based Kafka authorization].
+You can configure {oauth} authentication, then xref:assembly-oauth-authorization_{context}[{oauth} authorization].
+{oauth} authentication can also be used in conjunction with xref:simple-acl-using-uo[ACL-based Kafka authorization].
 
 Using {oauth} token-based authentication, application clients can access resources on application servers (called _resource servers_) without exposing account credentials.
 

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -5,28 +5,28 @@
 [id='assembly-oauth-authorization_{context}']
 = Using {oauth} token-based authorization
 
-{ProductName} supports the use of {oauth} authorization through  {oauth-server} Authorization Services,
-which allow you to manage security policies and permissions centrally.
-
-Security policies and permissions are used to grant access to Kafka brokers.
-Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
-
 If you are using {oauth} with {oauth-server} for token-based authentication,
 you can also use  {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 
+{ProductName} supports the use of {oauth} token-based authorization through {oauth-server} {oauth-authorization-services},
+which allows you to manage security policies and permissions centrally.
+
+Security policies and permissions defined in {oauth-server} are used to grant access to Kafka brokers.
+Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
+
 Kafka allows all users full access to brokers by default,
 and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
 ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
-However, {oauth} authorization with  {oauth-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+However, {oauth} token-based authorization with  {oauth-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
 
 .Additional resources
 
 * xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
 * xref:simple-acl-using-uo[ACL authorization]
-* {oauth-keycloak-doc}
+* {oauth-server-doc}
 
 include::modules/con-oauth-authorization-mechanism.adoc[leveloffset=+1]
 include::modules/proc-oauth-authorization-broker-config.adoc[leveloffset=+1]

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -13,7 +13,7 @@ Authorization decides the level of access for that user.
 {ProductName} supports the use of {oauth} token-based authorization through {oauth-server} {oauth-authorization-services},
 which allows you to manage security policies and permissions centrally.
 
-Security policies and permissions defined in {oauth-server} are used to grant access to Kafka brokers.
+Security policies and permissions defined in {oauth-server} are used to grant access to resources on Kafka brokers.
 Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
 
 Kafka allows all users full access to brokers by default,

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -5,21 +5,21 @@
 [id='assembly-oauth-authorization_{context}']
 = Using {oauth} token-based authorization
 
-If you are using {oauth} with {oauth-server} for token-based authentication,
-you can also use {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
+If you are using {oauth} with {keycloak-server} for token-based authentication,
+you can also use {keycloak-server} to configure authorization rules to constrain client access to Kafka brokers.
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 
-{ProductName} supports the use of {oauth} token-based authorization through {oauth-server} {oauth-authorization-services},
+{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {oauth-authorization-services},
 which allows you to manage security policies and permissions centrally.
 
-Security policies and permissions defined in {oauth-server} are used to grant access to resources on Kafka brokers.
+Security policies and permissions defined in {keycloak-server} are used to grant access to resources on Kafka brokers.
 Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
 
 Kafka allows all users full access to brokers by default,
 and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
 ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
-However, {oauth} token-based authorization with  {oauth-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+However, {oauth} token-based authorization with  {keycloak-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
 
 .Additional resources

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -10,7 +10,7 @@ you can also use {keycloak-server} to configure authorization rules to constrain
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 
-{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {oauth-authorization-services},
+{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {keycloak-authorization-services},
 which allows you to manage security policies and permissions centrally.
 
 Security policies and permissions defined in {keycloak-server} are used to grant access to resources on Kafka brokers.
@@ -26,7 +26,7 @@ In addition, you can configure your Kafka brokers to use {oauth} authorization a
 
 * xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
 * xref:simple-acl-using-uo[ACL authorization]
-* {oauth-server-doc}
+* {keycloak-server-doc}
 
 include::modules/con-oauth-authorization-mechanism.adoc[leveloffset=+1]
 include::modules/proc-oauth-authorization-broker-config.adoc[leveloffset=+1]

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -6,7 +6,7 @@
 = Using {oauth} token-based authorization
 
 If you are using {oauth} with {oauth-server} for token-based authentication,
-you can also use  {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
+you can also use {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -13,7 +13,6 @@ Users and clients are matched against policies that permit access to perform spe
 
 If you are using {oauth} with {oauth-server} for token-based authentication,
 you can also use  {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
-
 Authentication establishes the identity of a user.
 Authorization decides the level of access for that user.
 

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -1,0 +1,33 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deployment-configuration.adoc
+
+[id='assembly-oauth-authorization_{context}']
+= Using {oauth} token-based authorization
+
+{ProductName} supports the use of {oauth} authorization through  {oauth-server} Authorization Services,
+which allow you to manage security policies and permissions centrally.
+
+Security policies and permissions are used to grant access to Kafka brokers.
+Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
+
+If you are using {oauth} with {oauth-server} for token-based authentication,
+you can also use  {oauth-server} to configure authorization rules to constrain client access to Kafka brokers.
+
+Authentication establishes the identity of a user.
+Authorization decides the level of access for that user.
+
+Kafka allows all users full access to brokers by default,
+and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
+ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
+However, {oauth} authorization with  {oauth-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
+
+.Additional resources
+
+* xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
+* xref:simple-acl-using-uo[ACL authorization]
+* {oauth-keycloak-doc}
+
+include::modules/con-oauth-authorization-mechanism.adoc[leveloffset=+1]
+include::modules/proc-oauth-authorization-broker-config.adoc[leveloffset=+1]

--- a/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authorization.adoc
@@ -5,28 +5,6 @@
 [id='assembly-oauth-authorization_{context}']
 = Using {oauth} token-based authorization
 
-If you are using {oauth} with {keycloak-server} for token-based authentication,
-you can also use {keycloak-server} to configure authorization rules to constrain client access to Kafka brokers.
-Authentication establishes the identity of a user.
-Authorization decides the level of access for that user.
-
-{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {keycloak-authorization-services},
-which allows you to manage security policies and permissions centrally.
-
-Security policies and permissions defined in {keycloak-server} are used to grant access to resources on Kafka brokers.
-Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
-
-Kafka allows all users full access to brokers by default,
-and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
-ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
-However, {oauth} token-based authorization with  {keycloak-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
-In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
-
-.Additional resources
-
-* xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
-* xref:simple-acl-using-uo[ACL authorization]
-* {keycloak-server-doc}
-
+include::modules/con-oauth-authorization-intro.adoc[leveloffset=+1]
 include::modules/con-oauth-authorization-mechanism.adoc[leveloffset=+1]
 include::modules/proc-oauth-authorization-broker-config.adoc[leveloffset=+1]

--- a/documentation/modules/con-custom-resources-status.adoc
+++ b/documentation/modules/con-custom-resources-status.adoc
@@ -77,7 +77,7 @@ Here we see the `status` property specified for a Kafka custom resource.
 .Kafka custom resource with status
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
 spec:

--- a/documentation/modules/con-kafka-bridge-authentication.adoc
+++ b/documentation/modules/con-kafka-bridge-authentication.adoc
@@ -12,7 +12,7 @@ The currently supported authentication types are:
 * TLS client authentication
 * SASL-based authentication using the SCRAM-SHA-512 mechanism
 * SASL-based authentication using the PLAIN mechanism
-* xref:assembly-oauth-str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
 
 == TLS Client Authentication
 

--- a/documentation/modules/con-kafka-connect-authentication.adoc
+++ b/documentation/modules/con-kafka-connect-authentication.adoc
@@ -12,7 +12,7 @@ The supported authentication types are:
 * TLS client authentication
 * SASL-based authentication using the SCRAM-SHA-512 mechanism
 * SASL-based authentication using the PLAIN mechanism
-* xref:assembly-oauth-str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
 
 == TLS Client Authentication
 

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -66,7 +66,7 @@ The `tls` property is _true_ by default, so it can be left out.
 
 When you've defined the type of authentication as {oauth}, you add configuration based on the type of validation, either as xref:con-oauth-authentication-broker-fast-local[fast local JWT validation] or xref:con-oauth-authentication-broker-intro-local[token validation using an introspection endpoint].
 
-The procedure to configure {oauth} for listeners, with descriptions and examples, is described in xref:proc-oauth-broker-config-{context}[Configuring {oauth} support for Kafka brokers].
+The procedure to configure {oauth} for listeners, with descriptions and examples, is described in xref:proc-oauth-authentication-broker-config-{context}[Configuring {oauth} support for Kafka brokers].
 
 [[con-oauth-authentication-broker-fast-local]]
 == Fast local JWT token validation configuration

--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// assembly-oauth-authorization.adoc
+
+[id='con-oauth-authorization-intro_{context}']
+If you are using {oauth} with {keycloak-server} for token-based authentication,
+you can also use {keycloak-server} to configure authorization rules to constrain client access to Kafka brokers.
+Authentication establishes the identity of a user.
+Authorization decides the level of access for that user.
+
+{ProductName} supports the use of {oauth} token-based authorization through {keycloak-server} {keycloak-authorization-services},
+which allows you to manage security policies and permissions centrally.
+
+Security policies and permissions defined in {keycloak-server} are used to grant access to resources on Kafka brokers.
+Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
+
+Kafka allows all users full access to brokers by default,
+and also provides the `SimpleACLAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
+ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
+However, {oauth} token-based authorization with  {keycloak-server} offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+In addition, you can configure your Kafka brokers to use {oauth} authorization and ACLs.
+
+.Additional resources
+
+* xref:assembly-oauth-authentication_str[Using {oauth} token based authentication]
+* xref:simple-acl-using-uo[ACL authorization]
+* {keycloak-server-doc}

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -10,10 +10,11 @@ and providing a list of permissions granted on different resources for that user
 Policies use roles and groups to match permissions to users.
 {oauth} authorization enforces permissions locally based on the received list of grants for the user from {oauth-server} Authorization Services.
 
-== Kafka broker custom _authorizer_
+== Kafka broker custom authorizer
 
-To be able to use the {oauth-server} REST endpoints for Authorization Services,
-a custom _authorizer_ configuration is required on the Kafka Broker.
+A {oauth-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {ProductName}.
+To be able to use the {oauth-server} REST endpoints for Authorization Services provided by {oauth-server},
+a custom authorizer configuration is required on the Kafka Broker.
 
 The authorizer fetches a list of granted permissions from the authorization server one-time-only,
 and enforces authorization locally on the Kafka Broker, making rapid authorization decisions for each user session.

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -5,7 +5,7 @@
 [id='con-oauth-authorization-mechanism_{context}']
 = {oauth} authorization mechanism
 
-{oauth} authorization uses {oauth-server} Authorization Services REST endpoints to extend token-based authentication with {oauth-server} by applying defined security policies on a particular user,
+{oauth} authorization in {ProductName} uses {oauth-server} server Authorization Services REST endpoints to extend token-based authentication with {oauth-server} by applying defined security policies on a particular user,
 and providing a list of permissions granted on different resources for that user.
 Policies use roles and groups to match permissions to users.
 {oauth} authorization enforces permissions locally based on the received list of grants for the user from {oauth-server} Authorization Services.
@@ -14,7 +14,7 @@ Policies use roles and groups to match permissions to users.
 
 A {oauth-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {ProductName}.
 To be able to use the {oauth-server} REST endpoints for Authorization Services provided by {oauth-server},
-a custom authorizer configuration is required on the Kafka Broker.
+you configure a custom authorizer on the Kafka broker.
 
 The authorizer fetches a list of granted permissions from the authorization server one-time-only,
 and enforces authorization locally on the Kafka Broker, making rapid authorization decisions for each user session.

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -16,5 +16,5 @@ A {oauth-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {Produ
 To be able to use the {oauth-server} REST endpoints for Authorization Services provided by {oauth-server},
 you configure a custom authorizer on the Kafka broker.
 
-The authorizer fetches a list of granted permissions from the authorization server one-time-only,
-and enforces authorization locally on the Kafka Broker, making rapid authorization decisions for each user session.
+The authorizer fetches a list of granted permissions from the authorization server as needed,
+and enforces authorization locally on the Kafka Broker, making rapid authorization decisions for each client request.

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -5,15 +5,15 @@
 [id='con-oauth-authorization-mechanism_{context}']
 = {oauth} authorization mechanism
 
-{oauth} authorization in {ProductName} uses {oauth-server} server Authorization Services REST endpoints to extend token-based authentication with {oauth-server} by applying defined security policies on a particular user,
+{oauth} authorization in {ProductName} uses {keycloak-server} server Authorization Services REST endpoints to extend token-based authentication with {keycloak-server} by applying defined security policies on a particular user,
 and providing a list of permissions granted on different resources for that user.
 Policies use roles and groups to match permissions to users.
-{oauth} authorization enforces permissions locally based on the received list of grants for the user from {oauth-server} Authorization Services.
+{oauth} authorization enforces permissions locally based on the received list of grants for the user from {keycloak-server} Authorization Services.
 
 == Kafka broker custom authorizer
 
-A {oauth-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {ProductName}.
-To be able to use the {oauth-server} REST endpoints for Authorization Services provided by {oauth-server},
+A {keycloak-server} _authorizer_ (`KeycloakRBACAuthorizer`) is provided with {ProductName}.
+To be able to use the {keycloak-server} REST endpoints for Authorization Services provided by {keycloak-server},
 you configure a custom authorizer on the Kafka broker.
 
 The authorizer fetches a list of granted permissions from the authorization server as needed,

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// assembly-oauth-authorization.adoc
+
+[id='con-oauth-authorization-mechanism_{context}']
+= {oauth} authorization mechanism
+
+{oauth} authorization uses {oauth-server} Authorization Services REST endpoints to extend token-based authentication with {oauth-server} by applying defined security policies on a particular user,
+and providing a list of permissions granted on different resources for that user.
+Policies use roles and groups to match permissions to users.
+{oauth} authorization enforces permissions locally based on the received list of grants for the user from {oauth-server} Authorization Services.
+
+== Kafka broker custom _authorizer_
+
+To be able to use the {oauth-server} REST endpoints for Authorization Services,
+a custom _authorizer_ configuration is required on the Kafka Broker.
+
+The authorizer fetches a list of granted permissions from the authorization server one-time-only,
+and enforces authorization locally on the Kafka Broker, making rapid authorization decisions for each user session.

--- a/documentation/modules/oauth/con-oauth-config.adoc
+++ b/documentation/modules/oauth/con-oauth-config.adoc
@@ -10,11 +10,11 @@
 In order to use {oauth} for {ProductName}, you must:
 
 . xref:proc-oauth-server-config-{context}[Configure an {oauth} authorization server for the {ProductName} cluster and Kafka clients]
-. xref:proc-oauth-broker-config-{context}[Deploy or update the Kafka cluster with Kafka broker listeners configured to use {oauth}]
+. xref:proc-oauth-authentication-broker-config-{context}[Deploy or update the Kafka cluster with Kafka broker listeners configured to use {oauth}]
 . xref:proc-oauth-client-config-{context}[Update your Java-based Kafka clients to use {oauth}]
 . xref:proc-oauth-kafka-config-{context}[Update Kafka component clients to use {oauth}]
 
 include::proc-oauth-server-config.adoc[leveloffset=+1]
-include::proc-oauth-broker-config.adoc[leveloffset=+1]
+include::proc-oauth-authentication-broker-config.adoc[leveloffset=+1]
 include::proc-oauth-client-config.adoc[leveloffset=+1]
 include::proc-oauth-kafka-config.adoc[leveloffset=+1]

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -2,7 +2,7 @@
 //
 // con-oauth-config.adoc
 
-[id='proc-oauth-broker-config-{context}']
+[id='proc-oauth-authentication-broker-config-{context}']
 = Configuring {oauth} support for Kafka brokers
 
 This procedure describes how to configure Kafka brokers so that the broker listeners are enabled to use {oauth} authentication using an authorization server.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -23,7 +23,7 @@ NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Sup
 
 * {ProductName} must be configured to use {oauth} with {keycloak-server} for xref:assembly-oauth-authentication_str[token-based authentication].
 You use the same {keycloak-server} server endpoint when you set up authorization.
-* You need to understand how to manage policies and permissions for {keycloak-server} Authorization Services, as described in the {oauth-server-doc}.
+* You need to understand how to manage policies and permissions for {keycloak-server} Authorization Services, as described in the {keycloak-server-doc}.
 
 .Procedure
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -21,7 +21,7 @@ And roles are used to match users based on their function.
 With {oauth-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
 Storage and access to user data may be a factor in how you choose to configure authorization policies.
 
-NOTE: xref:ref-kafka-authorization-super-user[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on Kafka broker.
+NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on Kafka broker.
 
 .Prerequisites
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -7,9 +7,8 @@
 
 This procedure describes how to configure Kafka brokers to use {oauth} authorization using {oauth-server} Authorization Services.
 
-Some of the properties used to configure authorization for Kafka brokers might already be configured for xref:proc-oauth-authentication-broker-config-{context}[{oauth} authentication].
+The properties used to configure authorization for Kafka brokers might already be configured for xref:proc-oauth-authentication-broker-config-{context}[{oauth} authentication].
 If so, they are also used for authorization if specific authorization properties are not defined.
-The properties are highlighted in this procedure.
 
 .Before you begin
 Consider the access you require or want to limit for certain users.
@@ -27,7 +26,7 @@ NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Sup
 
 * {ProductName} must be configured to use {oauth} with {oauth-server} for xref:assembly-oauth-authentication_str[token-based authentication].
 You use the same {oauth-server} server endpoint when you set up authorization.
-* You need to understand how to manage policies and permissions for Keycloak Authorization Services, as described in the {oauth-keycloak-doc}.
+* You need to understand how to manage policies and permissions for {oauth-server} Authorization Services, as described in the {oauth-keycloak-doc}.
 
 
 .Procedure
@@ -35,76 +34,62 @@ You use the same {oauth-server} server endpoint when you set up authorization.
 . Access the {oauth-server} Admin Console or use the {oauth-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
 . Use Authorization Services to define resources, authorization scopes, policies and permissions for the client.
 . Bind the permissions to users and clients by assigning them roles and groups.
-. Configure the Kafka brokers to use the `{oauth-server}RBACAuthorizer`.
-. Add the following to the Kafka `server.properties` configuration file to install the authorizer in Kafka:
+. Configure the Kafka brokers to use the {oauth-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
 +
-[source,env,subs="+quotes,attributes"]
+[source,shell]
 ----
-authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer
-principal.builder.class=io.strimzi.kafka.oauth.server.authorizer.JwtKafkaPrincipalBuilder
+kubectl edit kafka my-cluster
 ----
 
-. Add configuration for the Kafka brokers to access the authorization server and Authorization Services.
-+
-Here we show example configuration added as additional properties to `server.properties`, but you can also define them as environment variables using capitalized or upper-case naming conventions.
-+
-[source,env,subs="+quotes,attributes"]
-----
-strimzi.authz.token.endpoint.uri="https://_<auth-server-address>_/token" <1>
-strimzi.authz.client.id="kafka" <2>
-----
-<1> The {oauth} token endpoint URL to Keycloak. For production, always use HTTPs.
-For example, _\https://keycloak:8443/auth/realms/master/protocol/openid-connect/token_.
-<2> The client ID of the {oauth} client definition in Keycloak that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-+
-If either of these properties are not added, the equivalent token endpoint and client ID properties configured for {oauth} authentication are used.
-
-. (Optional) Add configuration for specific Kafka clusters.
+. Configure the Kafka broker `kafka` configuration to use `keycloak` authorization, and to be able to access the authorization server and Authorization Services.
 +
 For example:
 +
-[source,env,subs="+quotes,attributes"]
+[source,yaml,subs="+quotes,attributes"]
 ----
-strimzi.authz.kafka.cluster.name="kafka-cluster" <1>
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka
+  # ...
+  authorization:
+    type: *keycloak* <1>
+    tokenEndpointUri: <__https://<auth-server-address>/auth/realms/external/protocol/openid-connect/token/introspect__> <2>
+    clientId: kafka <3>
+    delegateToKafkaAcls: false <4>
+    disableTlsHostnameVerification: false <5>
+    superUsers: <6>
+      - CN=fred
+      - sam
+      - CN=edward
+    tlsTrustedCertificates: <7>
+    - secretName: oauth-server-cert
+      certificate: ca.crt
+  #...
 ----
-<1> The name of a specific Kafka cluster.
-Names are used to target permissions,
-making it possible to manage multiple clusters within the same Keycloak realm.
-The default value is `kafka-cluster`.
-
-. (Optional) Delegate to simple authorization.
-+
-For example:
-+
-[source,env,subs="+quotes,attributes"]
-----
-strimzi.authz.delegate.to.kafka.acl="false" <1>
-----
-<1> Flag to delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by Keycloak Authorization Services policies.
+<1> Type `keycloak` enables {oauth-server} authorization.
+<2> URI of the {oauth-server} token introspection endpoint. For production, always use HTTPs.
+<3> The client ID of the {oauth} client definition in {oauth-server} that has Authorization Services enabled. Typically, `kafka` is used as the ID.
+<4> Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {oauth-server} Authorization Services policies.
 The default is `false`.
+<5> (Optional) Disable TLS hostname verification. Default is `false`.
+<6> Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].
+<7> (Optional) Trusted certificates for TLS connection to the authorization server.
++
+If the properties are not added, the equivalent properties configured for {oauth} authentication are used.
 
-. (Optional) Add TLS configuration for inter-broker communication.
+. Save and exit the editor, then wait for rolling updates to complete.
+
+. Check the update in the logs or by watching the pod state transitions:
 +
-For example:
-+
-[source,env,subs="+quotes,attributes"]
+[source,shell,subs="+quotes,attributes"]
 ----
-strimzi.authz.ssl.truststore.location=_<path-to-truststore>_ <1>
-strimzi.authz.ssl.truststore.password=_<my-truststore-password>_ <2>
-strimzi.authz.ssl.truststore.type=JKS <3>
-strimzi.authz.ssl.secure.random.implementation=SHA1PRNG <4>
-strimzi.authz.ssl.endpoint.identification.algorithm=HTTPS <5>
+kubectl logs -f ${POD_NAME} -c ${CONTAINER_NAME}
+kubectl get po -w
 ----
-<1> The path to the truststore that contain the certificates.
-<2> The password for the truststore.
-<3> The truststore type.
-If not set, the default Java keystore type is used.
-<4> Random number generator implementation.
-If not set, the Java platform SDK default is used.
-<5> Hostname verification.
-If set to an empty string, the hostname verification is turned off.
-If not set, the default value is `HTTPS`, which enforces hostname verification for server certificates.
 +
-If any of the TLS properties are not added, the equivalent properties used for {oauth} authentication are used.
+The rolling update configures the brokers to use {oauth} authorization.
 
 . Verify the configured permissions by accessing Kafka brokers as clients or  users with specific roles, making sure they have the necessary access, or do not have the access they are not supposed to have.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -8,11 +8,11 @@
 This procedure describes how to configure Kafka brokers to use {oauth} authorization using {oauth-server} Authorization Services.
 
 The properties used to configure authorization for Kafka brokers might already be configured for xref:proc-oauth-authentication-broker-config-{context}[{oauth} authentication].
-If so, they are also used for authorization if specific authorization properties are not defined.
+If so, they are also used for authorization if the equivalent authorization properties are not defined.
 
 .Before you begin
 Consider the access you require or want to limit for certain users.
-You can use a combination of groups, roles, clients and users to configure access.
+You can use a combination of groups, roles, clients, and users to configure access in {oauth-server}.
 
 Typically, groups are used to match users based on organizational departments or geographical locations.
 And roles are used to match users based on their function.
@@ -20,21 +20,21 @@ And roles are used to match users based on their function.
 With {oauth-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
 Storage and access to user data may be a factor in how you choose to configure authorization policies.
 
-NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on Kafka broker.
+NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on the Kafka broker.
 
 .Prerequisites
 
 * {ProductName} must be configured to use {oauth} with {oauth-server} for xref:assembly-oauth-authentication_str[token-based authentication].
 You use the same {oauth-server} server endpoint when you set up authorization.
-* You need to understand how to manage policies and permissions for {oauth-server} Authorization Services, as described in the {oauth-keycloak-doc}.
+* You need to understand how to manage policies and permissions for {oauth-server} Authorization Services, as described in the {oauth-server-doc}.
 
 
 .Procedure
 
 . Access the {oauth-server} Admin Console or use the {oauth-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
-. Use Authorization Services to define resources, authorization scopes, policies and permissions for the client.
+. Use Authorization Services to define resources, authorization scopes, policies, and permissions for the client.
 . Bind the permissions to users and clients by assigning them roles and groups.
-. Configure the Kafka brokers to use the {oauth-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
+. Configure the Kafka brokers to use {oauth-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
 +
 [source,shell]
 ----
@@ -78,7 +78,7 @@ The default is `false`.
 <6> Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].
 <7> (Optional) Trusted certificates for TLS connection to the authorization server.
 +
-If the properties are not added, the equivalent properties configured for {oauth} authentication are used.
+If the URI, client ID and TLS properties are not added, the equivalent properties configured for {oauth} authentication are used.
 
 . Save and exit the editor, then wait for rolling updates to complete.
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -1,0 +1,110 @@
+// Module included in the following module:
+//
+// con-oauth-config.adoc
+
+[id='proc-oauth-authorization-broker-config-{context}']
+= Configuring {oauth} authorization support
+
+This procedure describes how to configure Kafka brokers to use {oauth} authorization using {oauth-server} Authorization Services.
+
+Some of the properties used to configure authorization for Kafka brokers might already be configured for xref:proc-oauth-authentication-broker-config-{context}[{oauth} authentication].
+If so, they are also used for authorization if specific authorization properties are not defined.
+The properties are highlighted in this procedure.
+
+.Before you begin
+Consider the access you require or want to limit for certain users.
+You can use a combination of groups, roles, clients and users to configure access.
+
+Typically, groups are used to match users based on organizational departments or geographical locations.
+And roles are used to match users based on their function.
+
+With {oauth-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
+Storage and access to user data may be a factor in how you choose to configure authorization policies.
+
+NOTE: xref:ref-kafka-authorization-super-user[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on Kafka broker.
+
+.Prerequisites
+
+* {ProductName} must be configured to use {oauth} with {oauth-server} for xref:assembly-oauth-authentication_str[token-based authentication].
+You use the same {oauth-server} server endpoint when you set up authorization.
+* You need to understand how to manage policies and permissions for Keycloak Authorization Services, as described in the {oauth-keycloak-doc}.
+
+
+.Procedure
+
+. Access the {oauth-server} Admin Console or use the {oauth-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
+. Use Authorization Services to define resources, authorization scopes, policies and permissions for the client.
+. Bind the permissions to users and clients by assigning them roles and groups.
+. Configure the Kafka brokers to use the `{oauth-server}RBACAuthorizer`.
+. Add the following to the Kafka `server.properties` configuration file to install the authorizer in Kafka:
++
+[source,env,subs="+quotes,attributes"]
+----
+authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer
+principal.builder.class=io.strimzi.kafka.oauth.server.authorizer.JwtKafkaPrincipalBuilder
+----
+
+. Add configuration for the Kafka brokers to access the authorization server and Authorization Services.
++
+Here we show example configuration added as additional properties to `server.properties`, but you can also define them as environment variables using capitalized or upper-case naming conventions.
++
+[source,env,subs="+quotes,attributes"]
+----
+strimzi.authz.token.endpoint.uri="https://_<auth-server-address>_/token" <1>
+strimzi.authz.client.id="kafka" <2>
+----
+<1> The {oauth} token endpoint URL to Keycloak. For production, always use HTTPs.
+For example, _\https://keycloak:8443/auth/realms/master/protocol/openid-connect/token_.
+<2> The client ID of the {oauth} client definition in Keycloak that has Authorization Services enabled. Typically, `kafka` is used as the ID.
++
+If either of these properties are not added, the equivalent token endpoint and client ID properties configured for {oauth} authentication are used.
+
+. (Optional) Add configuration for specific Kafka clusters.
++
+For example:
++
+[source,env,subs="+quotes,attributes"]
+----
+strimzi.authz.kafka.cluster.name="kafka-cluster" <1>
+----
+<1> The name of a specific Kafka cluster.
+Names are used to target permissions,
+making it possible to manage multiple clusters within the same Keycloak realm.
+The default value is `kafka-cluster`.
+
+. (Optional) Delegate to simple authorization.
++
+For example:
++
+[source,env,subs="+quotes,attributes"]
+----
+strimzi.authz.delegate.to.kafka.acl="false" <1>
+----
+<1> Flag to delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by Keycloak Authorization Services policies.
+The default is `false`.
+
+. (Optional) Add TLS configuration for inter-broker communication.
++
+For example:
++
+[source,env,subs="+quotes,attributes"]
+----
+strimzi.authz.ssl.truststore.location=_<path-to-truststore>_ <1>
+strimzi.authz.ssl.truststore.password=_<my-truststore-password>_ <2>
+strimzi.authz.ssl.truststore.type=JKS <3>
+strimzi.authz.ssl.secure.random.implementation=SHA1PRNG <4>
+strimzi.authz.ssl.endpoint.identification.algorithm=HTTPS <5>
+----
+<1> The path to the truststore that contain the certificates.
+<2> The password for the truststore.
+<3> The truststore type.
+If not set, the default Java keystore type is used.
+<4> Random number generator implementation.
+If not set, the Java platform SDK default is used.
+<5> Hostname verification.
+If set to an empty string, the hostname verification is turned off.
+If not set, the default value is `HTTPS`, which enforces hostname verification for server certificates.
++
+If any of the TLS properties are not added, the equivalent properties used for {oauth} authentication are used.
+
+. Verify the configured permissions by accessing Kafka brokers as clients or  users with specific roles, making sure they have the necessary access, or do not have the access they are not supposed to have.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -5,32 +5,32 @@
 [id='proc-oauth-authorization-broker-config-{context}']
 = Configuring {oauth} authorization support
 
-This procedure describes how to configure Kafka brokers to use {oauth} authorization using {oauth-server} Authorization Services.
+This procedure describes how to configure Kafka brokers to use {oauth} authorization using {keycloak-server} Authorization Services.
 
 .Before you begin
 Consider the access you require or want to limit for certain users.
-You can use a combination of {oauth-server} _groups_, _roles_, _clients_, and _users_ to configure access in {oauth-server}.
+You can use a combination of {keycloak-server} _groups_, _roles_, _clients_, and _users_ to configure access in {keycloak-server}.
 
 Typically, groups are used to match users based on organizational departments or geographical locations.
 And roles are used to match users based on their function.
 
-With {oauth-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
+With {keycloak-server}, you can store users and groups in LDAP, whereas clients and roles cannot be stored this way.
 Storage and access to user data may be a factor in how you choose to configure authorization policies.
 
 NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Super users] always have unconstrained access to a Kafka broker regardless of the authorization implemented on the Kafka broker.
 
 .Prerequisites
 
-* {ProductName} must be configured to use {oauth} with {oauth-server} for xref:assembly-oauth-authentication_str[token-based authentication].
-You use the same {oauth-server} server endpoint when you set up authorization.
-* You need to understand how to manage policies and permissions for {oauth-server} Authorization Services, as described in the {oauth-server-doc}.
+* {ProductName} must be configured to use {oauth} with {keycloak-server} for xref:assembly-oauth-authentication_str[token-based authentication].
+You use the same {keycloak-server} server endpoint when you set up authorization.
+* You need to understand how to manage policies and permissions for {keycloak-server} Authorization Services, as described in the {oauth-server-doc}.
 
 .Procedure
 
-. Access the {oauth-server} Admin Console or use the {oauth-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
+. Access the {keycloak-server} Admin Console or use the {keycloak-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.
 . Use Authorization Services to define resources, authorization scopes, policies, and permissions for the client.
 . Bind the permissions to users and clients by assigning them roles and groups.
-. Configure the Kafka brokers to use {oauth-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
+. Configure the Kafka brokers to use {keycloak-server} authorization by updating the Kafka broker configuration (`Kafka.spec.kafka`) of your `Kafka` resource in an editor.
 +
 [source,shell]
 ----
@@ -65,10 +65,10 @@ spec:
       certificate: ca.crt
   #...
 ----
-<1> Type `keycloak` enables {oauth-server} authorization.
-<2> URI of the {oauth-server} token endpoint. For production, always use HTTPs.
-<3> The client ID of the {oauth} client definition in {oauth-server} that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {oauth-server} Authorization Services policies.
+<1> Type `keycloak` enables {keycloak-server} authorization.
+<2> URI of the {keycloak-server} token endpoint. For production, always use HTTPs.
+<3> The client ID of the {oauth} client definition in {keycloak-server} that has Authorization Services enabled. Typically, `kafka` is used as the ID.
+<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {keycloak-server} Authorization Services policies.
 The default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
 <6> (Optional) Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -7,12 +7,9 @@
 
 This procedure describes how to configure Kafka brokers to use {oauth} authorization using {oauth-server} Authorization Services.
 
-The properties used to configure authorization for Kafka brokers might already be configured for xref:proc-oauth-authentication-broker-config-{context}[{oauth} authentication].
-If so, they are also used for authorization if the equivalent authorization properties are not defined.
-
 .Before you begin
 Consider the access you require or want to limit for certain users.
-You can use a combination of groups, roles, clients, and users to configure access in {oauth-server}.
+You can use a combination of {oauth-server} _groups_, _roles_, _clients_, and _users_ to configure access in {oauth-server}.
 
 Typically, groups are used to match users based on organizational departments or geographical locations.
 And roles are used to match users based on their function.
@@ -56,7 +53,7 @@ spec:
   # ...
   authorization:
     type: *keycloak* <1>
-    tokenEndpointUri: <__https://<auth-server-address>/auth/realms/external/protocol/openid-connect/token/introspect__> <2>
+    tokenEndpointUri: <__https://<auth-server-address>/auth/realms/external/protocol/openid-connect/token__> <2>
     clientId: kafka <3>
     delegateToKafkaAcls: false <4>
     disableTlsHostnameVerification: false <5>
@@ -70,15 +67,13 @@ spec:
   #...
 ----
 <1> Type `keycloak` enables {oauth-server} authorization.
-<2> URI of the {oauth-server} token introspection endpoint. For production, always use HTTPs.
+<2> URI of the {oauth-server} token endpoint. For production, always use HTTPs.
 <3> The client ID of the {oauth} client definition in {oauth-server} that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-<4> Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {oauth-server} Authorization Services policies.
+<4> (Optional) Delegate authorization to Kafka `SimpleACLAuthorizer` if access is denied by {oauth-server} Authorization Services policies.
 The default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
-<6> Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].
+<6> (Optional) Designated xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[super users].
 <7> (Optional) Trusted certificates for TLS connection to the authorization server.
-+
-If the URI, client ID and TLS properties are not added, the equivalent properties configured for {oauth} authentication are used.
 
 . Save and exit the editor, then wait for rolling updates to complete.
 
@@ -86,7 +81,7 @@ If the URI, client ID and TLS properties are not added, the equivalent propertie
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl logs -f ${POD_NAME} -c ${CONTAINER_NAME}
+kubectl logs -f ${POD_NAME} -c kafka
 kubectl get po -w
 ----
 +

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -25,7 +25,6 @@ NOTE: xref:ref-kafka-authorization-super-user-deployment-configuration-kafka[Sup
 You use the same {oauth-server} server endpoint when you set up authorization.
 * You need to understand how to manage policies and permissions for {oauth-server} Authorization Services, as described in the {oauth-server-doc}.
 
-
 .Procedure
 
 . Access the {oauth-server} Admin Console or use the {oauth-server} Admin CLI to enable Authorization Services for the Kafka broker client you created when setting up {oauth} authentication.

--- a/documentation/modules/oauth/proc-oauth-server-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-server-config.adoc
@@ -25,4 +25,4 @@ Now prepare the authorization server to work with {ProductName}.
 . Configure clients for each Kafka client component of your application.
 
 .What to do next
-After deploying and configuring the authorization server, xref:proc-oauth-broker-config-{context}[configure the Kafka brokers to use {oauth}].
+After deploying and configuring the authorization server, xref:proc-oauth-authentication-broker-config-{context}[configure the Kafka brokers to use {oauth}].

--- a/documentation/modules/ref-kafka-authentication.adoc
+++ b/documentation/modules/ref-kafka-authentication.adoc
@@ -15,7 +15,7 @@ Supported authentication mechanisms:
 
 * TLS client authentication
 * SASL SCRAM-SHA-512
-* xref:assembly-oauth-str[{oauth} token based authentication]
+* xref:assembly-oauth-authentication_str[{oauth} token based authentication]
 
 == TLS client authentication
 

--- a/documentation/modules/ref-kafka-authorization.adoc
+++ b/documentation/modules/ref-kafka-authorization.adoc
@@ -5,12 +5,15 @@
 [id='ref-kafka-authorization-{context}']
 = Authorization
 
-You configure authorization for Kafka brokers using the `authorization` property in the `Kafka.spec.kafka` resource.
+You can configure simple authorization for Kafka brokers using the `authorization` property in the `Kafka.spec.kafka` resource.
 If the `authorization` property is missing, no authorization is enabled.
 When enabled, authorization is applied to all enabled xref:assembly-configuring-kafka-broker-listeners-{context}[listeners].
-The authorization method is defined in the `type` field; only Simple authorization is currently supported. 
+The authorization method is defined in the `type` field.
 
+Access rules for users are xref:simple-acl-using-uo[defined using Access Control Lists (ACLs)].
 You can optionally designate a list of super users in the `superUsers` field.
+
+Additionally, if you are using {oauth} token based authentication, you can also xref:assembly-oauth-authorization_str[configure {oauth} authorization].
 
 == Simple authorization
 
@@ -25,11 +28,11 @@ authorization:
   type: simple
 # ...
 ----
-
+[id='ref-kafka-authorization-super-user']
 == Super users
 
 Super users can access all resources in your Kafka cluster regardless of any access restrictions defined in ACLs.
-To designate super users for a Kafka cluster, enter a list of user principles in the `superUsers` field. 
+To designate super users for a Kafka cluster, enter a list of user principles in the `superUsers` field.
 If a user uses TLS Client Authentication, the username will be the common name from their certificate subject prefixed with `CN=`.
 
 .An example of designating super users

--- a/documentation/modules/ref-kafka-authorization.adoc
+++ b/documentation/modules/ref-kafka-authorization.adoc
@@ -28,7 +28,7 @@ authorization:
   type: simple
 # ...
 ----
-[id='ref-kafka-authorization-super-user']
+[id='ref-kafka-authorization-super-user-{context}']
 == Super users
 
 Super users can access all resources in your Kafka cluster regardless of any access restrictions defined in ACLs.

--- a/documentation/modules/ref-kafka-authorization.adoc
+++ b/documentation/modules/ref-kafka-authorization.adoc
@@ -5,15 +5,15 @@
 [id='ref-kafka-authorization-{context}']
 = Authorization
 
-You can configure simple authorization for Kafka brokers using the `authorization` property in the `Kafka.spec.kafka` resource.
+You can configure authorization for Kafka brokers using the `authorization` property in the `Kafka.spec.kafka` resource.
 If the `authorization` property is missing, no authorization is enabled.
 When enabled, authorization is applied to all enabled xref:assembly-configuring-kafka-broker-listeners-{context}[listeners].
 The authorization method is defined in the `type` field.
 
-Access rules for users are xref:simple-acl-using-uo[defined using Access Control Lists (ACLs)].
-You can optionally designate a list of super users in the `superUsers` field.
+You can configure:
 
-Additionally, if you are using {oauth} token based authentication, you can also xref:assembly-oauth-authorization_str[configure {oauth} authorization].
+* Simple authorization
+* xref:assembly-oauth-authorization_str[{oauth} authorization] (if you are using {oauth} token based authentication)
 
 == Simple authorization
 
@@ -28,6 +28,10 @@ authorization:
   type: simple
 # ...
 ----
+
+Access rules for users are xref:simple-acl-using-uo[defined using Access Control Lists (ACLs)].
+You can optionally designate a list of super users in the `superUsers` field.
+
 [id='ref-kafka-authorization-super-user-{context}']
 == Super users
 

--- a/documentation/modules/ref-kafka-user.adoc
+++ b/documentation/modules/ref-kafka-user.adoc
@@ -101,11 +101,12 @@ echo "Z2VuZXJhdGVkcGFzc3dvcmQ=" | base64 --decode
 [id='simple-acl-{context}']
 == Authorization
 
-Authorization is configured using the `authorization` property in `KafkaUser.spec`.
+Simple authorization is configured using the `authorization` property in `KafkaUser.spec`.
 The authorization type enabled for a user is specified using the `type` field.
-Currently, the only supported authorization type is simple authorization.
 
 If no authorization is specified, the User Operator does not provision any access rights for the user.
+
+Additionally, if you are using {oauth} token based authentication, you can also xref:assembly-oauth-authorization_str[configure {oauth} authorization].
 
 === Simple authorization
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -40,7 +40,7 @@
 :oauth: OAuth 2.0
 :oauth2-site: link:https://oauth.net/2/[{oauth} site^]
 :oauth-artifact-version: 0.2.0
-:oauth-server: Keycloak
+:keycloak-server: Keycloak
 :oauth-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :oauth-authorization-services: link: https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}^]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -41,10 +41,11 @@
 :oauth2-site: link:https://oauth.net/2/[{oauth} site^]
 :oauth-artifact-version: 0.2.0
 :oauth-server: Keycloak
-:oauth-keycloak-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
-:oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}]
-:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the {oauth} authorization server]
-:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the {oauth} authorization server]
+:oauth-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
+:oauth-authorization-services: link: https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
+:oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}^]
+:oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the {oauth} authorization server^]
+:oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the {oauth} authorization server^]
 
 // External links
 :docs-okd: link:https://docs.okd.io/3.9/dev_guide/builds/index.html[builds^]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -41,8 +41,8 @@
 :oauth2-site: link:https://oauth.net/2/[{oauth} site^]
 :oauth-artifact-version: 0.2.0
 :keycloak-server: Keycloak
-:oauth-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
-:oauth-authorization-services: link: https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
+:keycloak-server-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
+:keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}^]
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the {oauth} authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the {oauth} authorization server^]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -18,7 +18,6 @@
 :ContextProduct: strimzi
 :OpenShiftVersion: 3.11 and later
 :KubernetesVersion: 1.11 and later
-:oauth: OAuth 2.0
 
 // Kafka upgrade attributes used in kafka upgrades section
 :KafkaVersionLower: 2.3.1
@@ -38,8 +37,11 @@
 :kafka-exporter-project: link:https://github.com/danielqsj/kafka_exporter[Kafka Exporter^]
 
 //OAuth attributes and links
+:oauth: OAuth 2.0
 :oauth2-site: link:https://oauth.net/2/[{oauth} site^]
 :oauth-artifact-version: 0.2.0
+:oauth-server: Keycloak
+:oauth-keycloak-doc: link:https://www.keycloak.org/documentation.html[Keycloak documentation^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using {oauth}]
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples[Using Keycloak as the {oauth} authorization server]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/master/examples/docker[Using Hydra as the {oauth} authorization server]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

- Documentation

New asembly created to describe OAuth 2.0 authorization.
Includes concepts and a procedure to describe how Kafka brokers are configured.

Authorization sections in other parts of teh doc updated to reflect this new support.

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

