### PR TITLE
Rolling update in ST does not work with 1 zk replica

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -28,7 +28,6 @@ import io.strimzi.test.timemeasuring.Operation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -221,7 +220,6 @@ class LogSettingST extends BaseST {
 
     @Test
     @Order(11)
-    @Disabled("From some unknown reasons, rolling update of Kafka my-cluster never happen during an expected timeframe. Issue was raised and this test should be enabled after fix.")
     void testGcLoggingSetDisabled() {
         String connectName = KafkaConnectResources.deploymentName(CONNECT_NAME);
         String mmName = KafkaMirrorMakerResources.deploymentName(MM_NAME);
@@ -249,7 +247,7 @@ class LogSettingST extends BaseST {
             k.getSpec().getEntityOperator().getUserOperator().setJvmOptions(entityOperatorJvmOptions);
         });
 
-        StatefulSetUtils.waitTillSsHasRolled(zkName, 1, zkPods);
+        StatefulSetUtils.waitTillSsHasRolled(zkName, 3, zkPods);
         StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
         DeploymentUtils.waitTillDepHasRolled(eoName, 1, eoPods);
 
@@ -356,7 +354,7 @@ class LogSettingST extends BaseST {
 
         timeMeasuringSystem.setOperationID(startDeploymentMeasuring());
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
             .editSpec()
                 .editKafka()
                     .withNewInlineLogging()
@@ -395,7 +393,7 @@ class LogSettingST extends BaseST {
             .endSpec()
             .done();
 
-        KafkaResource.kafkaEphemeral(GC_LOGGING_SET_NAME, 1, 1)
+        KafkaResource.kafkaEphemeral(GC_LOGGING_SET_NAME, 1, 3)
             .editSpec()
                 .editKafka()
                     .withNewJvmOptions()

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -247,7 +247,7 @@ class LogSettingST extends BaseST {
             k.getSpec().getEntityOperator().getUserOperator().setJvmOptions(entityOperatorJvmOptions);
         });
 
-        StatefulSetUtils.waitTillSsHasRolled(zkName, 3, zkPods);
+        StatefulSetUtils.waitTillSsHasRolled(zkName, 1, zkPods);
         StatefulSetUtils.waitTillSsHasRolled(kafkaName, 3, kafkaPods);
         DeploymentUtils.waitTillDepHasRolled(eoName, 1, eoPods);
 
@@ -354,7 +354,7 @@ class LogSettingST extends BaseST {
 
         timeMeasuringSystem.setOperationID(startDeploymentMeasuring());
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 3)
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()
                     .withNewInlineLogging()
@@ -393,7 +393,7 @@ class LogSettingST extends BaseST {
             .endSpec()
             .done();
 
-        KafkaResource.kafkaEphemeral(GC_LOGGING_SET_NAME, 1, 3)
+        KafkaResource.kafkaPersistent(GC_LOGGING_SET_NAME, 1, 1)
             .editSpec()
                 .editKafka()
                     .withNewJvmOptions()


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Some tests depending on the rolling update should not use zk cluster of 1 replica. The quorum is lost during RU and the things are about to hit the fan.

Credit to @tombentley 

### Checklist

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

