### PR TITLE
feat: Use Promise instead of future for start stop

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -133,7 +133,6 @@ public class ClusterOperator extends AbstractVerticle {
 
 
     @Override
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST")
     public void stop(Promise<Void> stop) {
         log.info("Stopping ClusterOperator for namespace {}", namespace);
         vertx.cancelTimer(reconcileTimer);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -96,7 +96,7 @@ public class ClusterOperator extends AbstractVerticle {
     }
 
     @Override
-    public void start(Future<Void> start) {
+    public void start(Promise<Void> start) {
         log.info("Starting ClusterOperator for namespace {}", namespace);
 
         // Configure the executor here, but it is used only in other places
@@ -134,7 +134,7 @@ public class ClusterOperator extends AbstractVerticle {
 
     @Override
     @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST")
-    public void stop(Future<Void> stop) {
+    public void stop(Promise<Void> stop) {
         log.info("Stopping ClusterOperator for namespace {}", namespace);
         vertx.cancelTimer(reconcileTimer);
         for (Watch watch : watchByKind.values()) {
@@ -144,7 +144,7 @@ public class ClusterOperator extends AbstractVerticle {
             // TODO remove the watch from the watchByKind
         }
         client.close();
-        ((Promise<Void>) stop).complete();
+        stop.complete();
     }
 
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -75,7 +75,7 @@ public class Session extends AbstractVerticle {
      * Stop the operator.
      */
     @Override
-    public void stop(Future<Void> stopFuture) throws Exception {
+    public void stop(Promise<Void> stop) throws Exception {
         this.stopped = true;
         Long timerId = this.timerId;
         if (timerId != null) {
@@ -133,11 +133,11 @@ public class Session extends AbstractVerticle {
                 });
                 return Future.succeededFuture();
             });
-        }, stopFuture);
+        }, stop);
     }
 
     @Override
-    public void start(Future<Void> startupFuture) {
+    public void start(Promise<Void> start) {
         LOGGER.info("Starting");
         Properties adminClientProps = new Properties();
 
@@ -170,7 +170,7 @@ public class Session extends AbstractVerticle {
                 this.config.get(Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS).intValue(),
             zkResult -> {
                 if (zkResult.failed()) {
-                    ((Promise<Void>) startupFuture).fail(zkResult.cause());
+                    start.fail(zkResult.cause());
                     return;
                 }
                 this.zk = zkResult.result();
@@ -231,7 +231,7 @@ public class Session extends AbstractVerticle {
                     }
                 };
                 periodic.handle(null);
-                promise.future().setHandler(startupFuture);
+                promise.future().setHandler(start);
                 LOGGER.info("Started");
             });
     }

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.user;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
@@ -57,7 +56,7 @@ public class UserOperator extends AbstractVerticle {
     }
 
     @Override
-    public void start(Future<Void> start) {
+    public void start(Promise<Void> start) {
         log.info("Starting UserOperator for namespace {}", namespace);
 
         // Configure the executor here, but it is used only in other places
@@ -80,8 +79,7 @@ public class UserOperator extends AbstractVerticle {
     }
 
     @Override
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST")
-    public void stop(Future<Void> stop) {
+    public void stop(Promise<Void> stop) {
         log.info("Stopping UserOperator for namespace {}", namespace);
         vertx.cancelTimer(reconcileTimer);
 
@@ -90,7 +88,7 @@ public class UserOperator extends AbstractVerticle {
         }
 
         client.close();
-        ((Promise<Void>) stop).complete();
+        stop.complete();
     }
 
     /**


### PR DESCRIPTION
Switch to using Promise to remove casting future into promise
This is the vertx supported way of doing this v3.8<
https://github.com/vert-x3/wiki/wiki/3.8.0-Deprecations-and-breaking-changes#verticle-lifecycle

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

