### PR TITLE
ST: Add tests for cover topics recovery from PV

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -148,9 +148,12 @@ public interface Constants {
      * Tag for Helm tests
      */
     String HELM = "helm";
-
     /**
      * Tag for oauth tests
      */
     String OAUTH = "oauth";
+    /**
+     * Tag for recovery tests
+     */
+    String RECOVERY = "recovery";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -46,6 +46,14 @@ public class KafkaTopicUtils {
         );
     }
 
+    public static void waitForKafkaTopicCreationByNamePrefix(String topicNamePrefix) {
+        LOGGER.info("Waiting for Kafka topic creation {}", topicNamePrefix);
+        TestUtils.waitFor("Waits for Kafka topic creation " + topicNamePrefix, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->
+            Crds.topicOperation(kubeClient().getClient()).inNamespace(kubeClient().getNamespace())
+                .list().getItems().stream().filter(topic -> topic.getMetadata().getName().contains(topicNamePrefix)).findFirst().get().getStatus().getConditions().get(0).getType().equals("Ready")
+        );
+    }
+
     public static void waitForKafkaTopicDeletion(String topicName) {
         LOGGER.info("Waiting for Kafka topic deletion {}", topicName);
         TestUtils.waitFor("Waits for Kafka topic deletion " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS, () ->

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
@@ -21,6 +21,6 @@ public class NamespaceUtils {
         LOGGER.info("Waiting when Namespace {} to be deleted", name);
 
         TestUtils.waitFor("namespace " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.TIMEOUT_FOR_RESOURCE_READINESS,
-            () -> !kubeClient().getNamespaceStatus(name));
+            () -> kubeClient().getNamespace(name) == null);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
@@ -134,10 +134,12 @@ class NamespaceDeletionRecoveryST extends BaseST {
                 .endEntityOperator()
             .endSpec().done();
 
+        Thread.sleep(60000);
         // Remove all topic data from zookeeper
         String deleteZkDataCmd = "sh /opt/kafka/bin/zookeeper-shell.sh localhost:2181 <<< \"deleteall /strimzi\"";
         ExecResult zkResult = cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "/bin/bash", "-c", deleteZkDataCmd);
 
+        Thread.sleep(60000);
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
             k.getSpec().setEntityOperator(new EntityOperatorSpecBuilder()
                 .withNewTopicOperator()
@@ -178,7 +180,7 @@ class NamespaceDeletionRecoveryST extends BaseST {
                 .editZookeeper()
                     .withNewPersistentClaimStorage()
                         .withNewSize("100")
-                        .withStorageClass(storageClassName)
+//                        .withStorageClass(storageClassName)
                     .endPersistentClaimStorage()
                 .endZookeeper()
             .endSpec().done();

--- a/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.recovery;
+
+import io.fabric8.kubernetes.api.model.PersistentVolume;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.KubernetesResource;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+@Tag(REGRESSION)
+class NamespaceDeletionRecoveryST extends BaseST {
+
+    static final String NAMESPACE = "namespace-recovery-cluster-test";
+    static final String CLUSTER_NAME = "recovery-cluster";
+
+    private static final Logger LOGGER = LogManager.getLogger(NamespaceDeletionRecoveryST.class);
+
+    @Test
+    void testTopicAvailable() throws InterruptedException {
+        String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
+        int messageCount = 100;
+
+        prepareEnvironmentForRecovery(topicName, messageCount);
+
+        // Wait till consumer offset topic is created
+        Thread.sleep(30000);
+        // Get list of topics and list of PVC needed for recovery
+        List<KafkaTopic> kafkaTopicList = KafkaTopicResource.kafkaTopicClient().list().getItems();
+        List<PersistentVolumeClaim> persistentVolumeClaimList = kubeClient().getClient().persistentVolumeClaims().list().getItems();
+        deleteAndRecreateNamespace();
+        recreatePvcAndUpdatePv(persistentVolumeClaimList);
+        recreateClusterOperator();
+
+        // Recreate all KafkaTopic resources
+        for (KafkaTopic kafkaTopic : kafkaTopicList) {
+            kafkaTopic.getMetadata().setResourceVersion(null);
+            KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).createOrReplace(kafkaTopic);
+        }
+
+        String consumerGroup = "group-" + new Random().nextInt(Integer.MAX_VALUE);
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
+            .editSpec()
+                .editKafka()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endKafka()
+                .editZookeeper()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endZookeeper()
+            .endSpec().done();
+
+        KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+
+        String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        internalKafkaClient.setPodName(defaultKafkaClientsPodName);
+
+        LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
+        Integer consumed = internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messageCount, consumerGroup);
+        assertThat(consumed, is(messageCount));
+    }
+
+    @Test
+    void testTopicNotAvailable() throws InterruptedException {
+        String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
+        int messageCount = 100;
+
+        prepareEnvironmentForRecovery(topicName, messageCount);
+
+        // Wait till consumer offset topic is created
+        Thread.sleep(30000);
+        // Get list of topics and list of PVC needed for recovery
+        List<KafkaTopic> kafkaTopicList = KafkaTopicResource.kafkaTopicClient().list().getItems();
+        List<PersistentVolumeClaim> persistentVolumeClaimList = kubeClient().getClient().persistentVolumeClaims().list().getItems();
+        deleteAndRecreateNamespace();
+        recreatePvcAndUpdatePv(persistentVolumeClaimList);
+        recreateClusterOperator();
+
+        String consumerGroup = "group-" + new Random().nextInt(Integer.MAX_VALUE);
+        // Recreate Kafka Cluster
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
+            .editSpec()
+                .editKafka()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endKafka()
+                .editZookeeper()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endZookeeper()
+                .withNewEntityOperator()
+                .endEntityOperator()
+            .endSpec().done();
+
+        // Remove all topic data from zookeeper
+        cmdKubeClient().execInPod(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), "sh", "/opt/kafka/bin/zookeeper-shell.sh", "localhost:2181", "<<<", "'ls /config/users'");
+
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
+            k.getSpec().setEntityOperator(new EntityOperatorSpecBuilder()
+                .withNewTopicOperator()
+                .endTopicOperator()
+                .withNewUserOperator()
+                .endUserOperator().build());
+        });
+
+        DeploymentUtils.waitForDeploymentReady(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1);
+
+        KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+
+        String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        internalKafkaClient.setPodName(defaultKafkaClientsPodName);
+
+        LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
+        Integer consumed = internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messageCount, consumerGroup);
+        assertThat(consumed, is(messageCount));
+    }
+
+    private void prepareEnvironmentForRecovery(String topicName, int messageCount) throws InterruptedException {
+        String consumerGroup = "group-" + new Random().nextInt(Integer.MAX_VALUE);
+        // Setup Test environment with Kafka and store some messages
+        prepareEnvForOperator(NAMESPACE);
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE).done();
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
+            .editSpec()
+                .editKafka()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endKafka()
+                .editZookeeper()
+                    .withNewPersistentClaimStorage()
+                        .withNewSize("100")
+                        .withDeleteClaim(false)
+                    .endPersistentClaimStorage()
+                .endZookeeper()
+            .endSpec().done();
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
+
+        KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
+
+        String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        internalKafkaClient.setPodName(defaultKafkaClientsPodName);
+
+        LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
+        internalKafkaClient.checkProducedAndConsumedMessages(
+                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messageCount),
+                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messageCount, consumerGroup)
+        );
+    }
+
+    private void recreatePvcAndUpdatePv(List<PersistentVolumeClaim> persistentVolumeClaimList) {
+        for (PersistentVolumeClaim pvc : persistentVolumeClaimList) {
+            pvc.getMetadata().setResourceVersion(null);
+            kubeClient().getClient().persistentVolumeClaims().inNamespace(NAMESPACE).create(pvc);
+
+            PersistentVolume pv = kubeClient().getClient().persistentVolumes().withName(pvc.getSpec().getVolumeName()).get();
+            pv.getSpec().setClaimRef(null);
+            kubeClient().getClient().persistentVolumes().createOrReplace(pv);
+        }
+    }
+
+    private void recreateClusterOperator() {
+        // Recreate CO
+        cluster.applyClusterOperatorInstallFiles();
+        applyRoleBindings(NAMESPACE);
+        // 050-Deployment
+        KubernetesResource.clusterOperator(NAMESPACE).done();
+    }
+
+    private void deleteAndRecreateNamespace() {
+        // Delete namespace with all resources
+        kubeClient().deleteNamespace(NAMESPACE);
+        NamespaceUtils.waitForNamespaceDeletion(NAMESPACE);
+
+        // Recreate namespace
+        cluster.createNamespace(NAMESPACE);
+    }
+
+    @Override
+    protected void recreateTestEnv(String coNamespace, List<String> bindingsNamespaces) { }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/recovery/NamespaceDeletionRecoveryST.java
@@ -180,7 +180,7 @@ class NamespaceDeletionRecoveryST extends BaseST {
                 .editZookeeper()
                     .withNewPersistentClaimStorage()
                         .withNewSize("100")
-//                        .withStorageClass(storageClassName)
+                        .withStorageClass(storageClassName)
                     .endPersistentClaimStorage()
                 .endZookeeper()
             .endSpec().done();


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This tests covers topic recovery in case of namespace is deleted. The procedure is described at https://strimzi.io/docs/master/#namespace-deletion_str. 

Tests coveres both options for topic recovery described in documentation.

Tested on OCP4. Note that all volumes should be deleted manually after the tests (at least in case of Openstack). It's not working properly on `oc cluster up`

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

