### PR TITLE
Add listener certificate to the Kafka Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 0.17.0
+
+* Add public keys of TLS listeners to the status section of the Kafka CR
+
 ## 0.16.0
 
 * Add support for Kafka 2.4.0 and upgrade from Zookeeper 3.4.x to 3.5.x

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -27,13 +27,14 @@ import static java.util.Collections.emptyMap;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "type", "addresses" })
+@JsonPropertyOrder({ "type", "addresses", "certificates" })
 @EqualsAndHashCode
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String type;
     private List<ListenerAddress> addresses;
+    private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
     @Description("The type of the listener. " +
@@ -53,6 +54,16 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
 
     public void setAddresses(List<ListenerAddress> addresses) {
         this.addresses = addresses;
+    }
+
+    @Description("The A list of public TLS keys which can be used to verify the identity of the server when connecting " +
+            "to the given listener. Set only for `tls` and `external` listeners.")
+    public List<String> getCertificates() {
+        return certificates;
+    }
+
+    public void setCertificates(List<String> certificates) {
+        this.certificates = certificates;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -56,7 +56,7 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
         this.addresses = addresses;
     }
 
-    @Description("The A list of public TLS keys which can be used to verify the identity of the server when connecting " +
+    @Description("The list of public TLS keys which can be used to verify the identity of the server when connecting " +
             "to the given listener. Set only for `tls` and `external` listeners.")
     public List<String> getCertificates() {
         return certificates;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -56,7 +56,7 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
         this.addresses = addresses;
     }
 
-    @Description("The list of public TLS keys which can be used to verify the identity of the server when connecting " +
+    @Description("A list of TLS certificates which can be used to verify the identity of the server when connecting " +
             "to the given listener. Set only for `tls` and `external` listeners.")
     public List<String> getCertificates() {
         return certificates;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -98,6 +98,7 @@ import org.apache.logging.log4j.Logger;
 import org.quartz.CronExpression;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
@@ -1995,7 +1996,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(secret -> {
                         if (secret != null)  {
                             byte[] publicKeyBytes = Base64.getDecoder().decode(secret.getData().get(customCertSecret.getCertificate()));
-                            tlsListenerCustomCertificate = new String(publicKeyBytes, Charset.defaultCharset());
+                            tlsListenerCustomCertificate = new String(publicKeyBytes, StandardCharsets.US_ASCII);
                             tlsListenerCustomCertificateThumbprint = getCertificateThumbprint(secret, customCertSecret);
 
                             return Future.succeededFuture(this);
@@ -2012,7 +2013,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(secret -> {
                         if (secret != null)  {
                             byte[] publicKeyBytes = Base64.getDecoder().decode(secret.getData().get(customCertSecret.getCertificate()));
-                            externalListenerCustomCertificate = new String(publicKeyBytes, Charset.defaultCharset());
+                            externalListenerCustomCertificate = new String(publicKeyBytes, StandardCharsets.US_ASCII);
                             externalListenerCustomCertificateThumbprint = getCertificateThumbprint(secret, customCertSecret);
 
                             return Future.succeededFuture(this);
@@ -3119,7 +3120,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         void addCertificateToListener(String type, String certificate)    {
             if (certificate == null)    {
                 // When custom certificate is not used, use the current CA certificate
-                certificate = new String(clusterCa.currentCaCertBytes(), Charset.defaultCharset());
+                certificate = new String(clusterCa.currentCaCertBytes(), StandardCharsets.US_ASCII);
             }
 
             List<ListenerStatus> listeners = kafkaStatus.getListeners();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -97,6 +97,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.CronExpression;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
@@ -1994,7 +1995,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(secret -> {
                         if (secret != null)  {
                             byte[] publicKeyBytes = Base64.getDecoder().decode(secret.getData().get(customCertSecret.getCertificate()));
-                            tlsListenerCustomCertificate = new String(publicKeyBytes);
+                            tlsListenerCustomCertificate = new String(publicKeyBytes, Charset.defaultCharset());
                             tlsListenerCustomCertificateThumbprint = getCertificateThumbprint(secret, customCertSecret);
 
                             return Future.succeededFuture(this);
@@ -2011,7 +2012,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .compose(secret -> {
                         if (secret != null)  {
                             byte[] publicKeyBytes = Base64.getDecoder().decode(secret.getData().get(customCertSecret.getCertificate()));
-                            externalListenerCustomCertificate = new String(publicKeyBytes);
+                            externalListenerCustomCertificate = new String(publicKeyBytes, Charset.defaultCharset());
                             externalListenerCustomCertificateThumbprint = getCertificateThumbprint(secret, customCertSecret);
 
                             return Future.succeededFuture(this);
@@ -3118,7 +3119,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         void addCertificateToListener(String type, String certificate)    {
             if (certificate == null)    {
                 // When custom certificate is not used, use the current CA certificate
-                certificate = new String(clusterCa.currentCaCertBytes());
+                certificate = new String(clusterCa.currentCaCertBytes(), Charset.defaultCharset());
             }
 
             List<ListenerStatus> listeners = kafkaStatus.getListeners();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -97,7 +97,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.CronExpression;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -422,8 +422,10 @@ public class KafkaAssemblyOperatorCustomCertTest {
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             return reconcileState.reconcileCas(this::dateSupplier)
                     .compose(state -> state.getKafkaClusterDescription())
-                    .compose(state -> state.getCustomTlsListenerThumbprint())
-                    .compose(state -> state.getCustomExternalListenerThumbprint())
+                    //.compose(state -> state.getCustomTlsListenerThumbprint())
+                    //.compose(state -> state.getCustomExternalListenerThumbprint())
+                    .compose(state -> state.customTlsListenerCertificate())
+                    .compose(state -> state.customExternalListenerCertificate())
                     .compose(state -> state.kafkaStatefulSet())
                     .compose(state -> state.kafkaRollingUpdate())
                     .map((Void) null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -422,8 +422,6 @@ public class KafkaAssemblyOperatorCustomCertTest {
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             return reconcileState.reconcileCas(this::dateSupplier)
                     .compose(state -> state.getKafkaClusterDescription())
-                    //.compose(state -> state.getCustomTlsListenerThumbprint())
-                    //.compose(state -> state.getCustomExternalListenerThumbprint())
                     .compose(state -> state.customTlsListenerCertificate())
                     .compose(state -> state.customExternalListenerCertificate())
                     .compose(state -> state.kafkaStatefulSet())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -1041,5 +1041,6 @@ public class KafkaStatusTest {
                     .compose(state -> state.kafkaNodePortExternalListenerStatus())
                     .map((Void) null);
         }
+
     }
 }

--- a/cluster-operator/src/test/resources/log4j2-test.properties
+++ b/cluster-operator/src/test/resources/log4j2-test.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/cluster-operator/src/test/resources/log4j2-test.properties
+++ b/cluster-operator/src/test/resources/log4j2-test.properties
@@ -5,7 +5,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1384,7 +1384,7 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |string
 |addresses     1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
-|certificates  1.2+<.<|The list of public TLS keys which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
+|certificates  1.2+<.<|A list of TLS certificates which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1384,7 +1384,7 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 |string
 |addresses     1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
-|certificates  1.2+<.<|The A list of public TLS keys which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
+|certificates  1.2+<.<|The list of public TLS keys which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
 |string array
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1379,11 +1379,13 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 
 [options="header"]
 |====
-|Property          |Description
-|type       1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
+|Property             |Description
+|type          1.2+<.<|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
 |string
-|addresses  1.2+<.<|A list of the addresses for this listener.
+|addresses     1.2+<.<|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array
+|certificates  1.2+<.<|The A list of public TLS keys which can be used to verify the identity of the server when connecting to the given listener. Set only for `tls` and `external` listeners.
+|string array
 |====
 
 [id='type-ListenerAddress-{context}']

--- a/documentation/modules/con-custom-resources-status.adoc
+++ b/documentation/modules/con-custom-resources-status.adoc
@@ -96,10 +96,20 @@ status:
   - addresses:
     - host: my-cluster-kafka-bootstrap.myproject.svc
       port: 9093
+    certificates:
+    - |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
     type: tls
   - addresses:
     - host: 172.29.49.180
       port: 9094
+    certificates:
+    - |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
     type: external
     # ...
 ----

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -3691,4 +3691,8 @@ spec:
                           type: string
                         port:
                           type: integer
+                  certificates:
+                    type: array
+                    items:
+                      type: string
 {{- end -}}

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -3686,3 +3686,7 @@ spec:
                           type: string
                         port:
                           type: integer
+                  certificates:
+                    type: array
+                    items:
+                      type: string


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some cases, users might not have access to the secrets containing TLS certificates of the broker. This could be for example in order to protect the secrets with service account tokens etc. In such case, having the public keys in the KAfkastatus might be useful. This PR adds them.

An example how the new KAfka Status might look like can be found here:

```yaml
status:
  conditions:
  - lastTransitionTime: 2020-01-28T00:39:29+0000
    status: "True"
    type: Ready
  listeners:
  - addresses:
    - host: my-cluster-kafka-bootstrap.myproject.svc
      port: 9092
    type: plain
  - addresses:
    - host: my-cluster-kafka-bootstrap.myproject.svc
      port: 9093
    certificates:
    - |
      -----BEGIN CERTIFICATE-----
      MIIDLTCCAhWgAwIBAgIJAJCYKhSYn0jBMA0GCSqGSIb3DQEBCwUAMC0xEzARBgNV
      BAoMCmlvLnN0cmltemkxFjAUBgNVBAMMDWNsdXN0ZXItY2EgdjAwHhcNMjAwMTI4
      MDAzNzQ2WhcNMjIxMDI0MDAzNzQ2WjAtMRMwEQYDVQQKDAppby5zdHJpbXppMRYw
      FAYDVQQDDA1jbHVzdGVyLWNhIHYwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
      CgKCAQEAxq7p+dqcklO9mKAPhWAcb+fi6UwYd7wWfZ5M43rXxHPM2Q+dgq7wrztj
      YLBVBiBiqDRVNFPIraVnBiVFGxy1vICPYybNkcDAgQc9KRVwYlEs5YibYDSoTdCC
      5yS8aGP6VRN1geZIb2ZEtOdnIuheZxoyX+0oIO8ypZOncsXinJQioKXV7Ox8n79m
      ussiAH/YGu/FoEJlkT5SSiiaIt/MxRHbzvy/d0XwvEi7o2vHkKLDbGrCdWrHbFeP
      4VWzq6+GHviLqTv/sn0Is5zrwJbVaGIilc7NjuOSizPx/rbvizFQiwkUYsMGnqLQ
      HItYcmC9zlWN+fxoz7alvWXBHMJ6wwIDAQABo1AwTjAdBgNVHQ4EFgQUK5WfcD9l
      FpQffonJyP4FNA6AmRQwHwYDVR0jBBgwFoAUK5WfcD9lFpQffonJyP4FNA6AmRQw
      DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAlab3mNinaYh992FbMvsE
      JCQGZa/1IkKYXLySaOvY6x+sH7FO9cLejLDg0PCCAvFd4W9f62m43INYNW0MiTwS
      qwG1bXcehZb0BLA2gTvASTsiaWkElVGhOIAhYHD9x4GtYBGk14Mj21XH4Q899HFM
      m1ClemwT8x7PRq0uWUYrVV+IBE3EBAeSrf56RnyEr45TgegjowtrwAOqelECIhwu
      25WQ8MSwf2hL80zFVRKgXhSCZvmu4Nm+y1yFmrCzxVeg9W8ZYO26JDmW8eYlRHPv
      Z0wTgLDuIqeGHDE8eHDFGxHjJCsB82bgYx+oIlz6lPeaud51xTwNLjE1jcZXvVDL
      SA==
      -----END CERTIFICATE-----
    type: tls
  - addresses:
    - host: my-cluster-kafka-bootstrap-myproject.192.168.64.151.nip.io
      port: 443
    certificates:
    - |
      -----BEGIN CERTIFICATE-----
      MIIDLTCCAhWgAwIBAgIJAJCYKhSYn0jBMA0GCSqGSIb3DQEBCwUAMC0xEzARBgNV
      BAoMCmlvLnN0cmltemkxFjAUBgNVBAMMDWNsdXN0ZXItY2EgdjAwHhcNMjAwMTI4
      MDAzNzQ2WhcNMjIxMDI0MDAzNzQ2WjAtMRMwEQYDVQQKDAppby5zdHJpbXppMRYw
      FAYDVQQDDA1jbHVzdGVyLWNhIHYwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
      CgKCAQEAxq7p+dqcklO9mKAPhWAcb+fi6UwYd7wWfZ5M43rXxHPM2Q+dgq7wrztj
      YLBVBiBiqDRVNFPIraVnBiVFGxy1vICPYybNkcDAgQc9KRVwYlEs5YibYDSoTdCC
      5yS8aGP6VRN1geZIb2ZEtOdnIuheZxoyX+0oIO8ypZOncsXinJQioKXV7Ox8n79m
      ussiAH/YGu/FoEJlkT5SSiiaIt/MxRHbzvy/d0XwvEi7o2vHkKLDbGrCdWrHbFeP
      4VWzq6+GHviLqTv/sn0Is5zrwJbVaGIilc7NjuOSizPx/rbvizFQiwkUYsMGnqLQ
      HItYcmC9zlWN+fxoz7alvWXBHMJ6wwIDAQABo1AwTjAdBgNVHQ4EFgQUK5WfcD9l
      FpQffonJyP4FNA6AmRQwHwYDVR0jBBgwFoAUK5WfcD9lFpQffonJyP4FNA6AmRQw
      DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAlab3mNinaYh992FbMvsE
      JCQGZa/1IkKYXLySaOvY6x+sH7FO9cLejLDg0PCCAvFd4W9f62m43INYNW0MiTwS
      qwG1bXcehZb0BLA2gTvASTsiaWkElVGhOIAhYHD9x4GtYBGk14Mj21XH4Q899HFM
      m1ClemwT8x7PRq0uWUYrVV+IBE3EBAeSrf56RnyEr45TgegjowtrwAOqelECIhwu
      25WQ8MSwf2hL80zFVRKgXhSCZvmu4Nm+y1yFmrCzxVeg9W8ZYO26JDmW8eYlRHPv
      Z0wTgLDuIqeGHDE8eHDFGxHjJCsB82bgYx+oIlz6lPeaud51xTwNLjE1jcZXvVDL
      SA==
      -----END CERTIFICATE-----
    type: external
  observedGeneration: 1
```

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

