### PR TITLE
#2589 Allow the Topic Operator Zookeeper node path to be configurable

### DIFF
--- a/documentation/modules/ref-topic-operator-environment.adoc
+++ b/documentation/modules/ref-topic-operator-environment.adoc
@@ -28,6 +28,9 @@ The number of attempts at getting topic metadata from Kafka.
 The time between each attempt is defined as an exponential back-off.
 Consider increasing this value when topic creation could take more time due to the number of partitions or replicas.
 Default `6`.
+`STRIMZI_TOPICS_PATH`::
+The Zookeeper node path where the Topic Operator will store its metadata.
+Default `/strimzi/topics`
 `STRIMZI_LOG_LEVEL`::
 The level for printing logging messages.
 The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `TRACE`.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -99,6 +99,7 @@ public class Config {
     public static final String TC_REASSIGN_THROTTLE = "STRIMZI_REASSIGN_THROTTLE";
     public static final String TC_REASSIGN_VERIFY_INTERVAL_MS = "STRIMZI_REASSIGN_VERIFY_INTERVAL_MS";
     public static final String TC_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
+    public static final String TC_TOPICS_PATH = "STRIMZI_TOPICS_PATH";
 
     public static final String TC_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
     public static final String TC_TLS_TRUSTSTORE_LOCATION = "STRIMZI_TRUSTSTORE_LOCATION";
@@ -141,6 +142,9 @@ public class Config {
     /** The maximum number of retries for getting topic metadata from the Kafka cluster */
     public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, POSITIVE_INTEGER, "6");
 
+    /** The path to the Zookeeper node that stores the topic state in ZooKeeper. */
+    public static final Value<String> TOPICS_PATH = new Value<>(TC_TOPICS_PATH, STRING, "/strimzi/topics");
+
     /** If the connection with Kafka has to be encrypted by TLS protocol */
     public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
     /** The truststore with CA certificate for Kafka broker/server authentication */
@@ -164,6 +168,7 @@ public class Config {
         addConfigValue(configValues, REASSIGN_THROTTLE);
         addConfigValue(configValues, REASSIGN_VERIFY_INTERVAL_MS);
         addConfigValue(configValues, TOPIC_METADATA_MAX_ATTEMPTS);
+        addConfigValue(configValues, TOPICS_PATH);
         addConfigValue(configValues, TLS_ENABLED);
         addConfigValue(configValues, TLS_TRUSTSTORE_LOCATION);
         addConfigValue(configValues, TLS_TRUSTSTORE_PASSWORD);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -178,6 +178,7 @@ public class Session extends AbstractVerticle {
 
                 String topicsPath = config.get(Config.TOPICS_PATH);
                 ZkTopicStore topicStore = new ZkTopicStore(zk, topicsPath);
+
                 LOGGER.debug("Using TopicStore {}", topicStore);
 
                 this.topicOperator = new TopicOperator(vertx, kafka, k8s, topicStore, labels, namespace, config);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -176,7 +176,8 @@ public class Session extends AbstractVerticle {
                 this.zk = zkResult.result();
                 LOGGER.debug("Using ZooKeeper {}", zk);
 
-                ZkTopicStore topicStore = new ZkTopicStore(zk);
+                String topicsPath = config.get(Config.TOPICS_PATH);
+                ZkTopicStore topicStore = new ZkTopicStore(zk, topicsPath);
                 LOGGER.debug("Using TopicStore {}", topicStore);
 
                 this.topicOperator = new TopicOperator(vertx, kafka, k8s, topicStore, labels, namespace, config);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class ZkTopicStore implements TopicStore {
 
     private final static Logger LOGGER = LogManager.getLogger(ZkTopicStore.class);
-    public static final String TOPICS_PATH = "/strimzi/topics";
+    public static final String TOPICS_PATH = Config.TC_TOPICS_PATH;
 
     private final Zk zk;
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
@@ -24,16 +24,16 @@ import java.util.List;
 public class ZkTopicStore implements TopicStore {
 
     private final static Logger LOGGER = LogManager.getLogger(ZkTopicStore.class);
-    
-    private final Config config;
-    public final String TOPICS_PATH = config.get(Config.TOPICS_PATH);
+
+    private final String topicsPath;
 
     private final Zk zk;
 
     private final List<ACL> acl;
 
-    public ZkTopicStore(Zk zk) {
+    public ZkTopicStore(Zk zk, String topicsPath) {
         this.zk = zk;
+        this.topicsPath = topicsPath;
         acl = new AclBuilder().setWorld(AclBuilder.Permission.values()).build();
         createStrimziTopicsPath();
     }
@@ -46,10 +46,10 @@ public class ZkTopicStore implements TopicStore {
                     throw new RuntimeException(result.cause());
                 }
             }
-            zk.create(TOPICS_PATH, null, acl, CreateMode.PERSISTENT, result2 -> {
+            zk.create(topicsPath, null, acl, CreateMode.PERSISTENT, result2 -> {
                 if (result2.failed()) {
                     if (!(result2.cause() instanceof ZkNodeExistsException)) {
-                        LOGGER.error("Error creating {}", TOPICS_PATH, result2.cause());
+                        LOGGER.error("Error creating {}", topicsPath, result2.cause());
                         throw new RuntimeException(result2.cause());
                     }
                 }
@@ -58,8 +58,8 @@ public class ZkTopicStore implements TopicStore {
     }
 
 
-    private static String getTopicPath(TopicName name) {
-        return TOPICS_PATH + "/" + name;
+    private String getTopicPath(TopicName name) {
+        return topicsPath + "/" + name;
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ZkTopicStore.java
@@ -24,7 +24,9 @@ import java.util.List;
 public class ZkTopicStore implements TopicStore {
 
     private final static Logger LOGGER = LogManager.getLogger(ZkTopicStore.class);
-    public static final String TOPICS_PATH = Config.TC_TOPICS_PATH;
+    
+    private final Config config;
+    public final String TOPICS_PATH = config.get(Config.TOPICS_PATH);
 
     private final Zk zk;
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -41,7 +41,7 @@ public class ZkTopicStoreTest {
             throws IOException, InterruptedException {
         this.zkServer = new EmbeddedZooKeeper();
         zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
-        this.store = new ZkTopicStore(zk);
+        this.store = new ZkTopicStore(zk, "/strimzi/topics");
     }
 
     @AfterEach


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This enhancement will allow the Zookeeper node path to be configurable via an environment variable, `STRIMZI_TOPICS_PATH` - issue is described here #2589 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [x] Write tests - I think we can reuse the current tests?
- [x] Make sure all tests pass - there seem to be 3 tests which fail for the topic operator, even on the current master branch - I am quite sure I haven't introduced any degradation
- [x] Update documentation - would appreciate some direction on where you think the documentation for this configuration option should go
- [x] Check RBAC rights for Kubernetes / OpenShift roles - don't think this applies here?
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md - will need some direction

