### PR TITLE
Fix bad merge in CHANGELOG.md and add Mirror Maker 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 
 # CHANGELOG
+
 ## 0.17.0
+
+* Add support for Mirror Maker 2.0
 * Add Jmxtrans deployment
-
-## 0.17.0
-
 * Add public keys of TLS listeners to the status section of the Kafka CR
 
 ## 0.16.0


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There was some bad merging in the CHANGELOG.md file. It is also missing Mirror Maker 2.0. This PR should fix it.