### PR TITLE
ST: Check that Kafka configuration is correctly stored in CM and in Kafka pod

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -355,6 +355,16 @@ class KafkaST extends BaseST {
                 periodSeconds, successThreshold, failureThreshold);
         checkSpecificVariablesInContainer(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", envVarGeneral);
 
+        String kafkaConfiguration = kubeClient().getConfigMap(KafkaResources.kafkaMetricsAndLogConfigMapName(CLUSTER_NAME)).getData().get("server.config");
+        assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
+        assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
+        assertThat(kafkaConfiguration, containsString("default.replication.factor=1"));
+
+        String kafkaConfigurationFromPod = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "cat", "/tmp/strimzi.properties").out();
+        assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=1"));
+        assertThat(kafkaConfigurationFromPod, containsString("transaction.state.log.replication.factor=1"));
+        assertThat(kafkaConfigurationFromPod, containsString("default.replication.factor=1"));
+
         LOGGER.info("Testing Zookeepers");
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", initialDelaySeconds, timeoutSeconds,
                 periodSeconds, successThreshold, failureThreshold);
@@ -461,6 +471,16 @@ class KafkaST extends BaseST {
         checkReadinessLivenessProbe(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", updatedInitialDelaySeconds, updatedTimeoutSeconds,
                 updatedPeriodSeconds, successThreshold, updatedFailureThreshold);
         checkSpecificVariablesInContainer(kafkaStatefulSetName(CLUSTER_NAME), "tls-sidecar", envVarUpdated);
+
+        kafkaConfiguration = kubeClient().getConfigMap(KafkaResources.kafkaMetricsAndLogConfigMapName(CLUSTER_NAME)).getData().get("server.config");
+        assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=2"));
+        assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=2"));
+        assertThat(kafkaConfiguration, containsString("default.replication.factor=2"));
+
+        kafkaConfigurationFromPod = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "cat", "/tmp/strimzi.properties").out();
+        assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=2"));
+        assertThat(kafkaConfigurationFromPod, containsString("transaction.state.log.replication.factor=2"));
+        assertThat(kafkaConfigurationFromPod, containsString("default.replication.factor=2"));
 
         LOGGER.info("Testing Zookeepers");
         checkReadinessLivenessProbe(zookeeperStatefulSetName(CLUSTER_NAME), "zookeeper", updatedInitialDelaySeconds, updatedTimeoutSeconds,


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR add checks into existing test `testCustomAndUpdatedValues` which covers changes one in https://github.com/strimzi/strimzi-kafka-operator/pull/2342.

New checks do verification of Kafka CM, which contains user configuration specified by user via CR. When this is verified, additional check see if the same configuration is available in Kafka pod.

### Checklist

- [x] Make sure all tests pass

