### PR TITLE
Keep the natural language order of addresses and ports

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -110,12 +110,12 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -379,8 +379,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Service kafkaHeadlessService;
         /* test */ ReconcileResult<StatefulSet> kafkaDiffs;
         private Set<String> kafkaExternalBootstrapDnsName = new HashSet<>();
-        private Set<String> kafkaExternalAdvertisedHostnames = new LinkedHashSet<>();
-        private Set<String> kafkaExternalAdvertisedPorts = new LinkedHashSet<>();
+        private Set<String> kafkaExternalAdvertisedHostnames = new TreeSet<>();
+        private Set<String> kafkaExternalAdvertisedPorts = new TreeSet<>();
         private Map<Integer, Set<String>> kafkaExternalDnsNames = new HashMap<>();
 
         private String zkLoggingHash = "";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In asynchronous environments, it can happen that the ports or addresses will not be ready in the right order. With `LinkedHashSet`, we kept the order in which we obtained them for the Kubernetes API. But that might mean they can be reordered in follow up reconciliations and that might cause rolling update. By using `TreeSet`, they should be kept in a natural language order which should not change between reocnciliations (especially since the are using the URI format `0://<address0> 1://<address1> ...`).

Thsi should be cherry-picked for 0.17.0.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally (@ppatierno did this)