### PR TITLE
[MO] - [system test] -> fixes

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -107,6 +107,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     waitForDeletion((Kafka) resource);
                 });
@@ -117,6 +118,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     waitForDeletion((KafkaConnect) resource);
                 });
@@ -127,6 +129,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     waitForDeletion((KafkaConnectS2I) resource);
                 });
@@ -137,6 +140,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     waitForDeletion((KafkaMirrorMaker) resource);
                 });
@@ -147,6 +151,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     waitForDeletion((KafkaBridge) resource);
                 });
@@ -185,6 +190,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                     kubeClient().deleteIngress((Ingress) resource);
                 });
@@ -195,6 +201,7 @@ public class ResourceManager {
                             resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
                     operation.inNamespace(resource.getMetadata().getNamespace())
                             .withName(resource.getMetadata().getName())
+                            .cascading(true)
                             .delete();
                 });
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -126,8 +126,8 @@ class AllNamespaceST extends AbstractNamespaceST {
 
         SecretUtils.waitForSecretReady(USER_NAME);
         KafkaUserUtils.waitForKafkaUserCreation(USER_NAME);
-        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME).get()
-                .getStatus().getConditions().get(0);
+        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME)
+                .get().getStatus().getConditions().get(0);
         LOGGER.info("Kafka User condition status: {}", kafkaCondition.getStatus());
         LOGGER.info("Kafka User condition type: {}", kafkaCondition.getType());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -23,7 +23,6 @@ import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -335,6 +334,11 @@ class RollingUpdateST extends BaseST {
         final int initialZkReplicas = kubeClient().getStatefulSet(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).getStatus().getReplicas();
         assertThat(initialZkReplicas, is(3));
 
+        final String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        internalKafkaClient.setPodName(defaultKafkaClientsPodName);
+
         int sent = internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messageCount, "TLS");
 
         assertThat(sent, is(messageCount));
@@ -503,12 +507,6 @@ class RollingUpdateST extends BaseST {
     protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) {
         super.recreateTestEnv(coNamespace, bindingsNamespaces, Constants.CO_OPERATION_TIMEOUT_SHORT);
         deployTestSpecificResources();
-    }
-
-    @BeforeEach
-    void setKafkaClientsPodName() {
-        // Get clients pod name
-        internalKafkaClient.setPodName(kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName());
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Seequick1 <morsak@redhat.com>

### Type of change

- Bugfix

### Description

This PR fixing following tests:

- io.strimzi.RollingUpdateST.testRecoveryDuringZookeeperRollingUpdate
  - the invalid setting of Kafka client pod
- io.strimzi.metrics.MetricsST.io.strimzi.systemtest.metrics.MetricsST
  - wrong casting of client
- io.strimzi.tracing.TracingST.testConnectService
  - race condition, executed 6 times and it's passing
- io.strimzi.RollingUpdateST.testKafkaAndZookeeperScaleUpScaleDown
  - the invalid setting of Kafka client pod
- io.strimzi.ConnectS2IST.testSecretsWithKafkaConnectS2IWithTlsAndScramShaAuthentication
  - wrong deleting kafkas2i resoruces -> resolve .cascading() 


### Checklist

- [ ] Make sure all tests pass
