### PR TITLE
Removed not applicable step on prometheus-rules file

### DIFF
--- a/documentation/modules/proc-metrics-deploying-prometheus.adoc
+++ b/documentation/modules/proc-metrics-deploying-prometheus.adoc
@@ -40,18 +40,6 @@ oc create secret generic additional-scrape-configs --from-file=prometheus-additi
 
 .. Edit the `additionalScrapeConfigs` property in the `prometheus.yaml` file to include the name of the `Secret` and the YAML file (`prometheus-additional.yaml`) that contains the additional configuration.
 
-. Edit the `prometheus-rules.yaml` file that creates sample alert notification rules:
-+
-On Linux, use:
-+
-[source,shell,subs="+quotes,attributes"]
-sed -i 's/namespace: .*/namespace: _my-namespace_/' prometheus-rules.yaml
-+
-On MacOS, use:
-+
-[source,shell,subs="+quotes,attributes"]
-sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus-rules.yaml
-
 . Deploy the Prometheus resources:
 +
 [source,shell,subs="+quotes,attributes"]


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

This file removes a not applicable step while deploying Prometheus because the `prometheus-rules.yaml` file has no `namespace:` field to change.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

