### PR TITLE
CO validation for cluster size and dependent configs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -662,16 +662,25 @@ public class KafkaCluster extends AbstractModel {
         return result;
     }
 
-    private static void validateConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
+    protected static boolean validateConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
+        /* test */
+        boolean isOk = true;
         String orLess = kafkaClusterSpec.getReplicas() > 1 ? " or less" : "";
         if (kafkaClusterSpec.getConfig() != null) {
             if (kafkaClusterSpec.getConfig().get(propertyName) != null) {
-                if (Integer.parseInt(kafkaClusterSpec.getConfig().get(propertyName).toString()) > kafkaClusterSpec.getReplicas()) {
-                    log.warn("Kafka configuration '{}' should be set to {}{}.", propertyName, kafkaClusterSpec.getReplicas(), orLess);
-                    throw new InvalidResourceException("Kafka configuration '" + propertyName + "' should be set to " + kafkaClusterSpec.getReplicas() + orLess + ".");
+                try {
+                    int propertyVal = Integer.parseInt(kafkaClusterSpec.getConfig().get(propertyName).toString());
+                    if (propertyVal > kafkaClusterSpec.getReplicas()) {
+                        isOk = false;
+                        log.warn("Kafka configuration '{}' should be set to {}{} because 'spec.kafka.replicas' is {}", propertyName, kafkaClusterSpec.getReplicas(), orLess, kafkaClusterSpec.getReplicas());
+                    }
+                } catch (NumberFormatException e) {
+                    isOk = false;
+                    e.printStackTrace();
                 }
             }
         }
+        return isOk;
     }
 
     @SuppressWarnings("deprecation")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -395,9 +395,9 @@ public class KafkaCluster extends AbstractModel {
 
         result.setReplicas(kafkaClusterSpec.getReplicas());
 
-        validateConfigProperty("offsets.topic.replication.factor", kafkaClusterSpec);
-        validateConfigProperty("transaction.state.log.replication.factor", kafkaClusterSpec);
-        validateConfigProperty("transaction.state.log.min.isr", kafkaClusterSpec);
+        validateIntConfigProperty("offsets.topic.replication.factor", kafkaClusterSpec);
+        validateIntConfigProperty("transaction.state.log.replication.factor", kafkaClusterSpec);
+        validateIntConfigProperty("transaction.state.log.min.isr", kafkaClusterSpec);
 
         result.setImage(versions.kafkaImage(kafkaClusterSpec.getImage(), kafkaClusterSpec.getVersion()));
 
@@ -662,25 +662,23 @@ public class KafkaCluster extends AbstractModel {
         return result;
     }
 
-    protected static boolean validateConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
-        /* test */
-        boolean isOk = true;
+    protected static boolean validateIntConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
         String orLess = kafkaClusterSpec.getReplicas() > 1 ? " or less" : "";
         if (kafkaClusterSpec.getConfig() != null) {
             if (kafkaClusterSpec.getConfig().get(propertyName) != null) {
                 try {
                     int propertyVal = Integer.parseInt(kafkaClusterSpec.getConfig().get(propertyName).toString());
                     if (propertyVal > kafkaClusterSpec.getReplicas()) {
-                        isOk = false;
                         log.warn("Kafka configuration '{}' should be set to {}{} because 'spec.kafka.replicas' is {}", propertyName, kafkaClusterSpec.getReplicas(), orLess, kafkaClusterSpec.getReplicas());
+                        return false;
                     }
                 } catch (NumberFormatException e) {
-                    isOk = false;
-                    e.printStackTrace();
+                    log.warn("Property {} should be an integer", propertyName);
+                    return false;
                 }
             }
         }
-        return isOk;
+        return true;
     }
 
     @SuppressWarnings("deprecation")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -662,23 +662,18 @@ public class KafkaCluster extends AbstractModel {
         return result;
     }
 
-    protected static boolean validateIntConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
+    protected static void validateIntConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec) {
         String orLess = kafkaClusterSpec.getReplicas() > 1 ? " or less" : "";
-        if (kafkaClusterSpec.getConfig() != null) {
-            if (kafkaClusterSpec.getConfig().get(propertyName) != null) {
-                try {
-                    int propertyVal = Integer.parseInt(kafkaClusterSpec.getConfig().get(propertyName).toString());
-                    if (propertyVal > kafkaClusterSpec.getReplicas()) {
-                        log.warn("Kafka configuration '{}' should be set to {}{} because 'spec.kafka.replicas' is {}", propertyName, kafkaClusterSpec.getReplicas(), orLess, kafkaClusterSpec.getReplicas());
-                        return false;
-                    }
-                } catch (NumberFormatException e) {
-                    log.warn("Property {} should be an integer", propertyName);
-                    return false;
+        if (kafkaClusterSpec.getConfig() != null && kafkaClusterSpec.getConfig().get(propertyName) != null) {
+            try {
+                int propertyVal = Integer.parseInt(kafkaClusterSpec.getConfig().get(propertyName).toString());
+                if (propertyVal > kafkaClusterSpec.getReplicas()) {
+                    throw new InvalidResourceException("Kafka configuration option '" + propertyName + "' should be set to " + kafkaClusterSpec.getReplicas() + orLess + " because 'spec.kafka.replicas' is " + kafkaClusterSpec.getReplicas());
                 }
+            } catch (NumberFormatException e) {
+                throw new InvalidResourceException("Property " + propertyName + " should be an integer");
             }
         }
-        return true;
     }
 
     @SuppressWarnings("deprecation")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3323,16 +3323,19 @@ public class KafkaClusterTest {
 
     @Test
     public void testReplicasAndRelatedOptionsValidationNok() {
-
+        String propertyName = "offsets.topic.replication.factor";
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, metricsCm, configuration, emptyMap()))
                 .editSpec()
                     .editKafka()
-                        .withConfig(singletonMap("offsets.topic.replication.factor", replicas + 1))
+                        .withConfig(singletonMap(propertyName, replicas + 1))
                     .endKafka()
                 .endSpec()
                 .build();
-        assertThat(KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(false));
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
+            KafkaCluster.validateIntConfigProperty(propertyName, kafkaAssembly.getSpec().getKafka());
+        });
+        assertThat(ex.getMessage().equals("Kafka configuration option '" + propertyName + "' should be set to " + replicas + " or less because 'spec.kafka.replicas' is " + replicas), is(true));
     }
 
     @Test
@@ -3346,7 +3349,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        assertThat(KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(true));
+        KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka());
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3332,7 +3332,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        assertThat(KafkaCluster.validateConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(false));
+        assertThat(KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(false));
     }
 
     @Test
@@ -3346,7 +3346,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        assertThat(KafkaCluster.validateConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(true));
+        assertThat(KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka()), is(true));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2501

### Checklist
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging