### PR TITLE
Fix kafka ITs for ocp4

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,10 +49,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(),
-                anyOf(
-                        containsStringIgnoringCase("spec.bootstrapServers in body is required"),
-                        containsStringIgnoringCase("spec.bootstrapServers: Required value")));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.bootstrapServers");
     }
 
     @Test
@@ -74,13 +70,8 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-tls-auth-with-missing-required.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate in body is required"),
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate: Required value"),
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key: Required value"))));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.authentication.certificateAndKey.certificate",
+                "spec.authentication.certificateAndKey.key");
     }
 
     @Test
@@ -119,9 +110,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 createDelete(KafkaBridge.class, "KafkaBridge-with-missing-tracing-type.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase("spec.tracing.type in body is required"),
-                containsStringIgnoringCase("spec.tracing.type: Required value")));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.tracing.type");
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectCrdIT.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -54,10 +52,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-missing-required-property.yaml");
             });
 
-
-        assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase("spec.bootstrapServers in body is required"),
-                containsStringIgnoringCase("spec.bootstrapServers: Required value")));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.bootstrapServers");
     }
 
     @Test
@@ -90,13 +85,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-tls-auth-with-missing-required.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate in body is required"),
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.certificate: Required value"),
-                        containsStringIgnoringCase("spec.authentication.certificateAndKey.key: Required value"))));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.authentication.certificateAndKey.certificate", "spec.authentication.certificateAndKey.key");
     }
 
     @Test
@@ -122,9 +111,7 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
                 createDelete(KafkaConnect.class, "KafkaConnect-with-invalid-external-configuration.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase("spec.externalConfiguration.env.valueFrom in body is required"),
-                containsStringIgnoringCase("spec.externalConfiguration.env.valueFrom: Required value")));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.externalConfiguration.env.valueFrom");
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
@@ -56,13 +55,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "Kafka-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.zookeeper in body is required"),
-                        containsStringIgnoringCase("spec.kafka in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.kafka: Required value"),
-                        containsStringIgnoringCase("spec.zookeeper: Required value"))));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.zookeeper", "spec.kafka");
     }
 
     @Test
@@ -162,16 +155,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "JmxTrans-output-definition-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(),
-                allOf(
-                        anyOf(
-                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.outputType in body is required"),
-                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.outputType: Required value")),
-                        anyOf(
-                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.name in body is required"),
-                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.name: Required value"))
-                        )
-        );
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.jmxTrans.outputDefinitions.outputType", "spec.jmxTrans.outputDefinitions.name");
     }
 
     @Test
@@ -182,19 +166,10 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "JmxTrans-queries-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(),
-                allOf(
-                        anyOf(
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.targetMBean in body is required"),
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.targetMBean: Required value")),
-                        anyOf(
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.attributes in body is required"),
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.attributes: Required value")),
-                        anyOf(
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.outputs in body is required"),
-                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.outputs: Required value"))
-                )
-        );
+        assertMissingRequiredPropertiesMessage(exception.getMessage(),
+                "spec.jmxTrans.kafkaQueries.targetMBean",
+                "spec.jmxTrans.kafkaQueries.attributes",
+                "spec.jmxTrans.kafkaQueries.outputs");
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -163,8 +162,16 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "JmxTrans-output-definition-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(), CoreMatchers.containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.outputType in body is required"));
-        assertThat(exception.getMessage(), CoreMatchers.containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.name in body is required"));
+        assertThat(exception.getMessage(),
+                allOf(
+                        anyOf(
+                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.outputType in body is required"),
+                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.outputType: Required value")),
+                        anyOf(
+                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.name in body is required"),
+                                containsStringIgnoringCase("spec.jmxTrans.outputDefinitions.name: Required value"))
+                        )
+        );
     }
 
     @Test
@@ -175,9 +182,19 @@ public class KafkaCrdIT extends AbstractCrdIT {
                 createDelete(Kafka.class, "JmxTrans-queries-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(), CoreMatchers.containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.attributes in body is required"));
-        assertThat(exception.getMessage(), CoreMatchers.containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.targetMBean in body is required"));
-        assertThat(exception.getMessage(), CoreMatchers.containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.outputs in body is required"));
+        assertThat(exception.getMessage(),
+                allOf(
+                        anyOf(
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.targetMBean in body is required"),
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.targetMBean: Required value")),
+                        anyOf(
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.attributes in body is required"),
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.attributes: Required value")),
+                        anyOf(
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.outputs in body is required"),
+                                containsStringIgnoringCase("spec.jmxTrans.kafkaQueries.outputs: Required value"))
+                )
+        );
     }
 
     @BeforeAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -10,10 +10,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -55,16 +51,10 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
                 createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.consumer.bootstrapServers in body is required"),
-                        containsStringIgnoringCase("spec.producer in body is required"),
-                        containsStringIgnoringCase("spec.whitelist in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.consumer.bootstrapServers: Required value"),
-                        containsStringIgnoringCase("spec.whitelist: Required value"),
-                        containsStringIgnoringCase("spec.producer: Required value"))
-                ));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(),
+                "spec.consumer.bootstrapServers",
+                "spec.producer",
+                "spec.whitelist");
     }
 
     @Test
@@ -85,15 +75,10 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
                 createDelete(KafkaMirrorMaker.class, "KafkaMirrorMaker-with-tls-auth-with-missing-required.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.certificate in body is required"),
-                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.key in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.certificate: Required value"),
-                        containsStringIgnoringCase("spec.producer.authentication.certificateAndKey.key: Required value"),
-                        containsStringIgnoringCase("spec.whitelist: Required value"))
-        ));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(),
+                "spec.producer.authentication.certificateAndKey.certificate",
+                "spec.producer.authentication.certificateAndKey.key",
+                "spec.whitelist");
     }
 
     @Test

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -10,10 +10,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -54,14 +50,7 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
                 createDelete(KafkaTopic.class, "KafkaTopic-with-missing-required-property.yaml");
             });
 
-        assertThat(exception.getMessage(), anyOf(
-                allOf(
-                        containsStringIgnoringCase("spec.partitions in body is required"),
-                        containsStringIgnoringCase("spec.replicas in body is required")),
-                allOf(
-                        containsStringIgnoringCase("spec.partitions: Required value"),
-                        containsStringIgnoringCase("spec.replicas: Required value"))
-                ));
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "spec.partitions", "spec.replicas");
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Some of the kafka CRD IT were asserting only ocp 3.x output. Fixed.

The https://github.com/strimzi/strimzi-kafka-operator/pull/2519 should be fixed by this.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

