### PR TITLE
fix: Mock Kube deployment patcher handle zero replicas

### DIFF
--- a/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +79,7 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
             Deployment deployment = invocation.getArgument(0);
             String deploymentName = deployment.getMetadata().getName();
             // Initialize the map with empty collection in cases where deployment was initialized with zero replicas
-            podsForDeployments.putIfAbsent(deploymentName, Collections.emptyList());
+            podsForDeployments.putIfAbsent(deploymentName, new ArrayList<>());
 
             deployment.getMetadata().setGeneration(Long.valueOf(0));
             deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/DeploymentMockBuilder.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,16 +78,20 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
     protected void mockPatch(String resourceName, RollableScalableResource<Deployment, DoneableDeployment> resource) {
         when(resource.patch(any())).thenAnswer(invocation -> {
             Deployment deployment = invocation.getArgument(0);
+            String deploymentName = deployment.getMetadata().getName();
+            // Initialize the map with empty collection in cases where deployment was initialized with zero replicas
+            podsForDeployments.putIfAbsent(deploymentName, Collections.emptyList());
+
             deployment.getMetadata().setGeneration(Long.valueOf(0));
             deployment.setStatus(new DeploymentStatusBuilder().withObservedGeneration(Long.valueOf(0)).build());
             LOGGER.debug("patched {} {} -> {}", resourceType, resourceName, deployment);
             db.put(resourceName, copyResource(deployment));
 
             // Handle case where patch reduces replicas
-            int podsToDelete = podsForDeployments.get(deployment.getMetadata().getName()).size() - deployment.getSpec().getReplicas();
+            int podsToDelete = podsForDeployments.get(deploymentName).size() - deployment.getSpec().getReplicas();
             if (podsToDelete > 0) {
                 for (int i = 0; i < podsToDelete; i++) {
-                    String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
+                    String podToDelete = podsForDeployments.get(deploymentName).remove(0);
                     mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).delete();
                 }
             }
@@ -95,7 +100,7 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
             for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
                 // create a "new" Pod
                 String uuid = UUID.randomUUID().toString();
-                String newPodName = deployment.getMetadata().getName() + "-" + uuid;
+                String newPodName = deploymentName + "-" + uuid;
 
                 Pod newPod = new PodBuilder()
                         .withNewMetadataLike(deployment.getSpec().getTemplate().getMetadata())
@@ -109,13 +114,13 @@ class DeploymentMockBuilder extends MockBuilder<Deployment, DeploymentList, Done
                 newPodNames.add(newPodName);
 
                 // delete the first "old" Pod if there is one still remaining
-                if (podsForDeployments.get(deployment.getMetadata().getName()).size() > 0) {
-                    String podToDelete = podsForDeployments.get(deployment.getMetadata().getName()).remove(0);
+                if (podsForDeployments.get(deploymentName).size() > 0) {
+                    String podToDelete = podsForDeployments.get(deploymentName).remove(0);
                     mockPods.inNamespace(deployment.getMetadata().getNamespace()).withName(podToDelete).cascading(true).delete();
                 }
 
             }
-            podsForDeployments.get(deployment.getMetadata().getName()).addAll(newPodNames);
+            podsForDeployments.get(deploymentName).addAll(newPodNames);
 
             return deployment;
         });


### PR DESCRIPTION
In cases where the deployment is initialized with zero
replicas NPEs can be triggered from a null lookup in the
map. Avoid this by initializing an empty list in the map
if not set

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

