### PR TITLE
feat: Kubernetes component label addition 

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -111,6 +111,10 @@ public abstract class AbstractModel {
     // Number of replicas
     protected int replicas;
 
+    // Name of the component
+    protected String component;
+
+
     protected String readinessPath;
     protected String livenessPath;
 
@@ -203,6 +207,14 @@ public abstract class AbstractModel {
         this.replicas = replicas;
     }
 
+    public String getComponent() {
+        return component;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
     protected void setImage(String image) {
         this.image = image;
     }
@@ -266,11 +278,11 @@ public abstract class AbstractModel {
         return labels.withName(name).withUserLabels(userLabels).toMap();
     }
 
-    protected Map<String, String> getLabelsWithNameAndComponent(String component, Map<String, String> userLabels) {
-        return getLabelsWithNameAndComponent(name, component, userLabels);
+    protected Map<String, String> getLabelsWithNameAndComponent(Map<String, String> userLabels) {
+        return getLabelsWithNameAndComponent(name, userLabels);
     }
 
-    protected Map<String, String> getLabelsWithNameAndComponent(String name, String component, Map<String, String> userLabels) {
+    protected Map<String, String> getLabelsWithNameAndComponent(String name, Map<String, String> userLabels) {
         return labels.withName(name)
                 .withKubernetesComponent(component)
                 .withUserLabels(userLabels)
@@ -739,7 +751,6 @@ public abstract class AbstractModel {
     }
 
     protected StatefulSet createStatefulSet(
-            String component,
             Map<String, String> annotations,
             List<Volume> volumes,
             List<PersistentVolumeClaim> volumeClaims,
@@ -762,7 +773,7 @@ public abstract class AbstractModel {
         StatefulSet statefulSet = new StatefulSetBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithNameAndComponent(component, templateStatefulSetLabels))
+                    .withLabels(getLabelsWithNameAndComponent(templateStatefulSetLabels))
                     .withNamespace(namespace)
                     .withAnnotations(mergeLabelsOrAnnotations(annotations, templateStatefulSetAnnotations))
                     .withOwnerReferences(createOwnerReference())
@@ -776,7 +787,7 @@ public abstract class AbstractModel {
                     .withNewTemplate()
                         .withNewMetadata()
                             .withName(name)
-                            .withLabels(getLabelsWithNameAndComponent(component, templatePodLabels))
+                            .withLabels(getLabelsWithNameAndComponent(templatePodLabels))
                             .withAnnotations(mergeLabelsOrAnnotations(null, templatePodAnnotations))
                         .endMetadata()
                         .withNewSpec()
@@ -801,7 +812,6 @@ public abstract class AbstractModel {
     }
 
     protected Deployment createDeployment(
-            String component,
             DeploymentStrategy updateStrategy,
             Map<String, String> deploymentAnnotations,
             Map<String, String> podAnnotations,
@@ -814,7 +824,7 @@ public abstract class AbstractModel {
         Deployment dep = new DeploymentBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithNameAndComponent(component, templateDeploymentLabels))
+                    .withLabels(getLabelsWithNameAndComponent(templateDeploymentLabels))
                     .withNamespace(namespace)
                     .withAnnotations(mergeLabelsOrAnnotations(deploymentAnnotations, templateDeploymentAnnotations))
                     .withOwnerReferences(createOwnerReference())
@@ -825,7 +835,7 @@ public abstract class AbstractModel {
                     .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabelsAsMap()).build())
                     .withNewTemplate()
                         .withNewMetadata()
-                            .withLabels(getLabelsWithNameAndComponent(component, templatePodLabels))
+                            .withLabels(getLabelsWithNameAndComponent(templatePodLabels))
                             .withAnnotations(mergeLabelsOrAnnotations(podAnnotations, templatePodAnnotations))
                         .endMetadata()
                         .withNewSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -266,6 +266,17 @@ public abstract class AbstractModel {
         return labels.withName(name).withUserLabels(userLabels).toMap();
     }
 
+    protected Map<String, String> getLabelsWithNameAndComponent(String component, Map<String, String> userLabels) {
+        return getLabelsWithNameAndComponent(name, component, userLabels);
+    }
+
+    protected Map<String, String> getLabelsWithNameAndComponent(String name, String component, Map<String, String> userLabels) {
+        return labels.withName(name)
+                .withKubernetesComponent(component)
+                .withUserLabels(userLabels)
+                .toMap();
+    }
+
     protected Map<String, String> getLabelsWithNameAndDiscovery(String name) {
         return labels.withName(name).withDiscovery().toMap();
     }
@@ -273,6 +284,7 @@ public abstract class AbstractModel {
     protected Map<String, String> getLabelsWithNameAndDiscovery(String name, Map<String, String> userLabels) {
         return labels.withName(name).withDiscovery().withUserLabels(userLabels).toMap();
     }
+
 
     /**
      * @return Whether metrics are enabled.
@@ -727,6 +739,7 @@ public abstract class AbstractModel {
     }
 
     protected StatefulSet createStatefulSet(
+            String component,
             Map<String, String> annotations,
             List<Volume> volumes,
             List<PersistentVolumeClaim> volumeClaims,
@@ -749,7 +762,7 @@ public abstract class AbstractModel {
         StatefulSet statefulSet = new StatefulSetBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithName(templateStatefulSetLabels))
+                    .withLabels(getLabelsWithNameAndComponent(component, templateStatefulSetLabels))
                     .withNamespace(namespace)
                     .withAnnotations(mergeLabelsOrAnnotations(annotations, templateStatefulSetAnnotations))
                     .withOwnerReferences(createOwnerReference())
@@ -763,7 +776,7 @@ public abstract class AbstractModel {
                     .withNewTemplate()
                         .withNewMetadata()
                             .withName(name)
-                            .withLabels(getLabelsWithName(templatePodLabels))
+                            .withLabels(getLabelsWithNameAndComponent(component, templatePodLabels))
                             .withAnnotations(mergeLabelsOrAnnotations(null, templatePodAnnotations))
                         .endMetadata()
                         .withNewSpec()
@@ -788,6 +801,7 @@ public abstract class AbstractModel {
     }
 
     protected Deployment createDeployment(
+            String component,
             DeploymentStrategy updateStrategy,
             Map<String, String> deploymentAnnotations,
             Map<String, String> podAnnotations,
@@ -800,7 +814,7 @@ public abstract class AbstractModel {
         Deployment dep = new DeploymentBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithName(templateDeploymentLabels))
+                    .withLabels(getLabelsWithNameAndComponent(component, templateDeploymentLabels))
                     .withNamespace(namespace)
                     .withAnnotations(mergeLabelsOrAnnotations(deploymentAnnotations, templateDeploymentAnnotations))
                     .withOwnerReferences(createOwnerReference())
@@ -811,7 +825,7 @@ public abstract class AbstractModel {
                     .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabelsAsMap()).build())
                     .withNewTemplate()
                         .withNewMetadata()
-                            .withLabels(getLabelsWithName(templatePodLabels))
+                            .withLabels(getLabelsWithNameAndComponent(component, templatePodLabels))
                             .withAnnotations(mergeLabelsOrAnnotations(podAnnotations, templatePodAnnotations))
                         .endMetadata()
                         .withNewSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -67,6 +67,8 @@ public class EntityOperator extends AbstractModel {
         this.name = entityOperatorName(cluster);
         this.replicas = EntityOperatorSpec.DEFAULT_REPLICAS;
         this.zookeeperConnect = defaultZookeeperConnect(cluster);
+
+        setComponent(COMPONENT);
     }
 
     protected void setTlsSidecar(TlsSidecar tlsSidecar) {
@@ -227,7 +229,6 @@ public class EntityOperator extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -36,6 +36,8 @@ import java.util.Map;
  * Represents the Entity Operator deployment
  */
 public class EntityOperator extends AbstractModel {
+    protected static final String COMPONENT = "entity-operator";
+
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
     protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
@@ -225,6 +227,7 @@ public class EntityOperator extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -93,6 +93,8 @@ public class JmxTrans extends AbstractModel {
 
         // Metrics must be enabled as JmxTrans is all about gathering JMX metrics from the Kafka brokers and pushing it to remote sources.
         this.isMetricsEnabled = true;
+
+        setComponent(COMPONENT);
     }
 
     public static JmxTrans fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
@@ -145,7 +147,6 @@ public class JmxTrans extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -44,6 +44,7 @@ import java.util.Map;
  * JmxTrans deployment including: config map, deployment, and service accounts.
  */
 public class JmxTrans extends AbstractModel {
+    private static final String COMPONENT = "jmx-trans";
 
     // Configuration defaults
     private static final String STRIMZI_DEFAULT_JMXTRANS_IMAGE = "STRIMZI_DEFAULT_JMXTRANS_IMAGE";
@@ -144,6 +145,7 @@ public class JmxTrans extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 public class KafkaBridgeCluster extends AbstractModel {
+    public static final String COMPONENT = "kafka-bridge";
 
     // Port configuration
     public static final int DEFAULT_REST_API_PORT = 8080;
@@ -317,6 +318,7 @@ public class KafkaBridgeCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -134,6 +134,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         this.mountPath = "/var/lib/bridge";
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/strimzi/custom-config/";
+        setComponent(COMPONENT);
     }
 
     public static KafkaBridgeCluster fromCrd(KafkaBridge kafkaBridge, KafkaVersion.Lookup versions) {
@@ -318,7 +319,6 @@ public class KafkaBridgeCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -272,6 +272,7 @@ public class KafkaCluster extends AbstractModel {
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
 
         this.initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "strimzi/operator:latest");
+        setComponent(COMPONENT);
     }
 
     public static String kafkaClusterName(String cluster) {
@@ -1236,7 +1237,6 @@ public class KafkaCluster extends AbstractModel {
         annotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
 
         return createStatefulSet(
-                COMPONENT,
                 annotations,
                 getVolumes(isOpenShift),
                 getVolumeClaims(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -110,6 +110,8 @@ import java.util.Set;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class KafkaCluster extends AbstractModel {
+    protected static final String COMPONENT = "kafka";
+
     protected static final String INIT_NAME = "kafka-init";
     protected static final String INIT_VOLUME_NAME = "rack-volume";
     protected static final String INIT_VOLUME_MOUNT = "/opt/kafka/init";
@@ -1234,6 +1236,7 @@ public class KafkaCluster extends AbstractModel {
         annotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
 
         return createStatefulSet(
+                COMPONENT,
                 annotations,
                 getVolumes(isOpenShift),
                 getVolumeClaims(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import static io.strimzi.operator.cluster.model.ModelUtils.createHttpProbe;
 
 public class KafkaConnectCluster extends AbstractModel {
+    protected static final String COMPONENT = "kafka-connect";
 
     // Port configuration
     public static final int REST_API_PORT = 8083;
@@ -399,6 +400,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -123,6 +123,7 @@ public class KafkaConnectCluster extends AbstractModel {
         this.mountPath = "/var/lib/kafka";
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
+        setComponent(COMPONENT);
     }
 
     public static KafkaConnectCluster fromCrd(KafkaConnect kafkaConnect, KafkaVersion.Lookup versions) {
@@ -400,7 +401,6 @@ public class KafkaConnectCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -34,6 +34,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class KafkaExporter extends AbstractModel {
+    protected static final String COMPONENT = "kafka-exporter";
+
     // Configuration for mounting certificates
     protected static final String KAFKA_EXPORTER_CERTS_VOLUME_NAME = "kafka-exporter-certs";
     protected static final String KAFKA_EXPORTER_CERTS_VOLUME_MOUNT = "/etc/kafka-exporter/kafka-exporter-certs/";
@@ -200,6 +202,7 @@ public class KafkaExporter extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -86,6 +86,8 @@ public class KafkaExporter extends AbstractModel {
 
         // Kafka Exporter is all about metrics - they are always enabled
         this.isMetricsEnabled = true;
+
+        setComponent(COMPONENT);
     }
 
     public static KafkaExporter fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
@@ -202,7 +204,6 @@ public class KafkaExporter extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 
 public class KafkaMirrorMakerCluster extends AbstractModel {
+    protected static final String COMPONENT = "kafka-mirror-maker";
+
     protected static final String TLS_CERTS_VOLUME_MOUNT_CONSUMER = "/opt/kafka/consumer-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT_CONSUMER = "/opt/kafka/consumer-password/";
     protected static final String TLS_CERTS_VOLUME_MOUNT_PRODUCER = "/opt/kafka/producer-certs/";
@@ -299,6 +301,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -127,6 +127,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         this.mountPath = "/var/lib/kafka";
         this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
+
+        setComponent(COMPONENT);
     }
 
     public static KafkaMirrorMakerCluster fromCrd(KafkaMirrorMaker kafkaMirrorMaker, KafkaVersion.Lookup versions) {
@@ -301,7 +303,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 annotations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -117,6 +117,8 @@ public class TopicOperator extends AbstractModel {
         this.ancillaryConfigName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "topic-operator-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/topic-operator/custom-config/";
+
+        setComponent(COMPONENT);
     }
 
 
@@ -263,7 +265,6 @@ public class TopicOperator extends AbstractModel {
                 .build();
 
         return createDeployment(
-                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TopicOperator.java
@@ -45,6 +45,7 @@ import static java.util.Collections.singletonList;
 @Deprecated
 @SuppressWarnings("deprecation")
 public class TopicOperator extends AbstractModel {
+    protected static final String COMPONENT = "topic-operator";
 
     protected static final String TOPIC_OPERATOR_NAME = "topic-operator";
     private static final String NAME_SUFFIX = "-topic-operator";
@@ -262,6 +263,7 @@ public class TopicOperator extends AbstractModel {
                 .build();
 
         return createDeployment(
+                COMPONENT,
                 updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import static java.util.Arrays.asList;
 
 public class ZookeeperCluster extends AbstractModel {
+    protected static final String COMPONENT = "zookeeper";
 
     protected static final int CLIENT_PORT = 2181;
     protected static final String CLIENT_PORT_NAME = "clients";
@@ -437,6 +438,7 @@ public class ZookeeperCluster extends AbstractModel {
     public StatefulSet generateStatefulSet(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
 
         return createStatefulSet(
+                COMPONENT,
                 Collections.singletonMap(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage)),
                 getVolumes(isOpenShift),
                 getVolumeClaims(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -165,6 +165,8 @@ public class ZookeeperCluster extends AbstractModel {
 
         this.logAndMetricsConfigVolumeName = "zookeeper-metrics-and-logging";
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
+
+        setComponent(COMPONENT);
     }
 
     public static ZookeeperCluster fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
@@ -438,7 +440,6 @@ public class ZookeeperCluster extends AbstractModel {
     public StatefulSet generateStatefulSet(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
 
         return createStatefulSet(
-                COMPONENT,
                 Collections.singletonMap(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage)),
                 getVolumes(isOpenShift),
                 getVolumeClaims(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -96,6 +96,13 @@ public class KafkaBridgeClusterTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
+    private Map<String, String> expectedDeploymentLabels(String name)    {
+        Map<String, String> deploymentLabels = expectedLabels(KafkaBridgeResources.deploymentName(cluster));
+        deploymentLabels.put(Labels.KUBERNETES_COMPONENT_LABEL, KafkaBridgeCluster.COMPONENT);
+
+        return deploymentLabels;
+    }
+
     private Map<String, String> expectedServiceLabels(String name)    {
         Map<String, String> serviceLabels = expectedLabels(name);
         serviceLabels.put(Labels.STRIMZI_DISCOVERY_LABEL, "true");
@@ -177,11 +184,11 @@ public class KafkaBridgeClusterTest {
 
         assertThat(dep.getMetadata().getName(), is(KafkaBridgeResources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        Map<String, String> expectedLabels = expectedLabels();
-        assertThat(dep.getMetadata().getLabels(), is(expectedLabels));
+        Map<String, String> expectedDeploymentLabels = expectedDeploymentLabels(cluster);
+        assertThat(dep.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getSelector().getMatchLabels(), is(expectedSelectorLabels()));
         assertThat(dep.getSpec().getReplicas(), is(new Integer(replicas)));
-        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedLabels));
+        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().size(), is(1));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName(), is(KafkaBridgeResources.deploymentName(cluster)));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is(kbc.image));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -171,7 +171,8 @@ public class KafkaClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
+            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME,
+            Labels.KUBERNETES_COMPONENT_LABEL, KafkaCluster.COMPONENT);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -118,6 +118,13 @@ public class KafkaConnectClusterTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
+    private Map<String, String> expectedDeploymentLabels(String name)    {
+        Map<String, String> expectedDeploymentLabels = expectedLabels(name);
+        expectedDeploymentLabels.put(Labels.KUBERNETES_COMPONENT_LABEL, KafkaConnectCluster.COMPONENT);
+
+        return expectedDeploymentLabels;
+    }
+
     private Map<String, String> expectedSelectorLabels()    {
         return Labels.fromMap(expectedLabels()).strimziSelectorLabels().toMap();
     }
@@ -217,11 +224,11 @@ public class KafkaConnectClusterTest {
 
         assertThat(dep.getMetadata().getName(), is(KafkaConnectResources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        Map<String, String> expectedLabels = expectedLabels();
-        assertThat(dep.getMetadata().getLabels(), is(expectedLabels));
+        Map<String, String> expectedDeploymentLabels = expectedDeploymentLabels(KafkaConnectResources.deploymentName(cluster));
+        assertThat(dep.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getSelector().getMatchLabels(), is(expectedSelectorLabels()));
         assertThat(dep.getSpec().getReplicas(), is(new Integer(replicas)));
-        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedLabels));
+        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().size(), is(1));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName(), is(KafkaConnectResources.deploymentName(this.cluster)));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is(kc.image));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -136,6 +136,13 @@ public class KafkaMirrorMaker2ClusterTest {
         return expectedLabels(KafkaMirrorMaker2Resources.deploymentName(cluster));
     }
 
+    private Map<String, String> expectedDeploymentLabels()    {
+        Map<String, String> expectedDeploymentLabels = expectedLabels(KafkaMirrorMaker2Resources.deploymentName(cluster));
+        expectedDeploymentLabels.put(Labels.KUBERNETES_COMPONENT_LABEL, KafkaMirrorMaker2Cluster.COMPONENT);
+
+        return expectedDeploymentLabels;
+    }
+
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION).withValue(expectedConfiguration.asPairs()).build());
@@ -231,11 +238,11 @@ public class KafkaMirrorMaker2ClusterTest {
 
         assertThat(dep.getMetadata().getName(), is(KafkaMirrorMaker2Resources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        Map<String, String> expectedLabels = expectedLabels();
-        assertThat(dep.getMetadata().getLabels(), is(expectedLabels));
+        Map<String, String> expectedDeploymentLabels = expectedDeploymentLabels();
+        assertThat(dep.getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getSelector().getMatchLabels(), is(expectedSelectorLabels()));
         assertThat(dep.getSpec().getReplicas(), is(new Integer(replicas)));
-        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedLabels));
+        assertThat(dep.getSpec().getTemplate().getMetadata().getLabels(), is(expectedDeploymentLabels));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().size(), is(1));
         Container cont = getContainer(dep);
         assertThat(cont.getName(), is(KafkaMirrorMaker2Resources.deploymentName(this.cluster)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -119,7 +119,8 @@ public class KafkaMirrorMakerClusterTest {
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
+                Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME,
+                Labels.KUBERNETES_COMPONENT_LABEL, KafkaMirrorMakerCluster.COMPONENT);
     }
 
     private Map<String, String> expectedSelectorLabels()    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -133,7 +133,9 @@ public class ZookeeperClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
-            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
+            Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME,
+            Labels.KUBERNETES_COMPONENT_LABEL, ZookeeperCluster.COMPONENT);
+
     }
 
     @Test

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -65,6 +65,7 @@ public class Labels {
     public static final String KUBERNETES_NAME_LABEL = KUBERNETES_DOMAIN + "name";
     public static final String KUBERNETES_INSTANCE_LABEL = KUBERNETES_DOMAIN + "instance";
     public static final String KUBERNETES_MANAGED_BY_LABEL = KUBERNETES_DOMAIN + "managed-by";
+    public static final String KUBERNETES_COMPONENT_LABEL = KUBERNETES_DOMAIN + "component";
 
     public static final String KUBERNETES_NAME = "strimzi";
 
@@ -267,6 +268,15 @@ public class Labels {
      */
     public Labels withKubernetesManagedBy(String operatorName) {
         return with(Labels.KUBERNETES_MANAGED_BY_LABEL, operatorName);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code component} for the {@code app.kubernetes.io/component} key.
+     * @param component The component os Strimzi.
+     * @return A new instance with the given kubernetes component this is.
+     */
+    public Labels withKubernetesComponent(String component) {
+        return with(Labels.KUBERNETES_COMPONENT_LABEL, component);
     }
 
     /**


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Add the app.kubernetes.io/component label
This label is recommended by Kubernetes and
is applied to the pods, deployments and sts
constituting Strimzi
These labels are queryable to see all 'kafka'
or 'zookeeper' etc components are in your cluster

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

