### PR TITLE
Print a warning when single ZK replica with ephemeral storage is used

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -182,7 +182,7 @@ public class ZookeeperCluster extends AbstractModel {
             replicas = ZookeeperClusterSpec.DEFAULT_REPLICAS;
         }
 
-        if (replicas == 1 && zookeeperClusterSpec.getStorage().getType().equals("ephemeral")) {
+        if (replicas == 1 && zookeeperClusterSpec.getStorage() != null && "ephemeral".equals(zookeeperClusterSpec.getStorage().getType())) {
             log.warn("Zookeeper cluster with single replica and ephemeral storage will be in defective state after any restart or rolling update. It is recommended to use at least three replicas.");
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -183,7 +183,7 @@ public class ZookeeperCluster extends AbstractModel {
         }
 
         if (replicas == 1 && zookeeperClusterSpec.getStorage() != null && "ephemeral".equals(zookeeperClusterSpec.getStorage().getType())) {
-            log.warn("Zookeeper cluster with single replica and ephemeral storage will be in defective state after any restart or rolling update. It is recommended to use at least three replicas.");
+            log.warn("A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used.");
         }
 
         zk.setReplicas(replicas);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -181,6 +181,11 @@ public class ZookeeperCluster extends AbstractModel {
         if (replicas <= 0) {
             replicas = ZookeeperClusterSpec.DEFAULT_REPLICAS;
         }
+
+        if (replicas == 1 && zookeeperClusterSpec.getStorage().getType().equals("ephemeral")) {
+            log.warn("Zookeeper cluster with single replica and ephemeral storage will be in defective state after any restart or rolling update. It is recommended to use at least three replicas.");
+        }
+
         zk.setReplicas(replicas);
 
         String image = zookeeperClusterSpec.getImage();


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement 

### Description
While debugging faulty STs @tombentley noticed, we are using single node ZK clusters with ephemeral storage. It is ok, until we need any rolling update/restart. We do not want to disable this combination though. User should be at least log:WARNed the things will hit the fan eventually.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2555
### Checklist
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

