### PR TITLE
[DOC] Fixed cross-reference to the API docs

### DIFF
--- a/documentation/modules/con-custom-resources-status.adoc
+++ b/documentation/modules/con-custom-resources-status.adoc
@@ -26,7 +26,7 @@ m¦KafkaConnect
 ¦The Kafka Connect cluster, if deployed.
 
 m¦KafkaConnectS2I
-¦xref:type-KafkaConnectS2Istatus-reference[]
+¦xref:type-KafkaConnectS2IStatus-reference[]
 ¦The Kafka Connect cluster with Source-to-Image support, if deployed.
 
 m¦KafkaConnector


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

This pull request fixes a minor error in the format of a cross reference to the **`KafkaConnectS2IStatus` schema reference** section of the _Using Strimzi_ guide.

Changed destination to upper-case "S".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

