### PR TITLE
ST: CA renewal break

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -51,6 +51,7 @@ public interface Constants {
 
     long CO_OPERATION_TIMEOUT_DEFAULT = Duration.ofMinutes(5).toMillis();
     long CO_OPERATION_TIMEOUT_SHORT = Duration.ofSeconds(30).toMillis();
+    long CO_OPERATION_TIMEOUT_MEDIUM = Duration.ofMinutes(2).toMillis();
     long CO_OPERATION_TIMEOUT_WAIT = CO_OPERATION_TIMEOUT_SHORT + Duration.ofSeconds(80).toMillis();
     long CO_OPERATION_TIMEOUT_POLL = Duration.ofSeconds(2).toMillis();
     long RECONCILIATION_INTERVAL = Duration.ofSeconds(30).toMillis();

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -4,10 +4,13 @@
  */
 package io.strimzi.systemtest;
 
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicyPeerBuilder;
 import io.strimzi.api.kafka.model.AclOperation;
+import io.strimzi.api.kafka.model.CertificateAuthorityBuilder;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -17,20 +20,6 @@ import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.systemtest.kafkaclients.ClientFactory;
 import io.strimzi.systemtest.kafkaclients.EClientType;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
-import io.strimzi.systemtest.utils.specific.MetricsUtils;
-import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.exceptions.KubeClusterException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -39,6 +28,20 @@ import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
+import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.exceptions.KubeClusterException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -74,6 +77,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -201,7 +205,7 @@ class SecurityST extends BaseST {
             final List<String> secretsToAnnotate,
             boolean zkShouldRoll,
             boolean kafkaShouldRoll,
-            boolean eoShouldRoll) throws Exception {
+            boolean eoShouldRoll) {
         String userName = "alice";
         String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
 
@@ -220,8 +224,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME)
         );
 
         // Get all pods, and their resource versions
@@ -270,8 +274,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                messagesCount,
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            messagesCount,
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         // Check a new client (signed by new client key) can consume
@@ -287,8 +291,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                messagesCount,
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            messagesCount,
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         if (!zkShouldRoll) {
@@ -361,8 +365,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS", CONSUMER_GROUP_NAME)
         );
 
         // Get all pods, and their resource versions
@@ -425,8 +429,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                messagesCount,
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            messagesCount,
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         // Finally check a new client (signed by new client key) can consume
@@ -441,8 +445,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                messagesCount,
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+            messagesCount,
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         SecretUtils.waitForSecretReady(bobUserName);
@@ -540,8 +544,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         // Wait until the certificates have been replaced
@@ -552,8 +556,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
     }
 
@@ -630,7 +634,7 @@ class SecurityST extends BaseST {
 
     @Test
     @Tag(NODEPORT_SUPPORTED)
-    void testCertRenewalInMaintenanceWindow() throws Exception {
+    void testCertRenewalInMaintenanceWindow() {
         String secretName = CLUSTER_NAME + "-cluster-ca-cert";
         LocalDateTime maintenanceWindowStart = LocalDateTime.now().withSecond(0);
         long maintenanceWindowDuration = 14;
@@ -662,9 +666,9 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Annotate secret {} with secret force-renew annotation", secretName);
         Secret secret = new SecretBuilder(kubeClient().getSecret(secretName))
-                .editMetadata()
+            .editMetadata()
                 .addToAnnotations("strimzi.io/force-renew", "true")
-                .endMetadata().build();
+            .endMetadata().build();
         kubeClient().patchSecret(secretName, secret);
 
         LOGGER.info("Wait until maintenance windows starts");
@@ -684,15 +688,13 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, aliceUserName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
     }
 
     @Test
-    @Tag(NODEPORT_SUPPORTED)
-    void testCertRegeneratedAfterInternalCAisDeleted() throws Exception {
-
+    void testCertRegeneratedAfterInternalCAisDeleted() {
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 1).done();
 
         Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(kafkaStatefulSetName(CLUSTER_NAME));
@@ -742,8 +744,8 @@ class SecurityST extends BaseST {
 
         LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
         internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount),
-                internalKafkaClient.receiveMessages(topicName, NAMESPACE, CLUSTER_NAME, messagesCount, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
     }
@@ -755,25 +757,25 @@ class SecurityST extends BaseST {
         matchLabelForPlain.put("app", CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1)
-                .editSpec()
-                    .editKafka()
-                        .withNewListeners()
-                            .withNewPlain()
-                                .withNewKafkaListenerAuthenticationScramSha512Auth()
-                                .endKafkaListenerAuthenticationScramSha512Auth()
-                                .withNetworkPolicyPeers(
-                                    new NetworkPolicyPeerBuilder()
-                                        .withNewPodSelector()
-                                            .withMatchLabels(matchLabelForPlain)
-                                        .endPodSelector()
-                                        .build())
-                                .endPlain()
-                            .endListeners()
-                        .endKafka()
-                        .withNewKafkaExporter()
-                        .endKafkaExporter()
-                    .endSpec()
-                .done();
+            .editSpec()
+                .editKafka()
+                    .withNewListeners()
+                        .withNewPlain()
+                            .withNewKafkaListenerAuthenticationScramSha512Auth()
+                            .endKafkaListenerAuthenticationScramSha512Auth()
+                            .withNetworkPolicyPeers(
+                                new NetworkPolicyPeerBuilder()
+                                    .withNewPodSelector()
+                                        .withMatchLabels(matchLabelForPlain)
+                                    .endPodSelector()
+                                    .build())
+                            .endPlain()
+                        .endListeners()
+                    .endKafka()
+                    .withNewKafkaExporter()
+                    .endKafkaExporter()
+                .endSpec()
+            .done();
 
         String topic0 = "topic-example-0";
         String topic1 = "topic-example-1";
@@ -794,8 +796,8 @@ class SecurityST extends BaseST {
         internalKafkaClient.setPodName(kafkaClientsPodName);
 
         internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessages(topic0, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50),
-            internalKafkaClient.receiveMessages(topic0, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         KafkaClientsResource.deployKafkaClients(false, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-new", kafkaUser).done();
@@ -807,8 +809,8 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that {} pod is not able to exchange messages", kafkaClientsNewPodName);
         assertThrows(AssertionError.class, () ->  {
             internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessages(topic1, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50),
-                internalKafkaClient.receiveMessages(topic1, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, CONSUMER_GROUP_NAME)
+                internalKafkaClient.sendMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+                internalKafkaClient.receiveMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             );
         });
 
@@ -830,23 +832,23 @@ class SecurityST extends BaseST {
         matchLabelsForTls.put("app", CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS);
 
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 1)
-                .editSpec()
-                    .editKafka()
-                        .withNewListeners()
-                            .withNewTls()
-                                .withNewKafkaListenerAuthenticationScramSha512Auth()
-                                .endKafkaListenerAuthenticationScramSha512Auth()
-                                .withNetworkPolicyPeers(
-                                    new NetworkPolicyPeerBuilder()
-                                        .withNewPodSelector()
-                                            .withMatchLabels(matchLabelsForTls)
-                                        .endPodSelector()
-                                        .build())
-                            .endTls()
-                        .endListeners()
-                    .endKafka()
-                .endSpec()
-                .done();
+            .editSpec()
+                .editKafka()
+                    .withNewListeners()
+                        .withNewTls()
+                            .withNewKafkaListenerAuthenticationScramSha512Auth()
+                            .endKafkaListenerAuthenticationScramSha512Auth()
+                            .withNetworkPolicyPeers(
+                                new NetworkPolicyPeerBuilder()
+                                    .withNewPodSelector()
+                                        .withMatchLabels(matchLabelsForTls)
+                                    .endPodSelector()
+                                    .build())
+                        .endTls()
+                    .endListeners()
+                .endKafka()
+            .endSpec()
+            .done();
 
         String topic0 = "topic-example-0";
         String topic1 = "topic-example-1";
@@ -866,8 +868,8 @@ class SecurityST extends BaseST {
         internalKafkaClient.setPodName(kafkaClientsPodName);
 
         internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, "TLS"),
-            internalKafkaClient.receiveMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, "TLS", CONSUMER_GROUP_NAME)
+            internalKafkaClient.sendMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topic0, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
         );
 
         KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS + "-new", kafkaUser).done();
@@ -879,8 +881,8 @@ class SecurityST extends BaseST {
         LOGGER.info("Verifying that {} pod is  not able to exchange messages", kafkaClientsNewPodName);
         assertThrows(AssertionError.class, () -> {
             internalKafkaClient.checkProducedAndConsumedMessages(
-                internalKafkaClient.sendMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, "TLS"),
-                internalKafkaClient.receiveMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, kafkaUser.getMetadata().getName(), 50, "TLS", CONSUMER_GROUP_NAME)
+                internalKafkaClient.sendMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+                internalKafkaClient.receiveMessagesTls(topic1, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
             );
         });
     }
@@ -895,19 +897,19 @@ class SecurityST extends BaseST {
         LOGGER.info("Kafka connect without config {} will not connect to {}:9093", "ssl.endpoint.identification.algorithm", ipOfBootstrapService);
 
         KafkaConnect kafkaConnect = KafkaConnectResource.kafkaConnectWithoutWait(KafkaConnectResource.defaultKafkaConnect(CLUSTER_NAME, CLUSTER_NAME, 1)
-                .editMetadata()
-                    .addToLabels("type", "kafka-connect")
-                .endMetadata()
-                .editSpec()
-                    .withNewTls()
-                        .addNewTrustedCertificate()
-                            .withSecretName(CLUSTER_NAME + "-cluster-ca-cert")
-                            .withCertificate("ca.crt")
-                        .endTrustedCertificate()
-                    .endTls()
-                    .withBootstrapServers(ipOfBootstrapService + ":9093")
-                .endSpec()
-                .build());
+            .editMetadata()
+                .addToLabels("type", "kafka-connect")
+            .endMetadata()
+            .editSpec()
+                .withNewTls()
+                    .addNewTrustedCertificate()
+                        .withSecretName(CLUSTER_NAME + "-cluster-ca-cert")
+                        .withCertificate("ca.crt")
+                    .endTrustedCertificate()
+                .endTls()
+                .withBootstrapServers(ipOfBootstrapService + ":9093")
+            .endSpec()
+            .build());
 
         PodUtils.waitUntilPodIsPresent(CLUSTER_NAME + "-connect");
 
@@ -953,31 +955,31 @@ class SecurityST extends BaseST {
         LOGGER.info("Mirror maker without config {} will not connect to producer with address {}:9093", "ssl.endpoint.identification.algorithm", ipOfTargetBootstrapService);
 
         KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerWithoutWait(KafkaMirrorMakerResource.defaultKafkaMirrorMaker(CLUSTER_NAME, sourceKafkaCluster, targetKafkaCluster,
-                "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, true)
-                .editMetadata()
-                    .addToLabels("type", "kafka-mirror-maker")
-                .endMetadata()
-                .editSpec()
-                    .editConsumer()
-                        .withNewTls()
-                            .addNewTrustedCertificate()
-                                .withSecretName(KafkaResources.clusterCaCertificateSecretName(sourceKafkaCluster))
-                                .withCertificate("ca.crt")
-                            .endTrustedCertificate()
-                        .endTls()
-                        .withBootstrapServers(ipOfSourceBootstrapService + ":9093")
-                    .endConsumer()
-                    .editProducer()
-                        .withNewTls()
-                            .addNewTrustedCertificate()
-                                .withSecretName(KafkaResources.clusterCaCertificateSecretName(targetKafkaCluster))
-                                .withCertificate("ca.crt")
-                            .endTrustedCertificate()
-                        .endTls()
-                        .withBootstrapServers(ipOfTargetBootstrapService + ":9093")
-                    .endProducer()
-                .endSpec()
-                .build());
+            "my-group" + rng.nextInt(Integer.MAX_VALUE), 1, true)
+            .editMetadata()
+                .addToLabels("type", "kafka-mirror-maker")
+            .endMetadata()
+            .editSpec()
+                .editConsumer()
+                    .withNewTls()
+                        .addNewTrustedCertificate()
+                            .withSecretName(KafkaResources.clusterCaCertificateSecretName(sourceKafkaCluster))
+                            .withCertificate("ca.crt")
+                        .endTrustedCertificate()
+                    .endTls()
+                    .withBootstrapServers(ipOfSourceBootstrapService + ":9093")
+                .endConsumer()
+                .editProducer()
+                    .withNewTls()
+                        .addNewTrustedCertificate()
+                            .withSecretName(KafkaResources.clusterCaCertificateSecretName(targetKafkaCluster))
+                            .withCertificate("ca.crt")
+                        .endTrustedCertificate()
+                    .endTls()
+                    .withBootstrapServers(ipOfTargetBootstrapService + ":9093")
+                .endProducer()
+            .endSpec()
+            .build());
 
         PodUtils.waitUntilPodIsPresent(CLUSTER_NAME + "-mirror-maker");
 
@@ -1039,23 +1041,23 @@ class SecurityST extends BaseST {
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUserWrite)
-                .editSpec()
-                    .withNewKafkaUserAuthorizationSimple()
-                        .addNewAcl()
-                            .withNewAclRuleTopicResource()
-                                .withName(topicName)
-                            .endAclRuleTopicResource()
-                            .withOperation(AclOperation.WRITE)
-                        .endAcl()
-                        .addNewAcl()
-                            .withNewAclRuleTopicResource()
-                                .withName(topicName)
-                            .endAclRuleTopicResource()
-                            .withOperation(AclOperation.DESCRIBE)  // describe is for that user can find out metadata
-                        .endAcl()
-                    .endKafkaUserAuthorizationSimple()
-                .endSpec()
-                .done();
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(topicName)
+                        .endAclRuleTopicResource()
+                        .withOperation(AclOperation.WRITE)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(topicName)
+                        .endAclRuleTopicResource()
+                        .withOperation(AclOperation.DESCRIBE)  // describe is for that user can find out metadata
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec()
+            .done();
 
         SecretUtils.waitForSecretReady(kafkaUserWrite);
 
@@ -1072,29 +1074,29 @@ class SecurityST extends BaseST {
         });
 
         KafkaUserResource.tlsUser(CLUSTER_NAME, kafkaUserRead)
-                .editSpec()
-                    .withNewKafkaUserAuthorizationSimple()
-                        .addNewAcl()
-                            .withNewAclRuleTopicResource()
-                                .withName(topicName)
-                            .endAclRuleTopicResource()
-                            .withOperation(AclOperation.READ)
-                        .endAcl()
-                        .addNewAcl()
-                            .withNewAclRuleGroupResource()
-                                .withName(consumerGroupName)
-                            .endAclRuleGroupResource()
-                            .withOperation(AclOperation.READ)
-                        .endAcl()
-                        .addNewAcl()
-                            .withNewAclRuleTopicResource()
-                                .withName(topicName)
-                            .endAclRuleTopicResource()
-                            .withOperation(AclOperation.DESCRIBE)  // describe is for that user can find out metadata
-                        .endAcl()
-                    .endKafkaUserAuthorizationSimple()
-                .endSpec()
-                .done();
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(topicName)
+                        .endAclRuleTopicResource()
+                        .withOperation(AclOperation.READ)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleGroupResource()
+                            .withName(consumerGroupName)
+                        .endAclRuleGroupResource()
+                        .withOperation(AclOperation.READ)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(topicName)
+                        .endAclRuleTopicResource()
+                        .withOperation(AclOperation.DESCRIBE)  // describe is for that user can find out metadata
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec()
+            .done();
 
         SecretUtils.waitForSecretReady(kafkaUserRead);
 
@@ -1199,6 +1201,75 @@ class SecurityST extends BaseST {
                     "SSL");
             invalidConsumer.get(Duration.ofSeconds(10).toMillis(), TimeUnit.MILLISECONDS);
         });
+    }
+
+    @Test
+    void testCaRenewalBreakInMiddle() {
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3)
+            .editSpec()
+                .withNewClusterCa()
+                    .withRenewalDays(1)
+                    .withValidityDays(3)
+                .endClusterCa()
+            .endSpec().done();
+
+        String userName = "alice";
+        KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();
+        String topicName = TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
+
+        KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
+        KafkaClientsResource.deployKafkaClients(true, CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS, user).done();
+
+        String defaultKafkaClientsPodName =
+                ResourceManager.kubeClient().listPodsByPrefixInName(CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+
+        internalKafkaClient.setPodName(defaultKafkaClientsPodName);
+
+        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+        Map<String, String> eoPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME));
+        String clusterCaCert = createSecret("cluster-ca.crt", clusterCaCertificateSecretName(CLUSTER_NAME), "ca.crt");
+
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
+            k.getSpec()
+                .getZookeeper()
+                .setResources(new ResourceRequirementsBuilder()
+                    .addToRequests("cpu", new Quantity("100000m"))
+                    .build());
+            k.getSpec().setClusterCa(new CertificateAuthorityBuilder()
+                .withRenewalDays(4)
+                .withValidityDays(7)
+                .build());
+        });
+
+        StUtils.waitForReconciliation(testClass, testName, NAMESPACE);
+        StUtils.waitForReconciliation(testClass, testName, NAMESPACE);
+        List<String> podStatuses = kubeClient().listPods().stream()
+            .filter(p -> p.getMetadata().getName().startsWith(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME))
+                    && p.getMetadata().getLabels().containsKey("strimzi.io/kind")
+                    && p.getMetadata().getLabels().containsValue("Kafka"))
+            .map(p -> p.getStatus().getPhase()).sorted().collect(Collectors.toList());
+        assertThat(podStatuses, contains("Pending"));
+
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, k -> {
+            k.getSpec()
+                .getZookeeper()
+                .setResources(new ResourceRequirementsBuilder()
+                    .addToRequests("cpu", new Quantity("200m"))
+                    .build());
+        });
+
+        // Wait until the certificates have been replaced
+        waitForCertToChange(clusterCaCert, KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME));
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), 3, zkPods);
+        StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
+        DeploymentUtils.waitTillDepHasRolled(KafkaResources.entityOperatorDeploymentName(CLUSTER_NAME), 1, eoPods);
+
+        LOGGER.info("Checking produced and consumed messages to pod:{}", internalKafkaClient.getPodName());
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            internalKafkaClient.sendMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS"),
+            internalKafkaClient.receiveMessagesTls(topicName, NAMESPACE, CLUSTER_NAME, userName, messagesCount, "TLS", CONSUMER_GROUP_NAME + "-" + rng.nextInt(Integer.MAX_VALUE))
+        );
     }
 
     @BeforeAll


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR add test case, which covers test case when CA renewal is break in the middle and when cluster is fixed, all pods will be rolled with new certificates.

I also fixed problems in most of the `SecurityST`, when (cause wrong rebase) all message exchange was done with PLAIN communication instead of TLS.

That one failure in Jenkins is caused by flaky test and @im-konge is currently investigating it.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

