### PR TITLE
Fix make release command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ The `release` target will not build the Docker images - they should be built and
 The release process should normally look like this:
 1. Create a release branch
 2. Export the desired version into the environment variable `RELEASE_VERSION`
-3. Run `make clean release`
+3. Run `make release`
 4. Commit the changes to the existing files (do not add the newly created top level TAR.GZ, ZIP archives or .yaml files into Git)
 5. Push the changes to the release branch on GitHub
 6. Create the tag and push it to GitHub. Tag name determines the tag of the resulting Docker images. Therefore the Git tag name has to be the same as the `RELEASE_VERSION`, i.e. `git tag ${RELEASE_VERSION}`,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,22 +10,23 @@ The `release` target will not build the Docker images - they should be built and
 
 The release process should normally look like this:
 1. Create a release branch
-2. Export the desired version into the environment variable `RELEASE_VERSION`
-3. Run `make release`
-4. Commit the changes to the existing files (do not add the newly created top level TAR.GZ, ZIP archives or .yaml files into Git)
-5. Push the changes to the release branch on GitHub
-6. Create the tag and push it to GitHub. Tag name determines the tag of the resulting Docker images. Therefore the Git tag name has to be the same as the `RELEASE_VERSION`, i.e. `git tag ${RELEASE_VERSION}`,
-7. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. Attach the TAR.GZ/ZIP archives, YAML files (for installation from URL) from step 4 and the Helm Chart to the release
-8. On the `master` git branch
+2. Run `make clean`
+3. Export the desired version into the environment variable `RELEASE_VERSION`
+4. Run `make release`
+5. Commit the changes to the existing files (do not add the newly created top level TAR.GZ, ZIP archives or .yaml files into Git)
+6. Push the changes to the release branch on GitHub
+7. Create the tag and push it to GitHub. Tag name determines the tag of the resulting Docker images. Therefore the Git tag name has to be the same as the `RELEASE_VERSION`, i.e. `git tag ${RELEASE_VERSION}`,
+8. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, Create a GitHub release and tag based on the release branch. Attach the TAR.GZ/ZIP archives, YAML files (for installation from URL) from step 4 and the Helm Chart to the release
+9. On the `master` git branch
   * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
   * Copy the `helm-charts/index.yaml` from the `release` branch to `master`.
-9. Update the website
+10. Update the website
   * Add release documentation to `strimzi.github.io/docs/`. Update references to docs in `strimzi.github.io/documentation/index.md` and `strimzi.github.io/documentation/archive/index.md`. Update also the link from the start page: `strimzi.github.io/index.md`.
   * Update the Helm Chart repository file by copying `strimzi-kafka-operator/helm-charts/index.yaml` to `strimzi.github.io/charts/index.yaml`.
   * Update the Quickstarts for OKD and Minikube to use the latest stuff.
   * Update the `_redirects` file to make sure the `/install/latest` redirect points to the new release.
-10. The maven artifacts (`api` module) will be automatically staged from TravisCI during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
-11. Update the Strimzi manifest files in Operate Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
+11. The maven artifacts (`api` module) will be automatically staged from TravisCI during the tag build. It has to be releases from [Sonatype](https://oss.sonatype.org/#stagingRepositories) to get to the main Maven repositories.
+12. Update the Strimzi manifest files in Operate Hub [community operators](https://github.com/operator-framework/community-operators) repository and submit a pull request upstream. *Note*: Instructions for this step need updating.
 
 ## Updating Kafka Bridge version
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

_Select the type of your PR_

- Documentation

### Description

Actually, running a `clean` during the release process deletes the needed folder during the process.
The right way is just a `make release`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

