### PR TITLE
Fix the kafka rolling when the reconciliation failed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -102,6 +102,8 @@ public abstract class AbstractModel {
     @Deprecated
     public static final String ANNO_CO_STRIMZI_IO_DELETE_CLAIM = "cluster.operator.strimzi.io/delete-claim";
 
+    public static final String ANNO_STRIMZI_CM_GENERATION = Annotations.STRIMZI_DOMAIN + "/cm-generation";
+
     protected final String cluster;
     protected final String namespace;
     protected final Labels labels;
@@ -727,7 +729,8 @@ public abstract class AbstractModel {
     }
 
     protected StatefulSet createStatefulSet(
-            Map<String, String> annotations,
+            Map<String, String> stsAnnotations,
+            Map<String, String> podAnnotations,
             List<Volume> volumes,
             List<PersistentVolumeClaim> volumeClaims,
             Affinity affinity,
@@ -751,7 +754,7 @@ public abstract class AbstractModel {
                     .withName(name)
                     .withLabels(getLabelsWithName(templateStatefulSetLabels))
                     .withNamespace(namespace)
-                    .withAnnotations(mergeLabelsOrAnnotations(annotations, templateStatefulSetAnnotations))
+                    .withAnnotations(mergeLabelsOrAnnotations(stsAnnotations, templateStatefulSetAnnotations))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withNewSpec()
@@ -764,7 +767,7 @@ public abstract class AbstractModel {
                         .withNewMetadata()
                             .withName(name)
                             .withLabels(getLabelsWithName(templatePodLabels))
-                            .withAnnotations(mergeLabelsOrAnnotations(null, templatePodAnnotations))
+                            .withAnnotations(mergeLabelsOrAnnotations(podAnnotations, templatePodAnnotations))
                         .endMetadata()
                         .withNewSpec()
                             .withServiceAccountName(getServiceAccountName())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -653,6 +653,7 @@ public abstract class AbstractModel {
 
         return new ConfigMapBuilder()
                 .withNewMetadata()
+                    .withGeneration(0L)
                     .withName(name)
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -653,7 +653,6 @@ public abstract class AbstractModel {
 
         return new ConfigMapBuilder()
                 .withNewMetadata()
-//                    .withGeneration(0L)
                     .withName(name)
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -653,7 +653,7 @@ public abstract class AbstractModel {
 
         return new ConfigMapBuilder()
                 .withNewMetadata()
-                    .withGeneration(0L)
+//                    .withGeneration(0L)
                     .withName(name)
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1238,7 +1238,7 @@ public class KafkaCluster extends AbstractModel {
         Map<String, String> stsAnnotations = new HashMap<>(2);
         stsAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafkaVersion.version());
         stsAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
-        Map<String, String> podAnnotations = singletonMap(ANNO_STRIMZI_CM_GENERATION, Long.toString(ancillaryCmGeneration));
+        Map<String, String> podAnnotations = singletonMap(ANNO_STRIMZI_CM_GENERATION, Long.toString(ancillaryCmGeneration == null ? 0L : ancillaryCmGeneration));
 
         return createStatefulSet(
                 stsAnnotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -108,6 +108,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.singletonMap;
+
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class KafkaCluster extends AbstractModel {
     protected static final String INIT_NAME = "kafka-init";
@@ -808,7 +810,7 @@ public class KafkaCluster extends AbstractModel {
             }
         }
 
-        return Collections.singletonMap(Labels.STRIMZI_DISCOVERY_LABEL, anno.encodePrettily());
+        return singletonMap(Labels.STRIMZI_DISCOVERY_LABEL, anno.encodePrettily());
     }
 
     /**
@@ -1226,15 +1228,21 @@ public class KafkaCluster extends AbstractModel {
      * @param isOpenShift      True iff this operator is operating within OpenShift.
      * @param imagePullPolicy  The image pull policy.
      * @param imagePullSecrets The image pull secrets.
+     * @param ancillaryCmGeneration The generation of ConfigMap containing configuration
      * @return The generated StatefulSet.
      */
-    public StatefulSet generateStatefulSet(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
-        HashMap<String, String> annotations = new HashMap<>(2);
-        annotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafkaVersion.version());
-        annotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
+    public StatefulSet generateStatefulSet(boolean isOpenShift,
+                                           ImagePullPolicy imagePullPolicy,
+                                           List<LocalObjectReference> imagePullSecrets,
+                                           Long ancillaryCmGeneration) {
+        Map<String, String> stsAnnotations = new HashMap<>(2);
+        stsAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafkaVersion.version());
+        stsAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
+        Map<String, String> podAnnotations = singletonMap(ANNO_STRIMZI_CM_GENERATION, Long.toString(ancillaryCmGeneration));
 
         return createStatefulSet(
-                annotations,
+                stsAnnotations,
+                podAnnotations,
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
                 getMergedAffinity(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -438,6 +438,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         return createStatefulSet(
                 Collections.singletonMap(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage)),
+                Collections.emptyMap(),
                 getVolumes(isOpenShift),
                 getVolumeClaims(),
                 getMergedAffinity(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -375,7 +375,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Service zkHeadlessService;
         private ConfigMap zkMetricsAndLogsConfigMap;
         /* test */ ReconcileResult<StatefulSet> zkDiffs;
-        private boolean zkAncillaryCmChange;
         private boolean zkScalingUp = false;
 
         private KafkaCluster kafkaCluster = null;
@@ -1434,9 +1433,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return r.map(rr -> {
                 if (onlyMetricsSettingChanged) {
                     log.debug("Only metrics setting changed - not triggering rolling update");
-                    this.zkAncillaryCmChange = false;
-                } else {
-                    this.zkAncillaryCmChange = rr instanceof ReconcileResult.Patched;
+                }
+                if (rr != null) {
+                    this.ancillaryCmGeneration = rr.resource().getMetadata().getGeneration();
                 }
                 return this;
             });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1435,7 +1435,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 if (onlyMetricsSettingChanged) {
                     log.debug("Only metrics setting changed - not triggering rolling update");
                 }
-                if (rr != null) {
+                if (rr != null && rr.resource() != null) {
                     this.zkAncillaryCmGeneration = rr.resource().getMetadata().getGeneration();
                 }
                 return this;
@@ -1467,7 +1467,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 if (onlyMetricsSettingChanged) {
                     log.debug("Only metrics setting changed - not triggering rolling update");
                 }
-                if (rr != null) {
+                if (rr != null && rr.resource() != null) {
                     this.kafkaAncillaryCmGeneration = rr.resource().getMetadata().getGeneration();
                 }
                 return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1436,7 +1436,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     log.debug("Only metrics setting changed - not triggering rolling update");
                 }
                 if (rr != null && rr.resource() != null) {
-                    this.zkAncillaryCmGeneration = rr.resource().getMetadata().getGeneration();
+                    this.zkAncillaryCmGeneration = rr.resource().getMetadata().getGeneration() == null ? Long.valueOf(0L) : rr.resource().getMetadata().getGeneration();
+                } else {
+                    this.zkAncillaryCmGeneration = 0L;
                 }
                 return this;
             });
@@ -1468,7 +1470,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     log.debug("Only metrics setting changed - not triggering rolling update");
                 }
                 if (rr != null && rr.resource() != null) {
-                    this.kafkaAncillaryCmGeneration = rr.resource().getMetadata().getGeneration();
+                    this.kafkaAncillaryCmGeneration = rr.resource().getMetadata().getGeneration() == null ? Long.valueOf(0L) : rr.resource().getMetadata().getGeneration();
+                } else {
+                    this.kafkaAncillaryCmGeneration = 0L;
                 }
                 return this;
             });
@@ -2899,7 +2903,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 isPodCaCertUpToDate &= isPodCaCertUpToDate(pod, ca);
             }
 
-            int cmAnno = Annotations.intAnnotation(pod, ANNO_STRIMZI_CM_GENERATION, -1);
+            int cmAnno = Annotations.intAnnotation(pod, ANNO_STRIMZI_CM_GENERATION, 0);
 
             boolean isPodToRestart = !isPodUpToDate || ancillaryCmGeneration == null || cmAnno != ancillaryCmGeneration;
             isPodToRestart |= !isCustomCertTlsListenerUpToDate;
@@ -2927,7 +2931,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     }
                 }
                 if (ancillaryCmGeneration == null || cmAnno != ancillaryCmGeneration) {
-                    reasons.add("ancillary CM change");
+                    reasons.add("ancillary CM change " + cmAnno + " vs " + ancillaryCmGeneration);
                 }
                 if (!isPodUpToDate) {
                     reasons.add("Pod has old generation");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -303,7 +303,7 @@ public class KafkaClusterTest {
     @Test
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         checkStatefulSet(sts, kafkaAssembly, true);
         checkOwnerReference(kc.createOwnerReference(), sts);
     }
@@ -320,7 +320,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(false, null, null);
+        StatefulSet sts = kc.generateStatefulSet(false, null, null, -1L);
         assertThat(sts.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector().getMatchLabels(), is(selector));
     }
 
@@ -335,7 +335,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(false, null, null);
+        StatefulSet sts = kc.generateStatefulSet(false, null, null, -1L);
         assertThat(sts.getSpec().getVolumeClaimTemplates().get(0).getSpec().getSelector(), is(nullValue()));
     }
 
@@ -351,7 +351,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(false, null, null);
+        StatefulSet sts = kc.generateStatefulSet(false, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit().getAmount(), is(sizeLimit));
     }
 
@@ -366,7 +366,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(false, null, null);
+        StatefulSet sts = kc.generateStatefulSet(false, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(nullValue()));
     }
 
@@ -380,7 +380,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(editKafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         checkStatefulSet(sts, editKafkaAssembly, true);
     }
 
@@ -395,7 +395,7 @@ public class KafkaClusterTest {
                             .endKafka()
                         .endSpec().build();
         KafkaCluster kc = KafkaCluster.fromCrd(editKafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(false, null, null);
+        StatefulSet sts = kc.generateStatefulSet(false, null, null, -1L);
         checkStatefulSet(sts, editKafkaAssembly, false);
     }
 
@@ -531,49 +531,49 @@ public class KafkaClusterTest {
     public void withOldAffinityWithoutRack() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withOldAffinityWithoutRack");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withAffinityWithoutRack() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withAffinityWithoutRack");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withRackWithoutAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackWithoutAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withRackAndOldAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndOldAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withRackAndAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test
     public void withOldTolerations() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withOldTolerations");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getTolerations());
     }
 
     @Test
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withTolerations");
         resourceTester.assertDesiredResource("-STS.yaml",
-            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
+            kc -> kc.generateStatefulSet(true, null, null, -1L).getSpec().getTemplate().getSpec().getTolerations());
     }
 
     @Test
@@ -595,7 +595,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
 
         List<ContainerPort> ports = sts.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
         assertThat(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")), is(true));
@@ -706,7 +706,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
 
         List<ContainerPort> ports = sts.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
         assertThat(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")), is(true));
@@ -1019,7 +1019,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
 
         List<ContainerPort> ports = sts.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
         assertThat(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")), is(true));
@@ -1062,7 +1062,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         Container initCont = sts.getSpec().getTemplate().getSpec().getInitContainers().get(0);
 
         assertThat(initCont.getEnv().stream().filter(env -> KafkaCluster.ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS_TYPE.equals(env.getName()))
@@ -1095,7 +1095,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
 
         List<ContainerPort> ports = sts.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
         assertThat(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")), is(true));
@@ -1383,7 +1383,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check StatefulSet
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getMetadata().getLabels().entrySet().containsAll(ssLabels.entrySet()), is(true));
         assertThat(sts.getMetadata().getAnnotations().entrySet().containsAll(ssAnots.entrySet()), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
@@ -1592,7 +1592,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
         Lifecycle lifecycle = sts.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertThat(lifecycle, is(notNullValue()));
@@ -1606,7 +1606,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
         Lifecycle lifecycle = sts.getSpec().getTemplate().getSpec().getContainers().get(1).getLifecycle();
         assertThat(lifecycle, is(notNullValue()));
@@ -1694,7 +1694,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(2));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1713,7 +1713,7 @@ public class KafkaClusterTest {
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap());
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, secrets);
+        StatefulSet sts = kc.generateStatefulSet(true, null, secrets, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(2));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1738,7 +1738,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, singletonList(secret1));
+        StatefulSet sts = kc.generateStatefulSet(true, null, singletonList(secret1), -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(1));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(false));
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1751,7 +1751,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(0));
     }
 
@@ -1771,7 +1771,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(notNullValue()));
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(Long.valueOf(123)));
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(Long.valueOf(456)));
@@ -1785,7 +1785,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
@@ -1827,12 +1827,12 @@ public class KafkaClusterTest {
         kafkaAssembly.getSpec().getKafka().setRack(new RackBuilder().withTopologyKey("topology-key").build());
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
-        StatefulSet sts = kc.generateStatefulSet(true, ImagePullPolicy.ALWAYS, null);
+        StatefulSet sts = kc.generateStatefulSet(true, ImagePullPolicy.ALWAYS, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getInitContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(1).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
 
-        sts = kc.generateStatefulSet(true, ImagePullPolicy.IFNOTPRESENT, null);
+        sts = kc.generateStatefulSet(true, ImagePullPolicy.IFNOTPRESENT, null, -1L);
         assertThat(sts.getSpec().getTemplate().getSpec().getInitContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(1).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
@@ -1979,7 +1979,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2009,7 +2009,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2047,7 +2047,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2099,7 +2099,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2200,7 +2200,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2276,7 +2276,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
 
         // Check Storage annotation on STS
-        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
+        assertThat(kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, -1L).getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE),
                 is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
 
         // Check PVCs
@@ -2386,7 +2386,7 @@ public class KafkaClusterTest {
         assertThat(kc.isExposedWithIngress(), is(true));
 
         // Check StatefulSet changes
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
 
         List<ContainerPort> ports = sts.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts();
         assertThat(ports.contains(kc.createContainerPort(KafkaCluster.EXTERNAL_PORT_NAME, KafkaCluster.EXTERNAL_PORT, "TCP")), is(true));
@@ -2885,7 +2885,7 @@ public class KafkaClusterTest {
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         Container cont = sts.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaCluster.ENV_VAR_STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElse(null).getValueFrom().getSecretKeyRef().getName(), is("my-secret-secret"));
@@ -2934,7 +2934,7 @@ public class KafkaClusterTest {
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         Container cont = sts.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaCluster.ENV_VAR_STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElse(null).getValueFrom().getSecretKeyRef().getName(), is("my-secret-secret"));
@@ -3029,7 +3029,7 @@ public class KafkaClusterTest {
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         Container cont = sts.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaCluster.ENV_VAR_STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElse(null).getValueFrom().getSecretKeyRef().getName(), is("my-secret-secret"));
@@ -3304,7 +3304,7 @@ public class KafkaClusterTest {
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(kafkaAssembly, VERSIONS);
-        StatefulSet sts = kc.generateStatefulSet(true, null, null);
+        StatefulSet sts = kc.generateStatefulSet(true, null, null, -1L);
         Container cont = sts.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         // Volume mounts

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -165,7 +165,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         ArgumentCaptor<StatefulSet> reconcileStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockKafkaSetOps.reconcile(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)), reconcileStsCaptor.capture())).then(invocation -> {
@@ -226,7 +226,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         ArgumentCaptor<StatefulSet> reconcileStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockKafkaSetOps.reconcile(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)), reconcileStsCaptor.capture())).then(invocation -> {
@@ -290,7 +290,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         ArgumentCaptor<StatefulSet> reconcileStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockKafkaSetOps.reconcile(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)), reconcileStsCaptor.capture())).then(invocation -> {
@@ -365,7 +365,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         ArgumentCaptor<StatefulSet> reconcileStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockKafkaSetOps.reconcile(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)), reconcileStsCaptor.capture())).then(invocation -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.certs.CertManager;
+import io.strimzi.operator.KubernetesVersion;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.function.Predicate;
+
+import static io.strimzi.operator.cluster.model.AbstractModel.ANNO_STRIMZI_CM_GENERATION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaAssemblyOperatorRollingAfterConfigMapChangeTest {
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_11;
+    private final MockCertManager certManager = new MockCertManager();
+    private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
+    private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private final String namespace = "testns";
+    private final String clusterName = "testkafka";
+    protected static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    public Kafka getKafkaCrd() {
+        return new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                    .withNamespace(namespace)
+                    .withGeneration(2L)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                .endSpec()
+                .build();
+    }
+
+
+    public Pod getPod(StatefulSet sts) {
+        return new PodBuilder()
+                .withNewMetadataLike(sts.getSpec().getTemplate().getMetadata())
+                    .withNewName(KafkaCluster.kafkaClusterName(clusterName) + "-0")
+                .endMetadata()
+                .withNewSpecLike(sts.getSpec().getTemplate().getSpec())
+                .endSpec()
+                .build();
+    }
+
+    @Test
+    public void testWithChangedExternalCertificate(VertxTestContext context) throws InterruptedException {
+        Kafka kafka = getKafkaCrd();
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS, null);
+
+        // Mock the Kafka Operator
+        CrdOperator mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(getKafkaCrd()));
+        when(mockKafkaOps.updateStatusAsync(any())).thenReturn(Future.succeededFuture());
+
+        // Mock the KafkaSetOperator
+        KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
+
+        ArgumentCaptor<StatefulSet> reconcileStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
+        when(mockKafkaSetOps.reconcile(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)), reconcileStsCaptor.capture())).then(invocation -> {
+            return Future.succeededFuture(ReconcileResult.patched(invocation.getArgument(2)));
+        });
+
+        ArgumentCaptor<StatefulSet> maybeRollingUpdateStsCaptor = ArgumentCaptor.forClass(StatefulSet.class);
+        ArgumentCaptor<Predicate<Pod>> isPodToRestartPredicateCaptor = ArgumentCaptor.forClass(Predicate.class);
+        when(mockKafkaSetOps.maybeRollingUpdate(maybeRollingUpdateStsCaptor.capture(), isPodToRestartPredicateCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock the ConfigMapOperator
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.getAsync(eq(namespace), eq(clusterName))).thenReturn(Future.succeededFuture(kafkaCluster.generateMetricsAndLogConfigMap(null)));
+
+        // Mock the SecretOperator
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        ConfigMap configMap = new ConfigMapBuilder()
+                .editOrNewMetadata()
+                    .withName("cm")
+                    .withNamespace("ns")
+                    .withGeneration(500L)
+                .endMetadata()
+                .build();
+
+        ConfigMap configMapUpdated = new ConfigMapBuilder()
+                .editOrNewMetadata()
+                    .withName("cm")
+                    .withNamespace("ns")
+                    .withGeneration(501L)
+                .endMetadata()
+                .build();
+
+        when(mockCmOps.get(any(), any())).thenReturn(configMap);
+        when(mockCmOps.reconcile(any(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.patched(configMapUpdated)));
+        when(mockSecretOps.reconcile(any(), any(), any())).then(invocation -> {
+            return Future.succeededFuture(ReconcileResult.created(invocation.getArgument(2)));
+        });
+
+        KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.MockKafkaAssemblyOperator kao = new KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                certManager,
+                passwordGenerator,
+                supplier,
+                config);
+
+        Checkpoint async = context.checkpoint();
+        kao.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka).setHandler(res -> {
+            assertThat(res.succeeded(), is(true));
+
+            Predicate<Pod> isPodToRestart = isPodToRestartPredicateCaptor.getValue();
+
+
+            assertThat(reconcileStsCaptor.getAllValues().size(), is(1));
+            StatefulSet reconcileSts = reconcileStsCaptor.getValue();
+            Pod pod = getPod(reconcileSts);
+            // lets simulate pod with old sts
+            pod.getMetadata().getAnnotations().put(ANNO_STRIMZI_CM_GENERATION, Long.toString(500L));
+            assertThat(isPodToRestart.test(pod), is(true));
+
+            async.flag();
+        });
+    }
+
+    class MockKafkaAssemblyOperator extends KafkaAssemblyOperator  {
+        public MockKafkaAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, CertManager certManager, PasswordGenerator passwordGenerator, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
+            super(vertx, pfa, certManager, passwordGenerator, supplier, config);
+        }
+
+        @Override
+        Future<Void> reconcile(ReconciliationState reconcileState)  {
+            return reconcileState.reconcileCas(this::dateSupplier)
+                    .compose(state -> state.getKafkaClusterDescription())
+                    .compose(state -> state.kafkaAncillaryCm())
+                    .compose(state -> state.kafkaStatefulSet())
+                    .compose(state -> state.kafkaRollingUpdate())
+                    .map((Void) null);
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRollingAfterConfigMapChangeTest.java
@@ -103,7 +103,7 @@ public class KafkaAssemblyOperatorRollingAfterConfigMapChangeTest {
     }
 
     @Test
-    public void testWithChangedExternalCertificate(VertxTestContext context) throws InterruptedException {
+    public void testWithObsoletePodGeneration(VertxTestContext context) {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS, null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1030,7 +1030,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock StatefulSet get
         when(mockKsOps.get(clusterNamespace, KafkaCluster.kafkaClusterName(clusterName))).thenReturn(
-                originalKafkaCluster.generateStatefulSet(openShift, null, null)
+                originalKafkaCluster.generateStatefulSet(openShift, null, null, -1L)
         );
         when(mockZsOps.get(clusterNamespace, ZookeeperCluster.zookeeperClusterName(clusterName))).thenReturn(
                 originalZookeeperCluster.generateStatefulSet(openShift, null, null)
@@ -1169,8 +1169,8 @@ public class KafkaAssemblyOperatorTest {
             // rolling restart
             Set<String> expectedRollingRestarts = set();
             if (KafkaSetOperator.needsRollingUpdate(
-                    new StatefulSetDiff(originalKafkaCluster.generateStatefulSet(openShift, null, null),
-                    updatedKafkaCluster.generateStatefulSet(openShift, null, null)))) {
+                    new StatefulSetDiff(originalKafkaCluster.generateStatefulSet(openShift, null, null, -1L),
+                    updatedKafkaCluster.generateStatefulSet(openShift, null, null, -1L)))) {
                 expectedRollingRestarts.add(originalKafkaCluster.getName());
             }
             if (ZookeeperSetOperator.needsRollingUpdate(
@@ -1239,7 +1239,7 @@ public class KafkaAssemblyOperatorTest {
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
         when(mockKsOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
-                asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift, null, null))
+                asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift, null, null, -1L))
         );
 
         when(mockSecretOps.get(eq(clusterCmNamespace), eq(AbstractModel.clusterCaCertSecretName(foo.getMetadata().getName()))))
@@ -1251,7 +1251,7 @@ public class KafkaAssemblyOperatorTest {
         Labels barLabels = Labels.forCluster("bar");
         KafkaCluster barCluster = KafkaCluster.fromCrd(bar, VERSIONS);
         when(mockKsOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
-                asList(barCluster.generateStatefulSet(openShift, null, null))
+                asList(barCluster.generateStatefulSet(openShift, null, null, -1L))
         );
         when(mockSecretOps.list(eq(clusterCmNamespace), eq(barLabels))).thenAnswer(
             invocation -> new ArrayList<>(asList(
@@ -1343,14 +1343,14 @@ public class KafkaAssemblyOperatorTest {
         // providing the list of ALL StatefulSets for all the Kafka clusters
         Labels newLabels = Labels.forKind(Kafka.RESOURCE_KIND);
         when(mockKsOps.list(eq("*"), eq(newLabels))).thenReturn(
-                asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift, null, null))
+                asList(KafkaCluster.fromCrd(bar, VERSIONS).generateStatefulSet(openShift, null, null, -1L))
         );
 
         // providing the list StatefulSets for already "existing" Kafka clusters
         Labels barLabels = Labels.forCluster("bar");
         KafkaCluster barCluster = KafkaCluster.fromCrd(bar, VERSIONS);
         when(mockKsOps.list(eq("*"), eq(barLabels))).thenReturn(
-                asList(barCluster.generateStatefulSet(openShift, null, null))
+                asList(barCluster.generateStatefulSet(openShift, null, null, -1L))
         );
         when(mockSecretOps.list(eq("*"), eq(barLabels))).thenAnswer(
             invocation -> new ArrayList<>(asList(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -424,7 +424,7 @@ public class KafkaStatusTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -538,7 +538,7 @@ public class KafkaStatusTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -642,7 +642,7 @@ public class KafkaStatusTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -743,7 +743,7 @@ public class KafkaStatusTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -843,7 +843,7 @@ public class KafkaStatusTest {
 
         // Mock the KafkaSetOperator
         KafkaSetOperator mockKafkaSetOps = supplier.kafkaSetOperations;
-        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null)));
+        when(mockKafkaSetOps.getAsync(eq(namespace), eq(KafkaCluster.kafkaClusterName(clusterName)))).thenReturn(Future.succeededFuture(kafkaCluster.generateStatefulSet(false, null, null, -1L)));
 
         // Mock the ConfigMapOperator
         ConfigMapOperator mockCmOps = supplier.configMapOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -146,7 +146,7 @@ public class KafkaUpdateTest {
         states.put("sts", new ArrayList<StatefulSet>(2));
         states.put("cm", new ArrayList<ConfigMap>(2));
 
-        StatefulSet kafkaSts = initialSs != null ? initialSs : kafkaCluster.generateStatefulSet(false, null, null);
+        StatefulSet kafkaSts = initialSs != null ? initialSs : kafkaCluster.generateStatefulSet(false, null, null, -1L);
 
         when(kso.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kafkaSts));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -40,8 +40,8 @@ public class KafkaSetOperatorTest {
     @BeforeEach
     public void before() {
         KafkaVersion.Lookup versions = new KafkaVersion.Lookup(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
-        a = KafkaCluster.fromCrd(getResource(), versions).generateStatefulSet(true, null, null);
-        b = KafkaCluster.fromCrd(getResource(), versions).generateStatefulSet(true, null, null);
+        a = KafkaCluster.fromCrd(getResource(), versions).generateStatefulSet(true, null, null, -1L);
+        b = KafkaCluster.fromCrd(getResource(), versions).generateStatefulSet(true, null, null, -1L);
     }
 
     private Kafka getResource() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -28,7 +28,6 @@ import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -221,7 +220,6 @@ class LogSettingST extends BaseST {
 
     @Test
     @Order(11)
-    @Disabled("From some unknown reasons, rolling update of Kafka my-cluster never happen during an expected timeframe. Issue was raised and this test should be enabled after fix.")
     void testGcLoggingSetDisabled() {
         String connectName = KafkaConnectResources.deploymentName(CONNECT_NAME);
         String mmName = KafkaMirrorMakerResources.deploymentName(MM_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -28,6 +28,7 @@ import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -220,6 +221,7 @@ class LogSettingST extends BaseST {
 
     @Test
     @Order(11)
+    @Disabled("From some unknown reasons, rolling update of Kafka my-cluster never happen during an expected timeframe. Issue was raised and this test should be enabled after fix.")
     void testGcLoggingSetDisabled() {
         String connectName = KafkaConnectResources.deploymentName(CONNECT_NAME);
         String mmName = KafkaMirrorMakerResources.deploymentName(MM_NAME);


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
We have a kafka configuration placed in the ConfigMap and when this map changes, the reconciliation is started. But it may happen the reconciliation fails and the state of changed ConfigMap is lost. It is better to watch whether pods have the same value in annotation as the STS template has.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

