### PR TITLE
feat: Add description annotations to generated CRD yaml

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -521,7 +521,7 @@ public class CrdGenerator {
     private void addDescription(ObjectNode result, AnnotatedElement element) {
         if (element.isAnnotationPresent(Description.class)) {
             Description description = element.getAnnotation(Description.class);
-            result.put("description", description.value());
+            result.put("description", DocGenerator.getDescription(description));
         }
     }
 

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -474,6 +474,7 @@ public class CrdGenerator {
         } else {
             schema = buildObjectSchema(property, returnType);
         }
+        addDescription(schema, property);
         return schema;
     }
 
@@ -515,6 +516,13 @@ public class CrdGenerator {
 
 
         return result;
+    }
+
+    private void addDescription(ObjectNode result, AnnotatedElement element) {
+        if (element.isAnnotationPresent(Description.class)) {
+            Description description = element.getAnnotation(Description.class);
+            result.put("description", description.value());
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -164,7 +164,7 @@ public class DocGenerator {
                     err(property + " is not documented");
                 }
             } else {
-                out.append(getDescription(property, description2));
+                out.append(getDescription(description2));
             }
             KubeLink kubeLink = property.getAnnotation(KubeLink.class);
             String externalUrl = linker != null && kubeLink != null ? linker.link(kubeLink) : null;
@@ -209,8 +209,8 @@ public class DocGenerator {
         return msg;
     }
 
-    private String getDescription(Object property, Description description2) {
-        String doc = description2.value();
+    static String getDescription(Description description) {
+        String doc = description.value();
         if (!doc.trim().matches(".*[.!?]$")) {
             doc = doc + ".";
         }
@@ -286,7 +286,7 @@ public class DocGenerator {
 
             out.append("include::../" + filename + "[leveloffset=+1]").append(NL);
         } else if (description != null) {
-            out.append(getDescription(cls, description)).append(NL);
+            out.append(getDescription(description)).append(NL);
         }
         out.append(NL);
     }

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -283,11 +283,13 @@ spec:
           - "two"
         fieldProperty:
           type: "string"
+          description: "Example of field property."
         intProperty:
           type: "integer"
           example: "42"
           minimum: 42
           deprecated: true
+          description: "An example int property"
         listOfArray:
           type: "array"
           items:
@@ -341,8 +343,10 @@ spec:
                 - "right"
               leftProperty:
                 type: "string"
+                description: "when descrim=left, the left-hand property"
               rightProperty:
                 type: "string"
+                description: "when descrim=right, the right-hand property"
             required:
             - "discrim"
         listOfRawList:
@@ -382,6 +386,7 @@ spec:
           type: "integer"
           example: "42"
           minimum: 42
+          description: "An example long property"
         mapProperty:
           type: "object"
         normalEnum:
@@ -408,8 +413,10 @@ spec:
               - "right"
             leftProperty:
               type: "string"
+              description: "when descrim=left, the left-hand property"
             rightProperty:
               type: "string"
+              description: "when descrim=right, the right-hand property"
           required:
           - "discrim"
         rawList:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -289,7 +289,7 @@ spec:
           example: "42"
           minimum: 42
           deprecated: true
-          description: "An example int property"
+          description: "An example int property."
         listOfArray:
           type: "array"
           items:
@@ -343,10 +343,10 @@ spec:
                 - "right"
               leftProperty:
                 type: "string"
-                description: "when descrim=left, the left-hand property"
+                description: "when descrim=left, the left-hand property."
               rightProperty:
                 type: "string"
-                description: "when descrim=right, the right-hand property"
+                description: "when descrim=right, the right-hand property."
             required:
             - "discrim"
         listOfRawList:
@@ -386,7 +386,7 @@ spec:
           type: "integer"
           example: "42"
           minimum: 42
-          description: "An example long property"
+          description: "An example long property."
         mapProperty:
           type: "object"
         normalEnum:
@@ -413,10 +413,10 @@ spec:
               - "right"
             leftProperty:
               type: "string"
-              description: "when descrim=left, the left-hand property"
+              description: "when descrim=left, the left-hand property."
             rightProperty:
               type: "string"
-              description: "when descrim=right, the right-hand property"
+              description: "when descrim=right, the right-hand property."
           required:
           - "discrim"
         rawList:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -289,11 +289,13 @@ spec:
           - "two"
         fieldProperty:
           type: "string"
+          description: "Example of field property."
         intProperty:
           type: "integer"
           example: "42"
           minimum: 42
           deprecated: true
+          description: "An example int property"
         listOfArray:
           type: "array"
           items:
@@ -347,8 +349,10 @@ spec:
                 - "right"
               leftProperty:
                 type: "string"
+                description: "when descrim=left, the left-hand property"
               rightProperty:
                 type: "string"
+                description: "when descrim=right, the right-hand property"
             required:
             - "discrim"
         listOfRawList:
@@ -388,6 +392,7 @@ spec:
           type: "integer"
           example: "42"
           minimum: 42
+          description: "An example long property"
         mapProperty:
           type: "object"
         normalEnum:
@@ -414,8 +419,10 @@ spec:
               - "right"
             leftProperty:
               type: "string"
+              description: "when descrim=left, the left-hand property"
             rightProperty:
               type: "string"
+              description: "when descrim=right, the right-hand property"
           required:
           - "discrim"
         rawList:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -295,7 +295,7 @@ spec:
           example: "42"
           minimum: 42
           deprecated: true
-          description: "An example int property"
+          description: "An example int property."
         listOfArray:
           type: "array"
           items:
@@ -349,10 +349,10 @@ spec:
                 - "right"
               leftProperty:
                 type: "string"
-                description: "when descrim=left, the left-hand property"
+                description: "when descrim=left, the left-hand property."
               rightProperty:
                 type: "string"
-                description: "when descrim=right, the right-hand property"
+                description: "when descrim=right, the right-hand property."
             required:
             - "discrim"
         listOfRawList:
@@ -392,7 +392,7 @@ spec:
           type: "integer"
           example: "42"
           minimum: 42
-          description: "An example long property"
+          description: "An example long property."
         mapProperty:
           type: "object"
         normalEnum:
@@ -419,10 +419,10 @@ spec:
               - "right"
             leftProperty:
               type: "string"
-              description: "when descrim=left, the left-hand property"
+              description: "when descrim=left, the left-hand property."
             rightProperty:
               type: "string"
-              description: "when descrim=right, the right-hand property"
+              description: "when descrim=right, the right-hand property."
           required:
           - "discrim"
         rawList:

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -53,18 +53,26 @@ spec:
                 replicas:
                   type: integer
                   minimum: 1
+                  description: The number of pods in the cluster.
                 image:
                   type: string
+                  description: The docker image for the pods. The default value depends
+                    on the configured `Kafka.spec.kafka.version`.
                 storage:
                   type: object
                   properties:
                     class:
                       type: string
+                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'
                     overrides:
                       type: array
                       items:
@@ -72,21 +80,37 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
                           broker:
                             type: integer
+                            description: Id of the kafka broker (broker identifier)
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
                     selector:
                       type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
                     size:
                       type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
                     type:
                       type: string
                       enum:
                       - ephemeral
                       - persistent-claim
                       - jbod
+                      description: Storage type, must be either 'ephemeral', 'persistent-claim',
+                        or 'jbod'.
                     volumes:
                       type: array
                       items:
@@ -94,11 +118,18 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation.
                           deleteClaim:
                             type: boolean
+                            description: Specifies if the persistent volume claim
+                              has to be deleted when the cluster is un-deployed.
                           id:
                             type: integer
                             minimum: 0
+                            description: Storage identification number. It is mandatory
+                              only for storage volumes defined in a storage of type
+                              'jbod'
                           overrides:
                             type: array
                             items:
@@ -106,24 +137,44 @@ spec:
                               properties:
                                 class:
                                   type: string
+                                  description: The storage class to use for dynamic
+                                    volume allocation for this broker.
                                 broker:
                                   type: integer
+                                  description: Id of the kafka broker (broker identifier)
+                            description: Overrides for individual brokers. The `overrides`
+                              field allows to specify a different configuration for
+                              different brokers.
                           selector:
                             type: object
+                            description: Specifies a specific persistent volume to
+                              use. It contains key:value pairs representing labels
+                              for selecting such a volume.
                           size:
                             type: string
+                            description: When type=persistent-claim, defines the size
+                              of the persistent volume claim (i.e 1Gi). Mandatory
+                              when type=persistent-claim.
                           sizeLimit:
                             type: string
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                            description: When type=ephemeral, defines the total amount
+                              of local storage required for this EmptyDir volume (for
+                              example 1Gi).
                           type:
                             type: string
                             enum:
                             - ephemeral
                             - persistent-claim
+                            description: Storage type, must be either 'ephemeral'
+                              or 'persistent-claim'.
                         required:
                         - type
+                      description: List of volumes as Storage objects representing
+                        the JBOD disks array
                   required:
                   - type
+                  description: Storage configuration (disk). Cannot be updated.
                 listeners:
                   type: object
                   properties:
@@ -135,34 +186,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -170,23 +257,41 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: 'Authentication configuration for this listener.
+                            Since this listener does not use TLS transport you cannot
+                            configure an authentication with `type: tls`.'
                         networkPolicyPeers:
                           type: array
                           items:
@@ -237,6 +342,14 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures plain listener on port 9092.
                     tls:
                       type: object
                       properties:
@@ -245,34 +358,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -280,23 +429,39 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: Authentication configuration for this listener.
                         configuration:
                           type: object
                           properties:
@@ -305,14 +470,24 @@ spec:
                               properties:
                                 certificate:
                                   type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
                                 key:
                                   type: string
+                                  description: The name of the private key in the
+                                    Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
                               required:
                               - certificate
                               - key
                               - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: Configuration of TLS listener
                         networkPolicyPeers:
                           type: array
                           items:
@@ -363,6 +538,14 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures TLS listener on port 9093.
                     external:
                       type: object
                       properties:
@@ -371,34 +554,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -406,25 +625,44 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: Authentication configuration for Kafka brokers
                         class:
                           type: string
+                          description: Configures the `Ingress` class that defines
+                            which `Ingress` controller will be used. If not set, the
+                            `Ingress` class is set to `nginx`.
                         configuration:
                           type: object
                           properties:
@@ -433,12 +671,21 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
+                                  description: Annotations that will be added to the
+                                    `Ingress` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
                                 host:
                                   type: string
+                                  description: Host for the bootstrap route. This
+                                    field will be used in the Ingress resource.
                               required:
                               - host
+                              description: External bootstrap ingress configuration
                             brokers:
                               type: array
                               items:
@@ -446,29 +693,51 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
+                                    description: Id of the kafka broker (broker identifier)
                                   advertisedHost:
                                     type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`
                                   advertisedPort:
                                     type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`
                                   host:
                                     type: string
+                                    description: Host for the broker ingress. This
+                                      field will be used in the Ingress resource.
                                   dnsAnnotations:
                                     type: object
+                                    description: Annotations that will be added to
+                                      the `Ingress` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
                                 required:
                                 - host
+                              description: External broker ingress configuration
                             brokerCertChainAndKey:
                               type: object
                               properties:
                                 certificate:
                                   type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
                                 key:
                                   type: string
+                                  description: The name of the private key in the
+                                    Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
                               required:
                               - certificate
                               - key
                               - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: External listener configuration
                         networkPolicyPeers:
                           type: array
                           items:
@@ -519,6 +788,13 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
                         overrides:
                           type: object
                           properties:
@@ -527,10 +803,18 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
+                                  description: Annotations that will be added to the
+                                    `Service` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
+                                  description: Node port for the bootstrap service
+                              description: External bootstrap service configuration
                             brokers:
                               type: array
                               items:
@@ -538,16 +822,31 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
+                                    description: Id of the kafka broker (broker identifier)
                                   advertisedHost:
                                     type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`
                                   advertisedPort:
                                     type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`
                                   nodePort:
                                     type: integer
+                                    description: Node port for the broker service
                                   dnsAnnotations:
                                     type: object
+                                    description: Annotations that will be added to
+                                      the `Service` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
+                              description: External broker services configuration
+                          description: Overrides for external bootstrap and broker
+                            services and externally advertised addresses
                         tls:
                           type: boolean
+                          description: Enables TLS encryption on the listener. By
+                            default set to `true` for enabled TLS encryption.
                         type:
                           type: string
                           enum:
@@ -555,21 +854,39 @@ spec:
                           - loadbalancer
                           - nodeport
                           - ingress
+                          description: "Type of the external listener. Currently the
+                            supported types are `route`, `loadbalancer`, and `nodeport`.
+                            \n\n* `route` type uses OpenShift Routes to expose Kafka.*
+                            `loadbalancer` type uses LoadBalancer type services to
+                            expose Kafka.* `nodeport` type uses NodePort type services
+                            to expose Kafka."
                       required:
                       - type
+                      description: Configures external listener on port 9094.
+                  description: Configures listeners of Kafka brokers
                 authorization:
                   type: object
                   properties:
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     delegateToKafkaAcls:
                       type: boolean
+                      description: Whether authorization decision should be delegated
+                        to the 'Simple' authorizer if DENIED by Keycloak Authorization
+                        Services policies.Default value is `false`.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     superUsers:
                       type: array
                       items:
                         type: string
+                      description: List of super users. Should contain list of user
+                        principals which should get unlimited access rights.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -577,32 +894,52 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
                       - simple
                       - keycloak
+                      description: Authorization type. Currently the only supported
+                        type is `simple`. `simple` authorization type uses Kafka's
+                        `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
                   required:
                   - type
+                  description: Authorization configuration for Kafka brokers
                 config:
                   type: object
+                  description: 'The kafka broker config. Properties with the following
+                    prefixes cannot be set: listeners, advertised., broker., listener.,
+                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
+                    password., principal.builder.class, log.dir, zookeeper.connect,
+                    zookeeper.set.acl, authorizer., super.user'
                 rack:
                   type: object
                   properties:
                     topologyKey:
                       type: string
                       example: failure-domain.beta.kubernetes.io/zone
+                      description: A key that matches labels assigned to the Kubernetes
+                        cluster nodes. The value of the label is used to set the broker's
+                        `broker.rack` config.
                   required:
                   - topologyKey
+                  description: Configuration of the `broker.rack` broker config.
                 brokerRackInitImage:
                   type: string
+                  description: The image of the init container used for initializing
+                    the `broker.rack`.
                 affinity:
                   type: object
                   properties:
@@ -811,6 +1148,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -826,49 +1164,79 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
                 jvmOptions:
                   type: object
                   properties:
                     -XX:
                       type: object
+                      description: A map of -XX options to the JVM
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -876,8 +1244,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The system property name.
                           value:
                             type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods
                 jmxOptions:
                   type: object
                   properties:
@@ -888,8 +1261,14 @@ spec:
                           type: string
                           enum:
                           - password
+                          description: Authentication type. Currently the only supported
+                            types are `password`.`password` type creates a username
+                            and protected port with no TLS.
                       required:
                       - type
+                      description: Authentication configuration for connecting to
+                        the Kafka JMX port
+                  description: JMX Options for Kafka brokers
                 resources:
                   type: object
                   properties:
@@ -897,42 +1276,63 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 metrics:
                   type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration for Kafka
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -944,21 +1344,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -966,6 +1380,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -977,8 +1393,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka `StatefulSet`.
                     pod:
                       type: object
                       properties:
@@ -987,8 +1412,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -996,6 +1429,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1038,9 +1473,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -1249,10 +1693,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -1268,6 +1718,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
                       properties:
@@ -1276,8 +1728,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka bootstrap `Service`.
                     brokersService:
                       type: object
                       properties:
@@ -1286,8 +1747,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka broker `Service`.
                     externalBootstrapService:
                       type: object
                       properties:
@@ -1296,17 +1766,41 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
                           - Local
                           - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                      description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
                       properties:
@@ -1315,17 +1809,42 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
                           - Local
                           - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                      description: Template for Kafka per-pod `Services` used for
+                        access from outside of Kubernetes.
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -1334,8 +1853,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka external bootstrap `Route`.
                     perPodRoute:
                       type: object
                       properties:
@@ -1344,8 +1872,18 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka per-pod `Routes` used for access
+                        from outside of OpenShift.
                     externalBootstrapIngress:
                       type: object
                       properties:
@@ -1354,8 +1892,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka external bootstrap `Ingress`.
                     perPodIngress:
                       type: object
                       properties:
@@ -1364,8 +1911,18 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka per-pod `Ingress` used for access
+                        from outside of Kubernetes.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -1374,8 +1931,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for all Kafka `PersistentVolumeClaims`.
                     podDisruptionBudget:
                       type: object
                       properties:
@@ -1384,11 +1950,27 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for Kafka `PodDisruptionBudget`.
                     kafkaContainer:
                       type: object
                       properties:
@@ -1399,8 +1981,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker container
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -1411,8 +1998,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker TLS sidecar container
                     initContainer:
                       type: object
                       properties:
@@ -1423,32 +2015,51 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka init container
+                  description: Template for Kafka cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
                 version:
                   type: string
+                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}.
+                    Consult the user documentation to understand the process required
+                    to upgrade or downgrade the version.
               required:
               - replicas
               - storage
               - listeners
+              description: Configuration of the Kafka cluster
             zookeeper:
               type: object
               properties:
                 replicas:
                   type: integer
                   minimum: 1
+                  description: The number of pods in the cluster.
                 image:
                   type: string
+                  description: The docker image for the pods.
                 storage:
                   type: object
                   properties:
                     class:
                       type: string
+                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'
                     overrides:
                       type: array
                       items:
@@ -1456,24 +2067,43 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
                           broker:
                             type: integer
+                            description: Id of the kafka broker (broker identifier)
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
                     selector:
                       type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
                     size:
                       type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
                     type:
                       type: string
                       enum:
                       - ephemeral
                       - persistent-claim
+                      description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                   required:
                   - type
+                  description: Storage configuration (disk). Cannot be updated.
                 config:
                   type: object
+                  description: 'The ZooKeeper broker config. Properties with the following
+                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
+                    authProvider, quorum.auth, requireClientAuthScheme'
                 affinity:
                   type: object
                   properties:
@@ -1682,6 +2312,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -1697,49 +2328,79 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
                 jvmOptions:
                   type: object
                   properties:
                     -XX:
                       type: object
+                      description: A map of -XX options to the JVM
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -1747,8 +2408,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The system property name.
                           value:
                             type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods
                 resources:
                   type: object
                   properties:
@@ -1756,42 +2422,63 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 metrics:
                   type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration for ZooKeeper
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -1803,21 +2490,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -1825,6 +2526,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -1836,8 +2539,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper `StatefulSet`.
                     pod:
                       type: object
                       properties:
@@ -1846,8 +2558,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -1855,6 +2575,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1897,9 +2619,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -2108,10 +2839,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -2127,6 +2864,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
                       properties:
@@ -2135,8 +2874,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper client `Service`.
                     nodesService:
                       type: object
                       properties:
@@ -2145,8 +2893,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper nodes `Service`.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -2155,8 +2912,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for all ZooKeeper `PersistentVolumeClaims`.
                     podDisruptionBudget:
                       type: object
                       properties:
@@ -2165,11 +2931,27 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for ZooKeeper `PodDisruptionBudget`.
                     zookeeperContainer:
                       type: object
                       properties:
@@ -2180,8 +2962,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the ZooKeeper container
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -2192,24 +2979,37 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker TLS sidecar container
+                  description: Template for ZooKeeper cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
               required:
               - replicas
               - storage
+              description: Configuration of the ZooKeeper cluster
             topicOperator:
               type: object
               properties:
                 watchedNamespace:
                   type: string
+                  description: The namespace the Topic Operator should watch.
                 image:
                   type: string
+                  description: The image to use for the Topic Operator
                 reconciliationIntervalSeconds:
                   type: integer
                   minimum: 0
+                  description: Interval between periodic reconciliations.
                 zookeeperSessionTimeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: Timeout for the ZooKeeper session
                 affinity:
                   type: object
                   properties:
@@ -2418,6 +3218,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: Pod affinity rules.
                 resources:
                   type: object
                   properties:
@@ -2425,29 +3226,44 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 topicMetadataMaxAttempts:
                   type: integer
                   minimum: 0
+                  description: The number of attempts at getting topic metadata
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -2459,21 +3275,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2481,55 +3311,90 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration
                 jvmOptions:
                   type: object
                   properties:
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                  description: JVM Options for pods
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
+              description: Configuration of the Topic Operator
             entityOperator:
               type: object
               properties:
@@ -2538,44 +3403,72 @@ spec:
                   properties:
                     watchedNamespace:
                       type: string
+                      description: The namespace the Topic Operator should watch.
                     image:
                       type: string
+                      description: The image to use for the Topic Operator
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
+                      description: Interval between periodic reconciliations.
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: Timeout for the ZooKeeper session
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2583,71 +3476,110 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
                     topicMetadataMaxAttempts:
                       type: integer
                       minimum: 0
+                      description: The number of attempts at getting topic metadata
                     logging:
                       type: object
                       properties:
                         loggers:
                           type: object
+                          description: A Map from logger name to logger level.
                         name:
                           type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
                         type:
                           type: string
                           enum:
                           - inline
                           - external
+                          description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
+                      description: Logging configuration
                     jvmOptions:
                       type: object
                       properties:
                         gcLoggingEnabled:
                           type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                      description: JVM Options for pods
+                  description: Configuration of the Topic Operator
                 userOperator:
                   type: object
                   properties:
                     watchedNamespace:
                       type: string
+                      description: The namespace the User Operator should watch.
                     image:
                       type: string
+                      description: The image to use for the User Operator
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
+                      description: Interval between periodic reconciliations.
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: Timeout for the ZooKeeper session
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2655,25 +3587,35 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
                     logging:
                       type: object
                       properties:
                         loggers:
                           type: object
+                          description: A Map from logger name to logger level.
                         name:
                           type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
                         type:
                           type: string
                           enum:
                           - inline
                           - external
+                          description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
+                      description: Logging configuration
                     jvmOptions:
                       type: object
                       properties:
                         gcLoggingEnabled:
                           type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                      description: JVM Options for pods
+                  description: Configuration of the User Operator
                 affinity:
                   type: object
                   properties:
@@ -2882,6 +3824,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -2897,26 +3840,40 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -2928,21 +3885,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2950,6 +3921,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -2961,8 +3934,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Entity Operator `Deployment`.
                     pod:
                       type: object
                       properties:
@@ -2971,8 +3953,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -2980,6 +3970,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -3022,9 +4014,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3233,10 +4234,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -3252,6 +4259,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -3262,8 +4271,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity Operator TLS sidecar container
                     topicOperatorContainer:
                       type: object
                       properties:
@@ -3274,8 +4288,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity Topic Operator container
                     userOperatorContainer:
                       type: object
                       properties:
@@ -3286,45 +4305,86 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity User Operator container
+                  description: Template for Entity Operator resources. The template
+                    allows users to specify how is the `Deployment` and `Pods` generated.
+              description: Configuration of the Entity Operator
             clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
                   - renew-certificate
                   - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the cluster certificate authority
             clientsCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
                   - renew-certificate
                   - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the clients certificate authority
             jmxTrans:
               type: object
               properties:
                 image:
                   type: string
+                  description: The image to use for the JmxTrans
                 outputDefinitions:
                   type: array
                   items:
@@ -3332,23 +4392,44 @@ spec:
                     properties:
                       outputType:
                         type: string
+                        description: Template for setting the format of the data that
+                          will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
+                          OutputWriters]
                       host:
                         type: string
+                        description: The DNS/hostname of the remote host that the
+                          data is pushed to.
                       port:
                         type: integer
+                        description: The port of the remote host that the data is
+                          pushed to.
                       flushDelayInSeconds:
                         type: integer
+                        description: How many seconds the JmxTrans waits before pushing
+                          a new set of data out.
                       typeNames:
                         type: array
                         items:
                           type: string
+                        description: Template for filtering data to be included in
+                          response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
+                          queries]
                       name:
                         type: string
+                        description: Template for setting the name of the output definition.
+                          This is used to identify where to send the results of queries
+                          should be sent.
                     required:
                     - outputType
                     - name
+                  description: Defines the output hosts that will be referenced later
+                    on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate`
+                    schema reference].
                 logLevel:
                   type: string
+                  description: Sets the logging level of the JmxTrans deployment.For
+                    more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
+                    Logging Level]
                 kafkaQueries:
                   type: array
                   items:
@@ -3356,18 +4437,31 @@ spec:
                     properties:
                       targetMBean:
                         type: string
+                        description: If using wildcards instead of a specific MBean
+                          then the data is gathered from multiple MBeans. Otherwise
+                          if specifying an MBean then data is gathered from that specified
+                          MBean.
                       attributes:
                         type: array
                         items:
                           type: string
+                        description: Determine which attributes of the targeted MBean
+                          should be included
                       outputs:
                         type: array
                         items:
                           type: string
+                        description: List of the names of output definitions specified
+                          in the spec.kafka.jmxTrans.outputDefinitions that have defined
+                          where JMX metrics are pushed to, and in which data format
                     required:
                     - targetMBean
                     - attributes
                     - outputs
+                  description: Queries to send to the Kafka brokers to define what
+                    data should be read from each broker. For more information on
+                    these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate`
+                    schema reference].
                 resources:
                   type: object
                   properties:
@@ -3375,18 +4469,28 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
               required:
               - outputDefinitions
               - kafkaQueries
+              description: Configuration for JmxTrans. When the property is present
+                a JmxTrans deployment is created for gathering JMX metrics from each
+                Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
+                GitHub]
             kafkaExporter:
               type: object
               properties:
                 image:
                   type: string
+                  description: The docker image for the pods.
                 groupRegex:
                   type: string
+                  description: Regular expression to specify which consumer groups
+                    to collect. Default value is `.*`.
                 topicRegex:
                   type: string
+                  description: Regular expression to specify which topics to collect.
+                    Default value is `.*`.
                 resources:
                   type: object
                   properties:
@@ -3394,10 +4498,16 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 logging:
                   type: string
+                  description: 'Only log messages with the given severity or above.
+                    Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
+                    log level is `info`.'
                 enableSaramaLogging:
                   type: boolean
+                  description: Enable Sarama logging, a Go client library used by
+                    the Kafka Exporter.
                 template:
                   type: object
                   properties:
@@ -3409,8 +4519,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka Exporter `Deployment`.
                     pod:
                       type: object
                       properties:
@@ -3419,8 +4538,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -3428,6 +4555,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -3470,9 +4599,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3681,10 +4819,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -3700,6 +4844,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object
                       properties:
@@ -3708,8 +4854,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka Exporter `Service`.
                     container:
                       type: object
                       properties:
@@ -3720,45 +4875,81 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka Exporter container
+                  description: Customization of deployment templates and pods.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness check.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness check.
+              description: Configuration of the Kafka Exporter. Kafka Exporter can
+                provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:
               type: array
               items:
                 type: string
+              description: A list of time windows for maintenance tasks (that is,
+                certificates renewal). Each time window is defined by a cron expression.
           required:
           - kafka
           - zookeeper
+          description: The specification of the Kafka and ZooKeeper clusters, and
+            Topic Operator.
         status:
           type: object
           properties:
@@ -3769,16 +4960,30 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             listeners:
               type: array
               items:
@@ -3786,6 +4991,8 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: 'The type of the listener. Can be one of the following
+                      three types: `plain`, `tls`, and `external`.'
                   addresses:
                     type: array
                     items:
@@ -3793,10 +5000,19 @@ spec:
                       properties:
                         host:
                           type: string
+                          description: The DNS name or IP address of Kafka bootstrap
+                            service
                         port:
                           type: integer
+                          description: The port of the Kafka bootstrap service
+                    description: A list of the addresses for this listener.
                   certificates:
                     type: array
                     items:
                       type: string
+                    description: A list of TLS certificates which can be used to verify
+                      the identity of the server when connecting to the given listener.
+                      Set only for `tls` and `external` listeners.
+              description: Addresses of the internal and external listeners
+          description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -72,7 +72,7 @@ spec:
                       type: integer
                       minimum: 0
                       description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'
+                        only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -84,7 +84,7 @@ spec:
                               allocation for this broker.
                           broker:
                             type: integer
-                            description: Id of the kafka broker (broker identifier)
+                            description: Id of the kafka broker (broker identifier).
                       description: Overrides for individual brokers. The `overrides`
                         field allows to specify a different configuration for different
                         brokers.
@@ -129,7 +129,7 @@ spec:
                             minimum: 0
                             description: Storage identification number. It is mandatory
                               only for storage volumes defined in a storage of type
-                              'jbod'
+                              'jbod'.
                           overrides:
                             type: array
                             items:
@@ -141,7 +141,7 @@ spec:
                                     volume allocation for this broker.
                                 broker:
                                   type: integer
-                                  description: Id of the kafka broker (broker identifier)
+                                  description: Id of the kafka broker (broker identifier).
                             description: Overrides for individual brokers. The `overrides`
                               field allows to specify a different configuration for
                               different brokers.
@@ -171,7 +171,7 @@ spec:
                         required:
                         - type
                       description: List of volumes as Storage objects representing
-                        the JBOD disks array
+                        the JBOD disks array.
                   required:
                   - type
                   description: Storage configuration (disk). Cannot be updated.
@@ -487,7 +487,7 @@ spec:
                               description: Reference to the `Secret` which holds the
                                 certificate and private key pair. The certificate
                                 can optionally contain the whole chain.
-                          description: Configuration of TLS listener
+                          description: Configuration of TLS listener.
                         networkPolicyPeers:
                           type: array
                           items:
@@ -657,7 +657,7 @@ spec:
                               description: URI of the token issuer used for authentication.
                           required:
                           - type
-                          description: Authentication configuration for Kafka brokers
+                          description: Authentication configuration for Kafka brokers.
                         class:
                           type: string
                           description: Configures the `Ingress` class that defines
@@ -685,7 +685,7 @@ spec:
                                     field will be used in the Ingress resource.
                               required:
                               - host
-                              description: External bootstrap ingress configuration
+                              description: External bootstrap ingress configuration.
                             brokers:
                               type: array
                               items:
@@ -693,15 +693,15 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
-                                    description: Id of the kafka broker (broker identifier)
+                                    description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
                                     description: The host name which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
                                     description: The port number which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   host:
                                     type: string
                                     description: Host for the broker ingress. This
@@ -714,7 +714,7 @@ spec:
                                       such as External DNS.
                                 required:
                                 - host
-                              description: External broker ingress configuration
+                              description: External broker ingress configuration.
                             brokerCertChainAndKey:
                               type: object
                               properties:
@@ -737,7 +737,7 @@ spec:
                               description: Reference to the `Secret` which holds the
                                 certificate and private key pair. The certificate
                                 can optionally contain the whole chain.
-                          description: External listener configuration
+                          description: External listener configuration.
                         networkPolicyPeers:
                           type: array
                           items:
@@ -813,8 +813,8 @@ spec:
                                     configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
-                                  description: Node port for the bootstrap service
-                              description: External bootstrap service configuration
+                                  description: Node port for the bootstrap service.
+                              description: External bootstrap service configuration.
                             brokers:
                               type: array
                               items:
@@ -822,27 +822,27 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
-                                    description: Id of the kafka broker (broker identifier)
+                                    description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
                                     description: The host name which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
                                     description: The port number which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   nodePort:
                                     type: integer
-                                    description: Node port for the broker service
+                                    description: Node port for the broker service.
                                   dnsAnnotations:
                                     type: object
                                     description: Annotations that will be added to
                                       the `Service` resources for individual brokers.
                                       You can use this field to configure DNS providers
                                       such as External DNS.
-                              description: External broker services configuration
+                              description: External broker services configuration.
                           description: Overrides for external bootstrap and broker
-                            services and externally advertised addresses
+                            services and externally advertised addresses.
                         tls:
                           type: boolean
                           description: Enables TLS encryption on the listener. By
@@ -859,11 +859,11 @@ spec:
                             \n\n* `route` type uses OpenShift Routes to expose Kafka.*
                             `loadbalancer` type uses LoadBalancer type services to
                             expose Kafka.* `nodeport` type uses NodePort type services
-                            to expose Kafka."
+                            to expose Kafka.."
                       required:
                       - type
                       description: Configures external listener on port 9094.
-                  description: Configures listeners of Kafka brokers
+                  description: Configures listeners of Kafka brokers.
                 authorization:
                   type: object
                   properties:
@@ -916,14 +916,14 @@ spec:
                         `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
                   required:
                   - type
-                  description: Authorization configuration for Kafka brokers
+                  description: Authorization configuration for Kafka brokers.
                 config:
                   type: object
                   description: 'The kafka broker config. Properties with the following
                     prefixes cannot be set: listeners, advertised., broker., listener.,
                     host.name, port, inter.broker.listener.name, sasl., ssl., security.,
                     password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user'
+                    zookeeper.set.acl, authorizer., super.user.'
                 rack:
                   type: object
                   properties:
@@ -1224,15 +1224,15 @@ spec:
                   properties:
                     -XX:
                       type: object
-                      description: A map of -XX options to the JVM
+                      description: A map of -XX options to the JVM.
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xms option to to the JVM
+                      description: -Xms option to to the JVM.
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xmx option to to the JVM
+                      description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -1250,7 +1250,7 @@ spec:
                             description: The system property value.
                       description: A map of additional system properties which will
                         be passed using the `-D` option to the JVM.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 jmxOptions:
                   type: object
                   properties:
@@ -1267,8 +1267,8 @@ spec:
                       required:
                       - type
                       description: Authentication configuration for connecting to
-                        the Kafka JMX port
-                  description: JMX Options for Kafka brokers
+                        the Kafka JMX port.
+                  description: JMX Options for Kafka brokers.
                 resources:
                   type: object
                   properties:
@@ -1299,13 +1299,13 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration for Kafka
+                  description: Logging configuration for Kafka.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -1381,7 +1381,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -1799,7 +1799,7 @@ spec:
                             specified CIDR ranges. This field is applicable only for
                             loadbalancer type services and is ignored if the cloud
                             provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
@@ -1842,7 +1842,7 @@ spec:
                             specified CIDR ranges. This field is applicable only for
                             loadbalancer type services and is ignored if the cloud
                             provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka per-pod `Services` used for
                         access from outside of Kubernetes.
                     externalBootstrapRoute:
@@ -1987,7 +1987,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker container
+                      description: Template for the Kafka broker container.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -2004,7 +2004,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker TLS sidecar container
+                      description: Template for the Kafka broker TLS sidecar container.
                     initContainer:
                       type: object
                       properties:
@@ -2021,7 +2021,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka init container
+                      description: Template for the Kafka init container.
                   description: Template for Kafka cluster resources. The template
                     allows users to specify how are the `StatefulSet`, `Pods` and
                     `Services` generated.
@@ -2034,7 +2034,7 @@ spec:
               - replicas
               - storage
               - listeners
-              description: Configuration of the Kafka cluster
+              description: Configuration of the Kafka cluster.
             zookeeper:
               type: object
               properties:
@@ -2059,7 +2059,7 @@ spec:
                       type: integer
                       minimum: 0
                       description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'
+                        only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -2071,7 +2071,7 @@ spec:
                               allocation for this broker.
                           broker:
                             type: integer
-                            description: Id of the kafka broker (broker identifier)
+                            description: Id of the kafka broker (broker identifier).
                       description: Overrides for individual brokers. The `overrides`
                         field allows to specify a different configuration for different
                         brokers.
@@ -2103,7 +2103,7 @@ spec:
                   type: object
                   description: 'The ZooKeeper broker config. Properties with the following
                     prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
-                    authProvider, quorum.auth, requireClientAuthScheme'
+                    authProvider, quorum.auth, requireClientAuthScheme.'
                 affinity:
                   type: object
                   properties:
@@ -2388,15 +2388,15 @@ spec:
                   properties:
                     -XX:
                       type: object
-                      description: A map of -XX options to the JVM
+                      description: A map of -XX options to the JVM.
                     -Xms:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xms option to to the JVM
+                      description: -Xms option to to the JVM.
                     -Xmx:
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xmx option to to the JVM
+                      description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -2414,7 +2414,7 @@ spec:
                             description: The system property value.
                       description: A map of additional system properties which will
                         be passed using the `-D` option to the JVM.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 resources:
                   type: object
                   properties:
@@ -2445,13 +2445,13 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration for ZooKeeper
+                  description: Logging configuration for ZooKeeper.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -2527,7 +2527,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -2968,7 +2968,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the ZooKeeper container
+                      description: Template for the ZooKeeper container.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -2985,14 +2985,14 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker TLS sidecar container
+                      description: Template for the Kafka broker TLS sidecar container.
                   description: Template for ZooKeeper cluster resources. The template
                     allows users to specify how are the `StatefulSet`, `Pods` and
                     `Services` generated.
               required:
               - replicas
               - storage
-              description: Configuration of the ZooKeeper cluster
+              description: Configuration of the ZooKeeper cluster.
             topicOperator:
               type: object
               properties:
@@ -3001,7 +3001,7 @@ spec:
                   description: The namespace the Topic Operator should watch.
                 image:
                   type: string
-                  description: The image to use for the Topic Operator
+                  description: The image to use for the Topic Operator.
                 reconciliationIntervalSeconds:
                   type: integer
                   minimum: 0
@@ -3009,7 +3009,7 @@ spec:
                 zookeeperSessionTimeoutSeconds:
                   type: integer
                   minimum: 0
-                  description: Timeout for the ZooKeeper session
+                  description: Timeout for the ZooKeeper session.
                 affinity:
                   type: object
                   properties:
@@ -3230,13 +3230,13 @@ spec:
                 topicMetadataMaxAttempts:
                   type: integer
                   minimum: 0
-                  description: The number of attempts at getting topic metadata
+                  description: The number of attempts at getting topic metadata.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -3312,7 +3312,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 logging:
                   type: object
                   properties:
@@ -3331,7 +3331,7 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration
+                  description: Logging configuration.
                 jvmOptions:
                   type: object
                   properties:
@@ -3339,7 +3339,7 @@ spec:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
                         is enabled. The default is false.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 livenessProbe:
                   type: object
                   properties:
@@ -3394,7 +3394,7 @@ spec:
                       minimum: 0
                       description: The timeout for each attempted health check.
                   description: Pod readiness checking.
-              description: Configuration of the Topic Operator
+              description: Configuration of the Topic Operator.
             entityOperator:
               type: object
               properties:
@@ -3406,7 +3406,7 @@ spec:
                       description: The namespace the Topic Operator should watch.
                     image:
                       type: string
-                      description: The image to use for the Topic Operator
+                      description: The image to use for the Topic Operator.
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
@@ -3414,7 +3414,7 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
-                      description: Timeout for the ZooKeeper session
+                      description: Timeout for the ZooKeeper session.
                     livenessProbe:
                       type: object
                       properties:
@@ -3480,7 +3480,7 @@ spec:
                     topicMetadataMaxAttempts:
                       type: integer
                       minimum: 0
-                      description: The number of attempts at getting topic metadata
+                      description: The number of attempts at getting topic metadata.
                     logging:
                       type: object
                       properties:
@@ -3499,7 +3499,7 @@ spec:
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
-                      description: Logging configuration
+                      description: Logging configuration.
                     jvmOptions:
                       type: object
                       properties:
@@ -3507,8 +3507,8 @@ spec:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
                             is enabled. The default is false.
-                      description: JVM Options for pods
-                  description: Configuration of the Topic Operator
+                      description: JVM Options for pods.
+                  description: Configuration of the Topic Operator.
                 userOperator:
                   type: object
                   properties:
@@ -3517,7 +3517,7 @@ spec:
                       description: The namespace the User Operator should watch.
                     image:
                       type: string
-                      description: The image to use for the User Operator
+                      description: The image to use for the User Operator.
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
@@ -3525,7 +3525,7 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
-                      description: Timeout for the ZooKeeper session
+                      description: Timeout for the ZooKeeper session.
                     livenessProbe:
                       type: object
                       properties:
@@ -3606,7 +3606,7 @@ spec:
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
-                      description: Logging configuration
+                      description: Logging configuration.
                     jvmOptions:
                       type: object
                       properties:
@@ -3614,8 +3614,8 @@ spec:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
                             is enabled. The default is false.
-                      description: JVM Options for pods
-                  description: Configuration of the User Operator
+                      description: JVM Options for pods.
+                  description: Configuration of the User Operator.
                 affinity:
                   type: object
                   properties:
@@ -3846,7 +3846,7 @@ spec:
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -3922,7 +3922,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -4277,7 +4277,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity Operator TLS sidecar container
+                      description: Template for the Entity Operator TLS sidecar container.
                     topicOperatorContainer:
                       type: object
                       properties:
@@ -4294,7 +4294,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity Topic Operator container
+                      description: Template for the Entity Topic Operator container.
                     userOperatorContainer:
                       type: object
                       properties:
@@ -4311,10 +4311,10 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity User Operator container
+                      description: Template for the Entity User Operator container.
                   description: Template for Entity Operator resources. The template
                     allows users to specify how is the `Deployment` and `Pods` generated.
-              description: Configuration of the Entity Operator
+              description: Configuration of the Entity Operator.
             clusterCa:
               type: object
               properties:
@@ -4346,7 +4346,7 @@ spec:
                   description: How should CA certificate expiration be handled when
                     `generateCertificateAuthority=true`. The default is for a new
                     CA certificate to be generated reusing the existing private key.
-              description: Configuration of the cluster certificate authority
+              description: Configuration of the cluster certificate authority.
             clientsCa:
               type: object
               properties:
@@ -4378,13 +4378,13 @@ spec:
                   description: How should CA certificate expiration be handled when
                     `generateCertificateAuthority=true`. The default is for a new
                     CA certificate to be generated reusing the existing private key.
-              description: Configuration of the clients certificate authority
+              description: Configuration of the clients certificate authority.
             jmxTrans:
               type: object
               properties:
                 image:
                   type: string
-                  description: The image to use for the JmxTrans
+                  description: The image to use for the JmxTrans.
                 outputDefinitions:
                   type: array
                   items:
@@ -4394,7 +4394,7 @@ spec:
                         type: string
                         description: Template for setting the format of the data that
                           will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
-                          OutputWriters]
+                          OutputWriters].
                       host:
                         type: string
                         description: The DNS/hostname of the remote host that the
@@ -4413,7 +4413,7 @@ spec:
                           type: string
                         description: Template for filtering data to be included in
                           response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
-                          queries]
+                          queries].
                       name:
                         type: string
                         description: Template for setting the name of the output definition.
@@ -4429,7 +4429,7 @@ spec:
                   type: string
                   description: Sets the logging level of the JmxTrans deployment.For
                     more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
-                    Logging Level]
+                    Logging Level].
                 kafkaQueries:
                   type: array
                   items:
@@ -4446,14 +4446,14 @@ spec:
                         items:
                           type: string
                         description: Determine which attributes of the targeted MBean
-                          should be included
+                          should be included.
                       outputs:
                         type: array
                         items:
                           type: string
                         description: List of the names of output definitions specified
                           in the spec.kafka.jmxTrans.outputDefinitions that have defined
-                          where JMX metrics are pushed to, and in which data format
+                          where JMX metrics are pushed to, and in which data format.
                     required:
                     - targetMBean
                     - attributes
@@ -4476,7 +4476,7 @@ spec:
               description: Configuration for JmxTrans. When the property is present
                 a JmxTrans deployment is created for gathering JMX metrics from each
                 Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
-                GitHub]
+                GitHub].
             kafkaExporter:
               type: object
               properties:
@@ -4881,7 +4881,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka Exporter container
+                      description: Template for the Kafka Exporter container.
                   description: Customization of deployment templates and pods.
                 livenessProbe:
                   type: object
@@ -4970,7 +4970,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -4979,7 +4979,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
@@ -5001,10 +5001,10 @@ spec:
                         host:
                           type: string
                           description: The DNS name or IP address of Kafka bootstrap
-                            service
+                            service.
                         port:
                           type: integer
-                          description: The port of the Kafka bootstrap service
+                          description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
                   certificates:
                     type: array
@@ -5013,6 +5013,6 @@ spec:
                     description: A list of TLS certificates which can be used to verify
                       the identity of the server when connecting to the given listener.
                       Set only for `tls` and `external` listeners.
-              description: Addresses of the internal and external listeners
+              description: Addresses of the internal and external listeners.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -75,8 +75,8 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
-              description: TLS configuration
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
             authentication:
               type: object
               properties:
@@ -217,12 +217,12 @@ spec:
                   description: Username used for the authentication.
               required:
               - type
-              description: Authentication configuration for Kafka Connect
+              description: Authentication configuration for Kafka Connect.
             config:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
             resources:
               type: object
               properties:
@@ -291,15 +291,15 @@ spec:
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -317,7 +317,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -561,7 +561,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -574,7 +574,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -947,7 +947,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1105,7 +1105,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1114,7 +1114,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/041-Crd-kafkaconnect.yaml
@@ -45,12 +45,19 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
             image:
               type: string
+              description: The docker image for the pods.
             bootstrapServers:
               type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
             tls:
               type: object
               properties:
@@ -61,11 +68,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration
             authentication:
               type: object
               properties:
@@ -74,62 +85,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -137,13 +187,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -151,12 +206,23 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for Kafka Connect
             config:
               type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
             resources:
               type: object
               properties:
@@ -164,49 +230,80 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 -XX:
                   type: object
+                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -214,8 +311,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -424,6 +526,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -439,22 +542,30 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -462,8 +573,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             template:
               type: object
               properties:
@@ -475,8 +589,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -485,8 +607,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -494,6 +623,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -536,9 +667,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -747,10 +887,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -766,6 +911,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -774,8 +921,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -786,8 +941,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -796,11 +956,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -811,6 +988,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -823,6 +1003,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -832,9 +1013,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -860,8 +1048,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -882,10 +1074,17 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Connect cluster.
         status:
           type: object
           properties:
@@ -896,18 +1095,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -915,8 +1130,15 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
+          description: The status of the Kafka Connect cluster.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -45,8 +45,10 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             image:
               type: string
+              description: The docker image for the pods.
             buildResources:
               type: object
               properties:
@@ -54,49 +56,79 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 -XX:
                   type: object
+                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -104,8 +136,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -314,22 +351,30 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             template:
               type: object
               properties:
@@ -341,8 +386,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -351,8 +404,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -360,6 +420,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -402,9 +464,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -613,10 +684,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -632,6 +708,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -640,8 +718,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -652,8 +738,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -662,11 +753,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             authentication:
               type: object
               properties:
@@ -675,62 +783,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -738,13 +885,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -752,14 +904,27 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for Kafka Connect
             bootstrapServers:
               type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
             config:
               type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
             externalConfiguration:
               type: object
               properties:
@@ -770,6 +935,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -782,6 +950,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -791,9 +960,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -819,8 +995,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -841,10 +1021,19 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
             insecureSourceRepository:
               type: boolean
+              description: When true this configures the source repository with the
+                'Local' reference policy and an import policy that accepts insecure
+                source tags.
             resources:
               type: object
               properties:
@@ -852,6 +1041,8 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             tls:
               type: object
               properties:
@@ -862,11 +1053,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration
             tolerations:
               type: array
               items:
@@ -882,6 +1077,7 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             tracing:
               type: object
               properties:
@@ -889,12 +1085,20 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Connect Source-to-Image (S2I)
+            cluster.
         status:
           type: object
           properties:
@@ -905,18 +1109,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -924,10 +1144,18 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
             buildConfigName:
               type: string
+              description: The name of the build configuration
+          description: The status of the Kafka Connect Source-to-Image (S2I) cluster.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/042-Crd-kafkaconnects2i.yaml
@@ -116,15 +116,15 @@ spec:
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -142,7 +142,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -370,7 +370,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -744,7 +744,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -915,7 +915,7 @@ spec:
                   description: Username used for the authentication.
               required:
               - type
-              description: Authentication configuration for Kafka Connect
+              description: Authentication configuration for Kafka Connect.
             bootstrapServers:
               type: string
               description: Bootstrap servers to connect to. This should be given as
@@ -924,7 +924,7 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
             externalConfiguration:
               type: object
               properties:
@@ -1060,8 +1060,8 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
-              description: TLS configuration
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
             tolerations:
               type: array
               items:
@@ -1086,7 +1086,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -1119,7 +1119,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1128,7 +1128,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
@@ -1156,6 +1156,6 @@ spec:
                 deployment.
             buildConfigName:
               type: string
-              description: The name of the build configuration
+              description: The name of the build configuration.
           description: The status of the Kafka Connect Source-to-Image (S2I) cluster.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -91,7 +91,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -100,7 +100,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/043-Crd-kafkatopic.yaml
@@ -50,17 +50,27 @@ spec:
             partitions:
               type: integer
               minimum: 1
+              description: The number of partitions the topic should have. This cannot
+                be decreased after topic creation. It can be increased after topic
+                creation, but it is important to understand the consequences that
+                has, especially for topics with semantic partitioning.
             replicas:
               type: integer
               minimum: 1
               maximum: 32767
+              description: The number of replicas the topic should have.
             config:
               type: object
+              description: The topic configuration.
             topicName:
               type: string
+              description: The name of the topic. When absent this will default to
+                the metadata.name of the topic. It is recommended to not set this
+                unless the topic name is not a valid Kubernetes resource name.
           required:
           - partitions
           - replicas
+          description: The specification of the topic.
         status:
           type: object
           properties:
@@ -71,14 +81,29 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of the topic.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -189,7 +189,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -198,16 +198,16 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
                 operator.
             username:
               type: string
-              description: Username
+              description: Username.
             secret:
               type: string
-              description: The name of `Secret` where the credentials are stored
+              description: The name of `Secret` where the credentials are stored.
           description: The status of the Kafka User.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/044-Crd-kafkauser.yaml
@@ -55,8 +55,10 @@ spec:
                   enum:
                   - tls
                   - scram-sha-512
+                  description: Authentication type.
               required:
               - type
+              description: Authentication mechanism enabled for this Kafka user.
             authorization:
               type: object
               properties:
@@ -67,6 +69,8 @@ spec:
                     properties:
                       host:
                         type: string
+                        description: The host from which the action described in the
+                          ACL rule is allowed or denied.
                       operation:
                         type: string
                         enum:
@@ -81,16 +85,29 @@ spec:
                         - DescribeConfigs
                         - IdempotentWrite
                         - All
+                        description: 'Operation which will be allowed or denied. Supported
+                          operations are: Read, Write, Create, Delete, Alter, Describe,
+                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
+                          and All.'
                       resource:
                         type: object
                         properties:
                           name:
                             type: string
+                            description: Name of resource for which given ACL rule
+                              applies. Can be combined with `patternType` field to
+                              use prefix pattern.
                           patternType:
                             type: string
                             enum:
                             - literal
                             - prefix
+                            description: Describes the pattern used in the resource
+                              field. The supported types are `literal` and `prefix`.
+                              With `literal` pattern type, the resource field will
+                              be used as a definition of a full name. With `prefix`
+                              pattern type, the resource name will be used only as
+                              a prefix. Default value is `literal`.
                           type:
                             type: string
                             enum:
@@ -98,35 +115,60 @@ spec:
                             - group
                             - cluster
                             - transactionalId
+                            description: Resource type. The available resource types
+                              are `topic`, `group`, `cluster`, and `transactionalId`.
                         required:
                         - type
+                        description: Indicates the resource for which given ACL rule
+                          applies.
                       type:
                         type: string
                         enum:
                         - allow
                         - deny
+                        description: The type of the rule. Currently the only supported
+                          type is `allow`. ACL rules with type `allow` are used to
+                          allow user to execute the specified operations. Default
+                          value is `allow`.
                     required:
                     - operation
                     - resource
+                  description: List of ACL rules which should be applied to this user.
                 type:
                   type: string
                   enum:
                   - simple
+                  description: Authorization type. Currently the only supported type
+                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
+                    class for authorization.
               required:
               - acls
               - type
+              description: Authorization rules for this Kafka user.
             quotas:
               type: object
               properties:
                 consumerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can fetch from a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 producerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can publish to a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 requestPercentage:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum CPU utilization of each client
+                    group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used
+                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
+                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+          description: The specification of the user.
         status:
           type: object
           properties:
@@ -137,18 +179,35 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             username:
               type: string
+              description: Username
             secret:
               type: string
+              description: The name of `Secret` where the credentials are stored
+          description: The status of the Kafka User.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -56,22 +56,38 @@ spec:
             replicas:
               type: integer
               minimum: 1
+              description: The number of pods in the `Deployment`.
             image:
               type: string
+              description: The docker image for the pods.
             whitelist:
               type: string
+              description: List of topics which are included for mirroring. This option
+                allows any regular expression using Java-style regular expressions.
+                Mirroring two topics named A and B is achieved by using the whitelist
+                `'A|B'`. Or, as a special case, you can mirror all topics using the
+                whitelist '*'. You can also specify multiple regular expressions separated
+                by commas.
             consumer:
               type: object
               properties:
                 numStreams:
                   type: integer
                   minimum: 1
+                  description: Specifies the number of consumer stream threads to
+                    create.
                 offsetCommitInterval:
                   type: integer
+                  description: Specifies the offset auto-commit interval in ms. Default
+                    value is 60000.
                 groupId:
                   type: string
+                  description: A unique string that identifies the consumer group
+                    this consumer belongs to.
                 bootstrapServers:
                   type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
                 authentication:
                   type: object
                   properties:
@@ -80,62 +96,102 @@ spec:
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
                         certificate:
                           type: string
+                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
+                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the certificate.
                       required:
                       - certificate
                       - key
                       - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the password.
                       required:
                       - password
                       - secretName
+                      description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -143,13 +199,18 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
@@ -157,12 +218,24 @@ spec:
                       - scram-sha-512
                       - plain
                       - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
                     username:
                       type: string
+                      description: Username used for the authentication.
                   required:
                   - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
                 config:
                   type: object
+                  description: 'The MirrorMaker consumer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, group.id,
+                    sasl., security., interceptor.classes'
                 tls:
                   type: object
                   properties:
@@ -173,21 +246,31 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
               required:
               - groupId
               - bootstrapServers
+              description: Configuration of source cluster.
             producer:
               type: object
               properties:
                 bootstrapServers:
                   type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
                 abortOnSendFailure:
                   type: boolean
+                  description: Flag to set the MirrorMaker to exit on a failed send.
+                    Default value is `true`.
                 authentication:
                   type: object
                   properties:
@@ -196,62 +279,102 @@ spec:
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
                         certificate:
                           type: string
+                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
+                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the certificate.
                       required:
                       - certificate
                       - key
                       - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the password.
                       required:
                       - password
                       - secretName
+                      description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -259,13 +382,18 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
@@ -273,12 +401,24 @@ spec:
                       - scram-sha-512
                       - plain
                       - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
                     username:
                       type: string
+                      description: Username used for the authentication.
                   required:
                   - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
                 config:
                   type: object
+                  description: 'The MirrorMaker producer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
+                    security., interceptor.classes'
                 tls:
                   type: object
                   properties:
@@ -289,13 +429,19 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
               required:
               - bootstrapServers
+              description: Configuration of target cluster.
             resources:
               type: object
               properties:
@@ -303,6 +449,7 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             affinity:
               type: object
               properties:
@@ -511,6 +658,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -526,19 +674,25 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             jvmOptions:
               type: object
               properties:
                 -XX:
                   type: object
+                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -546,24 +700,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for MirrorMaker.
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See {JMXExporter}
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -571,8 +737,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka MirrorMaker.
             template:
               type: object
               properties:
@@ -584,8 +753,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -594,8 +771,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -603,6 +787,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -645,9 +831,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -856,10 +1051,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -875,6 +1075,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object
                   properties:
@@ -885,8 +1087,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for Kafka MirrorMaker container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -895,48 +1102,92 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
+              description: Template to specify how Kafka MirrorMaker resources, `Deployments`
+                and `Pods`, are generated.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             version:
               type: string
+              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}.
+                Consult the documentation to understand the process required to upgrade
+                or downgrade the version.
           required:
           - replicas
           - whitelist
           - consumer
           - producer
+          description: The specification of Kafka MirrorMaker.
         status:
           type: object
           properties:
@@ -947,14 +1198,29 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of Kafka MirrorMaker.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/045-Crd-kafkamirrormaker.yaml
@@ -65,7 +65,7 @@ spec:
               description: List of topics which are included for mirroring. This option
                 allows any regular expression using Java-style regular expressions.
                 Mirroring two topics named A and B is achieved by using the whitelist
-                `'A|B'`. Or, as a special case, you can mirror all topics using the
+                `'A\|B'`. Or, as a special case, you can mirror all topics using the
                 whitelist '*'. You can also specify multiple regular expressions separated
                 by commas.
             consumer:
@@ -235,7 +235,7 @@ spec:
                   type: object
                   description: 'The MirrorMaker consumer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes'
+                    sasl., security., interceptor.classes.'
                 tls:
                   type: object
                   properties:
@@ -253,7 +253,7 @@ spec:
                         required:
                         - certificate
                         - secretName
-                      description: Trusted certificates for TLS connection
+                      description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting MirrorMaker to the
                     cluster.
               required:
@@ -418,7 +418,7 @@ spec:
                   type: object
                   description: 'The MirrorMaker producer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes'
+                    security., interceptor.classes.'
                 tls:
                   type: object
                   properties:
@@ -436,7 +436,7 @@ spec:
                         required:
                         - certificate
                         - secretName
-                      description: Trusted certificates for TLS connection
+                      description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting MirrorMaker to the
                     cluster.
               required:
@@ -680,15 +680,15 @@ spec:
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -706,7 +706,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             logging:
               type: object
               properties:
@@ -738,7 +738,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka MirrorMaker.
@@ -1093,7 +1093,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for Kafka MirrorMaker container
+                  description: Template for Kafka MirrorMaker container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1208,7 +1208,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1217,7 +1217,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -48,10 +48,14 @@ spec:
             replicas:
               type: integer
               minimum: 0
+              description: The number of pods in the `Deployment`.
             image:
               type: string
+              description: The docker image for the pods.
             bootstrapServers:
               type: string
+              description: A list of host:port pairs for establishing the initial
+                connection to the Kafka cluster.
             tls:
               type: object
               properties:
@@ -62,11 +66,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
               type: object
               properties:
@@ -75,62 +83,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -138,13 +185,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -152,26 +204,45 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for connecting to the cluster.
             http:
               type: object
               properties:
                 port:
                   type: integer
                   minimum: 1023
+                  description: The port which is the server listening on.
+              description: The HTTP related configuration.
             consumer:
               type: object
               properties:
                 config:
                   type: object
+                  description: 'The Kafka consumer configuration used for consumer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
+                    security.'
+              description: Kafka consumer related configuration.
             producer:
               type: object
               properties:
                 config:
                   type: object
+                  description: 'The Kafka producer configuration used for producer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
+              description: Kafka producer related configuration
             resources:
               type: object
               properties:
@@ -179,19 +250,25 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             jvmOptions:
               type: object
               properties:
                 -XX:
                   type: object
+                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -199,54 +276,91 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: '**Currently not supported** JVM Options for pods'
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Bridge.
             metrics:
               type: object
+              description: '**Currently not supported** The Prometheus JMX Exporter
+                configuration. See {JMXExporter} for details of the structure of this
+                configuration.'
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             template:
               type: object
               properties:
@@ -258,8 +372,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Bridge `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -268,8 +390,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -277,6 +406,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -319,9 +450,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -530,10 +670,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -549,6 +694,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -557,8 +704,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Bridge API `Service`.
                 bridgeContainer:
                   type: object
                   properties:
@@ -569,8 +724,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Bridge container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -579,11 +739,27 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Bridge `PodDisruptionBudget`.
+              description: Template for Kafka Bridge resources. The template allows
+                users to specify how is the `Deployment` and `Pods` generated.
             tracing:
               type: object
               properties:
@@ -591,10 +767,14 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Bridge.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Bridge.
         status:
           type: object
           properties:
@@ -605,16 +785,33 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL at which external client applications can access
+                the Kafka Bridge.
+          description: The status of the Kafka Bridge.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/046-Crd-kafkabridge.yaml
@@ -73,7 +73,7 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
+                  description: Trusted certificates for TLS connection.
               description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
               type: object
@@ -242,7 +242,7 @@ spec:
                   description: 'The Kafka producer configuration used for producer
                     instances created by the bridge. Properties with the following
                     prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
-              description: Kafka producer related configuration
+              description: Kafka producer related configuration.
             resources:
               type: object
               properties:
@@ -256,15 +256,15 @@ spec:
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -282,7 +282,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: '**Currently not supported** JVM Options for pods'
+              description: '**Currently not supported** JVM Options for pods.'
             logging:
               type: object
               properties:
@@ -730,7 +730,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Bridge container
+                  description: Template for the Kafka Bridge container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -768,7 +768,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Bridge.
@@ -795,7 +795,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -804,7 +804,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -37,13 +37,19 @@ spec:
           properties:
             class:
               type: string
+              description: The Class for the Kafka Connector
             tasksMax:
               type: integer
               minimum: 1
+              description: The maximum number of tasks for the Kafka Connector
             config:
               type: object
+              description: 'The Kafka Connector configuration. The following properties
+                cannot be set: connector.class, tasks.max'
             pause:
               type: boolean
+              description: Whether the connector should be paused. Defaults to false.
+          description: The specification of the Kafka Connector.
         status:
           type: object
           properties:
@@ -54,16 +60,33 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             connectorStatus:
               type: object
+              description: The connector status, as reported by the Kafka Connect
+                REST API.
+          description: The status of the Kafka Connector.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/047-Crd-kafkaconnector.yaml
@@ -37,15 +37,15 @@ spec:
           properties:
             class:
               type: string
-              description: The Class for the Kafka Connector
+              description: The Class for the Kafka Connector.
             tasksMax:
               type: integer
               minimum: 1
-              description: The maximum number of tasks for the Kafka Connector
+              description: The maximum number of tasks for the Kafka Connector.
             config:
               type: object
               description: 'The Kafka Connector configuration. The following properties
-                cannot be set: connector.class, tasks.max'
+                cannot be set: connector.class, tasks.max.'
             pause:
               type: boolean
               description: Whether the connector should be paused. Defaults to false.
@@ -70,7 +70,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -79,7 +79,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -42,12 +42,19 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
             image:
               type: string
+              description: The docker image for the pods.
             connectCluster:
               type: string
+              description: The cluster alias used for Kafka Connect. The alias must
+                match a cluster in the list at `spec.clusters`.
             clusters:
               type: array
               items:
@@ -56,10 +63,17 @@ spec:
                   alias:
                     type: string
                     pattern: ^[a-zA-Z0-9\._\-]{1,100}$
+                    description: Alias used to reference the Kafka cluster.
                   bootstrapServers:
                     type: string
+                    description: A comma-separated list of `host:port` pairs for establishing
+                      the connection to the Kafka cluster.
                   config:
                     type: object
+                    description: 'The MirrorMaker 2.0 cluster config. Properties with
+                      the following prefixes cannot be set: ssl., sasl., security.,
+                      listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
+                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).'
                   tls:
                     type: object
                     properties:
@@ -70,11 +84,17 @@ spec:
                           properties:
                             certificate:
                               type: string
+                              description: The name of the file certificate in the
+                                Secret.
                             secretName:
                               type: string
+                              description: The name of the Secret containing the certificate.
                           required:
                           - certificate
                           - secretName
+                        description: Trusted certificates for TLS connection
+                    description: TLS configuration for connecting MirrorMaker 2.0
+                      connectors to a cluster.
                   authentication:
                     type: object
                     properties:
@@ -83,62 +103,102 @@ spec:
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the access
+                          token which was obtained from the authorization server.
                       accessTokenIsJwt:
                         type: boolean
+                        description: Configure whether access token should be treated
+                          as JWT. This should be set to `false` if the authorization
+                          server returns opaque tokens. Defaults to `true`.
                       certificateAndKey:
                         type: object
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           key:
                             type: string
+                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - key
                         - secretName
+                        description: Reference to the `Secret` which holds the certificate
+                          and private key pair.
                       clientId:
                         type: string
+                        description: OAuth Client ID which the Kafka client can use
+                          to authenticate against the OAuth server and use the token
+                          endpoint URI.
                       clientSecret:
                         type: object
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the OAuth
+                          client secret which the Kafka client can use to authenticate
+                          against the OAuth server and use the token endpoint URI.
                       disableTlsHostnameVerification:
                         type: boolean
+                        description: Enable or disable TLS hostname verification.
+                          Default value is `false`.
                       maxTokenExpirySeconds:
                         type: integer
+                        description: Set or limit time-to-live of the access tokens
+                          to the specified number of seconds. This should be set if
+                          the authorization server returns opaque tokens.
                       passwordSecret:
                         type: object
                         properties:
                           password:
                             type: string
+                            description: The name of the key in the Secret under which
+                              the password is stored.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the password.
                         required:
                         - password
                         - secretName
+                        description: Reference to the `Secret` which holds the password.
                       refreshToken:
                         type: object
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the refresh
+                          token which can be used to obtain access token from the
+                          authorization server.
                       tlsTrustedCertificates:
                         type: array
                         items:
@@ -146,13 +206,19 @@ spec:
                           properties:
                             certificate:
                               type: string
+                              description: The name of the file certificate in the
+                                Secret.
                             secretName:
                               type: string
+                              description: The name of the Secret containing the certificate.
                           required:
                           - certificate
                           - secretName
+                        description: Trusted certificates for TLS connection to the
+                          OAuth server.
                       tokenEndpointUri:
                         type: string
+                        description: Authorization server token endpoint URI.
                       type:
                         type: string
                         enum:
@@ -160,13 +226,23 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
+                        description: Authentication type. Currently the only supported
+                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                          Authentication. The `tls` type uses TLS Client Authentication.
+                          The `tls` type is supported only over TLS connections.
                       username:
                         type: string
+                        description: Username used for the authentication.
                     required:
                     - type
+                    description: Authentication configuration for connecting to the
+                      cluster.
                 required:
                 - alias
                 - bootstrapServers
+              description: Kafka clusters for mirroring.
             mirrors:
               type: array
               items:
@@ -174,49 +250,86 @@ spec:
                 properties:
                   sourceCluster:
                     type: string
+                    description: The alias of the source cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
                   targetCluster:
                     type: string
+                    description: The alias of the target cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
                   sourceConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 source
+                      connector.
                   checkpointConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint
+                      connector.
                   heartbeatConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat
+                      connector.
                   topicsPattern:
                     type: string
+                    description: A regular expression matching the topics to be mirrored,
+                      for example, "topic1|topic2|topic3". Comma-separated lists are
+                      also supported.
                   topicsBlacklistPattern:
                     type: string
+                    description: A regular expression matching the topics to exclude
+                      from mirroring. Comma-separated lists are also supported.
                   groupsPattern:
                     type: string
+                    description: A regular expression matching the consumer groups
+                      to be mirrored. Comma-separated lists are also supported.
                   groupsBlacklistPattern:
                     type: string
+                    description: A regular expression matching the consumer groups
+                      to exclude from mirroring. Comma-separated lists are also supported.
                 required:
                 - sourceCluster
                 - targetCluster
+              description: Configuration of the MirrorMaker 2.0 connectors.
             resources:
               type: object
               properties:
@@ -224,49 +337,80 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 -XX:
                   type: object
+                  description: A map of -XX options to the JVM
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -274,8 +418,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -484,6 +633,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -499,22 +649,30 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -522,8 +680,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             template:
               type: object
               properties:
@@ -535,8 +696,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -545,8 +714,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -554,6 +730,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -596,9 +774,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -807,10 +994,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -826,6 +1018,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -834,8 +1028,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -846,8 +1048,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -856,11 +1063,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -871,6 +1095,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -883,6 +1110,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -892,9 +1120,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -920,8 +1155,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -942,10 +1181,17 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
           required:
           - connectCluster
+          description: The specification of the Kafka MirrorMaker 2.0 cluster.
         status:
           type: object
           properties:
@@ -956,18 +1202,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -975,12 +1237,21 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
             connectors:
               type: array
               items:
                 type: object
+              description: List of MirrorMaker 2.0 connector statuses, as reported
+                by the Kafka Connect REST API.
+          description: The status of the Kafka MirrorMaker 2.0 cluster.
 {{- end -}}

--- a/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/048-Crd-kafkamirrormaker2.yaml
@@ -92,7 +92,7 @@ spec:
                           required:
                           - certificate
                           - secretName
-                        description: Trusted certificates for TLS connection
+                        description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker 2.0
                       connectors to a cluster.
                   authentication:
@@ -264,11 +264,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -281,11 +281,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -298,11 +298,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -312,8 +312,8 @@ spec:
                   topicsPattern:
                     type: string
                     description: A regular expression matching the topics to be mirrored,
-                      for example, "topic1|topic2|topic3". Comma-separated lists are
-                      also supported.
+                      for example, "topic1\|topic2\|topic3". Comma-separated lists
+                      are also supported.
                   topicsBlacklistPattern:
                     type: string
                     description: A regular expression matching the topics to exclude
@@ -398,15 +398,15 @@ spec:
               properties:
                 -XX:
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 -Xms:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 -Xmx:
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -424,7 +424,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -668,7 +668,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -681,7 +681,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -1054,7 +1054,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1212,7 +1212,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1221,7 +1221,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -67,7 +67,7 @@ spec:
                       type: integer
                       minimum: 0
                       description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'
+                        only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -79,7 +79,7 @@ spec:
                               allocation for this broker.
                           broker:
                             type: integer
-                            description: Id of the kafka broker (broker identifier)
+                            description: Id of the kafka broker (broker identifier).
                       description: Overrides for individual brokers. The `overrides`
                         field allows to specify a different configuration for different
                         brokers.
@@ -124,7 +124,7 @@ spec:
                             minimum: 0
                             description: Storage identification number. It is mandatory
                               only for storage volumes defined in a storage of type
-                              'jbod'
+                              'jbod'.
                           overrides:
                             type: array
                             items:
@@ -136,7 +136,7 @@ spec:
                                     volume allocation for this broker.
                                 broker:
                                   type: integer
-                                  description: Id of the kafka broker (broker identifier)
+                                  description: Id of the kafka broker (broker identifier).
                             description: Overrides for individual brokers. The `overrides`
                               field allows to specify a different configuration for
                               different brokers.
@@ -166,7 +166,7 @@ spec:
                         required:
                         - type
                       description: List of volumes as Storage objects representing
-                        the JBOD disks array
+                        the JBOD disks array.
                   required:
                   - type
                   description: Storage configuration (disk). Cannot be updated.
@@ -482,7 +482,7 @@ spec:
                               description: Reference to the `Secret` which holds the
                                 certificate and private key pair. The certificate
                                 can optionally contain the whole chain.
-                          description: Configuration of TLS listener
+                          description: Configuration of TLS listener.
                         networkPolicyPeers:
                           type: array
                           items:
@@ -652,7 +652,7 @@ spec:
                               description: URI of the token issuer used for authentication.
                           required:
                           - type
-                          description: Authentication configuration for Kafka brokers
+                          description: Authentication configuration for Kafka brokers.
                         class:
                           type: string
                           description: Configures the `Ingress` class that defines
@@ -680,7 +680,7 @@ spec:
                                     field will be used in the Ingress resource.
                               required:
                               - host
-                              description: External bootstrap ingress configuration
+                              description: External bootstrap ingress configuration.
                             brokers:
                               type: array
                               items:
@@ -688,15 +688,15 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
-                                    description: Id of the kafka broker (broker identifier)
+                                    description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
                                     description: The host name which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
                                     description: The port number which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   host:
                                     type: string
                                     description: Host for the broker ingress. This
@@ -709,7 +709,7 @@ spec:
                                       such as External DNS.
                                 required:
                                 - host
-                              description: External broker ingress configuration
+                              description: External broker ingress configuration.
                             brokerCertChainAndKey:
                               type: object
                               properties:
@@ -732,7 +732,7 @@ spec:
                               description: Reference to the `Secret` which holds the
                                 certificate and private key pair. The certificate
                                 can optionally contain the whole chain.
-                          description: External listener configuration
+                          description: External listener configuration.
                         networkPolicyPeers:
                           type: array
                           items:
@@ -808,8 +808,8 @@ spec:
                                     configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
-                                  description: Node port for the bootstrap service
-                              description: External bootstrap service configuration
+                                  description: Node port for the bootstrap service.
+                              description: External bootstrap service configuration.
                             brokers:
                               type: array
                               items:
@@ -817,27 +817,27 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
-                                    description: Id of the kafka broker (broker identifier)
+                                    description: Id of the kafka broker (broker identifier).
                                   advertisedHost:
                                     type: string
                                     description: The host name which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   advertisedPort:
                                     type: integer
                                     description: The port number which will be used
-                                      in the brokers' `advertised.brokers`
+                                      in the brokers' `advertised.brokers`.
                                   nodePort:
                                     type: integer
-                                    description: Node port for the broker service
+                                    description: Node port for the broker service.
                                   dnsAnnotations:
                                     type: object
                                     description: Annotations that will be added to
                                       the `Service` resources for individual brokers.
                                       You can use this field to configure DNS providers
                                       such as External DNS.
-                              description: External broker services configuration
+                              description: External broker services configuration.
                           description: Overrides for external bootstrap and broker
-                            services and externally advertised addresses
+                            services and externally advertised addresses.
                         tls:
                           type: boolean
                           description: Enables TLS encryption on the listener. By
@@ -854,11 +854,11 @@ spec:
                             \ \n\n* `route` type uses OpenShift Routes to expose Kafka.*\
                             \ `loadbalancer` type uses LoadBalancer type services\
                             \ to expose Kafka.* `nodeport` type uses NodePort type\
-                            \ services to expose Kafka."
+                            \ services to expose Kafka.."
                       required:
                       - type
                       description: Configures external listener on port 9094.
-                  description: Configures listeners of Kafka brokers
+                  description: Configures listeners of Kafka brokers.
                 authorization:
                   type: object
                   properties:
@@ -911,14 +911,14 @@ spec:
                         `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
                   required:
                   - type
-                  description: Authorization configuration for Kafka brokers
+                  description: Authorization configuration for Kafka brokers.
                 config:
                   type: object
                   description: 'The kafka broker config. Properties with the following
                     prefixes cannot be set: listeners, advertised., broker., listener.,
                     host.name, port, inter.broker.listener.name, sasl., ssl., security.,
                     password., principal.builder.class, log.dir, zookeeper.connect,
-                    zookeeper.set.acl, authorizer., super.user'
+                    zookeeper.set.acl, authorizer., super.user.'
                 rack:
                   type: object
                   properties:
@@ -1219,15 +1219,15 @@ spec:
                   properties:
                     "-XX":
                       type: object
-                      description: A map of -XX options to the JVM
+                      description: A map of -XX options to the JVM.
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xms option to to the JVM
+                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xmx option to to the JVM
+                      description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -1245,7 +1245,7 @@ spec:
                             description: The system property value.
                       description: A map of additional system properties which will
                         be passed using the `-D` option to the JVM.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 jmxOptions:
                   type: object
                   properties:
@@ -1262,8 +1262,8 @@ spec:
                       required:
                       - type
                       description: Authentication configuration for connecting to
-                        the Kafka JMX port
-                  description: JMX Options for Kafka brokers
+                        the Kafka JMX port.
+                  description: JMX Options for Kafka brokers.
                 resources:
                   type: object
                   properties:
@@ -1294,13 +1294,13 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration for Kafka
+                  description: Logging configuration for Kafka.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -1376,7 +1376,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -1794,7 +1794,7 @@ spec:
                             specified CIDR ranges. This field is applicable only for
                             loadbalancer type services and is ignored if the cloud
                             provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
@@ -1837,7 +1837,7 @@ spec:
                             specified CIDR ranges. This field is applicable only for
                             loadbalancer type services and is ignored if the cloud
                             provider does not support the feature. For more information,
-                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
                       description: Template for Kafka per-pod `Services` used for
                         access from outside of Kubernetes.
                     externalBootstrapRoute:
@@ -1982,7 +1982,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker container
+                      description: Template for the Kafka broker container.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -1999,7 +1999,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker TLS sidecar container
+                      description: Template for the Kafka broker TLS sidecar container.
                     initContainer:
                       type: object
                       properties:
@@ -2016,7 +2016,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka init container
+                      description: Template for the Kafka init container.
                   description: Template for Kafka cluster resources. The template
                     allows users to specify how are the `StatefulSet`, `Pods` and
                     `Services` generated.
@@ -2029,7 +2029,7 @@ spec:
               - replicas
               - storage
               - listeners
-              description: Configuration of the Kafka cluster
+              description: Configuration of the Kafka cluster.
             zookeeper:
               type: object
               properties:
@@ -2054,7 +2054,7 @@ spec:
                       type: integer
                       minimum: 0
                       description: Storage identification number. It is mandatory
-                        only for storage volumes defined in a storage of type 'jbod'
+                        only for storage volumes defined in a storage of type 'jbod'.
                     overrides:
                       type: array
                       items:
@@ -2066,7 +2066,7 @@ spec:
                               allocation for this broker.
                           broker:
                             type: integer
-                            description: Id of the kafka broker (broker identifier)
+                            description: Id of the kafka broker (broker identifier).
                       description: Overrides for individual brokers. The `overrides`
                         field allows to specify a different configuration for different
                         brokers.
@@ -2098,7 +2098,7 @@ spec:
                   type: object
                   description: 'The ZooKeeper broker config. Properties with the following
                     prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
-                    authProvider, quorum.auth, requireClientAuthScheme'
+                    authProvider, quorum.auth, requireClientAuthScheme.'
                 affinity:
                   type: object
                   properties:
@@ -2383,15 +2383,15 @@ spec:
                   properties:
                     "-XX":
                       type: object
-                      description: A map of -XX options to the JVM
+                      description: A map of -XX options to the JVM.
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xms option to to the JVM
+                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
-                      description: -Xmx option to to the JVM
+                      description: -Xmx option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
@@ -2409,7 +2409,7 @@ spec:
                             description: The system property value.
                       description: A map of additional system properties which will
                         be passed using the `-D` option to the JVM.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 resources:
                   type: object
                   properties:
@@ -2440,13 +2440,13 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration for ZooKeeper
+                  description: Logging configuration for ZooKeeper.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -2522,7 +2522,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -2963,7 +2963,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the ZooKeeper container
+                      description: Template for the ZooKeeper container.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -2980,14 +2980,14 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka broker TLS sidecar container
+                      description: Template for the Kafka broker TLS sidecar container.
                   description: Template for ZooKeeper cluster resources. The template
                     allows users to specify how are the `StatefulSet`, `Pods` and
                     `Services` generated.
               required:
               - replicas
               - storage
-              description: Configuration of the ZooKeeper cluster
+              description: Configuration of the ZooKeeper cluster.
             topicOperator:
               type: object
               properties:
@@ -2996,7 +2996,7 @@ spec:
                   description: The namespace the Topic Operator should watch.
                 image:
                   type: string
-                  description: The image to use for the Topic Operator
+                  description: The image to use for the Topic Operator.
                 reconciliationIntervalSeconds:
                   type: integer
                   minimum: 0
@@ -3004,7 +3004,7 @@ spec:
                 zookeeperSessionTimeoutSeconds:
                   type: integer
                   minimum: 0
-                  description: Timeout for the ZooKeeper session
+                  description: Timeout for the ZooKeeper session.
                 affinity:
                   type: object
                   properties:
@@ -3225,13 +3225,13 @@ spec:
                 topicMetadataMaxAttempts:
                   type: integer
                   minimum: 0
-                  description: The number of attempts at getting topic metadata
+                  description: The number of attempts at getting topic metadata.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -3307,7 +3307,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 logging:
                   type: object
                   properties:
@@ -3326,7 +3326,7 @@ spec:
                       description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
-                  description: Logging configuration
+                  description: Logging configuration.
                 jvmOptions:
                   type: object
                   properties:
@@ -3334,7 +3334,7 @@ spec:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging
                         is enabled. The default is false.
-                  description: JVM Options for pods
+                  description: JVM Options for pods.
                 livenessProbe:
                   type: object
                   properties:
@@ -3389,7 +3389,7 @@ spec:
                       minimum: 0
                       description: The timeout for each attempted health check.
                   description: Pod readiness checking.
-              description: Configuration of the Topic Operator
+              description: Configuration of the Topic Operator.
             entityOperator:
               type: object
               properties:
@@ -3401,7 +3401,7 @@ spec:
                       description: The namespace the Topic Operator should watch.
                     image:
                       type: string
-                      description: The image to use for the Topic Operator
+                      description: The image to use for the Topic Operator.
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
@@ -3409,7 +3409,7 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
-                      description: Timeout for the ZooKeeper session
+                      description: Timeout for the ZooKeeper session.
                     livenessProbe:
                       type: object
                       properties:
@@ -3475,7 +3475,7 @@ spec:
                     topicMetadataMaxAttempts:
                       type: integer
                       minimum: 0
-                      description: The number of attempts at getting topic metadata
+                      description: The number of attempts at getting topic metadata.
                     logging:
                       type: object
                       properties:
@@ -3494,7 +3494,7 @@ spec:
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
-                      description: Logging configuration
+                      description: Logging configuration.
                     jvmOptions:
                       type: object
                       properties:
@@ -3502,8 +3502,8 @@ spec:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
                             is enabled. The default is false.
-                      description: JVM Options for pods
-                  description: Configuration of the Topic Operator
+                      description: JVM Options for pods.
+                  description: Configuration of the Topic Operator.
                 userOperator:
                   type: object
                   properties:
@@ -3512,7 +3512,7 @@ spec:
                       description: The namespace the User Operator should watch.
                     image:
                       type: string
-                      description: The image to use for the User Operator
+                      description: The image to use for the User Operator.
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
@@ -3520,7 +3520,7 @@ spec:
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
-                      description: Timeout for the ZooKeeper session
+                      description: Timeout for the ZooKeeper session.
                     livenessProbe:
                       type: object
                       properties:
@@ -3601,7 +3601,7 @@ spec:
                           description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
-                      description: Logging configuration
+                      description: Logging configuration.
                     jvmOptions:
                       type: object
                       properties:
@@ -3609,8 +3609,8 @@ spec:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging
                             is enabled. The default is false.
-                      description: JVM Options for pods
-                  description: Configuration of the User Operator
+                      description: JVM Options for pods.
+                  description: Configuration of the User Operator.
                 affinity:
                   type: object
                   properties:
@@ -3841,7 +3841,7 @@ spec:
                   properties:
                     image:
                       type: string
-                      description: The docker image for the container
+                      description: The docker image for the container.
                     livenessProbe:
                       type: object
                       properties:
@@ -3917,7 +3917,7 @@ spec:
                         requests:
                           type: object
                       description: CPU and memory resources to reserve.
-                  description: TLS sidecar configuration
+                  description: TLS sidecar configuration.
                 template:
                   type: object
                   properties:
@@ -4272,7 +4272,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity Operator TLS sidecar container
+                      description: Template for the Entity Operator TLS sidecar container.
                     topicOperatorContainer:
                       type: object
                       properties:
@@ -4289,7 +4289,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity Topic Operator container
+                      description: Template for the Entity Topic Operator container.
                     userOperatorContainer:
                       type: object
                       properties:
@@ -4306,10 +4306,10 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Entity User Operator container
+                      description: Template for the Entity User Operator container.
                   description: Template for Entity Operator resources. The template
                     allows users to specify how is the `Deployment` and `Pods` generated.
-              description: Configuration of the Entity Operator
+              description: Configuration of the Entity Operator.
             clusterCa:
               type: object
               properties:
@@ -4341,7 +4341,7 @@ spec:
                   description: How should CA certificate expiration be handled when
                     `generateCertificateAuthority=true`. The default is for a new
                     CA certificate to be generated reusing the existing private key.
-              description: Configuration of the cluster certificate authority
+              description: Configuration of the cluster certificate authority.
             clientsCa:
               type: object
               properties:
@@ -4373,13 +4373,13 @@ spec:
                   description: How should CA certificate expiration be handled when
                     `generateCertificateAuthority=true`. The default is for a new
                     CA certificate to be generated reusing the existing private key.
-              description: Configuration of the clients certificate authority
+              description: Configuration of the clients certificate authority.
             jmxTrans:
               type: object
               properties:
                 image:
                   type: string
-                  description: The image to use for the JmxTrans
+                  description: The image to use for the JmxTrans.
                 outputDefinitions:
                   type: array
                   items:
@@ -4389,7 +4389,7 @@ spec:
                         type: string
                         description: Template for setting the format of the data that
                           will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
-                          OutputWriters]
+                          OutputWriters].
                       host:
                         type: string
                         description: The DNS/hostname of the remote host that the
@@ -4408,7 +4408,7 @@ spec:
                           type: string
                         description: Template for filtering data to be included in
                           response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
-                          queries]
+                          queries].
                       name:
                         type: string
                         description: Template for setting the name of the output definition.
@@ -4424,7 +4424,7 @@ spec:
                   type: string
                   description: Sets the logging level of the JmxTrans deployment.For
                     more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
-                    Logging Level]
+                    Logging Level].
                 kafkaQueries:
                   type: array
                   items:
@@ -4441,14 +4441,14 @@ spec:
                         items:
                           type: string
                         description: Determine which attributes of the targeted MBean
-                          should be included
+                          should be included.
                       outputs:
                         type: array
                         items:
                           type: string
                         description: List of the names of output definitions specified
                           in the spec.kafka.jmxTrans.outputDefinitions that have defined
-                          where JMX metrics are pushed to, and in which data format
+                          where JMX metrics are pushed to, and in which data format.
                     required:
                     - targetMBean
                     - attributes
@@ -4471,7 +4471,7 @@ spec:
               description: Configuration for JmxTrans. When the property is present
                 a JmxTrans deployment is created for gathering JMX metrics from each
                 Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
-                GitHub]
+                GitHub].
             kafkaExporter:
               type: object
               properties:
@@ -4876,7 +4876,7 @@ spec:
                                 description: The environment variable value.
                           description: Environment variables which should be applied
                             to the container.
-                      description: Template for the Kafka Exporter container
+                      description: Template for the Kafka Exporter container.
                   description: Customization of deployment templates and pods.
                 livenessProbe:
                   type: object
@@ -4965,7 +4965,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -4974,7 +4974,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
@@ -4996,10 +4996,10 @@ spec:
                         host:
                           type: string
                           description: The DNS name or IP address of Kafka bootstrap
-                            service
+                            service.
                         port:
                           type: integer
-                          description: The port of the Kafka bootstrap service
+                          description: The port of the Kafka bootstrap service.
                     description: A list of the addresses for this listener.
                   certificates:
                     type: array
@@ -5008,5 +5008,5 @@ spec:
                     description: A list of TLS certificates which can be used to verify
                       the identity of the server when connecting to the given listener.
                       Set only for `tls` and `external` listeners.
-              description: Addresses of the internal and external listeners
+              description: Addresses of the internal and external listeners.
           description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -48,18 +48,26 @@ spec:
                 replicas:
                   type: integer
                   minimum: 1
+                  description: The number of pods in the cluster.
                 image:
                   type: string
+                  description: The docker image for the pods. The default value depends
+                    on the configured `Kafka.spec.kafka.version`.
                 storage:
                   type: object
                   properties:
                     class:
                       type: string
+                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'
                     overrides:
                       type: array
                       items:
@@ -67,21 +75,37 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
                           broker:
                             type: integer
+                            description: Id of the kafka broker (broker identifier)
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
                     selector:
                       type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
                     size:
                       type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
                     type:
                       type: string
                       enum:
                       - ephemeral
                       - persistent-claim
                       - jbod
+                      description: Storage type, must be either 'ephemeral', 'persistent-claim',
+                        or 'jbod'.
                     volumes:
                       type: array
                       items:
@@ -89,11 +113,18 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation.
                           deleteClaim:
                             type: boolean
+                            description: Specifies if the persistent volume claim
+                              has to be deleted when the cluster is un-deployed.
                           id:
                             type: integer
                             minimum: 0
+                            description: Storage identification number. It is mandatory
+                              only for storage volumes defined in a storage of type
+                              'jbod'
                           overrides:
                             type: array
                             items:
@@ -101,24 +132,44 @@ spec:
                               properties:
                                 class:
                                   type: string
+                                  description: The storage class to use for dynamic
+                                    volume allocation for this broker.
                                 broker:
                                   type: integer
+                                  description: Id of the kafka broker (broker identifier)
+                            description: Overrides for individual brokers. The `overrides`
+                              field allows to specify a different configuration for
+                              different brokers.
                           selector:
                             type: object
+                            description: Specifies a specific persistent volume to
+                              use. It contains key:value pairs representing labels
+                              for selecting such a volume.
                           size:
                             type: string
+                            description: When type=persistent-claim, defines the size
+                              of the persistent volume claim (i.e 1Gi). Mandatory
+                              when type=persistent-claim.
                           sizeLimit:
                             type: string
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                            description: When type=ephemeral, defines the total amount
+                              of local storage required for this EmptyDir volume (for
+                              example 1Gi).
                           type:
                             type: string
                             enum:
                             - ephemeral
                             - persistent-claim
+                            description: Storage type, must be either 'ephemeral'
+                              or 'persistent-claim'.
                         required:
                         - type
+                      description: List of volumes as Storage objects representing
+                        the JBOD disks array
                   required:
                   - type
+                  description: Storage configuration (disk). Cannot be updated.
                 listeners:
                   type: object
                   properties:
@@ -130,34 +181,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -165,23 +252,41 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: 'Authentication configuration for this listener.
+                            Since this listener does not use TLS transport you cannot
+                            configure an authentication with `type: tls`.'
                         networkPolicyPeers:
                           type: array
                           items:
@@ -232,6 +337,14 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures plain listener on port 9092.
                     tls:
                       type: object
                       properties:
@@ -240,34 +353,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -275,23 +424,39 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: Authentication configuration for this listener.
                         configuration:
                           type: object
                           properties:
@@ -300,14 +465,24 @@ spec:
                               properties:
                                 certificate:
                                   type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
                                 key:
                                   type: string
+                                  description: The name of the private key in the
+                                    Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
                               required:
                               - certificate
                               - key
                               - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: Configuration of TLS listener
                         networkPolicyPeers:
                           type: array
                           items:
@@ -358,6 +533,14 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures TLS listener on port 9093.
                     external:
                       type: object
                       properties:
@@ -366,34 +549,70 @@ spec:
                           properties:
                             accessTokenIsJwt:
                               type: boolean
+                              description: Configure whether the access token should
+                                be treated as JWT. This should be set to `false` if
+                                the authorization server returns opaque tokens. Defaults
+                                to `true`.
                             checkAccessTokenType:
                               type: boolean
+                              description: Configure whether the access token type
+                                check should be performed or not. This should be set
+                                to `false` if the authorization server does not include
+                                'typ' claim in JWT token. Defaults to `true`.
                             clientId:
                               type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
                             clientSecret:
                               type: object
                               properties:
                                 key:
                                   type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
                               required:
                               - key
                               - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
                             disableTlsHostnameVerification:
                               type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
                             enableECDSA:
                               type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
                             introspectionEndpointUri:
                               type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
                             jwksEndpointUri:
                               type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
                             jwksExpirySeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
                             jwksRefreshSeconds:
                               type: integer
                               minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -401,25 +620,44 @@ spec:
                                 properties:
                                   certificate:
                                     type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
                                   secretName:
                                     type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
                                 required:
                                 - certificate
                                 - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
                             type:
                               type: string
                               enum:
                               - tls
                               - scram-sha-512
                               - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
                             userNameClaim:
                               type: string
+                              description: Name of the claim from the authentication
+                                token which will be used as the user principal. Defaults
+                                to `sub`.
                             validIssuerUri:
                               type: string
+                              description: URI of the token issuer used for authentication.
                           required:
                           - type
+                          description: Authentication configuration for Kafka brokers
                         class:
                           type: string
+                          description: Configures the `Ingress` class that defines
+                            which `Ingress` controller will be used. If not set, the
+                            `Ingress` class is set to `nginx`.
                         configuration:
                           type: object
                           properties:
@@ -428,12 +666,21 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
+                                  description: Annotations that will be added to the
+                                    `Ingress` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
                                 host:
                                   type: string
+                                  description: Host for the bootstrap route. This
+                                    field will be used in the Ingress resource.
                               required:
                               - host
+                              description: External bootstrap ingress configuration
                             brokers:
                               type: array
                               items:
@@ -441,29 +688,51 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
+                                    description: Id of the kafka broker (broker identifier)
                                   advertisedHost:
                                     type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`
                                   advertisedPort:
                                     type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`
                                   host:
                                     type: string
+                                    description: Host for the broker ingress. This
+                                      field will be used in the Ingress resource.
                                   dnsAnnotations:
                                     type: object
+                                    description: Annotations that will be added to
+                                      the `Ingress` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
                                 required:
                                 - host
+                              description: External broker ingress configuration
                             brokerCertChainAndKey:
                               type: object
                               properties:
                                 certificate:
                                   type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
                                 key:
                                   type: string
+                                  description: The name of the private key in the
+                                    Secret.
                                 secretName:
                                   type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
                               required:
                               - certificate
                               - key
                               - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: External listener configuration
                         networkPolicyPeers:
                           type: array
                           items:
@@ -514,6 +783,13 @@ spec:
                                             type: string
                                   matchLabels:
                                     type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
                         overrides:
                           type: object
                           properties:
@@ -522,10 +798,18 @@ spec:
                               properties:
                                 address:
                                   type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
                                 dnsAnnotations:
                                   type: object
+                                  description: Annotations that will be added to the
+                                    `Service` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
                                 nodePort:
                                   type: integer
+                                  description: Node port for the bootstrap service
+                              description: External bootstrap service configuration
                             brokers:
                               type: array
                               items:
@@ -533,16 +817,31 @@ spec:
                                 properties:
                                   broker:
                                     type: integer
+                                    description: Id of the kafka broker (broker identifier)
                                   advertisedHost:
                                     type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`
                                   advertisedPort:
                                     type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`
                                   nodePort:
                                     type: integer
+                                    description: Node port for the broker service
                                   dnsAnnotations:
                                     type: object
+                                    description: Annotations that will be added to
+                                      the `Service` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
+                              description: External broker services configuration
+                          description: Overrides for external bootstrap and broker
+                            services and externally advertised addresses
                         tls:
                           type: boolean
+                          description: Enables TLS encryption on the listener. By
+                            default set to `true` for enabled TLS encryption.
                         type:
                           type: string
                           enum:
@@ -550,21 +849,39 @@ spec:
                           - loadbalancer
                           - nodeport
                           - ingress
+                          description: "Type of the external listener. Currently the\
+                            \ supported types are `route`, `loadbalancer`, and `nodeport`.\
+                            \ \n\n* `route` type uses OpenShift Routes to expose Kafka.*\
+                            \ `loadbalancer` type uses LoadBalancer type services\
+                            \ to expose Kafka.* `nodeport` type uses NodePort type\
+                            \ services to expose Kafka."
                       required:
                       - type
+                      description: Configures external listener on port 9094.
+                  description: Configures listeners of Kafka brokers
                 authorization:
                   type: object
                   properties:
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     delegateToKafkaAcls:
                       type: boolean
+                      description: Whether authorization decision should be delegated
+                        to the 'Simple' authorizer if DENIED by Keycloak Authorization
+                        Services policies.Default value is `false`.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     superUsers:
                       type: array
                       items:
                         type: string
+                      description: List of super users. Should contain list of user
+                        principals which should get unlimited access rights.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -572,32 +889,52 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
                       - simple
                       - keycloak
+                      description: Authorization type. Currently the only supported
+                        type is `simple`. `simple` authorization type uses Kafka's
+                        `kafka.security.auth.SimpleAclAuthorizer` class for authorization.
                   required:
                   - type
+                  description: Authorization configuration for Kafka brokers
                 config:
                   type: object
+                  description: 'The kafka broker config. Properties with the following
+                    prefixes cannot be set: listeners, advertised., broker., listener.,
+                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
+                    password., principal.builder.class, log.dir, zookeeper.connect,
+                    zookeeper.set.acl, authorizer., super.user'
                 rack:
                   type: object
                   properties:
                     topologyKey:
                       type: string
                       example: failure-domain.beta.kubernetes.io/zone
+                      description: A key that matches labels assigned to the Kubernetes
+                        cluster nodes. The value of the label is used to set the broker's
+                        `broker.rack` config.
                   required:
                   - topologyKey
+                  description: Configuration of the `broker.rack` broker config.
                 brokerRackInitImage:
                   type: string
+                  description: The image of the init container used for initializing
+                    the `broker.rack`.
                 affinity:
                   type: object
                   properties:
@@ -806,6 +1143,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -821,49 +1159,79 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
                 jvmOptions:
                   type: object
                   properties:
                     "-XX":
                       type: object
+                      description: A map of -XX options to the JVM
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM
                     "-Xmx":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -871,8 +1239,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The system property name.
                           value:
                             type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods
                 jmxOptions:
                   type: object
                   properties:
@@ -883,8 +1256,14 @@ spec:
                           type: string
                           enum:
                           - password
+                          description: Authentication type. Currently the only supported
+                            types are `password`.`password` type creates a username
+                            and protected port with no TLS.
                       required:
                       - type
+                      description: Authentication configuration for connecting to
+                        the Kafka JMX port
+                  description: JMX Options for Kafka brokers
                 resources:
                   type: object
                   properties:
@@ -892,42 +1271,63 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 metrics:
                   type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration for Kafka
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -939,21 +1339,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -961,6 +1375,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -972,8 +1388,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka `StatefulSet`.
                     pod:
                       type: object
                       properties:
@@ -982,8 +1407,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -991,6 +1424,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1033,9 +1468,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -1244,10 +1688,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -1263,6 +1713,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka `Pods`.
                     bootstrapService:
                       type: object
                       properties:
@@ -1271,8 +1723,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka bootstrap `Service`.
                     brokersService:
                       type: object
                       properties:
@@ -1281,8 +1742,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka broker `Service`.
                     externalBootstrapService:
                       type: object
                       properties:
@@ -1291,17 +1761,41 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
                           - Local
                           - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                      description: Template for Kafka external bootstrap `Service`.
                     perPodService:
                       type: object
                       properties:
@@ -1310,17 +1804,42 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
                         externalTrafficPolicy:
                           type: string
                           enum:
                           - Local
                           - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
                         loadBalancerSourceRanges:
                           type: array
                           items:
                             type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+                      description: Template for Kafka per-pod `Services` used for
+                        access from outside of Kubernetes.
                     externalBootstrapRoute:
                       type: object
                       properties:
@@ -1329,8 +1848,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka external bootstrap `Route`.
                     perPodRoute:
                       type: object
                       properties:
@@ -1339,8 +1867,18 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka per-pod `Routes` used for access
+                        from outside of OpenShift.
                     externalBootstrapIngress:
                       type: object
                       properties:
@@ -1349,8 +1887,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka external bootstrap `Ingress`.
                     perPodIngress:
                       type: object
                       properties:
@@ -1359,8 +1906,18 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka per-pod `Ingress` used for access
+                        from outside of Kubernetes.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -1369,8 +1926,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for all Kafka `PersistentVolumeClaims`.
                     podDisruptionBudget:
                       type: object
                       properties:
@@ -1379,11 +1945,27 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for Kafka `PodDisruptionBudget`.
                     kafkaContainer:
                       type: object
                       properties:
@@ -1394,8 +1976,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker container
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -1406,8 +1993,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker TLS sidecar container
                     initContainer:
                       type: object
                       properties:
@@ -1418,32 +2010,51 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka init container
+                  description: Template for Kafka cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
                 version:
                   type: string
+                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}.
+                    Consult the user documentation to understand the process required
+                    to upgrade or downgrade the version.
               required:
               - replicas
               - storage
               - listeners
+              description: Configuration of the Kafka cluster
             zookeeper:
               type: object
               properties:
                 replicas:
                   type: integer
                   minimum: 1
+                  description: The number of pods in the cluster.
                 image:
                   type: string
+                  description: The docker image for the pods.
                 storage:
                   type: object
                   properties:
                     class:
                       type: string
+                      description: The storage class to use for dynamic volume allocation.
                     deleteClaim:
                       type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
                     id:
                       type: integer
                       minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'
                     overrides:
                       type: array
                       items:
@@ -1451,24 +2062,43 @@ spec:
                         properties:
                           class:
                             type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
                           broker:
                             type: integer
+                            description: Id of the kafka broker (broker identifier)
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
                     selector:
                       type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
                     size:
                       type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
                     sizeLimit:
                       type: string
                       pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
                     type:
                       type: string
                       enum:
                       - ephemeral
                       - persistent-claim
+                      description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
                   required:
                   - type
+                  description: Storage configuration (disk). Cannot be updated.
                 config:
                   type: object
+                  description: 'The ZooKeeper broker config. Properties with the following
+                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
+                    authProvider, quorum.auth, requireClientAuthScheme'
                 affinity:
                   type: object
                   properties:
@@ -1677,6 +2307,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -1692,49 +2323,79 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
                 jvmOptions:
                   type: object
                   properties:
                     "-XX":
                       type: object
+                      description: A map of -XX options to the JVM
                     "-Xms":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM
                     "-Xmx":
                       type: string
                       pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
                     javaSystemProperties:
                       type: array
                       items:
@@ -1742,8 +2403,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The system property name.
                           value:
                             type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods
                 resources:
                   type: object
                   properties:
@@ -1751,42 +2417,63 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 metrics:
                   type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration for ZooKeeper
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -1798,21 +2485,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -1820,6 +2521,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -1831,8 +2534,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper `StatefulSet`.
                     pod:
                       type: object
                       properties:
@@ -1841,8 +2553,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -1850,6 +2570,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -1892,9 +2614,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -2103,10 +2834,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -2122,6 +2859,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for ZooKeeper `Pods`.
                     clientService:
                       type: object
                       properties:
@@ -2130,8 +2869,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper client `Service`.
                     nodesService:
                       type: object
                       properties:
@@ -2140,8 +2888,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for ZooKeeper nodes `Service`.
                     persistentVolumeClaim:
                       type: object
                       properties:
@@ -2150,8 +2907,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for all ZooKeeper `PersistentVolumeClaims`.
                     podDisruptionBudget:
                       type: object
                       properties:
@@ -2160,11 +2926,27 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
                         maxUnavailable:
                           type: integer
                           minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for ZooKeeper `PodDisruptionBudget`.
                     zookeeperContainer:
                       type: object
                       properties:
@@ -2175,8 +2957,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the ZooKeeper container
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -2187,24 +2974,37 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka broker TLS sidecar container
+                  description: Template for ZooKeeper cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
               required:
               - replicas
               - storage
+              description: Configuration of the ZooKeeper cluster
             topicOperator:
               type: object
               properties:
                 watchedNamespace:
                   type: string
+                  description: The namespace the Topic Operator should watch.
                 image:
                   type: string
+                  description: The image to use for the Topic Operator
                 reconciliationIntervalSeconds:
                   type: integer
                   minimum: 0
+                  description: Interval between periodic reconciliations.
                 zookeeperSessionTimeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: Timeout for the ZooKeeper session
                 affinity:
                   type: object
                   properties:
@@ -2413,6 +3213,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: Pod affinity rules.
                 resources:
                   type: object
                   properties:
@@ -2420,29 +3221,44 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 topicMetadataMaxAttempts:
                   type: integer
                   minimum: 0
+                  description: The number of attempts at getting topic metadata
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -2454,21 +3270,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2476,55 +3306,90 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 logging:
                   type: object
                   properties:
                     loggers:
                       type: object
+                      description: A Map from logger name to logger level.
                     name:
                       type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
                     type:
                       type: string
                       enum:
                       - inline
                       - external
+                      description: Logging type, must be either 'inline' or 'external'.
                   required:
                   - type
+                  description: Logging configuration
                 jvmOptions:
                   type: object
                   properties:
                     gcLoggingEnabled:
                       type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                  description: JVM Options for pods
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
+              description: Configuration of the Topic Operator
             entityOperator:
               type: object
               properties:
@@ -2533,44 +3398,72 @@ spec:
                   properties:
                     watchedNamespace:
                       type: string
+                      description: The namespace the Topic Operator should watch.
                     image:
                       type: string
+                      description: The image to use for the Topic Operator
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
+                      description: Interval between periodic reconciliations.
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: Timeout for the ZooKeeper session
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2578,71 +3471,110 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
                     topicMetadataMaxAttempts:
                       type: integer
                       minimum: 0
+                      description: The number of attempts at getting topic metadata
                     logging:
                       type: object
                       properties:
                         loggers:
                           type: object
+                          description: A Map from logger name to logger level.
                         name:
                           type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
                         type:
                           type: string
                           enum:
                           - inline
                           - external
+                          description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
+                      description: Logging configuration
                     jvmOptions:
                       type: object
                       properties:
                         gcLoggingEnabled:
                           type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                      description: JVM Options for pods
+                  description: Configuration of the Topic Operator
                 userOperator:
                   type: object
                   properties:
                     watchedNamespace:
                       type: string
+                      description: The namespace the User Operator should watch.
                     image:
                       type: string
+                      description: The image to use for the User Operator
                     reconciliationIntervalSeconds:
                       type: integer
                       minimum: 0
+                      description: Interval between periodic reconciliations.
                     zookeeperSessionTimeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: Timeout for the ZooKeeper session
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2650,25 +3582,35 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
                     logging:
                       type: object
                       properties:
                         loggers:
                           type: object
+                          description: A Map from logger name to logger level.
                         name:
                           type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
                         type:
                           type: string
                           enum:
                           - inline
                           - external
+                          description: Logging type, must be either 'inline' or 'external'.
                       required:
                       - type
+                      description: Logging configuration
                     jvmOptions:
                       type: object
                       properties:
                         gcLoggingEnabled:
                           type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                      description: JVM Options for pods
+                  description: Configuration of the User Operator
                 affinity:
                   type: object
                   properties:
@@ -2877,6 +3819,7 @@ spec:
                                   type: string
                               topologyKey:
                                 type: string
+                  description: The pod's affinity rules.
                 tolerations:
                   type: array
                   items:
@@ -2892,26 +3835,40 @@ spec:
                         type: integer
                       value:
                         type: string
+                  description: The pod's tolerations.
                 tlsSidecar:
                   type: object
                   properties:
                     image:
                       type: string
+                      description: The docker image for the container
                     livenessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
                     logLevel:
                       type: string
                       enum:
@@ -2923,21 +3880,35 @@ spec:
                       - notice
                       - info
                       - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
                     readinessProbe:
                       type: object
                       properties:
                         failureThreshold:
                           type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
                         periodSeconds:
                           type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                         successThreshold:
                           type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
                         timeoutSeconds:
                           type: integer
                           minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
                     resources:
                       type: object
                       properties:
@@ -2945,6 +3916,8 @@ spec:
                           type: object
                         requests:
                           type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration
                 template:
                   type: object
                   properties:
@@ -2956,8 +3929,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Entity Operator `Deployment`.
                     pod:
                       type: object
                       properties:
@@ -2966,8 +3948,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -2975,6 +3965,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -3017,9 +4009,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3228,10 +4229,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -3247,6 +4254,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Entity Operator `Pods`.
                     tlsSidecarContainer:
                       type: object
                       properties:
@@ -3257,8 +4266,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity Operator TLS sidecar container
                     topicOperatorContainer:
                       type: object
                       properties:
@@ -3269,8 +4283,13 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity Topic Operator container
                     userOperatorContainer:
                       type: object
                       properties:
@@ -3281,45 +4300,86 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Entity User Operator container
+                  description: Template for Entity Operator resources. The template
+                    allows users to specify how is the `Deployment` and `Pods` generated.
+              description: Configuration of the Entity Operator
             clusterCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
                   - renew-certificate
                   - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the cluster certificate authority
             clientsCa:
               type: object
               properties:
                 generateCertificateAuthority:
                   type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
                 validityDays:
                   type: integer
                   minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
                 renewalDays:
                   type: integer
                   minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
                 certificateExpirationPolicy:
                   type: string
                   enum:
                   - renew-certificate
                   - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the clients certificate authority
             jmxTrans:
               type: object
               properties:
                 image:
                   type: string
+                  description: The image to use for the JmxTrans
                 outputDefinitions:
                   type: array
                   items:
@@ -3327,23 +4387,44 @@ spec:
                     properties:
                       outputType:
                         type: string
+                        description: Template for setting the format of the data that
+                          will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
+                          OutputWriters]
                       host:
                         type: string
+                        description: The DNS/hostname of the remote host that the
+                          data is pushed to.
                       port:
                         type: integer
+                        description: The port of the remote host that the data is
+                          pushed to.
                       flushDelayInSeconds:
                         type: integer
+                        description: How many seconds the JmxTrans waits before pushing
+                          a new set of data out.
                       typeNames:
                         type: array
                         items:
                           type: string
+                        description: Template for filtering data to be included in
+                          response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
+                          queries]
                       name:
                         type: string
+                        description: Template for setting the name of the output definition.
+                          This is used to identify where to send the results of queries
+                          should be sent.
                     required:
                     - outputType
                     - name
+                  description: Defines the output hosts that will be referenced later
+                    on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate`
+                    schema reference].
                 logLevel:
                   type: string
+                  description: Sets the logging level of the JmxTrans deployment.For
+                    more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
+                    Logging Level]
                 kafkaQueries:
                   type: array
                   items:
@@ -3351,18 +4432,31 @@ spec:
                     properties:
                       targetMBean:
                         type: string
+                        description: If using wildcards instead of a specific MBean
+                          then the data is gathered from multiple MBeans. Otherwise
+                          if specifying an MBean then data is gathered from that specified
+                          MBean.
                       attributes:
                         type: array
                         items:
                           type: string
+                        description: Determine which attributes of the targeted MBean
+                          should be included
                       outputs:
                         type: array
                         items:
                           type: string
+                        description: List of the names of output definitions specified
+                          in the spec.kafka.jmxTrans.outputDefinitions that have defined
+                          where JMX metrics are pushed to, and in which data format
                     required:
                     - targetMBean
                     - attributes
                     - outputs
+                  description: Queries to send to the Kafka brokers to define what
+                    data should be read from each broker. For more information on
+                    these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate`
+                    schema reference].
                 resources:
                   type: object
                   properties:
@@ -3370,18 +4464,28 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
               required:
               - outputDefinitions
               - kafkaQueries
+              description: Configuration for JmxTrans. When the property is present
+                a JmxTrans deployment is created for gathering JMX metrics from each
+                Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
+                GitHub]
             kafkaExporter:
               type: object
               properties:
                 image:
                   type: string
+                  description: The docker image for the pods.
                 groupRegex:
                   type: string
+                  description: Regular expression to specify which consumer groups
+                    to collect. Default value is `.*`.
                 topicRegex:
                   type: string
+                  description: Regular expression to specify which topics to collect.
+                    Default value is `.*`.
                 resources:
                   type: object
                   properties:
@@ -3389,10 +4493,16 @@ spec:
                       type: object
                     requests:
                       type: object
+                  description: CPU and memory resources to reserve.
                 logging:
                   type: string
+                  description: 'Only log messages with the given severity or above.
+                    Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
+                    log level is `info`.'
                 enableSaramaLogging:
                   type: boolean
+                  description: Enable Sarama logging, a Go client library used by
+                    the Kafka Exporter.
                 template:
                   type: object
                   properties:
@@ -3404,8 +4514,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka Exporter `Deployment`.
                     pod:
                       type: object
                       properties:
@@ -3414,8 +4533,16 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata applied to the resource.
                         imagePullSecrets:
                           type: array
                           items:
@@ -3423,6 +4550,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
                         securityContext:
                           type: object
                           properties:
@@ -3465,9 +4594,18 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
                         terminationGracePeriodSeconds:
                           type: integer
                           minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal and the time when the processes are forcibly halted
+                            with a kill signal. Set this value longer than the expected
+                            cleanup time for your process.Value must be non-negative
+                            integer. The value zero indicates delete immediately.
+                            Defaults to 30 seconds.
                         affinity:
                           type: object
                           properties:
@@ -3676,10 +4814,16 @@ spec:
                                           type: string
                                       topologyKey:
                                         type: string
+                          description: The pod's affinity rules.
                         priorityClassName:
                           type: string
+                          description: The name of the Priority Class to which these
+                            pods will be assigned.
                         schedulerName:
                           type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
                         tolerations:
                           type: array
                           items:
@@ -3695,6 +4839,8 @@ spec:
                                 type: integer
                               value:
                                 type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka Exporter `Pods`.
                     service:
                       type: object
                       properties:
@@ -3703,8 +4849,17 @@ spec:
                           properties:
                             labels:
                               type: object
+                              description: Labels which should be added to the resource
+                                template. Can be applied to different resources such
+                                as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               type: object
+                              description: Annotations which should be added to the
+                                resource template. Can be applied to different resources
+                                such as `StatefulSets`, `Deployments`, `Pods`, and
+                                `Services`.
+                          description: Metadata which should be applied to the resource.
+                      description: Template for Kafka Exporter `Service`.
                     container:
                       type: object
                       properties:
@@ -3715,45 +4870,81 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: The environment variable key.
                               value:
                                 type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                      description: Template for the Kafka Exporter container
+                  description: Customization of deployment templates and pods.
                 livenessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness check.
                 readinessProbe:
                   type: object
                   properties:
                     failureThreshold:
                       type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
                     periodSeconds:
                       type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
                     successThreshold:
                       type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
                     timeoutSeconds:
                       type: integer
                       minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness check.
+              description: Configuration of the Kafka Exporter. Kafka Exporter can
+                provide additional metrics, for example lag of consumer group at topic/partition.
             maintenanceTimeWindows:
               type: array
               items:
                 type: string
+              description: A list of time windows for maintenance tasks (that is,
+                certificates renewal). Each time window is defined by a cron expression.
           required:
           - kafka
           - zookeeper
+          description: The specification of the Kafka and ZooKeeper clusters, and
+            Topic Operator.
         status:
           type: object
           properties:
@@ -3764,16 +4955,30 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             listeners:
               type: array
               items:
@@ -3781,6 +4986,8 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: 'The type of the listener. Can be one of the following
+                      three types: `plain`, `tls`, and `external`.'
                   addresses:
                     type: array
                     items:
@@ -3788,9 +4995,18 @@ spec:
                       properties:
                         host:
                           type: string
+                          description: The DNS name or IP address of Kafka bootstrap
+                            service
                         port:
                           type: integer
+                          description: The port of the Kafka bootstrap service
+                    description: A list of the addresses for this listener.
                   certificates:
                     type: array
                     items:
                       type: string
+                    description: A list of TLS certificates which can be used to verify
+                      the identity of the server when connecting to the given listener.
+                      Set only for `tls` and `external` listeners.
+              description: Addresses of the internal and external listeners
+          description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -40,12 +40,19 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
             image:
               type: string
+              description: The docker image for the pods.
             bootstrapServers:
               type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
             tls:
               type: object
               properties:
@@ -56,11 +63,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration
             authentication:
               type: object
               properties:
@@ -69,62 +80,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -132,13 +182,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -146,12 +201,23 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for Kafka Connect
             config:
               type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
             resources:
               type: object
               properties:
@@ -159,49 +225,80 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 "-XX":
                   type: object
+                  description: A map of -XX options to the JVM
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -209,8 +306,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -419,6 +521,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -434,22 +537,30 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -457,8 +568,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             template:
               type: object
               properties:
@@ -470,8 +584,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -480,8 +602,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -489,6 +618,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -531,9 +662,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -742,10 +882,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -761,6 +906,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -769,8 +916,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -781,8 +936,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -791,11 +951,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -806,6 +983,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -818,6 +998,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -827,9 +1008,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -855,8 +1043,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -877,10 +1069,17 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Connect cluster.
         status:
           type: object
           properties:
@@ -891,18 +1090,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -910,7 +1125,14 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
+          description: The status of the Kafka Connect cluster.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -70,8 +70,8 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
-              description: TLS configuration
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
             authentication:
               type: object
               properties:
@@ -212,12 +212,12 @@ spec:
                   description: Username used for the authentication.
               required:
               - type
-              description: Authentication configuration for Kafka Connect
+              description: Authentication configuration for Kafka Connect.
             config:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
             resources:
               type: object
               properties:
@@ -286,15 +286,15 @@ spec:
               properties:
                 "-XX":
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -312,7 +312,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -556,7 +556,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -569,7 +569,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -942,7 +942,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1100,7 +1100,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1109,7 +1109,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -111,15 +111,15 @@ spec:
               properties:
                 "-XX":
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -137,7 +137,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -365,7 +365,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -739,7 +739,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -910,7 +910,7 @@ spec:
                   description: Username used for the authentication.
               required:
               - type
-              description: Authentication configuration for Kafka Connect
+              description: Authentication configuration for Kafka Connect.
             bootstrapServers:
               type: string
               description: Bootstrap servers to connect to. This should be given as
@@ -919,7 +919,7 @@ spec:
               type: object
               description: 'The Kafka Connect configuration. Properties with the following
                 prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
-                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes.'
             externalConfiguration:
               type: object
               properties:
@@ -1055,8 +1055,8 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
-              description: TLS configuration
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
             tolerations:
               type: array
               items:
@@ -1081,7 +1081,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -1114,7 +1114,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1123,7 +1123,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
@@ -1151,5 +1151,5 @@ spec:
                 deployment.
             buildConfigName:
               type: string
-              description: The name of the build configuration
+              description: The name of the build configuration.
           description: The status of the Kafka Connect Source-to-Image (S2I) cluster.

--- a/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -40,8 +40,10 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             image:
               type: string
+              description: The docker image for the pods.
             buildResources:
               type: object
               properties:
@@ -49,49 +51,79 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 "-XX":
                   type: object
+                  description: A map of -XX options to the JVM
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -99,8 +131,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -309,22 +346,30 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             template:
               type: object
               properties:
@@ -336,8 +381,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -346,8 +399,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -355,6 +415,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -397,9 +459,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -608,10 +679,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -627,6 +703,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -635,8 +713,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -647,8 +733,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -657,11 +748,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             authentication:
               type: object
               properties:
@@ -670,62 +778,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -733,13 +880,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -747,14 +899,27 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for Kafka Connect
             bootstrapServers:
               type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
             config:
               type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes'
             externalConfiguration:
               type: object
               properties:
@@ -765,6 +930,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -777,6 +945,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -786,9 +955,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -814,8 +990,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -836,10 +1016,19 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
             insecureSourceRepository:
               type: boolean
+              description: When true this configures the source repository with the
+                'Local' reference policy and an import policy that accepts insecure
+                source tags.
             resources:
               type: object
               properties:
@@ -847,6 +1036,8 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             tls:
               type: object
               properties:
@@ -857,11 +1048,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration
             tolerations:
               type: array
               items:
@@ -877,6 +1072,7 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             tracing:
               type: object
               properties:
@@ -884,12 +1080,20 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Connect Source-to-Image (S2I)
+            cluster.
         status:
           type: object
           properties:
@@ -900,18 +1104,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -919,9 +1139,17 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
             buildConfigName:
               type: string
+              description: The name of the build configuration
+          description: The status of the Kafka Connect Source-to-Image (S2I) cluster.

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -45,17 +45,27 @@ spec:
             partitions:
               type: integer
               minimum: 1
+              description: The number of partitions the topic should have. This cannot
+                be decreased after topic creation. It can be increased after topic
+                creation, but it is important to understand the consequences that
+                has, especially for topics with semantic partitioning.
             replicas:
               type: integer
               minimum: 1
               maximum: 32767
+              description: The number of replicas the topic should have.
             config:
               type: object
+              description: The topic configuration.
             topicName:
               type: string
+              description: The name of the topic. When absent this will default to
+                the metadata.name of the topic. It is recommended to not set this
+                unless the topic name is not a valid Kubernetes resource name.
           required:
           - partitions
           - replicas
+          description: The specification of the topic.
         status:
           type: object
           properties:
@@ -66,13 +76,28 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of the topic.

--- a/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -86,7 +86,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -95,7 +95,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -184,7 +184,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -193,15 +193,15 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
                 operator.
             username:
               type: string
-              description: Username
+              description: Username.
             secret:
               type: string
-              description: The name of `Secret` where the credentials are stored
+              description: The name of `Secret` where the credentials are stored.
           description: The status of the Kafka User.

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -50,8 +50,10 @@ spec:
                   enum:
                   - tls
                   - scram-sha-512
+                  description: Authentication type.
               required:
               - type
+              description: Authentication mechanism enabled for this Kafka user.
             authorization:
               type: object
               properties:
@@ -62,6 +64,8 @@ spec:
                     properties:
                       host:
                         type: string
+                        description: The host from which the action described in the
+                          ACL rule is allowed or denied.
                       operation:
                         type: string
                         enum:
@@ -76,16 +80,29 @@ spec:
                         - DescribeConfigs
                         - IdempotentWrite
                         - All
+                        description: 'Operation which will be allowed or denied. Supported
+                          operations are: Read, Write, Create, Delete, Alter, Describe,
+                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
+                          and All.'
                       resource:
                         type: object
                         properties:
                           name:
                             type: string
+                            description: Name of resource for which given ACL rule
+                              applies. Can be combined with `patternType` field to
+                              use prefix pattern.
                           patternType:
                             type: string
                             enum:
                             - literal
                             - prefix
+                            description: Describes the pattern used in the resource
+                              field. The supported types are `literal` and `prefix`.
+                              With `literal` pattern type, the resource field will
+                              be used as a definition of a full name. With `prefix`
+                              pattern type, the resource name will be used only as
+                              a prefix. Default value is `literal`.
                           type:
                             type: string
                             enum:
@@ -93,35 +110,60 @@ spec:
                             - group
                             - cluster
                             - transactionalId
+                            description: Resource type. The available resource types
+                              are `topic`, `group`, `cluster`, and `transactionalId`.
                         required:
                         - type
+                        description: Indicates the resource for which given ACL rule
+                          applies.
                       type:
                         type: string
                         enum:
                         - allow
                         - deny
+                        description: The type of the rule. Currently the only supported
+                          type is `allow`. ACL rules with type `allow` are used to
+                          allow user to execute the specified operations. Default
+                          value is `allow`.
                     required:
                     - operation
                     - resource
+                  description: List of ACL rules which should be applied to this user.
                 type:
                   type: string
                   enum:
                   - simple
+                  description: Authorization type. Currently the only supported type
+                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
+                    class for authorization.
               required:
               - acls
               - type
+              description: Authorization rules for this Kafka user.
             quotas:
               type: object
               properties:
                 consumerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can fetch from a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 producerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can publish to a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 requestPercentage:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum CPU utilization of each client
+                    group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used
+                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
+                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+          description: The specification of the user.
         status:
           type: object
           properties:
@@ -132,17 +174,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             username:
               type: string
+              description: Username
             secret:
               type: string
+              description: The name of `Secret` where the credentials are stored
+          description: The status of the Kafka User.

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -60,7 +60,7 @@ spec:
               description: List of topics which are included for mirroring. This option
                 allows any regular expression using Java-style regular expressions.
                 Mirroring two topics named A and B is achieved by using the whitelist
-                `'A|B'`. Or, as a special case, you can mirror all topics using the
+                `'A\|B'`. Or, as a special case, you can mirror all topics using the
                 whitelist '*'. You can also specify multiple regular expressions separated
                 by commas.
             consumer:
@@ -230,7 +230,7 @@ spec:
                   type: object
                   description: 'The MirrorMaker consumer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, group.id,
-                    sasl., security., interceptor.classes'
+                    sasl., security., interceptor.classes.'
                 tls:
                   type: object
                   properties:
@@ -248,7 +248,7 @@ spec:
                         required:
                         - certificate
                         - secretName
-                      description: Trusted certificates for TLS connection
+                      description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting MirrorMaker to the
                     cluster.
               required:
@@ -413,7 +413,7 @@ spec:
                   type: object
                   description: 'The MirrorMaker producer config. Properties with the
                     following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
-                    security., interceptor.classes'
+                    security., interceptor.classes.'
                 tls:
                   type: object
                   properties:
@@ -431,7 +431,7 @@ spec:
                         required:
                         - certificate
                         - secretName
-                      description: Trusted certificates for TLS connection
+                      description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting MirrorMaker to the
                     cluster.
               required:
@@ -675,15 +675,15 @@ spec:
               properties:
                 "-XX":
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -701,7 +701,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             logging:
               type: object
               properties:
@@ -733,7 +733,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka MirrorMaker.
@@ -1088,7 +1088,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for Kafka MirrorMaker container
+                  description: Template for Kafka MirrorMaker container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1203,7 +1203,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1212,7 +1212,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -51,22 +51,38 @@ spec:
             replicas:
               type: integer
               minimum: 1
+              description: The number of pods in the `Deployment`.
             image:
               type: string
+              description: The docker image for the pods.
             whitelist:
               type: string
+              description: List of topics which are included for mirroring. This option
+                allows any regular expression using Java-style regular expressions.
+                Mirroring two topics named A and B is achieved by using the whitelist
+                `'A|B'`. Or, as a special case, you can mirror all topics using the
+                whitelist '*'. You can also specify multiple regular expressions separated
+                by commas.
             consumer:
               type: object
               properties:
                 numStreams:
                   type: integer
                   minimum: 1
+                  description: Specifies the number of consumer stream threads to
+                    create.
                 offsetCommitInterval:
                   type: integer
+                  description: Specifies the offset auto-commit interval in ms. Default
+                    value is 60000.
                 groupId:
                   type: string
+                  description: A unique string that identifies the consumer group
+                    this consumer belongs to.
                 bootstrapServers:
                   type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
                 authentication:
                   type: object
                   properties:
@@ -75,62 +91,102 @@ spec:
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
                         certificate:
                           type: string
+                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
+                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the certificate.
                       required:
                       - certificate
                       - key
                       - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the password.
                       required:
                       - password
                       - secretName
+                      description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -138,13 +194,18 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
@@ -152,12 +213,24 @@ spec:
                       - scram-sha-512
                       - plain
                       - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
                     username:
                       type: string
+                      description: Username used for the authentication.
                   required:
                   - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
                 config:
                   type: object
+                  description: 'The MirrorMaker consumer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, group.id,
+                    sasl., security., interceptor.classes'
                 tls:
                   type: object
                   properties:
@@ -168,21 +241,31 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
               required:
               - groupId
               - bootstrapServers
+              description: Configuration of source cluster.
             producer:
               type: object
               properties:
                 bootstrapServers:
                   type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
                 abortOnSendFailure:
                   type: boolean
+                  description: Flag to set the MirrorMaker to exit on a failed send.
+                    Default value is `true`.
                 authentication:
                   type: object
                   properties:
@@ -191,62 +274,102 @@ spec:
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
                     accessTokenIsJwt:
                       type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
                     certificateAndKey:
                       type: object
                       properties:
                         certificate:
                           type: string
+                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
+                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the certificate.
                       required:
                       - certificate
                       - key
                       - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
                     clientId:
                       type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
                     clientSecret:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
                     disableTlsHostnameVerification:
                       type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
                     maxTokenExpirySeconds:
                       type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
                     passwordSecret:
                       type: object
                       properties:
                         password:
                           type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
                         secretName:
                           type: string
+                          description: The name of the Secret containing the password.
                       required:
                       - password
                       - secretName
+                      description: Reference to the `Secret` which holds the password.
                     refreshToken:
                       type: object
                       properties:
                         key:
                           type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
                         secretName:
                           type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
                       required:
                       - key
                       - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
                     tlsTrustedCertificates:
                       type: array
                       items:
@@ -254,13 +377,18 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
                     tokenEndpointUri:
                       type: string
+                      description: Authorization server token endpoint URI.
                     type:
                       type: string
                       enum:
@@ -268,12 +396,24 @@ spec:
                       - scram-sha-512
                       - plain
                       - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
                     username:
                       type: string
+                      description: Username used for the authentication.
                   required:
                   - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
                 config:
                   type: object
+                  description: 'The MirrorMaker producer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
+                    security., interceptor.classes'
                 tls:
                   type: object
                   properties:
@@ -284,13 +424,19 @@ spec:
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - secretName
+                      description: Trusted certificates for TLS connection
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
               required:
               - bootstrapServers
+              description: Configuration of target cluster.
             resources:
               type: object
               properties:
@@ -298,6 +444,7 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             affinity:
               type: object
               properties:
@@ -506,6 +653,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -521,19 +669,25 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             jvmOptions:
               type: object
               properties:
                 "-XX":
                   type: object
+                  description: A map of -XX options to the JVM
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -541,24 +695,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for MirrorMaker.
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See {JMXExporter}
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -566,8 +732,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka MirrorMaker.
             template:
               type: object
               properties:
@@ -579,8 +748,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka MirrorMaker `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -589,8 +766,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -598,6 +782,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -640,9 +826,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -851,10 +1046,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -870,6 +1070,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka MirrorMaker `Pods`.
                 mirrorMakerContainer:
                   type: object
                   properties:
@@ -880,8 +1082,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for Kafka MirrorMaker container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -890,48 +1097,92 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
+              description: Template to specify how Kafka MirrorMaker resources, `Deployments`
+                and `Pods`, are generated.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             version:
               type: string
+              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}.
+                Consult the documentation to understand the process required to upgrade
+                or downgrade the version.
           required:
           - replicas
           - whitelist
           - consumer
           - producer
+          description: The specification of Kafka MirrorMaker.
         status:
           type: object
           properties:
@@ -942,13 +1193,28 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of Kafka MirrorMaker.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -43,10 +43,14 @@ spec:
             replicas:
               type: integer
               minimum: 0
+              description: The number of pods in the `Deployment`.
             image:
               type: string
+              description: The docker image for the pods.
             bootstrapServers:
               type: string
+              description: A list of host:port pairs for establishing the initial
+                connection to the Kafka cluster.
             tls:
               type: object
               properties:
@@ -57,11 +61,15 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection
+              description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
               type: object
               properties:
@@ -70,62 +78,101 @@ spec:
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
                 accessTokenIsJwt:
                   type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
                 certificateAndKey:
                   type: object
                   properties:
                     certificate:
                       type: string
+                      description: The name of the file certificate in the Secret.
                     key:
                       type: string
+                      description: The name of the private key in the Secret.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the certificate.
                   required:
                   - certificate
                   - key
                   - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
                 clientId:
                   type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
                 clientSecret:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
                 disableTlsHostnameVerification:
                   type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
                 maxTokenExpirySeconds:
                   type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
                 passwordSecret:
                   type: object
                   properties:
                     password:
                       type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
                     secretName:
                       type: string
+                      description: The name of the Secret containing the password.
                   required:
                   - password
                   - secretName
+                  description: Reference to the `Secret` which holds the password.
                 refreshToken:
                   type: object
                   properties:
                     key:
                       type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
                     secretName:
                       type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
                   required:
                   - key
                   - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
                 tlsTrustedCertificates:
                   type: array
                   items:
@@ -133,13 +180,18 @@ spec:
                     properties:
                       certificate:
                         type: string
+                        description: The name of the file certificate in the Secret.
                       secretName:
                         type: string
+                        description: The name of the Secret containing the certificate.
                     required:
                     - certificate
                     - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
                 tokenEndpointUri:
                   type: string
+                  description: Authorization server token endpoint URI.
                 type:
                   type: string
                   enum:
@@ -147,26 +199,45 @@ spec:
                   - scram-sha-512
                   - plain
                   - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
                 username:
                   type: string
+                  description: Username used for the authentication.
               required:
               - type
+              description: Authentication configuration for connecting to the cluster.
             http:
               type: object
               properties:
                 port:
                   type: integer
                   minimum: 1023
+                  description: The port which is the server listening on.
+              description: The HTTP related configuration.
             consumer:
               type: object
               properties:
                 config:
                   type: object
+                  description: 'The Kafka consumer configuration used for consumer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
+                    security.'
+              description: Kafka consumer related configuration.
             producer:
               type: object
               properties:
                 config:
                   type: object
+                  description: 'The Kafka producer configuration used for producer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
+              description: Kafka producer related configuration
             resources:
               type: object
               properties:
@@ -174,19 +245,25 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: CPU and memory resources to reserve.
             jvmOptions:
               type: object
               properties:
                 "-XX":
                   type: object
+                  description: A map of -XX options to the JVM
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -194,54 +271,91 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: '**Currently not supported** JVM Options for pods'
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Bridge.
             metrics:
               type: object
+              description: '**Currently not supported** The Prometheus JMX Exporter
+                configuration. See {JMXExporter} for details of the structure of this
+                configuration.'
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             template:
               type: object
               properties:
@@ -253,8 +367,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Bridge `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -263,8 +385,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -272,6 +401,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -314,9 +445,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -525,10 +665,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -544,6 +689,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Bridge `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -552,8 +699,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Bridge API `Service`.
                 bridgeContainer:
                   type: object
                   properties:
@@ -564,8 +719,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Bridge container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -574,11 +734,27 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Bridge `PodDisruptionBudget`.
+              description: Template for Kafka Bridge resources. The template allows
+                users to specify how is the `Deployment` and `Pods` generated.
             tracing:
               type: object
               properties:
@@ -586,10 +762,14 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Bridge.
           required:
           - bootstrapServers
+          description: The specification of the Kafka Bridge.
         status:
           type: object
           properties:
@@ -600,15 +780,32 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL at which external client applications can access
+                the Kafka Bridge.
+          description: The status of the Kafka Bridge.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -68,7 +68,7 @@ spec:
                     required:
                     - certificate
                     - secretName
-                  description: Trusted certificates for TLS connection
+                  description: Trusted certificates for TLS connection.
               description: TLS configuration for connecting Kafka Bridge to the cluster.
             authentication:
               type: object
@@ -237,7 +237,7 @@ spec:
                   description: 'The Kafka producer configuration used for producer
                     instances created by the bridge. Properties with the following
                     prefixes cannot be set: ssl., bootstrap.servers, sasl., security.'
-              description: Kafka producer related configuration
+              description: Kafka producer related configuration.
             resources:
               type: object
               properties:
@@ -251,15 +251,15 @@ spec:
               properties:
                 "-XX":
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -277,7 +277,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: '**Currently not supported** JVM Options for pods'
+              description: '**Currently not supported** JVM Options for pods.'
             logging:
               type: object
               properties:
@@ -725,7 +725,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Bridge container
+                  description: Template for the Kafka Bridge container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -763,7 +763,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Bridge.
@@ -790,7 +790,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -799,7 +799,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -32,15 +32,15 @@ spec:
           properties:
             class:
               type: string
-              description: The Class for the Kafka Connector
+              description: The Class for the Kafka Connector.
             tasksMax:
               type: integer
               minimum: 1
-              description: The maximum number of tasks for the Kafka Connector
+              description: The maximum number of tasks for the Kafka Connector.
             config:
               type: object
               description: 'The Kafka Connector configuration. The following properties
-                cannot be set: connector.class, tasks.max'
+                cannot be set: connector.class, tasks.max.'
             pause:
               type: boolean
               description: Whether the connector should be paused. Defaults to false.
@@ -65,7 +65,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -74,7 +74,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -32,13 +32,19 @@ spec:
           properties:
             class:
               type: string
+              description: The Class for the Kafka Connector
             tasksMax:
               type: integer
               minimum: 1
+              description: The maximum number of tasks for the Kafka Connector
             config:
               type: object
+              description: 'The Kafka Connector configuration. The following properties
+                cannot be set: connector.class, tasks.max'
             pause:
               type: boolean
+              description: Whether the connector should be paused. Defaults to false.
+          description: The specification of the Kafka Connector.
         status:
           type: object
           properties:
@@ -49,15 +55,32 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             connectorStatus:
               type: object
+              description: The connector status, as reported by the Kafka Connect
+                REST API.
+          description: The status of the Kafka Connector.

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -87,7 +87,7 @@ spec:
                           required:
                           - certificate
                           - secretName
-                        description: Trusted certificates for TLS connection
+                        description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker 2.0
                       connectors to a cluster.
                   authentication:
@@ -259,11 +259,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -276,11 +276,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -293,11 +293,11 @@ spec:
                       tasksMax:
                         type: integer
                         minimum: 1
-                        description: The maximum number of tasks for the Kafka Connector
+                        description: The maximum number of tasks for the Kafka Connector.
                       config:
                         type: object
                         description: 'The Kafka Connector configuration. The following
-                          properties cannot be set: connector.class, tasks.max'
+                          properties cannot be set: connector.class, tasks.max.'
                       pause:
                         type: boolean
                         description: Whether the connector should be paused. Defaults
@@ -307,8 +307,8 @@ spec:
                   topicsPattern:
                     type: string
                     description: A regular expression matching the topics to be mirrored,
-                      for example, "topic1|topic2|topic3". Comma-separated lists are
-                      also supported.
+                      for example, "topic1\|topic2\|topic3". Comma-separated lists
+                      are also supported.
                   topicsBlacklistPattern:
                     type: string
                     description: A regular expression matching the topics to exclude
@@ -393,15 +393,15 @@ spec:
               properties:
                 "-XX":
                   type: object
-                  description: A map of -XX options to the JVM
+                  description: A map of -XX options to the JVM.
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xms option to to the JVM
+                  description: -Xms option to to the JVM.
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
-                  description: -Xmx option to to the JVM
+                  description: -Xmx option to to the JVM.
                 gcLoggingEnabled:
                   type: boolean
                   description: Specifies whether the Garbage Collection logging is
@@ -419,7 +419,7 @@ spec:
                         description: The system property value.
                   description: A map of additional system properties which will be
                     passed using the `-D` option to the JVM.
-              description: JVM Options for pods
+              description: JVM Options for pods.
             affinity:
               type: object
               properties:
@@ -663,7 +663,7 @@ spec:
                   description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
-              description: Logging configuration for Kafka Connect
+              description: Logging configuration for Kafka Connect.
             metrics:
               type: object
               description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
@@ -676,7 +676,7 @@ spec:
                   enum:
                   - jaeger
                   description: Type of the tracing used. Currently the only supported
-                    type is `jaeger` for Jaeger tracing
+                    type is `jaeger` for Jaeger tracing.
               required:
               - type
               description: The configuration of tracing in Kafka Connect.
@@ -1049,7 +1049,7 @@ spec:
                             description: The environment variable value.
                       description: Environment variables which should be applied to
                         the container.
-                  description: Template for the Kafka Connect container
+                  description: Template for the Kafka Connect container.
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -1207,7 +1207,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -1216,7 +1216,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -37,12 +37,19 @@ spec:
           properties:
             replicas:
               type: integer
+              description: The number of pods in the Kafka Connect group.
             version:
               type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
             image:
               type: string
+              description: The docker image for the pods.
             connectCluster:
               type: string
+              description: The cluster alias used for Kafka Connect. The alias must
+                match a cluster in the list at `spec.clusters`.
             clusters:
               type: array
               items:
@@ -51,10 +58,17 @@ spec:
                   alias:
                     type: string
                     pattern: ^[a-zA-Z0-9\._\-]{1,100}$
+                    description: Alias used to reference the Kafka cluster.
                   bootstrapServers:
                     type: string
+                    description: A comma-separated list of `host:port` pairs for establishing
+                      the connection to the Kafka cluster.
                   config:
                     type: object
+                    description: 'The MirrorMaker 2.0 cluster config. Properties with
+                      the following prefixes cannot be set: ssl., sasl., security.,
+                      listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
+                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm).'
                   tls:
                     type: object
                     properties:
@@ -65,11 +79,17 @@ spec:
                           properties:
                             certificate:
                               type: string
+                              description: The name of the file certificate in the
+                                Secret.
                             secretName:
                               type: string
+                              description: The name of the Secret containing the certificate.
                           required:
                           - certificate
                           - secretName
+                        description: Trusted certificates for TLS connection
+                    description: TLS configuration for connecting MirrorMaker 2.0
+                      connectors to a cluster.
                   authentication:
                     type: object
                     properties:
@@ -78,62 +98,102 @@ spec:
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the access
+                          token which was obtained from the authorization server.
                       accessTokenIsJwt:
                         type: boolean
+                        description: Configure whether access token should be treated
+                          as JWT. This should be set to `false` if the authorization
+                          server returns opaque tokens. Defaults to `true`.
                       certificateAndKey:
                         type: object
                         properties:
                           certificate:
                             type: string
+                            description: The name of the file certificate in the Secret.
                           key:
                             type: string
+                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the certificate.
                         required:
                         - certificate
                         - key
                         - secretName
+                        description: Reference to the `Secret` which holds the certificate
+                          and private key pair.
                       clientId:
                         type: string
+                        description: OAuth Client ID which the Kafka client can use
+                          to authenticate against the OAuth server and use the token
+                          endpoint URI.
                       clientSecret:
                         type: object
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the OAuth
+                          client secret which the Kafka client can use to authenticate
+                          against the OAuth server and use the token endpoint URI.
                       disableTlsHostnameVerification:
                         type: boolean
+                        description: Enable or disable TLS hostname verification.
+                          Default value is `false`.
                       maxTokenExpirySeconds:
                         type: integer
+                        description: Set or limit time-to-live of the access tokens
+                          to the specified number of seconds. This should be set if
+                          the authorization server returns opaque tokens.
                       passwordSecret:
                         type: object
                         properties:
                           password:
                             type: string
+                            description: The name of the key in the Secret under which
+                              the password is stored.
                           secretName:
                             type: string
+                            description: The name of the Secret containing the password.
                         required:
                         - password
                         - secretName
+                        description: Reference to the `Secret` which holds the password.
                       refreshToken:
                         type: object
                         properties:
                           key:
                             type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
                           secretName:
                             type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
                         required:
                         - key
                         - secretName
+                        description: Link to Kubernetes Secret containing the refresh
+                          token which can be used to obtain access token from the
+                          authorization server.
                       tlsTrustedCertificates:
                         type: array
                         items:
@@ -141,13 +201,19 @@ spec:
                           properties:
                             certificate:
                               type: string
+                              description: The name of the file certificate in the
+                                Secret.
                             secretName:
                               type: string
+                              description: The name of the Secret containing the certificate.
                           required:
                           - certificate
                           - secretName
+                        description: Trusted certificates for TLS connection to the
+                          OAuth server.
                       tokenEndpointUri:
                         type: string
+                        description: Authorization server token endpoint URI.
                       type:
                         type: string
                         enum:
@@ -155,13 +221,23 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
+                        description: Authentication type. Currently the only supported
+                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                          Authentication. The `tls` type uses TLS Client Authentication.
+                          The `tls` type is supported only over TLS connections.
                       username:
                         type: string
+                        description: Username used for the authentication.
                     required:
                     - type
+                    description: Authentication configuration for connecting to the
+                      cluster.
                 required:
                 - alias
                 - bootstrapServers
+              description: Kafka clusters for mirroring.
             mirrors:
               type: array
               items:
@@ -169,49 +245,86 @@ spec:
                 properties:
                   sourceCluster:
                     type: string
+                    description: The alias of the source cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
                   targetCluster:
                     type: string
+                    description: The alias of the target cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
                   sourceConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 source
+                      connector.
                   checkpointConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint
+                      connector.
                   heartbeatConnector:
                     type: object
                     properties:
                       tasksMax:
                         type: integer
                         minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector
                       config:
                         type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max'
                       pause:
                         type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat
+                      connector.
                   topicsPattern:
                     type: string
+                    description: A regular expression matching the topics to be mirrored,
+                      for example, "topic1|topic2|topic3". Comma-separated lists are
+                      also supported.
                   topicsBlacklistPattern:
                     type: string
+                    description: A regular expression matching the topics to exclude
+                      from mirroring. Comma-separated lists are also supported.
                   groupsPattern:
                     type: string
+                    description: A regular expression matching the consumer groups
+                      to be mirrored. Comma-separated lists are also supported.
                   groupsBlacklistPattern:
                     type: string
+                    description: A regular expression matching the consumer groups
+                      to exclude from mirroring. Comma-separated lists are also supported.
                 required:
                 - sourceCluster
                 - targetCluster
+              description: Configuration of the MirrorMaker 2.0 connectors.
             resources:
               type: object
               properties:
@@ -219,49 +332,80 @@ spec:
                   type: object
                 requests:
                   type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
             livenessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
             readinessProbe:
               type: object
               properties:
                 failureThreshold:
                   type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
                 initialDelaySeconds:
                   type: integer
                   minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
                 periodSeconds:
                   type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
                 successThreshold:
                   type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
                 timeoutSeconds:
                   type: integer
                   minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
             jvmOptions:
               type: object
               properties:
                 "-XX":
                   type: object
+                  description: A map of -XX options to the JVM
                 "-Xms":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM
                 "-Xmx":
                   type: string
                   pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM
                 gcLoggingEnabled:
                   type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
                 javaSystemProperties:
                   type: array
                   items:
@@ -269,8 +413,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: The system property name.
                       value:
                         type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods
             affinity:
               type: object
               properties:
@@ -479,6 +628,7 @@ spec:
                               type: string
                           topologyKey:
                             type: string
+              description: The pod's affinity rules.
             tolerations:
               type: array
               items:
@@ -494,22 +644,30 @@ spec:
                     type: integer
                   value:
                     type: string
+              description: The pod's tolerations.
             logging:
               type: object
               properties:
                 loggers:
                   type: object
+                  description: A Map from logger name to logger level.
                 name:
                   type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
                 type:
                   type: string
                   enum:
                   - inline
                   - external
+                  description: Logging type, must be either 'inline' or 'external'.
               required:
               - type
+              description: Logging configuration for Kafka Connect
             metrics:
               type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
             tracing:
               type: object
               properties:
@@ -517,8 +675,11 @@ spec:
                   type: string
                   enum:
                   - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing
               required:
               - type
+              description: The configuration of tracing in Kafka Connect.
             template:
               type: object
               properties:
@@ -530,8 +691,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
                 pod:
                   type: object
                   properties:
@@ -540,8 +709,15 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
                     imagePullSecrets:
                       type: array
                       items:
@@ -549,6 +725,8 @@ spec:
                         properties:
                           name:
                             type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod.
                     securityContext:
                       type: object
                       properties:
@@ -591,9 +769,18 @@ spec:
                               type: string
                             gmsaCredentialSpecName:
                               type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
                     terminationGracePeriodSeconds:
                       type: integer
                       minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value longer than the expected cleanup
+                        time for your process.Value must be non-negative integer.
+                        The value zero indicates delete immediately. Defaults to 30
+                        seconds.
                     affinity:
                       type: object
                       properties:
@@ -802,10 +989,15 @@ spec:
                                       type: string
                                   topologyKey:
                                     type: string
+                      description: The pod's affinity rules.
                     priorityClassName:
                       type: string
+                      description: The name of the Priority Class to which these pods
+                        will be assigned.
                     schedulerName:
                       type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
                     tolerations:
                       type: array
                       items:
@@ -821,6 +1013,8 @@ spec:
                             type: integer
                           value:
                             type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
                 apiService:
                   type: object
                   properties:
@@ -829,8 +1023,16 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata which should be applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
                 connectContainer:
                   type: object
                   properties:
@@ -841,8 +1043,13 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: The environment variable key.
                           value:
                             type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                  description: Template for the Kafka Connect container
                 podDisruptionBudget:
                   type: object
                   properties:
@@ -851,11 +1058,28 @@ spec:
                       properties:
                         labels:
                           type: object
+                          description: Labels which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                         annotations:
                           type: object
+                          description: Annotations which should be added to the resource
+                            template. Can be applied to different resources such as
+                            `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
                     maxUnavailable:
                       type: integer
                       minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
             externalConfiguration:
               type: object
               properties:
@@ -866,6 +1090,9 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
                       valueFrom:
                         type: object
                         properties:
@@ -878,6 +1105,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Refernce to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -887,9 +1115,16 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
                     required:
                     - name
                     - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
                 volumes:
                   type: array
                   items:
@@ -915,8 +1150,12 @@ spec:
                             type: string
                           optional:
                             type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
                       name:
                         type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
                       secret:
                         type: object
                         properties:
@@ -937,10 +1176,17 @@ spec:
                             type: boolean
                           secretName:
                             type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
                     required:
                     - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
           required:
           - connectCluster
+          description: The specification of the Kafka MirrorMaker 2.0 cluster.
         status:
           type: object
           properties:
@@ -951,18 +1197,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             url:
               type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
             connectorPlugins:
               type: array
               items:
@@ -970,11 +1232,20 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
                   version:
                     type: string
+                    description: The version of the connector plugin.
                   class:
                     type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
             connectors:
               type: array
               items:
                 type: object
+              description: List of MirrorMaker 2.0 connector statuses, as reported
+                by the Kafka Connect REST API.
+          description: The status of the Kafka MirrorMaker 2.0 cluster.

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -45,17 +45,27 @@ spec:
             partitions:
               type: integer
               minimum: 1
+              description: The number of partitions the topic should have. This cannot
+                be decreased after topic creation. It can be increased after topic
+                creation, but it is important to understand the consequences that
+                has, especially for topics with semantic partitioning.
             replicas:
               type: integer
               minimum: 1
               maximum: 32767
+              description: The number of replicas the topic should have.
             config:
               type: object
+              description: The topic configuration.
             topicName:
               type: string
+              description: The name of the topic. When absent this will default to
+                the metadata.name of the topic. It is recommended to not set this
+                unless the topic name is not a valid Kubernetes resource name.
           required:
           - partitions
           - replicas
+          description: The specification of the topic.
         status:
           type: object
           properties:
@@ -66,13 +76,28 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of the topic.

--- a/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -86,7 +86,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -95,7 +95,7 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -184,7 +184,7 @@ spec:
                     type: string
                     description: Last time the condition of a type changed from one
                       status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
-                      in the UTC time zone
+                      in the UTC time zone.
                   reason:
                     type: string
                     description: The reason for the condition's last transition (a
@@ -193,15 +193,15 @@ spec:
                     type: string
                     description: Human-readable message indicating details about the
                       condition's last transition.
-              description: List of status conditions
+              description: List of status conditions.
             observedGeneration:
               type: integer
               description: The generation of the CRD that was last reconciled by the
                 operator.
             username:
               type: string
-              description: Username
+              description: Username.
             secret:
               type: string
-              description: The name of `Secret` where the credentials are stored
+              description: The name of `Secret` where the credentials are stored.
           description: The status of the Kafka User.

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -50,8 +50,10 @@ spec:
                   enum:
                   - tls
                   - scram-sha-512
+                  description: Authentication type.
               required:
               - type
+              description: Authentication mechanism enabled for this Kafka user.
             authorization:
               type: object
               properties:
@@ -62,6 +64,8 @@ spec:
                     properties:
                       host:
                         type: string
+                        description: The host from which the action described in the
+                          ACL rule is allowed or denied.
                       operation:
                         type: string
                         enum:
@@ -76,16 +80,29 @@ spec:
                         - DescribeConfigs
                         - IdempotentWrite
                         - All
+                        description: 'Operation which will be allowed or denied. Supported
+                          operations are: Read, Write, Create, Delete, Alter, Describe,
+                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
+                          and All.'
                       resource:
                         type: object
                         properties:
                           name:
                             type: string
+                            description: Name of resource for which given ACL rule
+                              applies. Can be combined with `patternType` field to
+                              use prefix pattern.
                           patternType:
                             type: string
                             enum:
                             - literal
                             - prefix
+                            description: Describes the pattern used in the resource
+                              field. The supported types are `literal` and `prefix`.
+                              With `literal` pattern type, the resource field will
+                              be used as a definition of a full name. With `prefix`
+                              pattern type, the resource name will be used only as
+                              a prefix. Default value is `literal`.
                           type:
                             type: string
                             enum:
@@ -93,35 +110,60 @@ spec:
                             - group
                             - cluster
                             - transactionalId
+                            description: Resource type. The available resource types
+                              are `topic`, `group`, `cluster`, and `transactionalId`.
                         required:
                         - type
+                        description: Indicates the resource for which given ACL rule
+                          applies.
                       type:
                         type: string
                         enum:
                         - allow
                         - deny
+                        description: The type of the rule. Currently the only supported
+                          type is `allow`. ACL rules with type `allow` are used to
+                          allow user to execute the specified operations. Default
+                          value is `allow`.
                     required:
                     - operation
                     - resource
+                  description: List of ACL rules which should be applied to this user.
                 type:
                   type: string
                   enum:
                   - simple
+                  description: Authorization type. Currently the only supported type
+                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
+                    class for authorization.
               required:
               - acls
               - type
+              description: Authorization rules for this Kafka user.
             quotas:
               type: object
               properties:
                 consumerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can fetch from a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 producerByteRate:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can publish to a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
                 requestPercentage:
                   type: integer
                   minimum: 0
+                  description: A quota on the maximum CPU utilization of each client
+                    group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used
+                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
+                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+          description: The specification of the user.
         status:
           type: object
           properties:
@@ -132,17 +174,34 @@ spec:
                 properties:
                   type:
                     type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
                   status:
                     type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
                   lastTransitionTime:
                     type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone
                   reason:
                     type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
                   message:
                     type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions
             observedGeneration:
               type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
             username:
               type: string
+              description: Username
             secret:
               type: string
+              description: The name of `Secret` where the credentials are stored
+          description: The status of the Kafka User.


### PR DESCRIPTION
A minor update to CrdGenerator allows the description annotations
already in the Java source code to be included in the CRD yaml
files.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>