### PR TITLE
[MO] - [system test] -> add superuser system test

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClientProperties.java
@@ -54,7 +54,8 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with PLAINTEXT security
-     * @param namespace kafka namespace
+     *
+     * @param namespace   kafka namespace
      * @param clusterName kafka cluster name
      * @return producer properties
      */
@@ -64,22 +65,23 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with secure communication security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param caCertName custom or ca certificate to use for secure communication
-     * @param kafkaUsername kafka username
+     *
+     * @param namespace        kafka namespace
+     * @param clusterName      kafka cluster name
+     * @param caCertName       custom or ca certificate to use for secure communication
+     * @param kafkaUsername    kafka username
      * @param securityProtocol security protocol
      * @return producer properties
      */
     static Properties createBasicProducerTlsProperties(String namespace, String clusterName, String caCertName,
                                                        String kafkaUsername, String securityProtocol) throws IOException {
-        return createProducerProperties(namespace, clusterName, EClientType.BASIC,
-                caCertName, kafkaUsername, securityProtocol);
+        return createProducerProperties(namespace, clusterName, caCertName, kafkaUsername, securityProtocol);
     }
 
     /**
      * Create tracing producer properties with PLAINTEXT security
-     * @param namespace kafka namespace
+     *
+     * @param namespace   kafka namespace
      * @param clusterName kafka cluster name
      * @return producer properties
      */
@@ -89,10 +91,11 @@ class KafkaClientProperties {
 
     /**
      * Create oauth producer properties with PLAINTEXT security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param clientId oauth client id
-     * @param clientSecretName oauth client secret name
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param clientId              oauth client id
+     * @param clientSecretName      oauth client secret name
      * @param oauthTokenEndpointUri uri, where client will send a request for token
      * @return producer properties
      */
@@ -103,13 +106,14 @@ class KafkaClientProperties {
 
     /**
      * Create oauth producer properties with secure communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param caCertName custom or ca certificate to use for secure communication
-     * @param kafkaUsername kafka username
-     * @param securityProtocol security protocol
-     * @param clientId oauth client id
-     * @param clientSecretName oauth client secret name
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param caCertName            custom or ca certificate to use for secure communication
+     * @param kafkaUsername         kafka username
+     * @param securityProtocol      security protocol
+     * @param clientId              oauth client id
+     * @param clientSecretName      oauth client secret name
      * @param oauthTokenEndpointUri uri, where client will send a request for token
      * @return producer properties
      */
@@ -122,10 +126,27 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with PLAINTEXT security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param clientId oauth client id
-     * @param clientSecretName oauth client secret name
+     *
+     * @param namespace        kafka namespace
+     * @param clusterName      kafka cluster name
+     * @param caCertName       certificate name
+     * @param username         name of the kafka user
+     * @param securityProtocol security protocol
+     * @return producer properties
+     */
+    static Properties createProducerProperties(String namespace, String clusterName, String caCertName,
+                                               String username, String securityProtocol) throws IOException {
+        return createProducerProperties(namespace, clusterName, caCertName, username, securityProtocol, EClientType.BASIC,
+                "", "", "");
+    }
+
+    /**
+     * Create producer properties with PLAINTEXT security
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param clientId              oauth client id
+     * @param clientSecretName      oauth client secret name
      * @param oauthTokenEndpointUri uri, where client will send a request for token
      * @return producer properties
      */
@@ -138,7 +159,8 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with PLAINTEXT security
-     * @param namespace kafka namespace
+     *
+     * @param namespace   kafka namespace
      * @param clusterName kafka cluster name
      * @param eClientType enum for specific type of clients
      * @return producer properties
@@ -151,14 +173,15 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with SSL security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param caSecretName CA secret name
-     * @param userName user name for authorization
-     * @param securityProtocol security protocol
-     * @param clientType enum for specific type of clients
-     * @param clientId oauth client id
-     * @param clientSecretName oauth client secret name
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param caSecretName          CA secret name
+     * @param userName              user name for authorization
+     * @param securityProtocol      security protocol
+     * @param clientType            enum for specific type of clients
+     * @param clientId              oauth client id
+     * @param clientSecretName      oauth client secret name
      * @param oauthTokenEndpointUri uri, where client will send a request for token
      * @return producer configuration
      */
@@ -191,8 +214,9 @@ class KafkaClientProperties {
 
     /**
      * Create basic consumer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
+     *
+     * @param namespace     kafka namespace
+     * @param clusterName   kafka cluster name
      * @param consumerGroup consumer group
      * @return consumer configuration
      */
@@ -202,24 +226,26 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with secure communication security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param consumerGroup consumer group name
-     * @param caCertName custom or ca certificate to use for secure communication
-     * @param kafkaUsername kafka username
+     *
+     * @param namespace        kafka namespace
+     * @param clusterName      kafka cluster name
+     * @param consumerGroup    consumer group name
+     * @param caCertName       custom or ca certificate to use for secure communication
+     * @param kafkaUsername    kafka username
      * @param securityProtocol security protocol
      * @return producer properties
      */
-    static Properties createBasicConsumerTlsProperties(String namespace, String clusterName, String consumerGroup,
-                                                       String caCertName, String kafkaUsername, String securityProtocol) throws IOException {
-        return createConsumerProperties(namespace, clusterName, consumerGroup, EClientType.BASIC, caCertName,
-                kafkaUsername, securityProtocol);
+    static Properties createBasicConsumerTlsProperties(String namespace, String clusterName, String caCertName,
+                                                       String kafkaUsername, String securityProtocol, String consumerGroup) throws IOException {
+        return createConsumerProperties(namespace, clusterName, caCertName, kafkaUsername, consumerGroup,
+                EClientType.BASIC, securityProtocol);
     }
 
     /**
      * Create tracing producer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
+     *
+     * @param namespace     kafka namespace
+     * @param clusterName   kafka cluster name
      * @param consumerGroup consumer group
      * @return producer properties
      */
@@ -229,11 +255,12 @@ class KafkaClientProperties {
 
     /**
      * Create oauth consumer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param consumerGroup consumer group name
-     * @param clientId id of oauth client
-     * @param clientSecretName secret of oauth client
+     *
+     * @param namespace            kafka namespace
+     * @param clusterName          kafka cluster name
+     * @param consumerGroup        consumer group name
+     * @param clientId             id of oauth client
+     * @param clientSecretName     secret of oauth client
      * @param oauthTokenEndpoinUri uri where will client points to get access token
      * @return consumer configuration
      */
@@ -246,13 +273,14 @@ class KafkaClientProperties {
 
     /**
      * Create oauth consumer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param caCertName custom or ca certificate to use for secure communication
-     * @param kafkaUsername kafka username
-     * @param consumerGroup consumer group
-     * @param clientId id of oauth client
-     * @param clientSecretName secret of oauth client
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param caCertName            custom or ca certificate to use for secure communication
+     * @param kafkaUsername         kafka username
+     * @param consumerGroup         consumer group
+     * @param clientId              id of oauth client
+     * @param clientSecretName      secret of oauth client
      * @param oauthTokenEndpointUri uri where will client points to get access token
      * @return consumer configuration
      */
@@ -263,15 +291,31 @@ class KafkaClientProperties {
                 EClientType.OAUTH, clientId, clientSecretName, oauthTokenEndpointUri);
     }
 
+    /**
+     * Create consumer properties with plain communication
+     *
+     * @param namespace     kafka namespace
+     * @param clusterName   kafka cluster name
+     * @param consumerGroup consumer group
+     * @param clientType    enum for specific type of clients
+     * @return consumer configuration
+     */
+    static Properties createConsumerProperties(String namespace, String clusterName, String caCertName, String userName,
+                                               String consumerGroup, EClientType clientType, String securityProtocol) throws IOException {
+        return createConsumerProperties(namespace, clusterName, caCertName, userName, securityProtocol,
+                consumerGroup, clientType, "", "", "");
+    }
+
 
     /**
      * Create consumer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param consumerGroup consumer group
-     * @param clientType enum for specific type of clients
-     * @param clientId id of oauth client
-     * @param clientSecretName secret of oauth client
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param consumerGroup         consumer group
+     * @param clientType            enum for specific type of clients
+     * @param clientId              id of oauth client
+     * @param clientSecretName      secret of oauth client
      * @param oauthTokenEndpointUri uri where will client points to get access token
      * @return consumer configuration
      */
@@ -284,10 +328,11 @@ class KafkaClientProperties {
 
     /**
      * Create consumer properties with plain communication
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
+     *
+     * @param namespace     kafka namespace
+     * @param clusterName   kafka cluster name
      * @param consumerGroup consumer group
-     * @param clientType enum for specific type of clients
+     * @param clientType    enum for specific type of clients
      * @return consumer configuration
      */
     static Properties createConsumerProperties(String namespace, String clusterName, String consumerGroup, EClientType clientType) throws IOException {
@@ -298,15 +343,16 @@ class KafkaClientProperties {
 
     /**
      * Create consumer properties with SSL security
-     * @param namespace kafka namespace
-     * @param clusterName kafka cluster name
-     * @param caSecretName CA secret name
-     * @param userName user name for authorization
-     * @param securityProtocol security protocol
-     * @param consumerGroup consumer group
-     * @param clientType enum for specific type of clients
-     * @param clientId id of oauth client
-     * @param clientSecretName secret of oauth client
+     *
+     * @param namespace             kafka namespace
+     * @param clusterName           kafka cluster name
+     * @param caSecretName          CA secret name
+     * @param userName              user name for authorization
+     * @param securityProtocol      security protocol
+     * @param consumerGroup         consumer group
+     * @param clientType            enum for specific type of clients
+     * @param clientId              id of oauth client
+     * @param clientSecretName      secret of oauth client
      * @param oauthTokenEndpointUri uri where will client points to get access token
      * @return consumer configuration
      */
@@ -337,9 +383,10 @@ class KafkaClientProperties {
 
     /**
      * Create properties which are same pro producer and consumer
-     * @param namespace kafka namespace
-     * @param caSecretName CA secret name
-     * @param userName user name for authorization
+     *
+     * @param namespace        kafka namespace
+     * @param caSecretName     CA secret name
+     * @param userName         user name for authorization
      * @param securityProtocol security protocol
      * @return shared client properties
      */
@@ -426,7 +473,8 @@ class KafkaClientProperties {
 
     /**
      * Get external bootstrap connection
-     * @param namespace kafka namespace
+     *
+     * @param namespace   kafka namespace
      * @param clusterName kafka cluster name
      * @return bootstrap url as string
      */
@@ -468,9 +516,10 @@ class KafkaClientProperties {
 
     /**
      * Create keystore
-     * @param ca certificate authority
-     * @param cert certificate
-     * @param key key
+     *
+     * @param ca       certificate authority
+     * @param cert     certificate
+     * @param key      key
      * @param password password
      * @return keystore location as File
      * @throws IOException
@@ -509,6 +558,7 @@ class KafkaClientProperties {
     /**
      * Use Keycloak Admin API to update Authorization Services 'decisionStrategy' on 'kafka' client to AFFIRMATIVE
      * link to bug -> https://issues.redhat.com/browse/KEYCLOAK-12640
+     *
      * @throws IOException
      */
     static void fixBadlyImportedAuthzSettings() throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -1190,9 +1190,9 @@ class SecurityST extends BaseST {
         externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, nonSuperuserName, MESSAGE_COUNT,
                 "SSL");
         assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-
+        
         LOGGER.info("Checking kafka super user:{} that is not able to read messages to topic:{} because of defined" +
-                " ACLs on only write operation", USER_NAME, TOPIC_NAME);
+                " ACLs on only write operation", nonSuperuserName, TOPIC_NAME);
 
         assertThrows(ExecutionException.class, () -> {
             Future<Integer> invalidConsumer = externalBasicKafkaClient.receiveMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, nonSuperuserName, MESSAGE_COUNT,

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -1190,7 +1190,7 @@ class SecurityST extends BaseST {
         externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, nonSuperuserName, MESSAGE_COUNT,
                 "SSL");
         assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-        
+
         LOGGER.info("Checking kafka super user:{} that is not able to read messages to topic:{} because of defined" +
                 " ACLs on only write operation", USER_NAME, TOPIC_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -1151,7 +1151,6 @@ class SecurityST extends BaseST {
             .endSpec()
             .done();
 
-
         LOGGER.info("Checking kafka super user:{} that is able to send messages to topic:{}", USER_NAME, TOPIC_NAME);
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, USER_NAME, MESSAGE_COUNT,
@@ -1191,8 +1190,7 @@ class SecurityST extends BaseST {
         externalBasicKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, nonSuperuserName, MESSAGE_COUNT,
                 "SSL");
         assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-
-
+        
         LOGGER.info("Checking kafka super user:{} that is not able to read messages to topic:{} because of defined" +
                 " ACLs on only write operation", USER_NAME, TOPIC_NAME);
 


### PR DESCRIPTION
Signed-off-by: Seequick1 <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Refactoring

### Description

This PR fixing TLS externalClient with `NullPointer` and also adding one system test related to superusers. 

`
Superusers can access all resources in your Kafka cluster regardless of any access restrictions defined in ACLs. To designate super users for a Kafka cluster, enter a list of user principles in the superUsers field. If a user uses TLS Client Authentication, the username will be the common name from their certificate subject prefixed with
`
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass