### PR TITLE
Allow separate installation of CRD files

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -133,6 +133,7 @@
                                 <argument>${pom.basedir}${file.separator}target${file.separator}classes${path.separator}${pom.basedir}${file.separator}..${file.separator}crd-generator${file.separator}target${file.separator}crd-generator-${project.version}.jar</argument>
                                 <argument>io.strimzi.crdgenerator.CrdGenerator</argument>
                                 <argument>--label</argument><argument>app:strimzi</argument>
+                                <argument>--label</argument><argument>strimzi.io/crd-install:true</argument>
                                 <argument>--yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.Kafka=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}040-Crd-kafka.yaml</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnect=${pom.basedir}${file.separator}..${file.separator}install${file.separator}cluster-operator${file.separator}041-Crd-kafkaconnect.yaml</argument>

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkas.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkas.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkaconnects.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkaconnects.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkaconnects2is.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkaconnects2is.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkatopics.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkatopics.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkausers.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkausers.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkamirrormakers.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkamirrormakers.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkabridges.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkabridges.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkaconnectors.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkaconnectors.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafkamirrormaker2s.kafka.strimzi.io
   labels:
     app: '{{ template "strimzi.name" . }}'
+    strimzi.io/crd-install: "true"
     chart: '{{ template "strimzi.chart" . }}'
     component: kafkamirrormaker2.kafka.strimzi.io-crd
     release: '{{ .Release.Name }}'

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkas.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkaconnects.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkaconnects2is.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkatopics.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkausers.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkamirrormakers.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkabridges.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkaconnectors.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkamirrormaker2s.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkatopics.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafkausers.kafka.strimzi.io
   labels:
     app: strimzi
+    strimzi.io/crd-install: "true"
 spec:
   group: kafka.strimzi.io
   versions:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR address the issue #2504, where users are requesting having a special labels on the custom resource to allow their separate installation. Sometimes, when you would install all files from a single file, the actuall installation of the different resources takes different time. And it can happen that for example CRDs are not yet fully installed and _active_ while you already try to create a CR (an instance) of given CRD. That leads to errors.

It is therefore useful to be able to install the CRDs in a spearate step. This PR adds new label `strimzi.io/crd-install` to the CRD resources. That lets users do for example the following:

1) First install the CRS only:

```
$ kubectl apply --selector strimzi.io/crd-install=true -f install/cluster-operator
customresourcedefinition.apiextensions.k8s.io/kafkas.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkaconnects.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkaconnects2is.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkatopics.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkausers.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkamirrormakers.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkabridges.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkaconnectors.kafka.strimzi.io created
customresourcedefinition.apiextensions.k8s.io/kafkamirrormaker2s.kafka.strimzi.io created
```

2) Install the rest of Strimzi (including the CRDs, which will just remain unchanged):

```
$ kubectl apply -f install/cluster-operator
serviceaccount/strimzi-cluster-operator created
clusterrole.rbac.authorization.k8s.io/strimzi-cluster-operator-namespaced created
rolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator created
clusterrole.rbac.authorization.k8s.io/strimzi-cluster-operator-global created
clusterrolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator created
clusterrole.rbac.authorization.k8s.io/strimzi-kafka-broker created
clusterrolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator-kafka-broker-delegation created
clusterrole.rbac.authorization.k8s.io/strimzi-entity-operator created
rolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator-entity-operator-delegation created
clusterrole.rbac.authorization.k8s.io/strimzi-topic-operator created
rolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator-topic-operator-delegation created
customresourcedefinition.apiextensions.k8s.io/kafkas.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkaconnects.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkaconnects2is.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkatopics.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkausers.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkamirrormakers.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkabridges.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkaconnectors.kafka.strimzi.io unchanged
customresourcedefinition.apiextensions.k8s.io/kafkamirrormaker2s.kafka.strimzi.io unchanged
deployment.apps/strimzi-cluster-operator created
```

Thsi should close the issue #2504.