### PR TITLE
Use the actual default names in the Connect examle YAMLs

### DIFF
--- a/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i-single-node-kafka.yaml
@@ -16,10 +16,10 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -16,7 +16,7 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status

--- a/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
+++ b/examples/kafka-connect/kafka-connect-single-node-kafka.yaml
@@ -16,10 +16,10 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1
     status.storage.replication.factor: 1

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -16,7 +16,7 @@ spec:
       - secretName: my-cluster-cluster-ca-cert
         certificate: ca.crt
   config:
-    group.id: my-connect-cluster
-    offset.storage.topic: my-connect-cluster-offsets
-    config.storage.topic: my-connect-cluster-configs
-    status.storage.topic: my-connect-cluster-status
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status


### PR DESCRIPTION
The PR #2556 tried to add the default values for group ID and topic names to the YAML files. However, it screwed up and didn't used the actual default names. Tis PR attempts to fix it and use the real defaults.