### PR TITLE
Make sure KAFKA_OPTS can be used from outside

### DIFF
--- a/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_run.sh
@@ -52,7 +52,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # Enabling the Mirror Maker agent which monitors readiness / liveness
 rm /tmp/mirror-maker-ready /tmp/mirror-maker-alive 2> /dev/null
-export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/mirror-maker-agent*.jar)=/tmp/mirror-maker-ready:/tmp/mirror-maker-alive:${STRIMZI_READINESS_PERIOD:-10}:${STRIMZI_LIVENESS_PERIOD:-10}"
+export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/mirror-maker-agent*.jar)=/tmp/mirror-maker-ready:/tmp/mirror-maker-alive:${STRIMZI_READINESS_PERIOD:-10}:${STRIMZI_LIVENESS_PERIOD:-10}"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -15,7 +15,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 fi
 
 rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
+export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
 if [ "$KAFKA_JMX_ENABLED" = "true" ]; then
   KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"

--- a/docker-images/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka/scripts/zookeeper_run.sh
@@ -35,7 +35,7 @@ fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$ZOOKEEPER_METRICS_ENABLED" = "true" ]; then
-  export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
+  export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.yml"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Currently, we have in different images different handling of the `KAFKA_OPTS` environment vairbale. This variable is used by Kafka for all its components. It can be used to pass generic Java options tot he JVM. Currently, some of our containers let it be configured from the outside (e.g. Connect and Connect S2I) while some others (Broker, Zoo and Mirror Maker 1) override it inside the startup scripts.

This PR tries to unify it and have it configurable in alll containers. It basically means that if it is already defined in the container, the values from it will be used. That should help us to avoid situations when we are looking for some weird environment variables not used by Strimzi to be used by the users (e.g. in the past we recommended to use `KAFKA_JMX` to pass generic Java options).