### PR TITLE
ST: fix some failures

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
@@ -41,7 +41,7 @@ public class KafkaCmdClient {
         String podName = KafkaResources.zookeeperPodName(clusterName, zkPodId);
         int port = 2181 * 10 + zkPodId;
         return Arrays.asList(cmdKubeClient().execInPod(podName, "/bin/bash", "-c",
-            "bin/kafka-topics.sh --zookeeper localhost:" + port + " --describe --topic " + topic).out().split("\\s+"));
+            "bin/kafka-topics.sh --zookeeper localhost:" + port + " --describe --topic " + topic).out().replace(": ", ":").split("\\s+"));
     }
 
     public static String updateTopicPartitionsCountUsingPodCli(String clusterName, int zkPodId, String topic, int partitions) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/TopicST.java
@@ -6,6 +6,11 @@ package io.strimzi.systemtest;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -14,11 +19,8 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.strimzi.systemtest.resources.KubernetesResource;
-import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
-import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+
+import java.util.List;
 
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SCALABILITY;
@@ -255,9 +257,10 @@ public class TopicST extends BaseST {
     }
 
     void verifyTopicViaKafka(String topicName, int topicPartitions) {
-        LOGGER.info("Checking topic in Kafka {}", KafkaCmdClient.describeTopicUsingPodCli(CLUSTER_NAME, 0, topicName));
-        assertThat(KafkaCmdClient.describeTopicUsingPodCli(CLUSTER_NAME, 0, topicName),
-                hasItems("Topic:" + topicName, "PartitionCount:" + topicPartitions));
+        List<String> topicInfo = KafkaCmdClient.describeTopicUsingPodCli(CLUSTER_NAME, 0, topicName);
+        LOGGER.info("Checking topic {} in Kafka {}", topicName, CLUSTER_NAME);
+        LOGGER.debug("Topic {} info: {}", topicName, topicInfo);
+        assertThat(topicInfo, hasItems("Topic:" + topicName, "PartitionCount:" + topicPartitions));
     }
 
     void verifyTopicViaKafkaTopicCRK8s(KafkaTopic kafkaTopic, String topicName, int topicPartitions) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -39,6 +39,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 @Tag(REGRESSION)
 public class MetricsST extends BaseST {
@@ -182,7 +183,7 @@ public class MetricsST extends BaseST {
             LOGGER.info("Metrics collection for pod {} return code - {}", podName, ret);
         }
 
-        assertThat("Collected metrics should not be empty", exec.out(), emptyString());
+        assertThat("Collected metrics should not be empty", exec.out(), not(emptyString()));
         return exec.out();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -8,9 +8,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.ClientFactory;
-import io.strimzi.systemtest.kafkaclients.EClientType;
-import io.strimzi.systemtest.kafkaclients.externalclient.ExternalKafkaClient;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import io.strimzi.test.executor.Exec;
@@ -40,16 +37,13 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
 
 @Tag(REGRESSION)
 public class MetricsST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(MetricsST.class);
-
-    protected ExternalKafkaClient externalKafkaClient = (ExternalKafkaClient) ClientFactory.getClient(EClientType.BASIC.getClientType());
 
     public static final String NAMESPACE = "metrics-cluster-test";
     private final Object lock = new Object();
@@ -188,7 +182,7 @@ public class MetricsST extends BaseST {
             LOGGER.info("Metrics collection for pod {} return code - {}", podName, ret);
         }
 
-        assertThat("Collected metrics should not be empty", exec.out(), not(isEmptyString()));
+        assertThat("Collected metrics should not be empty", exec.out(), emptyString());
         return exec.out();
     }
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

With some last changes, we broke several tests:

- RollingUpdateST - fixed consumer group for clients
- Metrics - removed unnecessary cast for KafkaClients which leads to fail at the start of tests.
- TopicST - fix topic description validation after merge Kafka 2.4.0

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass

