### PR TITLE
Close vertx instances in tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -36,6 +36,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -109,7 +110,7 @@ public class CertificateRenewalTest {
         vertx = Vertx.vertx();
     }
 
-    @BeforeAll
+    @AfterAll
     public static void closeVertx() {
         if (vertx != null) {
             vertx.close();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -36,6 +36,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -88,7 +89,7 @@ public class CertificateRenewalTest {
     public static final String NAMESPACE = "test";
     public static final String NAME = "my-kafka";
     private String clusterCaStorePassword = "123456";
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
     private OpenSslCertManager certManager = new OpenSslCertManager();
     private PasswordGenerator passwordGenerator = new PasswordGenerator(12,
             "abcdefghijklmnopqrstuvwxyz" +
@@ -101,6 +102,18 @@ public class CertificateRenewalTest {
     @BeforeEach
     public void clearSecrets() {
         secrets = new ArrayList();
+    }
+
+    @BeforeAll
+    public static void initVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    @BeforeAll
+    public static void closeVertx() {
+        if (vertx != null) {
+            vertx.close();
+        }
     }
 
     private ArgumentCaptor<Secret> reconcileCa(VertxTestContext context, CertificateAuthority clusterCa, CertificateAuthority clientsCa) throws InterruptedException {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -35,6 +35,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -301,5 +302,10 @@ public class JbodStorageTest {
         Labels pvcSelector = Labels.forCluster(name).withKind(Kafka.RESOURCE_KIND).withName(kafkaStsName);
         return mockClient.persistentVolumeClaims().inNamespace(namespace).withLabels(pvcSelector.toMap())
                 .list().getItems();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        vertx.close();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -15,6 +15,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.connect.cli.ConnectDistributed;
 import org.apache.kafka.connect.runtime.Connect;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class KafkaConnectApiTest {
 
     private KafkaCluster cluster;
-    private Vertx vertx;
+    private static Vertx vertx;
     private Connect connect;
     private static final int PORT = 18083;
 
@@ -92,6 +93,11 @@ public class KafkaConnectApiTest {
             connect.awaitStop();
         }
         cluster.shutdown();
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -81,7 +81,9 @@ public class KafkaStatusTest {
 
     @AfterAll
     public static void after() {
-        vertx.close();
+        if (vertx != null) {
+            vertx.close();
+        }
     }
 
     public Kafka getKafkaCrd() throws ParseException {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpdateTest.java
@@ -32,6 +32,8 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -67,9 +69,19 @@ public class KafkaUpdateTest {
 
     public static final String NAMESPACE = "test";
     public static final String NAME = "my-kafka";
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
 
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
 
     public static EnvVar findEnv(List<EnvVar> env, String envVar) {
         EnvVar value = null;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -37,6 +37,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -151,6 +152,11 @@ public class PartialRollingUpdateTest {
         this.clientsCaCert = bootstrapClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME)).get();
         this.clientsCaKey = bootstrapClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaKeySecretName(CLUSTER_NAME)).get();
         context.completeNow();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        vertx.close();
     }
 
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -26,7 +26,9 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -61,12 +63,22 @@ public class ZookeeperLeaderFinderTest {
     public static final String NAMESPACE = "testns";
     public static final String CLUSTER = "testcluster";
 
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
     private SecretOperator mock = mock(SecretOperator.class);
     private SelfSignedCertificate zkCertificate = SelfSignedCertificate.create();
     private SelfSignedCertificate coCertificate = SelfSignedCertificate.create();
 
     private static final int MAX_ATTEMPTS = 4;
+
+    @BeforeAll
+    public static void initVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
+    }
 
     class TestingZookeeperLeaderFinder extends ZookeeperLeaderFinder {
         private final int[] ports;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -16,6 +16,8 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -32,7 +34,18 @@ import static org.mockito.Mockito.when;
 @ExtendWith(VertxExtension.class)
 public class K8sImplTest {
 
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
+
+    @BeforeAll
+    public static void initVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
+    }
+
 
     @Test
     public void testList(VertxTestContext context) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -80,7 +80,9 @@ public class TopicOperatorMockTest {
 
     @AfterAll
     public static void closeVertx() {
-        vertx.close();
+        if (vertx != null) {
+            vertx.close();
+        }
     }
 
     @BeforeEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ public class TopicOperatorMockTest {
     private KubernetesClient kubeClient;
     private Session session;
     private KafkaCluster kafkaCluster;
-    private Vertx vertx;
+    private static Vertx vertx;
     private String deploymentId;
     private AdminClient adminClient;
     private TopicConfigsWatcher topicsConfigWatcher;
@@ -75,6 +76,11 @@ public class TopicOperatorMockTest {
         if (kafkaCluster != null) {
             kafkaCluster.shutdown();
         }
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
     }
 
     @BeforeEach

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -30,17 +30,17 @@ public class KafkaUserQuotasIT {
 
     private KafkaUserQuotas defaultQuotas;
 
-    private Vertx vertx;
+    private static Vertx vertx;
 
 
     @BeforeAll
-    public void startZk() throws IOException, InterruptedException {
+    public static void startZk() throws IOException, InterruptedException {
         vertx = Vertx.vertx();
         zkServer = new EmbeddedZooKeeper();
     }
 
     @AfterAll
-    public void stopZk() {
+    public static void stopZk() {
         vertx.close();
         zkServer.close();
     }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -30,14 +30,18 @@ public class KafkaUserQuotasIT {
 
     private KafkaUserQuotas defaultQuotas;
 
+    private Vertx vertx;
+
 
     @BeforeAll
-    public static void startZk() throws IOException, InterruptedException {
+    public void startZk() throws IOException, InterruptedException {
+        vertx = Vertx.vertx();
         zkServer = new EmbeddedZooKeeper();
     }
 
     @AfterAll
-    public static void stopZk() {
+    public void stopZk() {
+        vertx.close();
         zkServer.close();
     }
 
@@ -46,7 +50,7 @@ public class KafkaUserQuotasIT {
         defaultQuotas = new KafkaUserQuotas();
         defaultQuotas.setConsumerByteRate(1000);
         defaultQuotas.setProducerByteRate(2000);
-        kuq = new KafkaUserQuotasOperator(Vertx.vertx(), zkServer.getZkConnectString(), 6_000);
+        kuq = new KafkaUserQuotasOperator(vertx, zkServer.getZkConnectString(), 6_000);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Some of the tests were not closing `vertx` instances and thus Jenkins build failed with `too many file descriptors` exception.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

