### PR TITLE
[DOC] Upgrading Zookeeper deployments to 3.5.6

### DIFF
--- a/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
+++ b/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
@@ -16,12 +16,11 @@ For the `Kafka` resource to be upgraded, check:
 * The `Kafka.spec.kafka.config` does not contain options that are not supported in the version of Kafka that you are upgrading to.
 * Whether the `log.message.format.version` for the current Kafka version needs to be updated for the new version.
 +
-xref:assembly-upgrade-{context}[Consult the Kafka versions table].
+xref:ref-kafka-versions-{context}[Consult the Kafka versions table] 
 
 .Procedure
 
 . Update the Kafka cluster configuration in an editor, as required:
-
 +
 [source,shell,subs=+quotes]
 ----
@@ -30,7 +29,7 @@ kubectl edit kafka _my-cluster_
 
 .. If the `log.message.format.version` of the current Kafka version is the same as that of the new Kafka version, proceed to the next step.
 +
-Otherwise, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` configured to the default for the current version.
+Otherwise, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` configured to the default for the _current_ version.
 +
 For example, if upgrading from Kafka {KafkaVersionLower}:
 +
@@ -75,6 +74,9 @@ See xref:con-versions-and-images-str[]
 
 . Save and exit the editor, then wait for rolling updates to complete.
 +
+NOTE: Additional rolling updates occur if the new version of Kafka has a new ZooKeeper version.
+
++
 Check the update in the logs or by watching the pod state transitions:
 +
 [source,shell,subs=+quotes]
@@ -107,7 +109,7 @@ The rolling updates:
 * Ensure each pod is using the broker binaries for the new version of Kafka
 * Configure the brokers to send messages using the interbroker protocol of the new version of Kafka
 +
-NOTE: Clients are still using the old version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, updates the clients as quickly as possible.
+NOTE: Clients are still using the old version, so brokers will convert messages to the old version before sending them to the clients. To minimize this additional load, update the clients as quickly as possible.
 
 . Depending on your chosen strategy for upgrading clients, upgrade all client applications to use the new version of the client binaries.
 +
@@ -119,7 +121,7 @@ WARNING: You cannot downgrade after completing this step. If you need to revert 
 If required, set the version property for Kafka Connect and Mirror Maker as the new version of Kafka:
 +
 .. For Kafka Connect, update `KafkaConnect.spec.version`
-.. For MIrror Maker, update `KafkaMirrorMaker.spec.version`
+.. For Mirror Maker, update `KafkaMirrorMaker.spec.version`
 
 . If the `log.message.format.version` identified in step 1 is the same as the new version proceed to the next step.
 +

--- a/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
+++ b/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
@@ -16,7 +16,7 @@ For the `Kafka` resource to be upgraded, check:
 * The `Kafka.spec.kafka.config` does not contain options that are not supported in the version of Kafka that you are upgrading to.
 * Whether the `log.message.format.version` for the current Kafka version needs to be updated for the new version.
 +
-xref:ref-kafka-versions-{context}[Consult the Kafka versions table] 
+xref:ref-kafka-versions-{context}[Consult the Kafka versions table].
 
 .Procedure
 

--- a/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
+++ b/documentation/modules/proc-upgrading-brokers-newer-kafka.adoc
@@ -75,7 +75,6 @@ See xref:con-versions-and-images-str[]
 . Save and exit the editor, then wait for rolling updates to complete.
 +
 NOTE: Additional rolling updates occur if the new version of Kafka has a new ZooKeeper version.
-
 +
 Check the update in the logs or by watching the pod state transitions:
 +


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Kafka version 2.4.0 supports a new version of ZooKeeper (version 3.5.6). Therefore, upgrading the Kafka version from 2.3.1 to 2.4.0 will trigger additional rolling updates for ZooKeeper.

This pull request adds a short note to the "Upgrading Kafka brokers and client applications" procedure to explain the additional rolling updates.

It also fixes a cross-reference that was pointing to the wrong place and corrects some typos.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

