### PR TITLE
Remove @Minimum and @DefaultValue from jwksRefreshSeconds and jwksExpirySeconds

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -8,9 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.GenericSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
@@ -95,8 +93,6 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     @Description("Configures how often are the JWKS certificates refreshed. " +
             "The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. " +
             "Defaults to 300 seconds.")
-    @Minimum(1)
-    @DefaultValue("300")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public int getJwksRefreshSeconds() {
         return jwksRefreshSeconds;
@@ -109,8 +105,6 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     @Description("Configures how often are the JWKS certificates considered valid. " +
             "The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. " +
             "Defaults to 360 seconds.")
-    @Minimum(1)
-    @DefaultValue("360")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public int getJwksExpirySeconds() {
         return jwksExpirySeconds;

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -158,10 +158,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -268,10 +266,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -394,10 +390,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -153,10 +153,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -263,10 +261,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -389,10 +385,8 @@ spec:
                               type: string
                             jwksExpirySeconds:
                               type: integer
-                              minimum: 1
                             jwksRefreshSeconds:
                               type: integer
-                              minimum: 1
                             tlsTrustedCertificates:
                               type: array
                               items:

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthBaseST.java
@@ -48,11 +48,13 @@ public class OauthBaseST extends BaseST {
 
     protected static final String OAUTH_CLIENT_NAME = "hello-world-producer";
     protected static final String OAUTH_CLIENT_SECRET = "hello-world-producer-secret";
+    protected static final String OAUTH_KAFKA_CLIENT_NAME = "kafka-broker";
 
     protected static final String CONNECT_OAUTH_SECRET = "my-connect-oauth";
     protected static final String MIRROR_MAKER_OAUTH_SECRET = "my-mirror-maker-oauth";
     protected static final String MIRROR_MAKER_2_OAUTH_SECRET = "my-mirror-maker-2-oauth";
     protected static final String BRIDGE_OAUTH_SECRET = "my-bridge-oauth";
+    protected static final String OAUTH_KAFKA_CLIENT_SECRET = "kafka-broker-secret";
     protected static final String OAUTH_KEY = "clientSecret";
 
     protected static String oauthTokenEndpointUri;


### PR DESCRIPTION


Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes failure when trying to use introspectionEndpointUri instead of jwksEndpointUri.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

