### PR TITLE
Push images to internal registry for PR builds

### DIFF
--- a/Jenkinsfile-pr
+++ b/Jenkinsfile-pr
@@ -62,7 +62,7 @@ pipeline {
                     } else {
                         env.TEST_ONLY = false
                         env.DOCKER_ORG="strimzi"
-                        env.DOCKER_REGISTRY="localhost:5000"
+                        env.DOCKER_REGISTRY="172.30.1.1:5000"
                         env.DOCKER_TAG="pr"
                     }
                     echo "TEST_ONLY: ${env.TEST_ONLY}"

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -97,8 +97,9 @@ def clearImages() {
 
 
 def buildStrimziImages() {
-    sh "make docker_build"
-    sh "make docker_tag"
+    sh(script: "make docker_build")
+    sh(script: "make docker_tag")
+    sh(script: "make docker_push")
 }
 
 def runSystemTests(String workspace, String testCases, String testProfile, String excludeGroups) {

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -100,7 +100,9 @@ def buildStrimziImages() {
     sh(script: "make docker_build")
     sh(script: "make docker_tag")
     // Login to internal registries
-    sh("script: docker login 172.30.1.1:5000 -u \$(oc whoami) -p \$(oc whoami -t)")
+    sh("script: docker login ${env.DOCKER_REGISTRY} -u \$(oc whoami) -p \$(oc whoami -t)")
+    // Create namespace for images
+    sh("script: oc create namespace ${env.DOCKER_ORG}")
     sh(script: "make docker_push")
 }
 

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -99,6 +99,8 @@ def clearImages() {
 def buildStrimziImages() {
     sh(script: "make docker_build")
     sh(script: "make docker_tag")
+    // Login to internal registries
+    sh("script: docker login 172.30.1.1:5000 -u \$(oc whoami) -p \$(oc whoami -t)")
     sh(script: "make docker_push")
 }
 

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -100,9 +100,9 @@ def buildStrimziImages() {
     sh(script: "make docker_build")
     sh(script: "make docker_tag")
     // Login to internal registries
-    sh("script: docker login ${env.DOCKER_REGISTRY} -u \$(oc whoami) -p \$(oc whoami -t)")
+    sh(script: "docker login ${env.DOCKER_REGISTRY} -u \$(oc whoami) -p \$(oc whoami -t)")
     // Create namespace for images
-    sh("script: oc create namespace ${env.DOCKER_ORG}")
+    sh(script: "oc create namespace ${env.DOCKER_ORG}")
     sh(script: "make docker_push")
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -22,6 +22,7 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.HelmClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
@@ -119,6 +120,10 @@ public abstract class BaseST implements TestSeparator {
         cluster.createNamespaces(clientNamespace, namespaces);
         cluster.createCustomResources(resources);
         cluster.applyClusterOperatorInstallFiles();
+        // This is needed in case you are using internal kubernetes registry and you want to pull images from there
+        for (String namespace : namespaces) {
+            Exec.exec(null, Arrays.asList("oc", "policy", "add-role-to-group", "system:image-puller", "system:serviceaccounts:" + namespace, "-n", Environment.STRIMZI_ORG), 0, false, false);
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fix Jenkins PR job which was broken when `ImagePullPolicy=Always` was set for system test. Now the images will be pushed into internal registry and pull from there for each test.

To make sure that each namespace has correct rights for pulling images, I added code which set correct rights to all newly created namespaces. In case user will use dockerhub or quay as registry, this piece of code will not affect any pulling from these.

### Checklist

- [x] Make sure all tests pass

