### PR TITLE
[systemtest] Fix two still failing tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -1434,7 +1434,7 @@ class KafkaST extends BaseST {
         labels.put(labelKeys[0], labelValues[0]);
         labels.put(labelKeys[1], labelValues[1]);
 
-        KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3, 1)
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 1)
                 .editMetadata()
                     .withLabels(labels)
                 .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -396,7 +396,7 @@ class SecurityST extends BaseST {
         }
         if (kafkaShouldRoll) {
             LOGGER.info("Wait for kafka to rolling restart (1)...");
-            kafkaPods = StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
+            kafkaPods = StatefulSetUtils.waitTillSsHasRolled(kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
         }
         if (eoShouldRoll) {
             LOGGER.info("Wait for EO to rolling restart (1)...");


### PR DESCRIPTION
### Type of change

- Test fix

### Description

KafkaST#testLabelModificationDoesNotBreakCluster
- change Kafka from Ephemeral to Persistent - this cause failing on rolling update

SecurityST#testAutoReplaceClientsCaKeysTriggeredByAnno
- edit check for rolling update

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

