### PR TITLE
Avoid NPE when the external config map does not have the right key

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -363,10 +363,10 @@ public abstract class AbstractModel {
             newSettings.addMapPairs(((InlineLogging) logging).getLoggers());
             return createPropertiesString(newSettings);
         } else if (logging instanceof ExternalLogging) {
-            if (externalCm != null) {
+            if (externalCm != null && externalCm.getData() != null && externalCm.getData().containsKey(getAncillaryConfigMapKeyLogConfig())) {
                 return externalCm.getData().get(getAncillaryConfigMapKeyLogConfig());
             } else {
-                log.warn("Configmap " + ((ExternalLogging) getLogging()).getName() + " does not exist. Default settings are used");
+                log.warn("ConfigMap {} with external logging configuration does not exist or doesn't contain the configuration under the {} key. Default logging settings are used.", ((ExternalLogging) getLogging()).getName(), getAncillaryConfigMapKeyLogConfig());
                 return createPropertiesString(getDefaultLogConfig());
             }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the external logging config map does not have the logging configuration under the right key it throws an NPE. This PR extends the check to throw an warning and use the default settings similarly when the whole config map does nto exist.

I wonder if we should throw `InvalidResourceException` instead, but so far this follows what was implemented before which was warning only.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally