### PR TITLE
ST: Fix zookeeper upgrade test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -121,14 +121,13 @@ public class ZookeeperUpgradeST extends BaseST {
         kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
         LOGGER.info("Kafka roll (image change) is complete");
 
-        if (testInfo.getDisplayName().contains("Downgrade")) {
-            kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
-            LOGGER.info("2nd Kafka roll (update) is complete");
-            kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaReplicas, kafkaPods);
-            LOGGER.info("3rd Kafka roll (update) is complete");
-        } else {
-            // Wait for the zk rolling update
-            StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), kafkaReplicas, zkPods);
+        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
+        LOGGER.info("2nd Kafka roll (update) is complete");
+        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaReplicas, kafkaPods);
+        LOGGER.info("3rd Kafka roll (update) is complete");
+
+        if (testInfo.getDisplayName().contains("Upgrade")) {
+            StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), zkReplicas, zkPods);
             LOGGER.info("2nd Zookeeper roll (update) is complete");
         }
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

Lukas accidentally commited duplicity code to `KafkaST` which was already in `ZookeeperUpgradeST` (it's needed only there). This PR removes it.

I also added fix for zookeeper upgrade test, from where I accidentally removed upgrade of `log.message.format.version` from upgrade and downgrade instead only from downgrade.

### Checklist

- [x] Make sure all tests pass
