### PR TITLE
Add enableECDSA config option that installs BouncyCastle crypto provider

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -44,6 +44,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private boolean accessTokenIsJwt = true;
     private List<CertSecretSource> tlsTrustedCertificates;
     private boolean disableTlsHostnameVerification = false;
+    private boolean enableECDSA = false;
 
     @Description("Must be `" + TYPE_OAUTH + "`")
     @Override
@@ -181,5 +182,16 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     public void setDisableTlsHostnameVerification(boolean disableTlsHostnameVerification) {
         this.disableTlsHostnameVerification = disableTlsHostnameVerification;
+    }
+
+    @Description("Enable or disable ECDSA support by installing BouncyCastle crypto provider. " +
+            "Default value is `false`.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isEnableECDSA() {
+        return enableECDSA;
+    }
+
+    public void setEnableECDSA(boolean enableECDSA) {
+        this.enableECDSA = enableECDSA;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -350,6 +350,7 @@ public class KafkaBrokerConfigurationBuilder {
         if (oauth.getJwksEndpointUri() != null) options.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_JWKS_ENDPOINT_URI, oauth.getJwksEndpointUri()));
         if (oauth.getJwksRefreshSeconds() > 0) options.add(String.format("%s=\"%d\"", ServerConfig.OAUTH_JWKS_REFRESH_SECONDS, oauth.getJwksRefreshSeconds()));
         if (oauth.getJwksExpirySeconds() > 0) options.add(String.format("%s=\"%d\"", ServerConfig.OAUTH_JWKS_EXPIRY_SECONDS, oauth.getJwksExpirySeconds()));
+        if (oauth.isEnableECDSA()) options.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE, true));
         if (oauth.getIntrospectionEndpointUri() != null) options.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI, oauth.getIntrospectionEndpointUri()));
         if (oauth.getUserNameClaim() != null) options.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_USERNAME_CLAIM, oauth.getUserNameClaim()));
         if (!oauth.isAccessTokenIsJwt()) options.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_TOKENS_NOT_JWT, true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -744,6 +744,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                     .withNewKafkaListenerAuthenticationOAuth()
                         .withNewValidIssuerUri("http://valid-issuer")
                         .withNewJwksEndpointUri("http://jwks")
+                        .withEnableECDSA(true)
                         .withNewUserNameClaim("preferred_username")
                     .endKafkaListenerAuthenticationOAuth()
                 .endPlain()
@@ -768,7 +769,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.secure.random.implementation=SHA1PRNG",
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.username.claim=\"preferred_username\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.crypto.provider.bouncycastle=\"true\" oauth.username.claim=\"preferred_username\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER"));
     }
 
@@ -784,6 +785,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                         .withNewKafkaListenerAuthenticationOAuth()
                         .withNewValidIssuerUri("https://valid-issuer")
                         .withNewJwksEndpointUri("https://jwks")
+                        .withEnableECDSA(true)
                         .withNewUserNameClaim("preferred_username")
                         .withDisableTlsHostnameVerification(true)
                         .withTlsTrustedCertificates(cert)
@@ -810,7 +812,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.secure.random.implementation=SHA1PRNG",
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"https://valid-issuer\" oauth.jwks.endpoint.uri=\"https://jwks\" oauth.username.claim=\"preferred_username\" oauth.ssl.endpoint.identification.algorithm=\"\" oauth.ssl.truststore.location=\"/tmp/kafka/oauth-plain-9092.truststore.p12\" oauth.ssl.truststore.password=\"${CERTS_STORE_PASSWORD}\" oauth.ssl.truststore.type=\"PKCS12\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"https://valid-issuer\" oauth.jwks.endpoint.uri=\"https://jwks\" oauth.crypto.provider.bouncycastle=\"true\" oauth.username.claim=\"preferred_username\" oauth.ssl.endpoint.identification.algorithm=\"\" oauth.ssl.truststore.location=\"/tmp/kafka/oauth-plain-9092.truststore.p12\" oauth.ssl.truststore.password=\"${CERTS_STORE_PASSWORD}\" oauth.ssl.truststore.type=\"PKCS12\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER"));
     }
 
@@ -866,6 +868,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withIntrospectionEndpointUri("http://introspection-endpoint")
                 .withJwksExpirySeconds(160)
                 .withJwksRefreshSeconds(50)
+                .withEnableECDSA(true)
                 .withUserNameClaim("preferred_username")
                 .withCheckAccessTokenType(false)
                 .withClientId("my-kafka-id")
@@ -879,6 +882,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_JWKS_ENDPOINT_URI, "http://jwks-endpoint"));
         expectedOptions.add(String.format("%s=\"%d\"", ServerConfig.OAUTH_JWKS_REFRESH_SECONDS, 50));
         expectedOptions.add(String.format("%s=\"%d\"", ServerConfig.OAUTH_JWKS_EXPIRY_SECONDS, 160));
+        expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE, true));
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI, "http://introspection-endpoint"));
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_USERNAME_CLAIM, "preferred_username"));
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_TOKENS_NOT_JWT, true));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -261,6 +261,8 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
 |disableTlsHostnameVerification  1.2+<.<|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
+|enableECDSA                     1.2+<.<|Enable or disable ECDSA support by installing BouncyCastle crypto provider. Default value is `false`.
+|boolean
 |introspectionEndpointUri        1.2+<.<|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
 |string
 |jwksEndpointUri                 1.2+<.<|URI of the JWKS certificate endpoint, which can be used for local JWT validation.

--- a/documentation/modules/oauth/proc-oauth-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-broker-config.adoc
@@ -62,6 +62,7 @@ external:
     disableTlsHostnameVerification: true <6>
     jwksExpirySeconds: 360 <7>
     jwksRefreshSeconds: 300 <8>
+    enableECDSA: "true" <9>
 ----
 <1> Listener type set to `oauth`.
 <2> URI of the token issuer used for authentication.
@@ -71,6 +72,7 @@ external:
 <6> (Optional) Disable TLS hostname verification. Default is `false`.
 <7> The duration the JWKs certificates are considered valid before they expire. Default is `360` seconds. If you specify a longer time, consider the risk of allowing access to revoked certificates.
 <8> The period between refreshes of JWKs certificates. The interval must be at least 60 seconds shorter than the expiry interval. Default is `300` seconds.
+<9> (Optional) If ECDSA is used for signing JWT tokens on authorization server, then this needs to be enabled. It installs additional crypto providers using BouncyCastle crypto library. Default is `false`.
 
 [[example-2]]
 .Example 2: Configuring token validation using an introspection endpoint

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -150,6 +150,8 @@ spec:
                               - secretName
                             disableTlsHostnameVerification:
                               type: boolean
+                            enableECDSA:
+                              type: boolean
                             introspectionEndpointUri:
                               type: string
                             jwksEndpointUri:
@@ -257,6 +259,8 @@ spec:
                               - key
                               - secretName
                             disableTlsHostnameVerification:
+                              type: boolean
+                            enableECDSA:
                               type: boolean
                             introspectionEndpointUri:
                               type: string
@@ -381,6 +385,8 @@ spec:
                               - key
                               - secretName
                             disableTlsHostnameVerification:
+                              type: boolean
+                            enableECDSA:
                               type: boolean
                             introspectionEndpointUri:
                               type: string

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -145,6 +145,8 @@ spec:
                               - secretName
                             disableTlsHostnameVerification:
                               type: boolean
+                            enableECDSA:
+                              type: boolean
                             introspectionEndpointUri:
                               type: string
                             jwksEndpointUri:
@@ -252,6 +254,8 @@ spec:
                               - key
                               - secretName
                             disableTlsHostnameVerification:
+                              type: boolean
+                            enableECDSA:
                               type: boolean
                             introspectionEndpointUri:
                               type: string
@@ -376,6 +380,8 @@ spec:
                               - key
                               - secretName
                             disableTlsHostnameVerification:
+                              type: boolean
+                            enableECDSA:
                               type: boolean
                             introspectionEndpointUri:
                               type: string

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -130,6 +130,7 @@ public class OauthBaseST extends BaseST {
                 .withJwksEndpointUri(jwksEndpointUri)
                 .withJwksExpirySeconds(500)
                 .withJwksRefreshSeconds(400)
+                .withEnableECDSA(true)
                 .withUserNameClaim(userNameClaim)
                 .withTlsTrustedCertificates(
                         new CertSecretSourceBuilder()
@@ -145,6 +146,7 @@ public class OauthBaseST extends BaseST {
                 .withJwksEndpointUri(jwksEndpointUri)
                 .withJwksExpirySeconds(500)
                 .withJwksRefreshSeconds(400)
+                .withEnableECDSA(true)
                 .withUserNameClaim(userNameClaim)
                 .withTlsTrustedCertificates(
                         new CertSecretSourceBuilder()
@@ -160,6 +162,7 @@ public class OauthBaseST extends BaseST {
                 .withJwksExpirySeconds(500)
                 .withJwksRefreshSeconds(400)
                 .withJwksEndpointUri(jwksEndpointUri)
+                .withEnableECDSA(true)
                 .withUserNameClaim(userNameClaim)
                 .withTlsTrustedCertificates(
                         new CertSecretSourceBuilder()

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -166,6 +166,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksEndpointUri(jwksEndpointUri)
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()
@@ -181,6 +182,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksEndpointUri(jwksEndpointUri)
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()
@@ -196,6 +198,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
                                     .withJwksEndpointUri(jwksEndpointUri)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()
@@ -279,6 +282,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksEndpointUri(jwksEndpointUri)
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()
@@ -294,6 +298,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksEndpointUri(jwksEndpointUri)
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()
@@ -309,6 +314,7 @@ public class OauthPlainST extends OauthBaseST {
                                     .withJwksExpirySeconds(500)
                                     .withJwksRefreshSeconds(400)
                                     .withJwksEndpointUri(jwksEndpointUri)
+                                    .withEnableECDSA(true)
                                     .withUserNameClaim(userNameClaim)
                                     .withTlsTrustedCertificates(
                                         new CertSecretSourceBuilder()


### PR DESCRIPTION
Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change
- Enhancement / new feature

### Description
Add `enableECDSA` configuration property to `authentication` of type `oauth`.
It needs to be set to true if authorization server signs JWT tokens using ECDSA algorithm.
If enabled, the BouncyCastle crypto provider is installed, and used for handling keys and signatures for ECDSA.  

### Checklist
- [ ] Update/write design documentation in `./design`
- [*] Write tests
- [ ] Make sure all tests pass
- [*] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [*] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

