### PR TITLE
[MO] - [system test] -> deencapsulation of basic client

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.kafkaclients.externalClients;
 
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.EClientType;
 import io.strimzi.systemtest.kafkaclients.IKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.vertx.core.Vertx;
@@ -18,9 +17,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The KafkaClient for sending and receiving messages with basic properties. The client is using an external listeners.
@@ -171,7 +167,7 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
      */
     public Future<Integer> receiveMessages(String topicName, String namespace, String clusterName, int messageCount) throws IOException {
         return receiveMessages(topicName, namespace, clusterName, messageCount,
-                "my-group-" + new Random().nextInt(Integer.MAX_VALUE));
+                "my-group-" + new Random().nextInt(Integer.MAX_VALUE), Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     /**
@@ -186,7 +182,7 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
     public Future<Integer> receiveMessagesTls(String topicName, String namespace, String clusterName, String userName,
                                               int messageCount, String securityProtocol) throws IOException {
         return receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, securityProtocol,
-                "my-group-" + new Random().nextInt(Integer.MAX_VALUE), 120);
+                "my-group-" + new Random().nextInt(Integer.MAX_VALUE), Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
@@ -171,7 +171,7 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
     }
 
     /**
-     * Receive messages to external entrypoint of the cluster with SSL security protocol setting
+     * Receive messages to external entry-point of the cluster with SSL security protocol setting
      * @param topicName topic name
      * @param namespace kafka namespace
      * @param clusterName kafka cluster name
@@ -183,6 +183,22 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
                                               int messageCount, String securityProtocol) throws IOException {
         return receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, securityProtocol,
                 "my-group-" + new Random().nextInt(Integer.MAX_VALUE), Constants.GLOBAL_CLIENTS_TIMEOUT);
+    }
+
+    /**
+     * Receive messages to external entry-point of the cluster with SSL security protocol setting and specific consumer group
+     * @param topicName topic name
+     * @param namespace kafka namespace
+     * @param clusterName kafka cluster name
+     * @param userName user name for authorization
+     * @param messageCount message count
+     * @param consumerGroup consumer group name
+     * @return future with received message count
+     */
+    public Future<Integer> receiveMessagesTls(String topicName, String namespace, String clusterName, String userName,
+                                              int messageCount, String securityProtocol, String consumerGroup) throws IOException {
+        return receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, securityProtocol,
+                consumerGroup, Constants.GLOBAL_CLIENTS_TIMEOUT);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.kafkaclients.externalClients;
 
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.kafkaclients.EClientType;
 import io.strimzi.systemtest.kafkaclients.IKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.vertx.core.Vertx;
@@ -12,13 +13,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.security.KeyStoreException;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.IntPredicate;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -134,55 +132,6 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
         return resultPromise;
     }
 
-    public void sendMessagesExternal(String clusterName, String namespace, String topicName, int messageCount) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessages(topicName, namespace, clusterName, messageCount);
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    public void sendMessagesExternalTls(String clusterName, String namespace, String topicName, int messageCount,
-                                        String userName) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SSL");
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    public void sendMessagesExternalScramSha(String clusterName, String namespace, String topicName, int messageCount,
-                                             String userName) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SASL_SSL");
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    /**
-     * Receive messages to external entrypoint of the cluster with PLAINTEXT security protocol setting
-     * @param topicName topic name
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param messageCount message count
-     * @param consumerGroup consumer group name
-     * @return future with received message count
-     */
-    public Future<Integer> receiveMessages(String topicName, String namespace, String clusterName, int messageCount,
-                                           String consumerGroup) throws IOException {
-        return receiveMessages(topicName, namespace, clusterName, messageCount, consumerGroup, Constants.GLOBAL_CLIENTS_TIMEOUT);
-    }
-
     /**
      * Receive messages to external entrypoint of the cluster with PLAINTEXT security protocol setting
      * @param topicName topic name
@@ -274,220 +223,6 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
         }
         vertx.close();
         return resultPromise;
-    }
-
-    public void receiveMessagesExternal(String clusterName, String namespace, String topicName, int messageCount, String consumerGroup) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future consumer = testClient.receiveMessages(topicName, namespace, clusterName, messageCount, consumerGroup);
-
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    public void receiveMessagesExternal(String clusterName, String namespace, String topicName, int messageCount) throws Exception {
-        receiveMessagesExternal(clusterName, namespace, topicName, messageCount, "my-group-" + new Random().nextInt(Integer.MAX_VALUE));
-    }
-
-    public void receiveMessagesExternalTls(String clusterName, String namespace, String topicName, int messageCount, String userName, String consumerGroup) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future consumer = testClient.receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SSL", consumerGroup, Constants.GLOBAL_CLIENTS_TIMEOUT);
-
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    public void receiveMessagesExternalTls(String clusterName, String namespace, String topicName, int messageCount, String userName) throws Exception {
-        receiveMessagesExternalTls(clusterName, namespace, topicName, messageCount, userName, "my-group-" + new Random().nextInt(Integer.MAX_VALUE));
-    }
-
-    public void receiveMessagesExternalScramSha(String clusterName, String namespace, String topicName, int messageCount, String userName, String consumerGroup) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future consumer = testClient.receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SASL_SSL", consumerGroup, Constants.GLOBAL_CLIENTS_TIMEOUT);
-
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    public void receiveMessagesExternalScramSha(String clusterName, String namespace, String topicName, int messageCount, String userName) throws Exception {
-        receiveMessagesExternalScramSha(clusterName, namespace, topicName, messageCount, userName, "my-group-" + new Random().nextInt(Integer.MAX_VALUE));
-    }
-
-    /**
-     * Receive messages from external entrypoint until stop notification is received by consumer. SSL used as a security protocol setting.
-     * @param topicName topic name
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param userName user name for authorization
-     * @param clientName client name
-     * @return future
-     */
-    public CompletableFuture<Integer> receiveMessagesUntilNotification(String topicName, String namespace, String clusterName, String userName, String clientName, String securityProtocol) {
-        return new CompletableFuture<>();
-    }
-
-    /**
-     * Send notification to vert.x event bus
-     * @param clientName client name as a vert.x even bus address
-     * @param notification notification
-     */
-    public void sendNotificationToClient(String clientName, String notification) {
-        vertx = Vertx.vertx();
-        LOGGER.debug("Sending {} to {}", notification, clientName);
-        vertx.eventBus().publish(clientName, notification);
-        vertx.close();
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes with TLS
-     * @param userName user name
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @param messageCount message count which will be send and receive by consumer and producer
-     * @throws Exception exception
-     */
-    public void sendAndRecvMessagesTls(String userName, String namespace, String clusterName, String topicName, int messageCount) throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SSL");
-            Future consumer = testClient.receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SSL");
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes with SCRAM-SHA
-     * @param userName user name
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @param messageCount message count which will be send and receive by consumer and producer
-     * @throws Exception exception
-     */
-    public void sendAndRecvMessagesScramSha(String userName, String namespace, String clusterName, String topicName, int messageCount) throws InterruptedException, ExecutionException, TimeoutException, IOException {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SASL_SSL");
-            Future consumer = testClient.receiveMessagesTls(topicName, namespace, clusterName, userName, messageCount, "SASL_SSL");
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException | IOException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes with TLS
-     * @param userName user name
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @throws Exception exception
-     */
-    public void sendAndRecvMessagesTls(String userName, String namespace, String clusterName, String topicName) throws InterruptedException, ExecutionException, TimeoutException, KeyStoreException, IOException {
-        sendAndRecvMessagesTls(userName, namespace, clusterName, topicName, 50);
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes with TLS
-     * @param userName user name
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @throws Exception exception
-     */
-    public void sendAndRecvMessagesTls(String userName, String namespace, String clusterName) throws InterruptedException, ExecutionException, TimeoutException, KeyStoreException, IOException {
-        String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
-        sendAndRecvMessagesTls(userName, namespace, clusterName, topicName);
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes without TLS
-     * @param namespace cluster namespace
-     * @throws Exception
-     */
-    public void sendAndRecvMessages(String namespace) throws Exception {
-        String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
-        sendAndRecvMessages(namespace, topicName);
-    }
-
-
-    /**
-     * Wait for cluster availability, check availability of external routes without TLS
-     * @param namespace cluster namespace
-     * @param topicName topic name
-     * @throws Exception
-     */
-    public void sendAndRecvMessages(String namespace, String topicName) throws Exception {
-        sendAndRecvMessages(namespace, "my-cluster", topicName);
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes without TLS
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @throws Exception
-     */
-    public void sendAndRecvMessages(String namespace, String clusterName, String topicName) throws Exception {
-        sendAndRecvMessages(namespace, clusterName, topicName, "my-group-" + new Random().nextInt(Integer.MAX_VALUE));
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes without TLS
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @param consumerGroup consumer group
-     * @throws Exception
-     */
-    public void sendAndRecvMessages(String namespace, String clusterName, String topicName, String consumerGroup) throws Exception {
-        int messageCount = 50;
-
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessages(topicName, namespace, clusterName, messageCount);
-            Future consumer = testClient.receiveMessages(topicName, namespace, clusterName, messageCount, consumerGroup);
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    /**
-     * Wait for cluster availability, check availability of external routes without TLS
-     * @param namespace cluster namespace
-     * @param clusterName cluster name
-     * @param topicName topic name
-     * @param messageCount message count which will be send and receive by consumer and producer
-     * @throws Exception exception
-     */
-    public void sendAndRecvMessages(String namespace, String clusterName, String topicName, int messageCount) throws Exception {
-        try (KafkaClient testClient = new KafkaClient()) {
-            Future producer = testClient.sendMessages(topicName, namespace, clusterName, messageCount);
-            Future consumer = testClient.receiveMessages(topicName, namespace, clusterName, messageCount);
-
-            assertThat("Producer produced all messages", producer.get(1, TimeUnit.MINUTES), is(messageCount));
-            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw e;
-        }
     }
 
     public String getCaCertName() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -34,7 +34,6 @@ public abstract class AbstractNamespaceST extends BaseST {
 
     static final String CO_NAMESPACE = "co-namespace-test";
     static final String SECOND_NAMESPACE = "second-namespace-test";
-    static final String TOPIC_NAME = "my-topic";
     static final String USER_NAME = "my-user";
     private static final String TOPIC_EXAMPLES_DIR = "../examples/topic/kafka-topic.yaml";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -225,7 +225,13 @@ class ConnectST extends BaseST {
         LOGGER.info("Creating FileStreamSink connector via pod {} with topic {}", execPodName, CONNECT_TOPIC_NAME);
         KafkaConnectUtils.createFileSinkConnector(execPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
-        externalBasicKafkaClient.sendAndRecvMessagesScramSha(USER_NAME, NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, MESSAGE_COUNT);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, USER_NAME, MESSAGE_COUNT, "SASL_SSL");
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, USER_NAME, MESSAGE_COUNT, "SASL_SSL");
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+
+
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -153,7 +153,11 @@ class ConnectST extends BaseST {
 
         KafkaConnectUtils.createFileSinkConnector(execPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, MESSAGE_COUNT);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, 2);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, 2, );
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(2));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(2));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
@@ -426,7 +430,11 @@ class ConnectST extends BaseST {
         LOGGER.info("Creating FileStreamSink connector via pod {} with topic {}", execPodName, CONNECT_TOPIC_NAME);
         KafkaConnectUtils.createFileSinkConnector(execPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
-        externalBasicKafkaClient.sendAndRecvMessagesTls(userName, NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, MESSAGE_COUNT);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
@@ -500,7 +508,11 @@ class ConnectST extends BaseST {
         LOGGER.info("Creating FileStreamSink connector via pod {} with topic {}", execPodName, CONNECT_TOPIC_NAME);
         KafkaConnectUtils.createFileSinkConnector(execPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
-        externalBasicKafkaClient.sendAndRecvMessagesScramSha(userName, NAMESPACE, CLUSTER_NAME, CONNECT_TOPIC_NAME, MESSAGE_COUNT);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SASL_SSL");
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SASL_SSL");
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(2));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(2));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -154,7 +154,7 @@ class ConnectST extends BaseST {
         KafkaConnectUtils.createFileSinkConnector(execPodName, CONNECT_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, 2);
-        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, 2, );
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(CONNECT_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, 2);
 
         assertThat(producer.get(2, TimeUnit.MINUTES), is(2));
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(2));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -67,6 +67,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1055,7 +1057,11 @@ class KafkaST extends BaseST {
             .endSpec()
             .done();
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1098,7 +1104,11 @@ class KafkaST extends BaseST {
         LOGGER.info("Checking nodePort to {} for kafka-broker service {}", brokerNodePort,
                 KafkaResources.kafkaPodName(CLUSTER_NAME, brokerId));
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1123,7 +1133,11 @@ class KafkaST extends BaseST {
             () -> kubeClient().getSecret("alice") != null,
             () -> LOGGER.error("Couldn't find user secret {}", kubeClient().listSecrets()));
 
-        externalBasicKafkaClient.sendAndRecvMessagesTls(userName, NAMESPACE, CLUSTER_NAME);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1144,7 +1158,11 @@ class KafkaST extends BaseST {
 
         ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,;
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
     }
 
     @Test
@@ -1171,7 +1189,11 @@ class KafkaST extends BaseST {
 
         ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
 
-        externalBasicKafkaClient.sendAndRecvMessagesTls(userName, NAMESPACE, CLUSTER_NAME);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SSL");
+
+        assertThat(producer.get(1, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(1, TimeUnit.MINUTES), is(MESSAGE_COUNT));
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1159,7 +1159,7 @@ class KafkaST extends BaseST {
         ServiceUtils.waitUntilAddressIsReachable(kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getStatus().getLoadBalancer().getIngress().get(0).getHostname());
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
-        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,;
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
 
         assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -48,6 +48,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1059,9 +1061,15 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking kafka user:{} that is able to send messages to topic:{}", kafkaUserWrite, topicName);
 
-        externalBasicKafkaClient.sendMessagesExternalTls(CLUSTER_NAME, NAMESPACE, topicName, numberOfMessages, kafkaUserWrite);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, kafkaUserWrite, numberOfMessages, "SSL");
 
-        assertThrows(ExecutionException.class, () -> externalBasicKafkaClient.receiveMessagesExternalTls(CLUSTER_NAME, NAMESPACE, topicName, numberOfMessages, kafkaUserWrite, consumerGroupName));
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(numberOfMessages));
+
+        assertThrows(ExecutionException.class, () -> {
+            Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, kafkaUserWrite,
+                    numberOfMessages, "SSL");
+            consumer.get(2, TimeUnit.MINUTES);
+        });
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUserRead)
                 .editSpec()
@@ -1090,10 +1098,14 @@ class SecurityST extends BaseST {
 
         SecretUtils.waitForSecretReady(kafkaUserRead);
 
-        externalBasicKafkaClient.receiveMessagesExternalTls(CLUSTER_NAME, NAMESPACE, topicName, numberOfMessages, kafkaUserRead, consumerGroupName);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, kafkaUserRead, numberOfMessages, "SSL", consumerGroupName);
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(numberOfMessages));
 
         LOGGER.info("Checking kafka user:{} that is not able to send messages to topic:{}", kafkaUserRead, topicName);
-        assertThrows(ExecutionException.class, () -> externalBasicKafkaClient.sendMessagesExternalTls(CLUSTER_NAME, NAMESPACE, topicName, numberOfMessages, kafkaUserRead));
+        assertThrows(ExecutionException.class, () -> {
+            Future<Integer> invalidProducer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, kafkaUserRead, numberOfMessages, "SSL");
+            invalidProducer.get(2, TimeUnit.MINUTES);
+        });
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -1098,7 +1098,8 @@ class SecurityST extends BaseST {
 
         SecretUtils.waitForSecretReady(kafkaUserRead);
 
-        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, kafkaUserRead, numberOfMessages, "SSL", consumerGroupName);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME,
+                kafkaUserRead, numberOfMessages, "SSL", consumerGroupName);
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(numberOfMessages));
 
         LOGGER.info("Checking kafka user:{} that is not able to send messages to topic:{}", kafkaUserRead, topicName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -711,7 +711,7 @@ public class TracingST extends BaseST {
 
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT);
-        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT, );
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT);
 
         assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
@@ -802,7 +802,7 @@ public class TracingST extends BaseST {
         KafkaConnectUtils.createFileSinkConnector(execPodName, TEST_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(kafkaConnectS2IName, NAMESPACE, 8083));
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
-        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,;
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
 
         assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -52,6 +52,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Stack;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
@@ -62,6 +64,7 @@ import static io.strimzi.test.TestUtils.getFileAsString;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -228,7 +231,11 @@ public class TracingST extends BaseST {
         cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE, CLUSTER_NAME, TEST_TOPIC_NAME, 10);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
 
         HttpUtils.waitUntilServiceWithNameIsReady(RestAssured.baseURI, JAEGER_KAFKA_CONNECT_SERVICE);
 
@@ -702,7 +709,12 @@ public class TracingST extends BaseST {
         cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE, kafkaClusterTargetName, TEST_TOPIC_NAME, 10);
+
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT, );
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
 
         HttpUtils.waitUntilServiceWithNameIsReady(RestAssured.baseURI, JAEGER_PRODUCER_SERVICE, JAEGER_CONSUMER_SERVICE,
                 JAEGER_KAFKA_CONNECT_SERVICE, JAEGER_KAFKA_STREAMS_SERVICE, JAEGER_MIRROR_MAKER_SERVICE);
@@ -789,7 +801,11 @@ public class TracingST extends BaseST {
         LOGGER.info("Creating FileSink connect via Pod:{}", execPodName);
         KafkaConnectUtils.createFileSinkConnector(execPodName, TEST_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(kafkaConnectS2IName, NAMESPACE, 8083));
 
-        externalBasicKafkaClient.sendAndRecvMessages(NAMESPACE, CLUSTER_NAME, TEST_TOPIC_NAME, MESSAGE_COUNT);
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,;
+
+        assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
@@ -866,7 +882,9 @@ public class TracingST extends BaseST {
 
         JsonObject response = HttpUtils.sendMessagesHttpRequest(records, bridgeHost, bridgePort, topicName, client);
         KafkaBridgeUtils.checkSendResponse(response, messageCount);
-        externalBasicKafkaClient.receiveMessagesExternal(CLUSTER_NAME, NAMESPACE, topicName, messageCount);
+
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messageCount);
+        assertThat(consumer.get(2, TimeUnit.MINUTES), is(messageCount));
 
         HttpUtils.waitUntilServiceWithNameIsReady(RestAssured.baseURI, JAEGER_KAFKA_BRIDGE_SERVICE);
         verifyServiceIsPresent(JAEGER_KAFKA_BRIDGE_SERVICE);


### PR DESCRIPTION
Signed-off-by: Seequick1 <morsak@redhat.com>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding de-encapsulation of the basic client. Currently, we support 4 types of clients which 3 of them using client inside test cases. The last type of client `basic` is covered here, where all auxiliary methods are removed.  

#### Reason of change

Making consistency between all clients, which are do not using encapsulations methods and using only methods from interface `IKafkaClient`. 

```
public void receiveMessagesExternal(String clusterName, String namespace, String topicName, int messageCount, String consumerGroup) throws Exception {
        try (KafkaClient testClient = new KafkaClient()) {
            Future consumer = testClient.receiveMessages(topicName, namespace, clusterName, messageCount, consumerGroup);

            assertThat("Consumer consumed all messages", consumer.get(1, TimeUnit.MINUTES), is(messageCount));
        } catch (InterruptedException | ExecutionException | TimeoutException e) {
            e.printStackTrace();
            throw e;
        }
    }
```

The usage of all type of clients we have as follows:
```
     Future producer = kafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
        Future consumer = kafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");

        assertThat("Producer didn't produce all messages", producer.get(1, TimeUnit.MINUTES), is(10));
        assertThat("Consumer didn't consume all messages", consumer.get(1, TimeUnit.MINUTES), is(10));
```

### Checklist

- [ ] Make sure all tests pass
