### PR TITLE
ST: Add s2i to different namespace tests and improve connect tests AllNamespaceST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -76,6 +76,8 @@ public interface Constants {
      */
     String KAFKA_BRIDGE_JSON = "application/vnd.kafka.v2+json";
 
+    String DEFAULT_SINK_FILE_NAME = "/tmp/test-file-sink.txt";
+
     int HTTP_BRIDGE_DEFAULT_PORT = 8080;
     int HTTP_JAEGER_DEFAULT_TCP_PORT = 5778;
     int HTTP_JAEGER_DEFAULT_NODE_PORT = 32480;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -63,6 +63,7 @@ public class KafkaConnectResource {
                 .withName(name)
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withClusterName(kafkaClusterName)
+                .addToLabels("type", "kafka-connect")
             .endMetadata()
             .editOrNewSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectS2IResource.java
@@ -49,6 +49,7 @@ public class KafkaConnectS2IResource {
                 .withName(name)
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
                 .withClusterName(kafkaClusterName)
+                .addToLabels("type", "kafka-connect-s2i")
             .endMetadata()
             .editSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -19,11 +19,11 @@ public class KafkaConnectUtils {
 
     private KafkaConnectUtils() {}
 
-    public static void createFileSinkConnector(String podName, String topicName) {
+    public static void createFileSinkConnector(String podName, String topicName, String sinkFileName) {
         cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
             "curl -X POST -H \"Content-Type: application/json\" " + "--data '{ \"name\": \"sink-test\", " +
                 "\"config\": " + "{ \"connector.class\": \"FileStreamSink\", " +
-                "\"tasks.max\": \"1\", \"topics\": \"" + topicName + "\"," + " \"file\": \"/tmp/test-file-sink.txt\" } }' " +
+                "\"tasks.max\": \"1\", \"topics\": \"" + topicName + "\"," + " \"file\": \"" + sinkFileName + "\" } }' " +
                 "http://localhost:8083/connectors"
         );
     }
@@ -42,13 +42,14 @@ public class KafkaConnectUtils {
         LOGGER.info("Kafka connect service is present");
     }
 
-    public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String message) {
+    public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String sinkFileName, String message) {
         LOGGER.info("Waiting for messages in file sink");
         TestUtils.waitFor("messages in file sink", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_SEND_RECEIVE_MSG,
-            () -> cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out().contains(message));
+            () -> cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message));
+        LOGGER.info("Expected messages are in file sink");
     }
 
-    public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName) {
-        waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, "0\n1\n");
+    public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String sinkFileName) {
+        waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, sinkFileName, "0\n1\n");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -106,7 +106,7 @@ public abstract class AbstractNamespaceST extends BaseST {
         String kafkaConnectPodName = kubeClient().listPods("type", connectLabel).get(0).getMetadata().getName();
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
-        KafkaClientsResource.deployKafkaClients(clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS, clusterName, namespace).done();
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
         externalKafkaClient.setPodName(kafkaClientsPodName);
         int sent = externalKafkaClient.sendMessages(topicName, namespace, clusterName, 10);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -7,17 +7,24 @@ package io.strimzi.systemtest;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import org.hamcrest.Matchers;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -79,5 +86,31 @@ public abstract class AbstractNamespaceST extends BaseST {
         cluster.setNamespace(namespace);
         cmdKubeClient().deleteByName("KafkaTopic", topic);
         cluster.setNamespace(CO_NAMESPACE);
+    }
+
+    void deployKafkaConnectorWithSink(String clusterName, String namespace, String topicName, String connectLabel) throws InterruptedException {
+        // Deploy Kafka Connector
+        Map<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("topics", topicName);
+        connectorConfig.put("file", Constants.DEFAULT_SINK_FILE_NAME);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.storage.StringConverter");
+
+        KafkaConnectorResource.kafkaConnector(clusterName)
+            .editSpec()
+                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                .withConfig(connectorConfig)
+            .endSpec().done();
+        KafkaConnectUtils.waitForConnectorReady(clusterName);
+
+        String kafkaConnectPodName = kubeClient().listPods("type", connectLabel).get(0).getMetadata().getName();
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
+
+        KafkaClientsResource.deployKafkaClients(clusterName + "-" + Constants.KAFKA_CLIENTS).done();
+        final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+        externalKafkaClient.setPodName(kafkaClientsPodName);
+        int sent = externalKafkaClient.sendMessages(topicName, namespace, clusterName, 10);
+        assertThat(sent, Matchers.is(10));
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -181,13 +181,13 @@ class ConnectS2IST extends BaseST {
         assertThat(kafkaConnectS2ILogs, not(containsString("ERROR")));
 
         LOGGER.info("Creating FileStreamSink connector in pod {} with topic {}", kafkaConnectS2IPodName, CONNECT_S2I_TOPIC_NAME);
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectS2IPodName, CONNECT_S2I_TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectS2IPodName, CONNECT_S2I_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         kafkaClient.sendAndRecvMessagesScramSha(userName, NAMESPACE, CLUSTER_NAME, CONNECT_S2I_TOPIC_NAME, 2);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName);
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectS2IPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
+        assertThat(cmdKubeClient().execInPod(kafkaConnectS2IPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
                 containsString("0\n1\n"));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -132,9 +132,6 @@ class ConnectST extends BaseST {
                 .done();
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
-            .editMetadata()
-                .addToLabels("type", "kafka-connect")
-            .endMetadata()
             .editSpec()
                 .addToConfig("key.converter.schemas.enable", false)
                 .addToConfig("value.converter.schemas.enable", false)
@@ -145,11 +142,11 @@ class ConnectST extends BaseST {
 
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         kafkaClient.sendAndRecvMessages(NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, 2);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName);
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
         cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);
@@ -347,13 +344,13 @@ class ConnectST extends BaseST {
 
         LOGGER.info("Creating FileStreamSink connector in pod {} with topic {}", kafkaConnectPodName, CONNECT_TOPIC_NAME);
 
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         kafkaClient.sendAndRecvMessagesTls(userName, NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, 2);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName);
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
+        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
                 containsString("0\n1\n"));
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
@@ -420,11 +417,11 @@ class ConnectST extends BaseST {
         assertThat(kafkaConnectLogs, not(containsString("ERROR")));
 
         LOGGER.info("Creating FileStreamSink connector in pod {} with topic {}", kafkaConnectPodName, CONNECT_TOPIC_NAME);
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         kafkaClient.sendAndRecvMessagesScramSha(userName, NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, 2);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName);
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
         assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
                 containsString("0\n1\n"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.oauth;
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.HttpUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
@@ -134,13 +135,13 @@ public class OauthPlainST extends OauthBaseST {
 
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         String message = "Hello world - " + END_MESSAGE_OFFSET;
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, message);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
+        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
                 containsString(message));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.oauth;
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.HttpUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
@@ -141,13 +142,13 @@ public class OauthTlsST extends OauthBaseST {
 
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(kafkaConnectPodName);
 
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectPodName, TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         String message = "Hello world - " + END_MESSAGE_OFFSET;
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, message);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
+        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
                 containsString(message));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -791,11 +791,11 @@ public class TracingST extends BaseST {
         String kafkaConnectS2IPodName = kubeClient().listPods("type", "kafka-connect-s2i").get(0).getMetadata().getName();
 
         LOGGER.info("Creating FileSink connect in Pod:{}", kafkaConnectS2IPodName);
-        KafkaConnectUtils.createFileSinkConnector(kafkaConnectS2IPodName, TEST_TOPIC_NAME);
+        KafkaConnectUtils.createFileSinkConnector(kafkaConnectS2IPodName, TEST_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME);
 
         kafkaClient.sendAndRecvMessages(NAMESPACE, CLUSTER_NAME, TEST_TOPIC_NAME, 10);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName);
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
         HttpUtils.waitUntilServiceWithNameIsReady(RestAssured.baseURI, JAEGER_PRODUCER_SERVICE, JAEGER_CONSUMER_SERVICE,
                 JAEGER_KAFKA_CONNECT_S2I_SERVICE);


### PR DESCRIPTION

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change


- Enhancement / new feature
- Refactoring


### Description

This PR add test coverage for KafkaConnector resource in different namespace than CO and covers https://github.com/strimzi/strimzi-kafka-operator/pull/2418. I also added S2I deployment to different namespace than CO.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

