### PR TITLE
Added clean when building the project

### DIFF
--- a/DEV_QUICK_START.md
+++ b/DEV_QUICK_START.md
@@ -40,14 +40,16 @@ To build Strimzi from source the operator and Kafka code needs to be compiled in
         export DOCKER_ORG=docker_hub_username
 
 3. Now build the Docker images and push them to your repository on Docker Hub:
-    
-        make clean all
+
+        make clean
+        make all
 
    Once this completes you should have several new repositories under your Docker Hub account (`docker_hub_username/operator`, `docker_hub_username/kafka` and `docker_hub_username/test-client`).
 
    The tests run during the build can be skipped by setting the `MVN_ARGS` environment variable and passing that to the make command:
 
-        make MVN_ARGS='-DskipTests -DskipIT' clean all
+        make clean
+        make MVN_ARGS='-DskipTests -DskipIT' all
 
 4. In order to use the newly built images, you need to update the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yml` to obtain the images from your repositories on Docker Hub rather than the official Strimzi images. That can be done using the following command:
 

--- a/DEV_QUICK_START.md
+++ b/DEV_QUICK_START.md
@@ -41,13 +41,13 @@ To build Strimzi from source the operator and Kafka code needs to be compiled in
 
 3. Now build the Docker images and push them to your repository on Docker Hub:
     
-        make all
+        make clean all
 
    Once this completes you should have several new repositories under your Docker Hub account (`docker_hub_username/operator`, `docker_hub_username/kafka` and `docker_hub_username/test-client`).
 
    The tests run during the build can be skipped by setting the `MVN_ARGS` environment variable and passing that to the make command:
 
-        make MVN_ARGS='-DskipTests -DskipIT' all
+        make MVN_ARGS='-DskipTests -DskipIT' clean all
 
 4. In order to use the newly built images, you need to update the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yml` to obtain the images from your repositories on Docker Hub rather than the official Strimzi images. That can be done using the following command:
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

With `clean` , we are sure that the build starts from scratch compiling last binaries (not using dirty stuff from a previous build maybe on a different branch).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

