### PR TITLE
Add topic names and group.id t the Connect exaples to make it more clear they might need to be changed

### DIFF
--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -16,6 +16,10 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
+    group.id: my-connect-cluster
+    offset.storage.topic: my-connect-cluster-offsets
+    config.storage.topic: my-connect-cluster-configs
+    status.storage.topic: my-connect-cluster-status
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -15,3 +15,8 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
+  config:
+    group.id: my-connect-cluster
+    offset.storage.topic: my-connect-cluster-offsets
+    config.storage.topic: my-connect-cluster-configs
+    status.storage.topic: my-connect-cluster-status

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -16,6 +16,10 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
+    group.id: my-connect-cluster
+    offset.storage.topic: my-connect-cluster-offsets
+    config.storage.topic: my-connect-cluster-configs
+    status.storage.topic: my-connect-cluster-status
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -15,3 +15,8 @@ spec:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
+  config:
+    group.id: my-connect-cluster
+    offset.storage.topic: my-connect-cluster-offsets
+    config.storage.topic: my-connect-cluster-configs
+    status.storage.topic: my-connect-cluster-status


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Right now our Kafka Connect examples do not configure the `group.id` and the topic names for offsets, status and configs. While there are some default settings, they default to the ssame for every KafkaConnect / KafkaConnectS2I which is created. I think that is very unintuitive. I think adding it to our examples makes it IMHO a bit more clear.