### PR TITLE
[DOC] Visible backticks in K8sEmptyDir attribute

### DIFF
--- a/documentation/modules/ref-storage-ephemeral.adoc
+++ b/documentation/modules/ref-storage-ephemeral.adoc
@@ -5,7 +5,7 @@
 [id='ref-ephemeral-storage-{context}']
 = Ephemeral storage
 
-Ephemeral storage uses the {K8sEmptyDir} to store data.
+Ephemeral storage uses the `{K8sEmptyDir}` volumes to store data.
 To use ephemeral storage, the `type` field should be set to `ephemeral`.
 
 IMPORTANT: `EmptyDir` volumes are not persistent and the data stored in them will be lost when the Pod is restarted.

--- a/documentation/modules/ref-storage-ephemeral.adoc
+++ b/documentation/modules/ref-storage-ephemeral.adoc
@@ -8,7 +8,7 @@
 Ephemeral storage uses the `{K8sEmptyDir}` volumes to store data.
 To use ephemeral storage, the `type` field should be set to `ephemeral`.
 
-IMPORTANT: `EmptyDir` volumes are not persistent and the data stored in them will be lost when the Pod is restarted.
+IMPORTANT: `emptyDir` volumes are not persistent and the data stored in them will be lost when the Pod is restarted.
 After the new pod is started, it has to recover all data from other nodes of the cluster.
 Ephemeral storage is not suitable for use with single node ZooKeeper clusters and for Kafka topics with replication factor 1, because it will lead to data loss.
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -50,7 +50,7 @@
 :KafkaRacks: link:https://kafka.apache.org/documentation/#basic_ops_racks[Kafka racks documentation^]
 :K8sAffinity: link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Kubernetes node and pod affinity documentation^]
 :K8sTolerations: link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes taints and tolerations^]
-:K8sEmptyDir: link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[`emptyDir` volumes^]
+:K8sEmptyDir: link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[emptyDir^]
 :K8sPersistentVolumeClaims: link:https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/[Persistent Volume Claims^]
 :K8sLocalPersistentVolumes: link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local persistent volumes^]
 :K8SStorageClass: link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage Class^]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This pull request fixes issue #2404 

There are no other instances of rendered backticks in the Strimzi documentation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

