### PR TITLE
feat: Add clean to docker_build step

### DIFF
--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -8,7 +8,7 @@ DOCKER_TAG ?= latest
 clean:
 	./build.sh clean
 
-docker_build:
+docker_build: clean
 	./build.sh docker_build
 
 docker_tag:


### PR DESCRIPTION
Add clean to docker_build step of docker-images project
This ensures dependencies for local builds are never leftover
in the tmp folder

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

