### PR TITLE
ST: Improve checks for nodeport status

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerExternalLoadBalancer;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePort;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalRoute;
 import io.strimzi.api.kafka.model.listener.KafkaListenerTls;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -252,5 +253,9 @@ public class KafkaResource {
 
         return kafkaListenerExternalConfiguration == null ?
                 KafkaResources.clusterCaCertificateSecretName(clusterName) : kafkaListenerExternalConfiguration.getBrokerCertChainAndKey().getSecretName();
+    }
+
+    public static KafkaStatus getKafkaStatus(String clusterName, String namespace) {
+        return kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1078,10 +1078,10 @@ class KafkaST extends BaseST {
                 } else {
                     listNodeAddress = listNodes.stream().filter(node -> node.getMetadata().getLabels().containsKey("node-role.kubernetes.io/compute"))
                             .map(p -> p.getStatus().getAddresses().get(0).getAddress()).collect(Collectors.toList());
-                    listNodeAddress.sort(Comparator.comparing( String::toString));
+                    listNodeAddress.sort(Comparator.comparing(String::toString));
                 }
                 List<String> listStatusAddresses = listenerStatus.getAddresses().stream().map(ListenerAddress::getHost).collect(Collectors.toList());
-                listStatusAddresses.sort(Comparator.comparing( String::toString));
+                listStatusAddresses.sort(Comparator.comparing(String::toString));
                 List<Integer> listStatusPorts = listenerStatus.getAddresses().stream().map(ListenerAddress::getPort).collect(Collectors.toList());
                 Integer nodePort = kubeClient().getService(KafkaResources.externalBootstrapServiceName(CLUSTER_NAME)).getSpec().getPorts().get(0).getNodePort();
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR add test coverage for  https://github.com/strimzi/strimzi-kafka-operator/pull/2355. 

`testNodePort` now contains check, for retrieve Kafka status with nodePort information and compare it with kubernetes node IP. Tested on multinode kube cluster and on `oc cluster up`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
