### PR TITLE
Remove Kafka Connect properties from root of KafkaMirrorMaker2Spec

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -30,9 +30,10 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "replicas", "image",
+@JsonPropertyOrder({ "replicas", "version", "image", "resources", 
         "livenessProbe", "readinessProbe", "jvmOptions",
-        "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
+        "affinity", "tolerations", "logging", "metrics", "tracing", 
+        "template", "externalConfiguration"})
 @EqualsAndHashCode(doNotUseGetters = true)
 public abstract class AbstractKafkaConnectSpec implements Serializable, UnknownPropertyPreserving {
 
@@ -97,7 +98,7 @@ public abstract class AbstractKafkaConnectSpec implements Serializable, UnknownP
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("CPU and memory resources to reserve.")
+    @Description("The maximum limits for CPU and memory resources and the requested initial resources.")
     public ResourceRequirements getResources() {
         return resources;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.strimzi.api.annotations.DeprecatedProperty;
+import io.strimzi.api.kafka.model.connect.ExternalConfiguration;
+import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
+import io.strimzi.api.kafka.model.tracing.Tracing;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.sundr.builder.annotations.Buildable;
+import io.vertx.core.cli.annotations.DefaultValue;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "replicas", "image",
+        "livenessProbe", "readinessProbe", "jvmOptions",
+        "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
+@EqualsAndHashCode(doNotUseGetters = true)
+public abstract class AbstractKafkaConnectSpec implements Serializable, UnknownPropertyPreserving {
+
+    private static final long serialVersionUID = 1L;
+
+    private Logging logging;
+    private Integer replicas;
+
+    private String version;
+    private String image;
+    private ResourceRequirements resources;
+    private Probe livenessProbe;
+    private Probe readinessProbe;
+    private JvmOptions jvmOptions;
+    private Map<String, Object> metrics;
+    private Tracing tracing;
+    private Affinity affinity;
+    private List<Toleration> tolerations;
+    private KafkaConnectTemplate template;
+    private ExternalConfiguration externalConfiguration;
+
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("The number of pods in the Kafka Connect group.")
+    @DefaultValue("3")
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    @Description("Logging configuration for Kafka Connect")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public Logging getLogging() {
+        return logging == null ? new InlineLogging() : logging;
+    }
+
+    public void setLogging(Logging logging) {
+        this.logging = logging;
+    }
+
+    public void setReplicas(Integer replicas) {
+        this.replicas = replicas;
+    }
+
+    @Description("The Kafka Connect version. Defaults to {DefaultKafkaVersion}. " +
+            "Consult the user documentation to understand the process required to upgrade or downgrade the version.")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Description("The docker image for the pods.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("CPU and memory resources to reserve.")
+    public ResourceRequirements getResources() {
+        return resources;
+    }
+
+    public void setResources(ResourceRequirements resources) {
+        this.resources = resources;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("Pod liveness checking.")
+    public Probe getLivenessProbe() {
+        return livenessProbe;
+    }
+
+    public void setLivenessProbe(Probe livenessProbe) {
+        this.livenessProbe = livenessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Pod readiness checking.")
+    public Probe getReadinessProbe() {
+        return readinessProbe;
+    }
+
+    public void setReadinessProbe(Probe readinessProbe) {
+        this.readinessProbe = readinessProbe;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("JVM Options for pods")
+    public JvmOptions getJvmOptions() {
+        return jvmOptions;
+    }
+
+    public void setJvmOptions(JvmOptions jvmOptions) {
+        this.jvmOptions = jvmOptions;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The Prometheus JMX Exporter configuration. " +
+            "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
+    public Map<String, Object> getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The configuration of tracing in Kafka Connect.")
+    public Tracing getTracing() {
+        return tracing;
+    }
+
+    public void setTracing(Tracing tracing) {
+        this.tracing = tracing;
+    }
+
+    @Description("The pod's affinity rules.")
+    @KubeLink(group = "core", version = "v1", kind = "affinity")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @DeprecatedProperty(movedToPath = "spec.template.pod.affinity")
+    @Deprecated
+    public Affinity getAffinity() {
+        return affinity;
+    }
+
+    @Deprecated
+    public void setAffinity(Affinity affinity) {
+        this.affinity = affinity;
+    }
+
+    @Description("The pod's tolerations.")
+    @KubeLink(group = "core", version = "v1", kind = "toleration")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @DeprecatedProperty(movedToPath = "spec.template.pod.tolerations")
+    @Deprecated
+    public List<Toleration> getTolerations() {
+        return tolerations;
+    }
+
+    @Deprecated
+    public void setTolerations(List<Toleration> tolerations) {
+        this.tolerations = tolerations;
+    }
+
+    @Description("Template for Kafka Connect and Kafka Connect S2I resources. " +
+            "The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public KafkaConnectTemplate getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(KafkaConnectTemplate template) {
+        this.template = template;
+    }
+
+    @Description("Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ExternalConfiguration getExternalConfiguration() {
+        return externalConfiguration;
+    }
+
+    public void setExternalConfiguration(ExternalConfiguration externalConfiguration) {
+        this.externalConfiguration = externalConfiguration;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -21,9 +21,11 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "replicas", "image", "bootstrapServers", "config",
+@JsonPropertyOrder({ "replicas", "version", "image", 
+        "bootstrapServers", "tls", "authentication", "config", "resources", 
         "livenessProbe", "readinessProbe", "jvmOptions",
-        "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
+        "affinity", "tolerations", "logging", "metrics", "tracing", 
+        "template", "externalConfiguration"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -7,23 +7,12 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.fabric8.kubernetes.api.model.Affinity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.Toleration;
-import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
-import io.strimzi.api.kafka.model.connect.ExternalConfiguration;
-import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
-import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
-import java.io.Serializable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Buildable(
@@ -32,11 +21,11 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "replicas", "config", "image",
+@JsonPropertyOrder({ "replicas", "image", "bootstrapServers", "config",
         "livenessProbe", "readinessProbe", "jvmOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing", "template"})
-@EqualsAndHashCode(doNotUseGetters = true)
-public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving {
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     private static final long serialVersionUID = 1L;
 
@@ -45,32 +34,9 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
 
     private Map<String, Object> config = new HashMap<>(0);
 
-    private Logging logging;
-    private Integer replicas;
-
-    private String version;
-    private String image;
-    private ResourceRequirements resources;
-    private Probe livenessProbe;
-    private Probe readinessProbe;
-    private JvmOptions jvmOptions;
-    private Map<String, Object> metrics;
-    private Tracing tracing;
-    private Affinity affinity;
-    private List<Toleration> tolerations;
     private String bootstrapServers;
     private KafkaConnectTls tls;
     private KafkaClientAuthentication authentication;
-    private KafkaConnectTemplate template;
-    private ExternalConfiguration externalConfiguration;
-
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
-
-    @Description("The number of pods in the Kafka Connect group.")
-    @DefaultValue("3")
-    public Integer getReplicas() {
-        return replicas;
-    }
 
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)
     public Map<String, Object> getConfig() {
@@ -81,128 +47,6 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
         this.config = config;
     }
 
-    @Description("Logging configuration for Kafka Connect")
-    @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public Logging getLogging() {
-        return logging == null ? new InlineLogging() : logging;
-    }
-
-    public void setLogging(Logging logging) {
-        this.logging = logging;
-    }
-
-    public void setReplicas(Integer replicas) {
-        this.replicas = replicas;
-    }
-
-    @Description("The Kafka Connect version. Defaults to {DefaultKafkaVersion}. " +
-            "Consult the user documentation to understand the process required to upgrade or downgrade the version.")
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    @Description("The docker image for the pods.")
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public String getImage() {
-        return image;
-    }
-
-    public void setImage(String image) {
-        this.image = image;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("CPU and memory resources to reserve.")
-    public ResourceRequirements getResources() {
-        return resources;
-    }
-
-    public void setResources(ResourceRequirements resources) {
-        this.resources = resources;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @Description("Pod liveness checking.")
-    public Probe getLivenessProbe() {
-        return livenessProbe;
-    }
-
-    public void setLivenessProbe(Probe livenessProbe) {
-        this.livenessProbe = livenessProbe;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @Description("Pod readiness checking.")
-    public Probe getReadinessProbe() {
-        return readinessProbe;
-    }
-
-    public void setReadinessProbe(Probe readinessProbe) {
-        this.readinessProbe = readinessProbe;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @Description("JVM Options for pods")
-    public JvmOptions getJvmOptions() {
-        return jvmOptions;
-    }
-
-    public void setJvmOptions(JvmOptions jvmOptions) {
-        this.jvmOptions = jvmOptions;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("The Prometheus JMX Exporter configuration. " +
-            "See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.")
-    public Map<String, Object> getMetrics() {
-        return metrics;
-    }
-
-    public void setMetrics(Map<String, Object> metrics) {
-        this.metrics = metrics;
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("The configuration of tracing in Kafka Connect.")
-    public Tracing getTracing() {
-        return tracing;
-    }
-
-    public void setTracing(Tracing tracing) {
-        this.tracing = tracing;
-    }
-
-    @Description("The pod's affinity rules.")
-    @KubeLink(group = "core", version = "v1", kind = "affinity")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @DeprecatedProperty(movedToPath = "spec.template.pod.affinity")
-    @Deprecated
-    public Affinity getAffinity() {
-        return affinity;
-    }
-
-    @Deprecated
-    public void setAffinity(Affinity affinity) {
-        this.affinity = affinity;
-    }
-
-    @Description("The pod's tolerations.")
-    @KubeLink(group = "core", version = "v1", kind = "toleration")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @DeprecatedProperty(movedToPath = "spec.template.pod.tolerations")
-    @Deprecated
-    public List<Toleration> getTolerations() {
-        return tolerations;
-    }
-
-    @Deprecated
-    public void setTolerations(List<Toleration> tolerations) {
-        this.tolerations = tolerations;
-    }
 
     @Description("Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:\u200D_<port>_ pairs.")
     @JsonProperty(required = true)
@@ -232,36 +76,5 @@ public class KafkaConnectSpec implements Serializable, UnknownPropertyPreserving
 
     public void setAuthentication(KafkaClientAuthentication authentication) {
         this.authentication = authentication;
-    }
-
-    @Description("Template for Kafka Connect and Kafka Connect S2I resources. " +
-            "The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public KafkaConnectTemplate getTemplate() {
-        return template;
-    }
-
-    public void setTemplate(KafkaConnectTemplate template) {
-        this.template = template;
-    }
-
-    @Description("Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ExternalConfiguration getExternalConfiguration() {
-        return externalConfiguration;
-    }
-
-    public void setExternalConfiguration(ExternalConfiguration externalConfiguration) {
-        this.externalConfiguration = externalConfiguration;
-    }
-
-    @Override
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
-
-    @Override
-    public void setAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, Serializable {
 
-    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes";
+    public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm";
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -20,9 +20,11 @@ import lombok.EqualsAndHashCode;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"replicas", "connectCluster", "image",
+@JsonPropertyOrder({"replicas", "version", "image", "connectCluster", 
+        "clusters", "mirrors", "resources", 
         "livenessProbe", "readinessProbe", "jvmOptions",
-        "affinity", "tolerations", "logging", "metrics", "tracing", "template", "clusters", "mirrors"})
+        "affinity", "tolerations", "logging", "metrics", "tracing", 
+        "template", "externalConfiguration"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.api.kafka.model;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,18 +20,17 @@ import lombok.EqualsAndHashCode;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"replicas", "connectCluster", "config", "image",
+@JsonPropertyOrder({"replicas", "connectCluster", "image",
         "livenessProbe", "readinessProbe", "jvmOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing", "template", "clusters", "mirrors"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
-public class KafkaMirrorMaker2Spec extends KafkaConnectSpec {
+public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
 
     private static final long serialVersionUID = 1L;
     
     private List<KafkaMirrorMaker2ClusterSpec> clusters;
     private String connectCluster;
     private List<KafkaMirrorMaker2MirrorSpec> mirrors;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Kafka clusters for mirroring.")
     public List<KafkaMirrorMaker2ClusterSpec> getClusters() {
@@ -61,21 +58,5 @@ public class KafkaMirrorMaker2Spec extends KafkaConnectSpec {
 
     public void setMirrors(List<KafkaMirrorMaker2MirrorSpec> mirrors) {
         this.mirrors = mirrors;
-    }
-
-    @Override
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
-
-    @Override
-    public void setAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
-    }
-
-    @Description("Bootstrap servers to connect to. This can be given as a comma separated list of _<hostname>_:\u200D_<port>_ pairs.")
-    @JsonProperty(required = false)
-    public String getBootstrapServers() {
-        return super.getBootstrapServers();
     }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
@@ -5,9 +5,10 @@ metadata:
   name: "test-kafka-connect"
 spec:
   replicas: 6
+  image: "foo"
+  bootstrapServers: "kafka:9092"
   config:
     name: "bar"
-  image: "foo"
   tolerations:
   - effect: "NoSchedule"
     key: "key1"
@@ -20,7 +21,6 @@ spec:
   logging:
     type: "inline"
     loggers: {}
-  bootstrapServers: "kafka:9092"
   externalConfiguration:
     env:
     - name: "SOME_VARIABLE"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   replicas: 6
   connectCluster: "target"
-  config:
-    name: "bar"
   image: "foo"
   tolerations:
   - effect: "NoSchedule"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -5,20 +5,8 @@ metadata:
   name: "test-kafka-mirror-maker-2"
 spec:
   replicas: 6
-  connectCluster: "target"
   image: "foo"
-  tolerations:
-  - effect: "NoSchedule"
-    key: "key1"
-    operator: "Equal"
-    value: "value1"
-  - effect: "NoSchedule"
-    key: "key2"
-    operator: "Equal"
-    value: "value2"
-  logging:
-    type: "inline"
-    loggers: {}
+  connectCluster: "target"
   clusters:
   - alias: "source"
     bootstrapServers: "my-source-kafka:9092"
@@ -44,6 +32,18 @@ spec:
         heartbeats.topic.replication.factor: 1
     topics: "my-topic"
     groups: "my-group"
+  tolerations:
+  - effect: "NoSchedule"
+    key: "key1"
+    operator: "Equal"
+    value: "value1"
+  - effect: "NoSchedule"
+    key: "key2"
+    operator: "Equal"
+    value: "value2"
+  logging:
+    type: "inline"
+    loggers: {}
   externalConfiguration:
     env:
     - name: "SOME_VARIABLE"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
@@ -6,8 +6,6 @@ spec:
   image: foo
   replicas: 6
   connectCluster: target
-  config:
-    name: bar
   tolerations:
     - key: "key1"
       operator: "Equal"

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -5,7 +5,7 @@
 
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.api.kafka.model.KafkaConnectSpec;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
 
 import java.util.HashMap;
 import java.util.List;
@@ -22,8 +22,8 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_OPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIXES.split(", "));
-        EXCEPTIONS = asList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
+        FORBIDDEN_OPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES.split(", "));
+        EXCEPTIONS = asList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS.split(", "));
 
         DEFAULTS = new HashMap<>();
         DEFAULTS.put("group.id", "mirrormaker2-cluster");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -137,6 +137,8 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         annotations.put(ANNO_STRIMZI_IO_LOGGING, logAndMetricsConfigMap.getData().get(mirrorMaker2Cluster.ANCILLARY_CM_KEY_LOG_CONFIG));
 
         log.debug("{}: Updating Kafka MirrorMaker 2.0 cluster", reconciliation, name, namespace);
+        log.info("{}: Updating Kafka MirrorMaker 2.0 cluster {} in {}", reconciliation, name, namespace);
+        log.info("{}: Updating Kafka MirrorMaker 2.0 generatePodDisruptionBudget {}", reconciliation, mirrorMaker2Cluster.generatePodDisruptionBudget());
         mirrorMaker2ServiceAccount(namespace, mirrorMaker2Cluster)
                 .compose(i -> deploymentOperations.scaleDown(namespace, mirrorMaker2Cluster.getName(), mirrorMaker2Cluster.getReplicas()))
                 .compose(scale -> serviceOperations.reconcile(namespace, mirrorMaker2Cluster.getServiceName(), mirrorMaker2Cluster.generateService()))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -93,11 +93,11 @@ public class KafkaMirrorMaker2ClusterTest {
     private final KafkaMirrorMaker2ClusterSpec targetCluster = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(targetClusterAlias)
             .withBootstrapServers(bootstrapServers)
+            .withConfig((Map<String, Object>) TestUtils.fromJson(configurationJson, Map.class))
             .build();
     private final KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2Cluster(namespace, cluster))
             .withNewSpec()
             .withMetrics((Map<String, Object>) TestUtils.fromJson(metricsCmJson, Map.class))
-            .withConfig((Map<String, Object>) TestUtils.fromJson(configurationJson, Map.class))
             .withImage(image)
             .withReplicas(replicas)
             .withReadinessProbe(new Probe(healthDelay, healthTimeout))

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1536,10 +1536,12 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |Property                      |Description
 |replicas               1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
-|map
 |image                  1.2+<.<|The docker image for the pods.
 |string
+|bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|string
+|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
+|map
 |livenessProbe          1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe         1.2+<.<|Pod readiness checking.
@@ -1560,12 +1562,10 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |map
 |tracing                1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
+|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
-|string
 |externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |resources              1.2+<.<|CPU and memory resources to reserve.
@@ -1615,7 +1615,7 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 [id='type-KafkaClientAuthenticationTls-{context}']
 ### `KafkaClientAuthenticationTls` schema reference
 
-Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls.adoc[leveloffset=+1]
 
@@ -1633,7 +1633,7 @@ It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 [id='type-KafkaClientAuthenticationScramSha512-{context}']
 ### `KafkaClientAuthenticationScramSha512` schema reference
 
-Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha512.adoc[leveloffset=+1]
 
@@ -1668,7 +1668,7 @@ Used in: xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenti
 [id='type-KafkaClientAuthenticationPlain-{context}']
 ### `KafkaClientAuthenticationPlain` schema reference
 
-Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain.adoc[leveloffset=+1]
 
@@ -1688,7 +1688,7 @@ It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [id='type-KafkaClientAuthenticationOAuth-{context}']
 ### `KafkaClientAuthenticationOAuth` schema reference
 
-Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
 
 include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth.adoc[leveloffset=+1]
 
@@ -1792,7 +1792,7 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 [id='type-KafkaConnectTls-{context}']
 ### `KafkaConnectTls` schema reference
 
-Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
 
 [options="header"]
@@ -1880,7 +1880,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |metrics                   1.2+<.<|The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter for details of the structure of this configuration.
 |map
-|template                  1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
+|template                  1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |authentication            1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
@@ -2554,8 +2554,6 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |integer
 |connectCluster         1.2+<.<|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
-|map
 |image                  1.2+<.<|The docker image for the pods.
 |string
 |livenessProbe          1.2+<.<|Pod liveness checking.
@@ -2578,22 +2576,16 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |map
 |tracing                1.2+<.<|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
-|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how is the `Deployment`, `Pods` and `Service` generated.
+|template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |clusters               1.2+<.<|Kafka clusters for mirroring.
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
 |mirrors                1.2+<.<|Configuration of the MirrorMaker 2.0 connectors.
 |xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
-|authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This can be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
-|string
 |externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |resources              1.2+<.<|CPU and memory resources to reserve.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|tls                    1.2+<.<|TLS configuration.
-|xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
 |version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |====
@@ -2611,7 +2603,7 @@ Used in: xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 |string
 |bootstrapServers  1.2+<.<|A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
 |string
-|config            1.2+<.<|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).
+|config            1.2+<.<|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).
 |map
 |tls               1.2+<.<|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
 |xref:type-KafkaMirrorMaker2Tls-{context}[`KafkaMirrorMaker2Tls`]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1536,12 +1536,20 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |Property                      |Description
 |replicas               1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
+|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|string
 |image                  1.2+<.<|The docker image for the pods.
 |string
 |bootstrapServers       1.2+<.<|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
 |string
+|tls                    1.2+<.<|TLS configuration.
+|xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
+|authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config                 1.2+<.<|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.
 |map
+|resources              1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources.
+|xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
 |livenessProbe          1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe         1.2+<.<|Pod readiness checking.
@@ -1564,52 +1572,21 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
 |template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|authentication         1.2+<.<|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|resources              1.2+<.<|CPU and memory resources to reserve.
-|xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|tls                    1.2+<.<|TLS configuration.
-|xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
-|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
-|string
 |====
 
-[id='type-JaegerTracing-{context}']
-### `JaegerTracing` schema reference
+[id='type-KafkaConnectTls-{context}']
+### `KafkaConnectTls` schema reference
 
-Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
-
-
-The `type` property is a discriminator that distinguishes the use of the type `JaegerTracing` from other subtypes which may be added in the future.
-It must have the value `jaeger` for the type `JaegerTracing`.
-[options="header"]
-|====
-|Property     |Description
-|type  1.2+<.<|Must be `jaeger`.
-|string
-|====
-
-[id='type-KafkaConnectTemplate-{context}']
-### `KafkaConnectTemplate` schema reference
-
-Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
 
 
 [options="header"]
 |====
 |Property                    |Description
-|deployment           1.2+<.<|Template for Kafka Connect `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                  1.2+<.<|Template for Kafka Connect `Pods`.
-|xref:type-PodTemplate-{context}[`PodTemplate`]
-|apiService           1.2+<.<|Template for Kafka Connect API `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|connectContainer     1.2+<.<|Template for the Kafka Connect container.
-|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|podDisruptionBudget  1.2+<.<|Template for Kafka Connect `PodDisruptionBudget`.
-|xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
+|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
 [id='type-KafkaClientAuthenticationTls-{context}']
@@ -1719,6 +1696,42 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 |string
 |====
 
+[id='type-JaegerTracing-{context}']
+### `JaegerTracing` schema reference
+
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
+
+
+The `type` property is a discriminator that distinguishes the use of the type `JaegerTracing` from other subtypes which may be added in the future.
+It must have the value `jaeger` for the type `JaegerTracing`.
+[options="header"]
+|====
+|Property     |Description
+|type  1.2+<.<|Must be `jaeger`.
+|string
+|====
+
+[id='type-KafkaConnectTemplate-{context}']
+### `KafkaConnectTemplate` schema reference
+
+Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
+
+
+[options="header"]
+|====
+|Property                    |Description
+|deployment           1.2+<.<|Template for Kafka Connect `Deployment`.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|pod                  1.2+<.<|Template for Kafka Connect `Pods`.
+|xref:type-PodTemplate-{context}[`PodTemplate`]
+|apiService           1.2+<.<|Template for Kafka Connect API `Service`.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|connectContainer     1.2+<.<|Template for the Kafka Connect container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|podDisruptionBudget  1.2+<.<|Template for Kafka Connect `PodDisruptionBudget`.
+|xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
+|====
+
 [id='type-ExternalConfiguration-{context}']
 ### `ExternalConfiguration` schema reference
 
@@ -1787,19 +1800,6 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#secretvolumesource-v1-core[SecretVolumeSource]
-|====
-
-[id='type-KafkaConnectTls-{context}']
-### `KafkaConnectTls` schema reference
-
-Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`]
-
-
-[options="header"]
-|====
-|Property                    |Description
-|trustedCertificates  1.2+<.<|Trusted certificates for TLS connection.
-|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |====
 
 [id='type-KafkaConnectStatus-{context}']
@@ -1892,7 +1892,7 @@ Used in: xref:type-KafkaConnectS2I-{context}[`KafkaConnectS2I`]
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |insecureSourceRepository  1.2+<.<|When true this configures the source repository with the 'Local' reference policy and an import policy that accepts insecure source tags.
 |boolean
-|resources                 1.2+<.<|CPU and memory resources to reserve.
+|resources                 1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources.
 |xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
 |tls                       1.2+<.<|TLS configuration.
 |xref:type-KafkaConnectTls-{context}[`KafkaConnectTls`]
@@ -2552,10 +2552,18 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |Property                      |Description
 |replicas               1.2+<.<|The number of pods in the Kafka Connect group.
 |integer
-|connectCluster         1.2+<.<|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
 |image                  1.2+<.<|The docker image for the pods.
 |string
+|connectCluster         1.2+<.<|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+|string
+|clusters               1.2+<.<|Kafka clusters for mirroring.
+|xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
+|mirrors                1.2+<.<|Configuration of the MirrorMaker 2.0 connectors.
+|xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
+|resources              1.2+<.<|The maximum limits for CPU and memory resources and the requested initial resources.
+|xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
 |livenessProbe          1.2+<.<|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe         1.2+<.<|Pod readiness checking.
@@ -2578,16 +2586,8 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
 |template               1.2+<.<|Template for Kafka Connect and Kafka Connect S2I resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|clusters               1.2+<.<|Kafka clusters for mirroring.
-|xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
-|mirrors                1.2+<.<|Configuration of the MirrorMaker 2.0 connectors.
-|xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
 |externalConfiguration  1.2+<.<|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|resources              1.2+<.<|CPU and memory resources to reserve.
-|xref:type-ResourceRequirements-{context}[`ResourceRequirements`]
-|version                1.2+<.<|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
-|string
 |====
 
 [id='type-KafkaMirrorMaker2ClusterSpec-{context}']

--- a/examples/kafka-mirror-maker-2/kafka-mirror-maker-2.yaml
+++ b/examples/kafka-mirror-maker-2/kafka-mirror-maker-2.yaml
@@ -6,15 +6,15 @@ spec:
   version: 2.4.0
   replicas: 1
   connectCluster: "my-cluster-target"
-  config:
-    config.storage.replication.factor: 1
-    offset.storage.replication.factor: 1
-    status.storage.replication.factor: 1
   clusters:
   - alias: "my-cluster-source"
     bootstrapServers: my-cluster-source-kafka-bootstrap:9092
   - alias: "my-cluster-target"
     bootstrapServers: my-cluster-target-kafka-bootstrap:9092
+    config:
+      config.storage.replication.factor: 1
+      offset.storage.replication.factor: 1
+      status.storage.replication.factor: 1
   mirrors:
   - sourceCluster: "my-cluster-source"
     targetCluster: "my-cluster-target"

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -44,12 +44,125 @@ spec:
           properties:
             replicas:
               type: integer
+            version:
+              type: string
             image:
               type: string
             bootstrapServers:
               type: string
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+            authentication:
+              type: object
+              properties:
+                accessToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                accessTokenIsJwt:
+                  type: boolean
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                clientId:
+                  type: string
+                clientSecret:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                disableTlsHostnameVerification:
+                  type: boolean
+                maxTokenExpirySeconds:
+                  type: integer
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
+                refreshToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                tlsTrustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+                tokenEndpointUri:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  - plain
+                  - oauth
+                username:
+                  type: string
+              required:
+              - type
             config:
               type: object
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
             livenessProbe:
               type: object
               properties:
@@ -687,95 +800,6 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
-            authentication:
-              type: object
-              properties:
-                accessToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                accessTokenIsJwt:
-                  type: boolean
-                certificateAndKey:
-                  type: object
-                  properties:
-                    certificate:
-                      type: string
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - certificate
-                  - key
-                  - secretName
-                clientId:
-                  type: string
-                clientSecret:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                disableTlsHostnameVerification:
-                  type: boolean
-                maxTokenExpirySeconds:
-                  type: integer
-                passwordSecret:
-                  type: object
-                  properties:
-                    password:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - password
-                  - secretName
-                refreshToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                tlsTrustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-                tokenEndpointUri:
-                  type: string
-                type:
-                  type: string
-                  enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                username:
-                  type: string
-              required:
-              - type
             externalConfiguration:
               type: object
               properties:
@@ -859,30 +883,6 @@ spec:
                             type: string
                     required:
                     - name
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                requests:
-                  type: object
-            tls:
-              type: object
-              properties:
-                trustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-            version:
-              type: string
           required:
           - bootstrapServers
         status:

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -44,10 +44,12 @@ spec:
           properties:
             replicas:
               type: integer
-            config:
-              type: object
             image:
               type: string
+            bootstrapServers:
+              type: string
+            config:
+              type: object
             livenessProbe:
               type: object
               properties:
@@ -774,8 +776,6 @@ spec:
                   type: string
               required:
               - type
-            bootstrapServers:
-              type: string
             externalConfiguration:
               type: object
               properties:

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -41,10 +41,188 @@ spec:
           properties:
             replicas:
               type: integer
-            connectCluster:
+            version:
               type: string
             image:
               type: string
+            connectCluster:
+              type: string
+            clusters:
+              type: array
+              items:
+                type: object
+                properties:
+                  alias:
+                    type: string
+                    pattern: ^[a-zA-Z0-9\._\-]{1,100}$
+                  bootstrapServers:
+                    type: string
+                  config:
+                    type: object
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                  authentication:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      accessTokenIsJwt:
+                        type: boolean
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                      clientId:
+                        type: string
+                      clientSecret:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      disableTlsHostnameVerification:
+                        type: boolean
+                      maxTokenExpirySeconds:
+                        type: integer
+                      passwordSecret:
+                        type: object
+                        properties:
+                          password:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - password
+                        - secretName
+                      refreshToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      tlsTrustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                      tokenEndpointUri:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      username:
+                        type: string
+                    required:
+                    - type
+                required:
+                - alias
+                - bootstrapServers
+            mirrors:
+              type: array
+              items:
+                type: object
+                properties:
+                  sourceCluster:
+                    type: string
+                  targetCluster:
+                    type: string
+                  sourceConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  checkpointConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  heartbeatConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  topicsPattern:
+                    type: string
+                  topicsBlacklistPattern:
+                    type: string
+                  groupsPattern:
+                    type: string
+                  groupsBlacklistPattern:
+                    type: string
+                required:
+                - sourceCluster
+                - targetCluster
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
             livenessProbe:
               type: object
               properties:
@@ -682,175 +860,6 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
-            clusters:
-              type: array
-              items:
-                type: object
-                properties:
-                  alias:
-                    type: string
-                    pattern: ^[a-zA-Z0-9\._\-]{1,100}$
-                  bootstrapServers:
-                    type: string
-                  config:
-                    type: object
-                  tls:
-                    type: object
-                    properties:
-                      trustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                            secretName:
-                              type: string
-                          required:
-                          - certificate
-                          - secretName
-                  authentication:
-                    type: object
-                    properties:
-                      accessToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      accessTokenIsJwt:
-                        type: boolean
-                      certificateAndKey:
-                        type: object
-                        properties:
-                          certificate:
-                            type: string
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - certificate
-                        - key
-                        - secretName
-                      clientId:
-                        type: string
-                      clientSecret:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      disableTlsHostnameVerification:
-                        type: boolean
-                      maxTokenExpirySeconds:
-                        type: integer
-                      passwordSecret:
-                        type: object
-                        properties:
-                          password:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - password
-                        - secretName
-                      refreshToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      tlsTrustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                            secretName:
-                              type: string
-                          required:
-                          - certificate
-                          - secretName
-                      tokenEndpointUri:
-                        type: string
-                      type:
-                        type: string
-                        enum:
-                        - tls
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                      username:
-                        type: string
-                    required:
-                    - type
-                required:
-                - alias
-                - bootstrapServers
-            mirrors:
-              type: array
-              items:
-                type: object
-                properties:
-                  sourceCluster:
-                    type: string
-                  targetCluster:
-                    type: string
-                  sourceConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  checkpointConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  heartbeatConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  topicsPattern:
-                    type: string
-                  topicsBlacklistPattern:
-                    type: string
-                  groupsPattern:
-                    type: string
-                  groupsBlacklistPattern:
-                    type: string
-                required:
-                - sourceCluster
-                - targetCluster
             externalConfiguration:
               type: object
               properties:
@@ -934,15 +943,6 @@ spec:
                             type: string
                     required:
                     - name
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                requests:
-                  type: object
-            version:
-              type: string
           required:
           - connectCluster
         status:

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -43,8 +43,6 @@ spec:
               type: integer
             connectCluster:
               type: string
-            config:
-              type: object
             image:
               type: string
             livenessProbe:
@@ -853,97 +851,6 @@ spec:
                 required:
                 - sourceCluster
                 - targetCluster
-            authentication:
-              type: object
-              properties:
-                accessToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                accessTokenIsJwt:
-                  type: boolean
-                certificateAndKey:
-                  type: object
-                  properties:
-                    certificate:
-                      type: string
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - certificate
-                  - key
-                  - secretName
-                clientId:
-                  type: string
-                clientSecret:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                disableTlsHostnameVerification:
-                  type: boolean
-                maxTokenExpirySeconds:
-                  type: integer
-                passwordSecret:
-                  type: object
-                  properties:
-                    password:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - password
-                  - secretName
-                refreshToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                tlsTrustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-                tokenEndpointUri:
-                  type: string
-                type:
-                  type: string
-                  enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                username:
-                  type: string
-              required:
-              - type
-            bootstrapServers:
-              type: string
             externalConfiguration:
               type: object
               properties:
@@ -1034,21 +941,6 @@ spec:
                   type: object
                 requests:
                   type: object
-            tls:
-              type: object
-              properties:
-                trustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
             version:
               type: string
           required:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -39,10 +39,12 @@ spec:
           properties:
             replicas:
               type: integer
-            config:
-              type: object
             image:
               type: string
+            bootstrapServers:
+              type: string
+            config:
+              type: object
             livenessProbe:
               type: object
               properties:
@@ -769,8 +771,6 @@ spec:
                   type: string
               required:
               - type
-            bootstrapServers:
-              type: string
             externalConfiguration:
               type: object
               properties:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -39,12 +39,125 @@ spec:
           properties:
             replicas:
               type: integer
+            version:
+              type: string
             image:
               type: string
             bootstrapServers:
               type: string
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+            authentication:
+              type: object
+              properties:
+                accessToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                accessTokenIsJwt:
+                  type: boolean
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                clientId:
+                  type: string
+                clientSecret:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                disableTlsHostnameVerification:
+                  type: boolean
+                maxTokenExpirySeconds:
+                  type: integer
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
+                refreshToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - key
+                  - secretName
+                tlsTrustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+                tokenEndpointUri:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  - plain
+                  - oauth
+                username:
+                  type: string
+              required:
+              - type
             config:
               type: object
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
             livenessProbe:
               type: object
               properties:
@@ -682,95 +795,6 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
-            authentication:
-              type: object
-              properties:
-                accessToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                accessTokenIsJwt:
-                  type: boolean
-                certificateAndKey:
-                  type: object
-                  properties:
-                    certificate:
-                      type: string
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - certificate
-                  - key
-                  - secretName
-                clientId:
-                  type: string
-                clientSecret:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                disableTlsHostnameVerification:
-                  type: boolean
-                maxTokenExpirySeconds:
-                  type: integer
-                passwordSecret:
-                  type: object
-                  properties:
-                    password:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - password
-                  - secretName
-                refreshToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                tlsTrustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-                tokenEndpointUri:
-                  type: string
-                type:
-                  type: string
-                  enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                username:
-                  type: string
-              required:
-              - type
             externalConfiguration:
               type: object
               properties:
@@ -854,30 +878,6 @@ spec:
                             type: string
                     required:
                     - name
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                requests:
-                  type: object
-            tls:
-              type: object
-              properties:
-                trustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-            version:
-              type: string
           required:
           - bootstrapServers
         status:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -38,8 +38,6 @@ spec:
               type: integer
             connectCluster:
               type: string
-            config:
-              type: object
             image:
               type: string
             livenessProbe:
@@ -848,97 +846,6 @@ spec:
                 required:
                 - sourceCluster
                 - targetCluster
-            authentication:
-              type: object
-              properties:
-                accessToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                accessTokenIsJwt:
-                  type: boolean
-                certificateAndKey:
-                  type: object
-                  properties:
-                    certificate:
-                      type: string
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - certificate
-                  - key
-                  - secretName
-                clientId:
-                  type: string
-                clientSecret:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                disableTlsHostnameVerification:
-                  type: boolean
-                maxTokenExpirySeconds:
-                  type: integer
-                passwordSecret:
-                  type: object
-                  properties:
-                    password:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - password
-                  - secretName
-                refreshToken:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                  - key
-                  - secretName
-                tlsTrustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
-                tokenEndpointUri:
-                  type: string
-                type:
-                  type: string
-                  enum:
-                  - tls
-                  - scram-sha-512
-                  - plain
-                  - oauth
-                username:
-                  type: string
-              required:
-              - type
-            bootstrapServers:
-              type: string
             externalConfiguration:
               type: object
               properties:
@@ -1029,21 +936,6 @@ spec:
                   type: object
                 requests:
                   type: object
-            tls:
-              type: object
-              properties:
-                trustedCertificates:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                    - certificate
-                    - secretName
             version:
               type: string
           required:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -36,10 +36,188 @@ spec:
           properties:
             replicas:
               type: integer
-            connectCluster:
+            version:
               type: string
             image:
               type: string
+            connectCluster:
+              type: string
+            clusters:
+              type: array
+              items:
+                type: object
+                properties:
+                  alias:
+                    type: string
+                    pattern: ^[a-zA-Z0-9\._\-]{1,100}$
+                  bootstrapServers:
+                    type: string
+                  config:
+                    type: object
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                  authentication:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      accessTokenIsJwt:
+                        type: boolean
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                      clientId:
+                        type: string
+                      clientSecret:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      disableTlsHostnameVerification:
+                        type: boolean
+                      maxTokenExpirySeconds:
+                        type: integer
+                      passwordSecret:
+                        type: object
+                        properties:
+                          password:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - password
+                        - secretName
+                      refreshToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                      tlsTrustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                      tokenEndpointUri:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                      username:
+                        type: string
+                    required:
+                    - type
+                required:
+                - alias
+                - bootstrapServers
+            mirrors:
+              type: array
+              items:
+                type: object
+                properties:
+                  sourceCluster:
+                    type: string
+                  targetCluster:
+                    type: string
+                  sourceConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  checkpointConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  heartbeatConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                      config:
+                        type: object
+                      pause:
+                        type: boolean
+                  topicsPattern:
+                    type: string
+                  topicsBlacklistPattern:
+                    type: string
+                  groupsPattern:
+                    type: string
+                  groupsBlacklistPattern:
+                    type: string
+                required:
+                - sourceCluster
+                - targetCluster
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
             livenessProbe:
               type: object
               properties:
@@ -677,175 +855,6 @@ spec:
                     maxUnavailable:
                       type: integer
                       minimum: 0
-            clusters:
-              type: array
-              items:
-                type: object
-                properties:
-                  alias:
-                    type: string
-                    pattern: ^[a-zA-Z0-9\._\-]{1,100}$
-                  bootstrapServers:
-                    type: string
-                  config:
-                    type: object
-                  tls:
-                    type: object
-                    properties:
-                      trustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                            secretName:
-                              type: string
-                          required:
-                          - certificate
-                          - secretName
-                  authentication:
-                    type: object
-                    properties:
-                      accessToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      accessTokenIsJwt:
-                        type: boolean
-                      certificateAndKey:
-                        type: object
-                        properties:
-                          certificate:
-                            type: string
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - certificate
-                        - key
-                        - secretName
-                      clientId:
-                        type: string
-                      clientSecret:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      disableTlsHostnameVerification:
-                        type: boolean
-                      maxTokenExpirySeconds:
-                        type: integer
-                      passwordSecret:
-                        type: object
-                        properties:
-                          password:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - password
-                        - secretName
-                      refreshToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          secretName:
-                            type: string
-                        required:
-                        - key
-                        - secretName
-                      tlsTrustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                            secretName:
-                              type: string
-                          required:
-                          - certificate
-                          - secretName
-                      tokenEndpointUri:
-                        type: string
-                      type:
-                        type: string
-                        enum:
-                        - tls
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                      username:
-                        type: string
-                    required:
-                    - type
-                required:
-                - alias
-                - bootstrapServers
-            mirrors:
-              type: array
-              items:
-                type: object
-                properties:
-                  sourceCluster:
-                    type: string
-                  targetCluster:
-                    type: string
-                  sourceConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  checkpointConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  heartbeatConnector:
-                    type: object
-                    properties:
-                      tasksMax:
-                        type: integer
-                        minimum: 1
-                      config:
-                        type: object
-                      pause:
-                        type: boolean
-                  topicsPattern:
-                    type: string
-                  topicsBlacklistPattern:
-                    type: string
-                  groupsPattern:
-                    type: string
-                  groupsBlacklistPattern:
-                    type: string
-                required:
-                - sourceCluster
-                - targetCluster
             externalConfiguration:
               type: object
               properties:
@@ -929,15 +938,6 @@ spec:
                             type: string
                     required:
                     - name
-            resources:
-              type: object
-              properties:
-                limits:
-                  type: object
-                requests:
-                  type: object
-            version:
-              type: string
           required:
           - connectCluster
         status:

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -57,6 +57,9 @@ public class KafkaMirrorMaker2Resource {
         KafkaMirrorMaker2ClusterSpec targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaTargetClusterName)
             .withBootstrapServers(KafkaResources.plainBootstrapAddress(kafkaTargetClusterName))
+            .addToConfig("config.storage.replication.factor", 1)
+            .addToConfig("offset.storage.replication.factor", 1)
+            .addToConfig("status.storage.replication.factor", 1)
             .build();
         
         KafkaMirrorMaker2ClusterSpec sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
@@ -79,7 +82,6 @@ public class KafkaMirrorMaker2Resource {
                 .endTls()
                 .build();
         }
-    
 
         return new KafkaMirrorMaker2Builder(kafkaMirrorMaker2)
             .withNewMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/MirrorMaker2ST.java
@@ -229,6 +229,9 @@ class MirrorMaker2ST extends BaseST {
                 .withNewTls()
                     .withTrustedCertificates(certSecretTarget)
                 .endTls()
+                .addToConfig("config.storage.replication.factor", 1)
+                .addToConfig("offset.storage.replication.factor", 1)
+                .addToConfig("status.storage.replication.factor", 1)
                 .build();
         KafkaMirrorMaker2Resource.kafkaMirrorMaker2(CLUSTER_NAME, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
@@ -364,6 +367,9 @@ class MirrorMaker2ST extends BaseST {
                 .withNewTls()
                     .withTrustedCertificates(certSecretTarget)
                 .endTls()
+                .addToConfig("config.storage.replication.factor", 1)
+                .addToConfig("offset.storage.replication.factor", 1)
+                .addToConfig("status.storage.replication.factor", 1)
                 .build();
 
         KafkaMirrorMaker2Resource.kafkaMirrorMaker2(CLUSTER_NAME, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

This PR refactors KafkaMirrorMaker2Spec to extend a new
AbstractKafkaConnectSpec that doesn't include the properties that
should only apply at the `spec.clusters` level. It also uses the
AbstractKafkaConnectSpec as the super class of the KafkaConnectSpec.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

