### PR TITLE
using single ZK node as well, like on Kafka

### DIFF
--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -17,7 +17,7 @@ spec:
     storage:
       type: ephemeral
   zookeeper:
-    replicas: 3
+    replicas: 1
     storage:
       type: ephemeral
   entityOperator:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

like the `kafka`, I think the Zookeeper should be also single, in the single example.

