### PR TITLE
[MO] - [system fixes] -> green tests incoming

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/Producer.java
@@ -50,7 +50,7 @@ public class Producer extends ClientHandlerBase<Integer> {
         if (msgCntPredicate.negate().test(numSent.get())) {
 
             KafkaProducerRecord<String, String> record =
-                    KafkaProducerRecord.create(topic, String.valueOf("Sending messages: Hello-world - " + numSent.get()));
+                    KafkaProducerRecord.create(topic, String.valueOf("\"Sending messages\": \"Hello-world - " + numSent.get() + "\""));
 
             producer.send(record, done -> {
                 if (done.succeeded()) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
@@ -125,15 +125,17 @@ public class HttpUtils {
                         if (response.body().size() > 0) {
                             for (int i = 0; i < response.body().size(); i++) {
                                 JsonObject jsonResponse = response.body().getJsonObject(i);
+                                LOGGER.info("This is jsonResponse object {}", jsonResponse.toString());
                                 String kafkaTopic = jsonResponse.getString("topic");
                                 int kafkaPartition = jsonResponse.getInteger("partition");
                                 String key = jsonResponse.getString("key");
-                                int value = jsonResponse.getInteger("value");
+                                String value = jsonResponse.getString("value");
                                 long offset = jsonResponse.getLong("offset");
                                 LOGGER.debug("Received msg: topic:{} partition:{} key:{} value:{} offset{}", kafkaTopic, kafkaPartition, key, value, offset);
                             }
                             LOGGER.info("Received {} messages from the bridge", response.body().size());
                         } else {
+                            LOGGER.info("Received body:{}", response.body());
                             LOGGER.debug("Received 0 messages, going to consume again");
                         }
                         future.complete(response.body());
@@ -160,6 +162,6 @@ public class HttpUtils {
                         future.completeExceptionally(ar.cause());
                     }
                 });
-        return future.get(1, TimeUnit.MINUTES);
+        return future.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/HttpUtils.java
@@ -162,6 +162,6 @@ public class HttpUtils {
                         future.completeExceptionally(ar.cause());
                     }
                 });
-        return future.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS);
+        return future.get(1, TimeUnit.MINUTES);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -59,7 +59,7 @@ public class KafkaConnectUtils {
 
     public static void waitForMessagesInKafkaConnectFileSink(String kafkaConnectPodName, String sinkFileName) {
         waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, sinkFileName,
-                "Sending messages: Hello-world - 99");
+                "\"Sending messages\": \"Hello-world - 99\"");
     }
 
     public static String getCreatedConnectors(String connectPodName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractNamespaceST.java
@@ -108,8 +108,8 @@ public abstract class AbstractNamespaceST extends BaseST {
         KafkaClientsResource.deployKafkaClients(false, clusterName + "-" + Constants.KAFKA_CLIENTS).done();
         final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
         internalKafkaClient.setPodName(kafkaClientsPodName);
-        int sent = internalKafkaClient.sendMessages(topicName, namespace, clusterName, 100);
-        assertThat(sent, Matchers.is(10));
+        int sent = internalKafkaClient.sendMessages(topicName, namespace, clusterName, MESSAGE_COUNT);
+        assertThat(sent, Matchers.is(MESSAGE_COUNT));
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -79,7 +79,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     }
 
     @Test
-    void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() throws Exception {
+    void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         // Deploy Kafka Connect in other namespace than CO
@@ -94,7 +94,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     }
 
     @Test
-    void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() throws Exception {
+    void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         // Deploy Kafka Connect in other namespace than CO
@@ -120,7 +120,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     }
 
     @Test
-    void testUserInDifferentNamespace() throws Exception {
+    void testUserInDifferentNamespace() {
         String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
         KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, USER_NAME).done();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -180,7 +180,7 @@ class ConnectS2IST extends BaseST {
                     .addToConfig("value.converter.schemas.enable", false)
                     .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                     .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .withNewTls()
+                    .withNewTls()
                         .addNewTrustedCertificate()
                             .withSecretName(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME))
                             .withCertificate("ca.crt")
@@ -199,7 +199,7 @@ class ConnectS2IST extends BaseST {
 
         KafkaTopicResource.topic(CLUSTER_NAME, CONNECT_S2I_TOPIC_NAME).done();
 
-        KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
+        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
 
         final String defaultKafkaClientsPodName =
                 ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -147,7 +147,7 @@ class ConnectS2IST extends BaseST {
     }
 
     @Test
-    void testSecretsWithKafkaConnectS2IWithTlsAndScramShaAuthentication() throws Exception {
+    void testSecretsWithKafkaConnectS2IWithTlsAndScramShaAuthentication() {
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
             .editSpec()
                 .editKafka()
@@ -161,13 +161,10 @@ class ConnectS2IST extends BaseST {
             .endSpec()
             .done();
 
-
         final String userName = "user-example-one";
         final String kafkaConnectS2IName = "kafka-connect-s2i-name-2";
 
-        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
-
-        KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
+        KafkaUser user = KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
 
         SecretUtils.waitForSecretReady(userName);
 
@@ -217,8 +214,8 @@ class ConnectS2IST extends BaseST {
         KafkaConnectUtils.createFileSinkConnector(execPod, CONNECT_S2I_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(kafkaConnectS2IName, NAMESPACE, 8083));
 
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessagesTls(CONNECT_S2I_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SASL_SSL"),
-                internalKafkaClient.receiveMessagesTls(CONNECT_S2I_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SASL_SSL", CONSUMER_GROUP_NAME + rng.nextInt(Integer.MAX_VALUE))
+                internalKafkaClient.sendMessagesTls(CONNECT_S2I_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "TLS"),
+                internalKafkaClient.receiveMessagesTls(CONNECT_S2I_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "TLS", CONSUMER_GROUP_NAME + rng.nextInt(Integer.MAX_VALUE))
         );
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectS2IPodName, Constants.DEFAULT_SINK_FILE_NAME, "99");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectST.java
@@ -237,9 +237,6 @@ class ConnectST extends BaseST {
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
-                containsString("Sending messages: Hello-world - 99"));
-
         KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(CONNECT_TOPIC_NAME).cascading(true).delete();
         LOGGER.info("Topic {} deleted", CONNECT_TOPIC_NAME);
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
@@ -448,9 +445,6 @@ class ConnectST extends BaseST {
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
 
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
-                containsString("Sending messages: Hello-world - 99"));
-
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
         cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);
         KafkaTopicUtils.waitForKafkaTopicDeletion(CONNECT_TOPIC_NAME);
@@ -527,9 +521,6 @@ class ConnectST extends BaseST {
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
-
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat /tmp/test-file-sink.txt").out(),
-                containsString("Sending messages: Hello-world - 99"));
 
         LOGGER.info("Deleting topic {} from CR", CONNECT_TOPIC_NAME);
         cmdKubeClient().deleteByName("kafkatopic", CONNECT_TOPIC_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -61,7 +61,7 @@ class RollingUpdateST extends BaseST {
     private static final Pattern ZK_SERVER_STATE = Pattern.compile("zk_server_state\\s+(leader|follower)");
 
     @Test
-    void testRecoveryDuringZookeeperRollingUpdate() throws Exception {
+    void testRecoveryDuringZookeeperRollingUpdate() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         int messageCount = 50;
 
@@ -120,7 +120,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    void testRecoveryDuringKafkaRollingUpdate() throws Exception {
+    void testRecoveryDuringKafkaRollingUpdate() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         int messageCount = 50;
 
@@ -185,7 +185,7 @@ class RollingUpdateST extends BaseST {
 
     @Test
     @Tag(ACCEPTANCE)
-    void testKafkaAndZookeeperScaleUpScaleDown() throws Exception {
+    void testKafkaAndZookeeperScaleUpScaleDown() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         int messageCount = 50;
 
@@ -318,7 +318,7 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    void testZookeeperScaleUpScaleDown() throws Exception {
+    void testZookeeperScaleUpScaleDown() {
         int messageCount = 50;
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
 
@@ -392,7 +392,7 @@ class RollingUpdateST extends BaseST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
-    void testManualTriggeringRollingUpdate() throws Exception {
+    void testManualTriggeringRollingUpdate() {
         // This test needs Operation Timetout set to higher value, because manual rolling update work in different way
         kubeClient().deleteDeployment(Constants.STRIMZI_DEPLOYMENT_NAME);
         ResourceManager.setClassResources();

--- a/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/UserST.java
@@ -187,17 +187,20 @@ class UserST extends BaseST {
     }
 
     void createBigAmountOfUsers(String typeOfUser) {
+
         int numberOfUsers = 100;
 
         for (int i = 0; i < numberOfUsers; i++) {
             String userName = "alisa" + i;
             LOGGER.info("Creating user with name {}", userName);
+
             if (typeOfUser.equals("TLS")) {
                 KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
             } else {
                 KafkaUserResource.scramShaUser(CLUSTER_NAME, userName).done();
             }
-            SecretUtils.waitForSecretReady(userName);
+
+            KafkaUserUtils.waitForKafkaUserCreation(userName);
             LOGGER.info("Checking status of deployed Kafka User {}", userName);
             Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(userName).get()
                     .getStatus().getConditions().get(0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -74,7 +74,6 @@ class HttpBridgeST extends HttpBridgeBaseST {
 
     @Test
     void testReceiveSimpleMessage() throws Exception {
-        int messageCount = 50;
         String topicName = "topic-simple-receive";
         // Create topic
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
@@ -97,14 +96,14 @@ class HttpBridgeST extends HttpBridgeBaseST {
         // Subscribe
         assertThat(HttpUtils.subscribeHttpConsumer(topics, bridgeHost, bridgePort, groupId, name, client), is(true));
         // Send messages to Kafka
-        kafkaClient.sendMessages(CLUSTER_NAME, NAMESPACE, topicName, messageCount);
+        kafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
         // Try to consume messages
         JsonArray bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);
         if (bridgeResponse.size() == 0) {
             // Real consuming
             bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);
         }
-        assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(messageCount));
+        assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(MESSAGE_COUNT));
         // Delete consumer
         assertThat(deleteConsumer(bridgeHost, bridgePort, groupId, name), is(true));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -55,7 +55,6 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
     private int bridgePort = Constants.HTTP_BRIDGE_DEFAULT_PORT;
     private String userName = "bob";
 
-
     @Test
     void testSendSimpleMessageTlsScramSha() throws Exception {
         int messageCount = 50;
@@ -68,18 +67,17 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
         KafkaBridgeUtils.checkSendResponse(response, messageCount);
 
         Future<Integer> consumer = kafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messageCount, "SASL_SSL");
-        assertThat(consumer.get(2, TimeUnit.MINUTES), is(messageCount));
+        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(messageCount));
     }
 
     @Test
     void testReceiveSimpleMessageTlsScramSha() throws Exception {
-        int messageCount = 50;
         String topicName = "topic-simple-receive-" + new Random().nextInt(Integer.MAX_VALUE);
         // Create topic
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
         // Send messages to Kafka
-        Future<Integer> producer = kafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messageCount, "SASL_SSL");
-        assertThat(producer.get(2, TimeUnit.MINUTES), is(messageCount));
+        Future<Integer> producer = kafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, MESSAGE_COUNT, "SASL_SSL");
+        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
 
         String name = "kafka-consumer-simple-receive";
         String groupId = "my-group-" + new Random().nextInt(Integer.MAX_VALUE);
@@ -105,7 +103,7 @@ class HttpBridgeScramShaST extends HttpBridgeBaseST {
             bridgeResponse = HttpUtils.receiveMessagesHttpRequest(bridgeHost, bridgePort, groupId, name, client);
         }
 
-        assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(messageCount));
+        assertThat("Sent message count is not equal with received message count", bridgeResponse.size(), is(MESSAGE_COUNT));
         // Delete consumer
         assertThat(deleteConsumer(bridgeHost, bridgePort, groupId, name), is(true));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -8,9 +8,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.systemtest.BaseST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.ClientFactory;
-import io.strimzi.systemtest.kafkaclients.EClientType;
-import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import io.strimzi.test.executor.Exec;
@@ -48,8 +45,6 @@ import static org.hamcrest.Matchers.not;
 public class MetricsST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(MetricsST.class);
-
-    protected InternalKafkaClient internalKafkaClient = (InternalKafkaClient) ClientFactory.getClient(EClientType.BASIC);
 
     public static final String NAMESPACE = "metrics-cluster-test";
     private final Object lock = new Object();

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthPlainST.java
@@ -53,11 +53,9 @@ import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 
 @Tag(OAUTH)
@@ -71,7 +69,7 @@ public class OauthPlainST extends OauthBaseST {
             "As an oauth producer, I should be able to produce messages to the kafka broker\n" +
             "As an oauth consumer, I should be able to consumer messages from the kafka broker.")
     @Test
-    void testProducerConsumer() throws IOException, KeyStoreException, InterruptedException, ExecutionException, TimeoutException {
+    void testProducerConsumer() throws IOException, InterruptedException, ExecutionException, TimeoutException {
         Future<Integer> producer = oauthKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
         Future<Integer> consumer = oauthKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,
                 CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
@@ -82,7 +80,7 @@ public class OauthPlainST extends OauthBaseST {
 
     @Description("As an oauth kafka connect, I should be able to sink messages from kafka broker topic.")
     @Test
-    void testProducerConsumerConnect() throws IOException, KeyStoreException, InterruptedException, ExecutionException, TimeoutException {
+    void testProducerConsumerConnect() throws IOException, InterruptedException, ExecutionException, TimeoutException {
         Future<Integer> producer = oauthKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
         Future<Integer> consumer = oauthKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,
                 CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));
@@ -119,18 +117,13 @@ public class OauthPlainST extends OauthBaseST {
 
         KafkaConnectUtils.createFileSinkConnector(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
-        String message = "Sending messages: Hello-world - 99";
-
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
-
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
-                containsString(message));
     }
 
     @Disabled("MM doesn't replicate messages to target cluster. Investigate in the next PR")
     @Description("As an oauth mirror maker, I should be able to replicate topic data between kafka clusters")
     @Test
-    void testProducerConsumerMirrorMaker() throws IOException, KeyStoreException, InterruptedException, ExecutionException, TimeoutException {
+    void testProducerConsumerMirrorMaker() throws IOException, InterruptedException, ExecutionException, TimeoutException {
         Future<Integer> producer = oauthKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
         Future<Integer> consumer = oauthKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT,
                 CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE));

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -42,9 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -123,9 +121,6 @@ public class OauthTlsST extends OauthBaseST {
         KafkaConnectUtils.createFileSinkConnector(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_NAME);
-
-        assertThat(cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + Constants.DEFAULT_SINK_FILE_NAME).out(),
-                containsString("Sending messages: Hello-world - 99"));
     }
 
     @Description("As a oauth bridge, i am able to send messages to bridge endpoint using encrypted communication")

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -709,7 +709,6 @@ public class TracingST extends BaseST {
         cmdKubeClient().execInPod(kafkaConnectPodName, "/bin/bash", "-c", "curl -X POST -H \"Content-Type: application/json\" --data "
                 + "'" + connectorConfig + "'" + " http://localhost:8083/connectors");
 
-
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT);
         Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, kafkaClusterTargetName, MESSAGE_COUNT);
 
@@ -801,7 +800,8 @@ public class TracingST extends BaseST {
         String execPodName = KafkaResources.kafkaPodName(CLUSTER_NAME, 0);
 
         LOGGER.info("Creating FileSink connect via Pod:{}", execPodName);
-        KafkaConnectUtils.createFileSinkConnector(execPodName, TEST_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME, KafkaConnectResources.url(kafkaConnectS2IName, NAMESPACE, 8083));
+        KafkaConnectUtils.createFileSinkConnector(execPodName, TEST_TOPIC_NAME, Constants.DEFAULT_SINK_FILE_NAME,
+                KafkaConnectResources.url(kafkaConnectS2IName, NAMESPACE, 8083));
 
         Future<Integer> producer = externalBasicKafkaClient.sendMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
         Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TEST_TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);


### PR DESCRIPTION
Signed-off-by: see-quick <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixing the following test cases:

- io.strimzi.systemtest.oauth.OauthTlsST.io.strimzi.systemtest.oauth.OauthTlsST
  - Bad image of keycloak i replace version of image it should be fixed in
- io.strimzi.systemtest.UserST.testBigAmountOfScramShaUsers
  - Change waiting on CR status ready instead of secret, where can occur race condition.
-  io.strimzi.systemtest.oauth.OauthAuthorizationST
   - The bad image of keycloak I replace the version of the image it should be fixed in
- io.strimzi.systemtest.oauth.OauthPlainST.io.strimzi.systemtest.oauth.OauthPlainST
  - Bad image of keycloak i replace version of image it should be fixed in
- io.strimzi.systemtest.bridge.HttpBridgeTlsST.testReceiveSimpleMessageTls
  - Bad usage of serializer need to change generating of messaging of Producer
- io.strimzi.systemtest.bridge.HttpBridgeST.testReceiveSimpleMessage
  - Bad order of parameters
- io.strimzi.systemtest.bridge.HttpBridgeScramShaST.testReceiveSimpleMessageTlsScramSha
- io.strimzi.systemtest.AllNamespaceST.testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO
  - Bad message count on verifcation phase...
- io.strimzi.systemtest.AllNamespaceST.testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO
  - Bad message count on verification phase...
- io.strimzi.systemtest.metrics.MetricsST.io.strimzi.systemtest.metrics.MetricsST
  - Removed client instance from the Class bad explicit casting
- testSecretsWithKafkaConnectS2IWithTlsAndScramShaAuthentication
  - using redundant TLS user, bad PLAIN usage of internal kafka clients and bad value inside send and recv methods.
### Checklist

- [x] Write tests
- [x] Make sure all tests pass

