### PR TITLE
Fix incorrect argument order

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -225,7 +225,7 @@ public class KafkaImpl implements Kafka {
                 Collections.singleton(topicName.toString())).values().get(topicName.toString());
         queueWork(new UniWork<>("deleteTopic", future, handler));
         return handler.future().compose(ig ->
-                Util.waitFor(vertx, "deleted sync " + topicName, Long.MAX_VALUE, 1000, () -> {
+                Util.waitFor(vertx, "deleted sync " + topicName, 1000, 120_000, () -> {
                     try {
                         return adminClient.describeTopics(Collections.singleton(topicName.toString())).all().get().get(topicName.toString()) == null;
                     } catch (ExecutionException e) {


### PR DESCRIPTION
Signed-off-by: Tom Bentley <tbentley@redhat.com>

### Type of change

- Bugfix

### Description

The argument order in this call to `waitFor` was incorrect. I also think it's a mistake to poll forever here, so timeout after 2 minutes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

