### PR TITLE
Remove ZK readiness check

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1391,7 +1391,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> zkScaleUp() {
             if (zkScalingUp) {
                 return zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas())
-                        .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(zkCluster.getReplicas() - 1), 1_000, operationTimeoutMs))
                         .map(this);
             } else {
                 return Future.succeededFuture(this);


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This commit remove the Zookeeper readiness check as the delay caused by this causes new brokers to be elected leader immediately before the rest of the cluster is rolled. This causes issues with establishing a stable quorum.

This deals with issue #2494.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

