### PR TITLE
ST: Fix posibility to change CO image pull policy

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -201,7 +201,8 @@ All environment variables can be seen in [Environment](systemtest/src/main/java/
 | TEST_CLUSTER_CONTEXT      | Context which will be used to reach the cluster*                                     | currently active kubernetes context              |
 | TEST_CLUSTER_USER         | Default user which will be used for command line admin operations                    | developer                                        |
 | SKIP_TEARDOWN             | Variable for skip teardown phase for more debug if needed                            | false                                            |
-| IMAGE_PULL_POLICY         | Image Pull Policy                                                                    | IfNotPresent                                     |
+| OPERATOR_IMAGE_PULL_POLICY   | Image Pull Policy for Operator image                                              | Always                                           |
+| COMPONENTS_IMAGE_PULL_POLICY | Image Pull Policy for Kafka, Bridge, etc.                                         | IfNotPresent                                     |
 | STRIMZI_TEST_LOG_LEVEL    | Log level for system tests                                                           | INFO                                             |
 
 If you want to use your own images with a different tag or from a different repository, you can use `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` environment variables.

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -55,7 +55,8 @@ public interface Constants {
 
     String KAFKA_CLIENTS = "kafka-clients";
     String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
-    String IMAGE_PULL_POLICY = "Always";
+    String ALWAYS_IMAGE_PULL_POLICY = "Always";
+    String IF_NOT_PRESENT_IMAGE_PULL_POLICY = "IfNotPresent";
 
     int HTTP_KEYCLOAK_DEFAULT_PORT = 8080;
     int HTTPS_KEYCLOAK_DEFAULT_PORT = 8443;

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -51,9 +51,13 @@ public class Environment {
      */
     private static final String KUBERNETES_DOMAIN_ENV = "KUBERNETES_DOMAIN";
     /**
-     * Image pull policy env var
+     * Image pull policy env var for Components images (Kafka, Bridge, ...)
      */
-    private static final String IMAGE_PULL_POLICY_ENV = "IMAGE_PULL_POLICY";
+    private static final String COMPONENTS_IMAGE_PULL_POLICY_ENV = "IMAGE_PULL_POLICY";
+    /**
+     * Image pull policy env var for Operator images
+     */
+    private static final String OPERATOR_IMAGE_PULL_POLICY_ENV = "OPERATOR_IMAGE_PULL_POLICY";
     /**
      * CO reconciliation interval.
      */
@@ -68,7 +72,8 @@ public class Environment {
     private static final String TEST_LOG_DIR_DEFAULT = "../systemtest/target/logs/";
     private static final String STRIMZI_LOG_LEVEL_DEFAULT = "DEBUG";
     static final String KUBERNETES_DOMAIN_DEFAULT = ".nip.io";
-    public static final String IMAGE_PULL_POLICY_ENV_DEFAULT = "IfNotPresent";
+    public static final String COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT = Constants.IF_NOT_PRESENT_IMAGE_PULL_POLICY;
+    public static final String OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT = Constants.ALWAYS_IMAGE_PULL_POLICY;
     public static final int KAFKA_CLIENTS_DEFAULT_PORT = 4242;
 
     public static final String STRIMZI_ORG = System.getenv().getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
@@ -85,7 +90,9 @@ public class Environment {
     // variables for kafka bridge image
     private static final String BRIDGET_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka-bridge:" + STRIMZI_TAG_DEFAULT;
     public static final String BRIDGE_IMAGE = System.getenv().getOrDefault(BRIDGE_IMAGE_ENV, BRIDGET_IMAGE_DEFAULT);
-    public static final String IMAGE_PULL_POLICY = System.getenv().getOrDefault(IMAGE_PULL_POLICY_ENV, IMAGE_PULL_POLICY_ENV_DEFAULT);
+    // Image pull policy variables
+    public static final String COMPONENTS_IMAGE_PULL_POLICY = System.getenv().getOrDefault(COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY_ENV_DEFAULT);
+    public static final String OPERATOR_IMAGE_PULL_POLICY = System.getenv().getOrDefault(OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY_ENV_DEFAULT);
 
     private Environment() {
     }
@@ -102,6 +109,7 @@ public class Environment {
         LOGGER.info(debugFormat, ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION);
         LOGGER.info(debugFormat, STRIMZI_LOG_LEVEL_ENV, STRIMZI_LOG_LEVEL);
         LOGGER.info(debugFormat, KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN);
-        LOGGER.info(debugFormat, IMAGE_PULL_POLICY_ENV, IMAGE_PULL_POLICY);
+        LOGGER.info(debugFormat, COMPONENTS_IMAGE_PULL_POLICY_ENV, COMPONENTS_IMAGE_PULL_POLICY);
+        LOGGER.info(debugFormat, OPERATOR_IMAGE_PULL_POLICY_ENV, OPERATOR_IMAGE_PULL_POLICY);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -86,7 +86,7 @@ public class KubernetesResource {
             }
         }
 
-        envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_POLICY", Environment.IMAGE_PULL_POLICY, null));
+        envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_POLICY", Environment.COMPONENTS_IMAGE_PULL_POLICY, null));
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
 
@@ -99,7 +99,7 @@ public class KubernetesResource {
                     .editSpec()
                         .editFirstContainer()
                             .withImage(StUtils.changeOrgAndTag(coImage))
-                            .withImagePullPolicy(Constants.IMAGE_PULL_POLICY)
+                            .withImagePullPolicy(Environment.OPERATOR_IMAGE_PULL_POLICY)
                         .endContainer()
                     .endSpec()
                 .endTemplate()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -73,7 +73,7 @@ public class KafkaClientsResource {
             .withImage(Environment.TEST_CLIENT_IMAGE)
             .withCommand("sleep")
             .withArgs("infinity")
-            .withImagePullPolicy(Environment.IMAGE_PULL_POLICY);
+            .withImagePullPolicy(Environment.COMPONENTS_IMAGE_PULL_POLICY);
 
         String producerConfiguration = ProducerConfig.ACKS_CONFIG + "=all\n";
         String consumerConfiguration = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest\n";

--- a/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/BaseST.java
@@ -327,7 +327,7 @@ public abstract class BaseST implements TestSeparator {
         Map<String, String> values = Collections.unmodifiableMap(Stream.of(
             entry("imageRepositoryOverride", dockerOrg),
             entry("imageTagOverride", dockerTag),
-            entry("image.pullPolicy", Constants.IMAGE_PULL_POLICY),
+            entry("image.pullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY),
             entry("resources.requests.memory", REQUESTS_MEMORY),
             entry("resources.requests.cpu", REQUESTS_CPU),
             entry("resources.limits.memory", LIMITS_MEMORY),


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

Yesterday during merge of mm2 PR we hit an issue during nightly build, that tests started using CO image with implemented MM2, but configuration for CO wasn't contain mm2 configuration, because original checkout was performed before merge.

This PR fix CO image pull policy option and make it possible to set pull policy via env variable for long test runs for example. Default value remains `Always`

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation

