### PR TITLE
[MO] - [system fixes] -> NPE

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -15,7 +15,7 @@ import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalLoadBalancer;
-import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePort;
+import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePortBuilder;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
@@ -696,12 +696,19 @@ class RollingUpdateST extends BaseST {
 
         KafkaResource.kafkaPersistent(CLUSTER_NAME, 3, 3).done();
 
-        Map<String, String> kafkaPods =  StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
 
         KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka -> {
 
             LOGGER.info("Adding new bootstrap dns:{} to external listeners", bootstrapDns);
-            ((KafkaListenerExternalNodePort) kafka.getSpec().getKafka().getListeners().getExternal()).getOverrides().getBootstrap().setAddress(bootstrapDns);
+            kafka.getSpec().getKafka().getListeners().setExternal(
+                new KafkaListenerExternalNodePortBuilder()
+                    .withNewOverrides()
+                        .withNewBootstrap()
+                            .withAddress(bootstrapDns)
+                        .endBootstrap()
+                    .endOverrides()
+                    .build());
         });
 
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.listener.KafkaListenerExternalLoadBalancer;
+import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePort;
 import io.strimzi.api.kafka.model.listener.KafkaListenerExternalNodePortBuilder;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -714,7 +714,7 @@ class RollingUpdateST extends BaseST {
         StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), 3, kafkaPods);
         KafkaUtils.waitUntilKafkaCRIsReady(CLUSTER_NAME);
 
-        String bootstrapAddressDns = ((KafkaListenerExternalLoadBalancer) Crds.kafkaOperation(kubeClient().getClient())
+        String bootstrapAddressDns = ((KafkaListenerExternalNodePort) Crds.kafkaOperation(kubeClient().getClient())
                 .inNamespace(kubeClient().getNamespace()).withName(CLUSTER_NAME).get().getSpec().getKafka()
                 .getListeners().getExternal()).getOverrides().getBootstrap().getAddress();
 


### PR DESCRIPTION
Signed-off-by: see-quick <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixing test with NPE. 
 - NPE happened because it was setting new bootstrap address to the none-allocated fields in YAML 
 - to be concrete it was invoked by the call of `.getOverrides()` inside the chain method
### Checklist

- [x] Make sure all tests pass


