### PR TITLE
Fix bug in broker configuration => broker.rack is the right option, not rack.id

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -72,7 +72,7 @@ public class KafkaBrokerConfigurationBuilder {
     public KafkaBrokerConfigurationBuilder withRackId(Rack rack)   {
         if (rack != null) {
             printSectionHeader("Rack ID");
-            writer.println("rack.id=${STRIMZI_RACK_ID}");
+            writer.println("broker.rack=${STRIMZI_RACK_ID}");
             writer.println();
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -65,7 +65,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withRackId(new Rack("failure-domain.kubernetes.io/zone"))
                 .build();
 
-        assertThat(configuration, isEquivalent("rack.id=${STRIMZI_RACK_ID}"));
+        assertThat(configuration, isEquivalent("broker.rack=${STRIMZI_RACK_ID}"));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=${STRIMZI_BROKER_ID}\n" +
-                                                                "rack.id=${STRIMZI_RACK_ID}"));
+                                                                "broker.rack=${STRIMZI_RACK_ID}"));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like we messed up the rack awareness configuration while rewriting the broker configuration. It uses `rack.id` instead of `broker.rack`. This PR should fix it. This was discovered in #2537 

Thsi needs to be cherry-picked for 0.17.0 release.