### PR TITLE
Add Mirror Maker 2 examples to release artifacts

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,6 +11,7 @@ release:
 	$(CP) -r ./kafka $(RELEASE_PATH)/
 	$(CP) -r ./kafka-connect $(RELEASE_PATH)/
 	$(CP) -r ./kafka-mirror-maker $(RELEASE_PATH)/
+	$(CP) -r ./kafka-mirror-maker-2 $(RELEASE_PATH)/
 	$(CP) -r ./kafka-bridge $(RELEASE_PATH)/
 	$(CP) -r ./user $(RELEASE_PATH)/
 	$(CP) -r ./topic $(RELEASE_PATH)/


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Mirror Maker 2 examples are currently missing in the 0.17.0-rc1 artifacts because they were not in the `Makefile`. This PR adds them.

Thsi should be cherry-picked for the 0.17.0 release.