### PR TITLE
[systemtest] Add test for KafkaStatus certificate

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClient.java
@@ -225,7 +225,7 @@ public class KafkaClient implements AutoCloseable, IKafkaClient<Future<Integer>>
         LOGGER.info("Going to use the following CA certificate: {}", caCertName);
 
         vertx.deployVerticle(new Consumer(KafkaClientProperties.createBasicConsumerTlsProperties(namespace, clusterName,
-                caCertName, kafkaUsername, securityProtocol, consumerGroup),
+                consumerGroup, caCertName, kafkaUsername, securityProtocol),
                 resultPromise, msgCntPredicate, topicName, clientName));
 
         try {

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/KafkaClientProperties.java
@@ -75,7 +75,8 @@ class KafkaClientProperties {
      */
     static Properties createBasicProducerTlsProperties(String namespace, String clusterName, String caCertName,
                                                        String kafkaUsername, String securityProtocol) throws IOException {
-        return createProducerProperties(namespace, clusterName, caCertName, kafkaUsername, securityProtocol);
+        return createProducerProperties(namespace, clusterName, kafkaUsername, EClientType.BASIC,
+                caCertName, securityProtocol);
     }
 
     /**
@@ -126,27 +127,10 @@ class KafkaClientProperties {
 
     /**
      * Create producer properties with PLAINTEXT security
-     *
-     * @param namespace        kafka namespace
-     * @param clusterName      kafka cluster name
-     * @param caCertName       certificate name
-     * @param username         name of the kafka user
-     * @param securityProtocol security protocol
-     * @return producer properties
-     */
-    static Properties createProducerProperties(String namespace, String clusterName, String caCertName,
-                                               String username, String securityProtocol) throws IOException {
-        return createProducerProperties(namespace, clusterName, caCertName, username, securityProtocol, EClientType.BASIC,
-                "", "", "");
-    }
-
-    /**
-     * Create producer properties with PLAINTEXT security
-     *
-     * @param namespace             kafka namespace
-     * @param clusterName           kafka cluster name
-     * @param clientId              oauth client id
-     * @param clientSecretName      oauth client secret name
+     * @param namespace kafka namespace
+     * @param clusterName kafka cluster name
+     * @param clientId oauth client id
+     * @param clientSecretName oauth client secret name
      * @param oauthTokenEndpointUri uri, where client will send a request for token
      * @return producer properties
      */
@@ -155,6 +139,22 @@ class KafkaClientProperties {
         return createProducerProperties(namespace, clusterName, KafkaResources.clusterCaCertificateSecretName(clusterName),
                 "", CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL, eClientType,
                 clientId, clientSecretName, oauthTokenEndpointUri);
+    }
+
+    /**
+     * Create producer properties with PLAINTEXT security
+     * @param namespace kafka namespace
+     * @param clusterName kafka cluster name
+     * @param userName user name for authorization
+     * @param eClientType enum for specific type of clients
+     * @param caCertName custom or ca certificate to use for secure communication
+     * @param securityProtocol security protocol
+     * @return producer properties
+     */
+    static Properties createProducerProperties(String namespace, String clusterName, String userName, EClientType eClientType,
+                                               String caCertName, String securityProtocol) throws IOException {
+        return createProducerProperties(namespace, clusterName, caCertName, userName, securityProtocol, eClientType,
+                "", "", "");
     }
 
     /**
@@ -235,10 +235,10 @@ class KafkaClientProperties {
      * @param securityProtocol security protocol
      * @return producer properties
      */
-    static Properties createBasicConsumerTlsProperties(String namespace, String clusterName, String caCertName,
-                                                       String kafkaUsername, String securityProtocol, String consumerGroup) throws IOException {
-        return createConsumerProperties(namespace, clusterName, caCertName, kafkaUsername, consumerGroup,
-                EClientType.BASIC, securityProtocol);
+    static Properties createBasicConsumerTlsProperties(String namespace, String clusterName, String consumerGroup,
+                                                       String caCertName, String kafkaUsername, String securityProtocol) throws IOException {
+        return createConsumerProperties(namespace, clusterName, caCertName, consumerGroup, kafkaUsername, EClientType.BASIC,
+                 securityProtocol);
     }
 
     /**
@@ -291,21 +291,6 @@ class KafkaClientProperties {
                 EClientType.OAUTH, clientId, clientSecretName, oauthTokenEndpointUri);
     }
 
-    /**
-     * Create consumer properties with plain communication
-     *
-     * @param namespace     kafka namespace
-     * @param clusterName   kafka cluster name
-     * @param consumerGroup consumer group
-     * @param clientType    enum for specific type of clients
-     * @return consumer configuration
-     */
-    static Properties createConsumerProperties(String namespace, String clusterName, String caCertName, String userName,
-                                               String consumerGroup, EClientType clientType, String securityProtocol) throws IOException {
-        return createConsumerProperties(namespace, clusterName, caCertName, userName, securityProtocol,
-                consumerGroup, clientType, "", "", "");
-    }
-
 
     /**
      * Create consumer properties with plain communication
@@ -324,6 +309,24 @@ class KafkaClientProperties {
         return createConsumerProperties(namespace, clusterName, KafkaResources.clusterCaCertificateSecretName(clusterName),
                 "", CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL, consumerGroup, clientType, clientId,
                 clientSecretName, oauthTokenEndpointUri);
+    }
+
+    /**
+     * Create consumer properties with plain communication
+     * @param namespace kafka namespace
+     * @param clusterName kafka cluster name
+     * @param caCertName custom or ca certificate to use for secure communication
+     * @param consumerGroup consumer group
+     * @param userName user name for authorization
+     * @param clientType enum for specific type of clients
+     * @param securityProtocol security protocol
+     * @return consumer configuration
+     */
+    static Properties createConsumerProperties(String namespace, String clusterName, String caCertName, String consumerGroup, String userName,
+                                                EClientType clientType, String securityProtocol) throws IOException {
+        return createConsumerProperties(namespace, clusterName, caCertName,
+                userName, securityProtocol, consumerGroup, clientType, "",
+                "", "");
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -15,6 +15,7 @@ import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -98,7 +99,7 @@ public class KafkaUtils {
         String secretCerts = "";
         secretCerts = kubeClient().getSecret(secretName).getData().get(certType);
         byte[] decodedBytes = Base64.getDecoder().decode(secretCerts);
-        secretCerts = new String(decodedBytes);
+        secretCerts = new String(decodedBytes, Charset.defaultCharset());
 
         return secretCerts;
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -55,6 +55,8 @@ import java.util.stream.Collectors;
 import static io.strimzi.api.kafka.model.KafkaResources.externalBootstrapServiceName;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaSecretCertificates;
+import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaStatusCertificates;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -288,6 +290,15 @@ class CustomResourceStatusST extends BaseST {
         KafkaTopicResource.topicWithoutWait(KafkaTopicResource.defaultTopic(CLUSTER_NAME, topicName, 1, 10, 10).build());
         waitForKafkaTopic("NotReady", topicName);
         assertKafkaTopicStatus(1, topicName);
+    }
+
+    @Test
+    void testKafkaStatusCertificate() {
+        String certs = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        String secretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(secretCerts, is(certs));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -378,12 +378,12 @@ public class ListenersST extends BaseST {
         String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
+        //External secret cert is same as internal in this case
+        assertThat(externalSecretCerts, is(internalCerts));
 
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
@@ -423,7 +423,7 @@ public class ListenersST extends BaseST {
         externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
 
         internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+        String internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));
@@ -531,12 +531,12 @@ public class ListenersST extends BaseST {
         String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
+        //External secret cert is same as internal in this case
+        assertThat(externalSecretCerts, is(internalCerts));
 
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
@@ -576,7 +576,7 @@ public class ListenersST extends BaseST {
         externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
 
         internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+        String internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));
@@ -684,12 +684,12 @@ public class ListenersST extends BaseST {
         String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));
         LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
+        //External secret cert is same as internal in this case
+        assertThat(externalSecretCerts, is(internalCerts));
 
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
@@ -729,7 +729,7 @@ public class ListenersST extends BaseST {
         externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
 
         internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
-        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+        String internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
 
         LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
         assertThat(externalSecretCerts, is(externalCerts));

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ListenersST.java
@@ -35,6 +35,8 @@ import java.util.concurrent.TimeUnit;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaSecretCertificates;
+import static io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils.getKafkaStatusCertificates;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -372,6 +374,17 @@ public class ListenersST extends BaseST {
 
         KafkaUser aliceUser = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
 
+        String externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
 
@@ -405,6 +418,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(customCertServer1);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 20, "SSL");
 
@@ -431,6 +456,17 @@ public class ListenersST extends BaseST {
         kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaSnapshot);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 40, "SSL");
 
@@ -452,6 +488,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(null);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 60, "SSL");
 
@@ -478,6 +526,17 @@ public class ListenersST extends BaseST {
             .endSpec().done();
 
         KafkaUser aliceUser = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+
+        String externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
 
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
@@ -512,6 +571,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(customCertServer1);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 20, "SSL");
 
@@ -538,6 +609,17 @@ public class ListenersST extends BaseST {
         kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaSnapshot);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 40, "SSL");
 
@@ -559,6 +641,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(null);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 60, "SSL");
 
@@ -585,6 +679,17 @@ public class ListenersST extends BaseST {
             .endSpec().done();
 
         KafkaUser aliceUser = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+
+        String externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        String externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        String internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        String internalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
 
         Future producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         Future consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
@@ -619,6 +724,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(customCertServer1);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 20, "SSL");
 
@@ -645,6 +762,17 @@ public class ListenersST extends BaseST {
         kafkaSnapshot = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaSnapshot);
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(customCertServer1, "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 40, "SSL");
 
@@ -666,6 +794,18 @@ public class ListenersST extends BaseST {
         StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3);
 
         externalBasicKafkaClient.setCaCertName(null);
+
+        externalCerts = getKafkaStatusCertificates("external", NAMESPACE, CLUSTER_NAME);
+        externalSecretCerts = getKafkaSecretCertificates(CLUSTER_NAME + "-cluster-ca-cert", "ca.crt");
+
+        internalCerts = getKafkaStatusCertificates("tls", NAMESPACE, CLUSTER_NAME);
+        internalSecretCerts = getKafkaSecretCertificates(customCertServer2, "ca.crt");
+
+        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
+        assertThat(externalSecretCerts, is(externalCerts));
+        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
+        assertThat(internalSecretCerts, is(internalCerts));
+
         producer = externalBasicKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 10, "SSL");
         consumer = externalBasicKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, 60, "SSL");
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Add new asserts that checks if certs from KafkaStatus and secret certs are matching (both external and internal TLS).
Also add test that checks if certs are present in KafkaStatus and if they are matching with secret certs.

Should fix tests from ListenersST (failed in nightly jobs)

Testing: https://issues.redhat.com/browse/ENTMQST-1103

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

