### PR TITLE
[MO] - [system test] -> load balancer source range

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -13,18 +13,26 @@ import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBootstrapOverride
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverride;
 import io.strimzi.api.kafka.model.listener.LoadBalancerListenerBrokerOverrideBuilder;
 import io.strimzi.systemtest.BaseST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -34,6 +42,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(SPECIFIC)
 public class SpecificST extends BaseST {
@@ -145,6 +154,67 @@ public class SpecificST extends BaseST {
         KafkaUtils.waitUntilKafkaCRIsNotReady(CLUSTER_NAME);
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE, nonExistingVersionMessage);
     }
+
+    @Test
+    @Tag(LOADBALANCER_SUPPORTED)
+    void testLoadBalancerSourceRanges() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+
+        String networkInterfaces = Exec.exec("ip", "route").out();
+        Pattern ipv4InterfacesPattern = Pattern.compile("[0-9]+.[0-9]+.[0-9]+.[0-9]+\\/[0-9]+ dev (eth0|enp11s0u1).*");
+        Matcher ipv4InterfacesMatcher = ipv4InterfacesPattern.matcher(networkInterfaces);
+
+        ipv4InterfacesMatcher.find();
+        LOGGER.info(ipv4InterfacesMatcher.group(0));
+        String correctNetworkInterface = ipv4InterfacesMatcher.group(0);
+
+        String[] correctNetworkInterfaceStrings = correctNetworkInterface.split(" ");
+
+        String ipWithPrefix = correctNetworkInterfaceStrings[0];
+
+        LOGGER.info("Network address of machine with associated prefix is {}", ipWithPrefix);
+
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)
+            .editSpec()
+                .editKafka()
+                    .editListeners()
+                        .withNewKafkaListenerExternalLoadBalancer()
+                            .withTls(false)
+                        .endKafkaListenerExternalLoadBalancer()
+                    .endListeners()
+                    .withNewTemplate()
+                        .withNewExternalBootstrapService()
+                            .withLoadBalancerSourceRanges(Collections.singletonList(ipWithPrefix))
+                        .endExternalBootstrapService()
+                        .withNewPerPodService()
+                            .withLoadBalancerSourceRanges(ipWithPrefix)
+                        .endPerPodService()
+                    .endTemplate()
+                .endKafka()
+            .endSpec()
+            .done();
+
+        Future<Integer> producer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+        Future<Integer> consumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+
+        assertThat(producer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+        assertThat(consumer.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
+
+        String invalidNetworkAddress = "255.255.255.111/30";
+
+        LOGGER.info("Replacing Kafka CR invalid load-balancer source range to {}", invalidNetworkAddress);
+
+        KafkaResource.replaceKafkaResource(CLUSTER_NAME, kafka ->
+                kafka.getSpec().getKafka().getTemplate().getExternalBootstrapService().setLoadBalancerSourceRanges(Collections.singletonList(invalidNetworkAddress))
+        );
+
+        LOGGER.info("Expecting that clients will not be able to connect to external load-balancer service cause of invalid load-balancer source range.");
+
+        assertThrows(ExecutionException.class, () -> {
+            Future<Integer> invalidProducer = externalBasicKafkaClient.sendMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT);
+            Future<Integer> invalidConsumer = externalBasicKafkaClient.receiveMessages(TOPIC_NAME, NAMESPACE, CLUSTER_NAME, MESSAGE_COUNT * 2);
+        });
+    }
+
 
     @BeforeAll
     void setup() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -215,7 +215,6 @@ public class SpecificST extends BaseST {
         });
     }
 
-
     @BeforeAll
     void setup() {
         ResourceManager.setClassResources();


### PR DESCRIPTION
Signed-off-by: see-quick <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding a test for `loadBalancerSourceRanges`

more info here:


`
A list of CIDR ranges (for example 10.0.0.0/8 or 130.211.204.1/32) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the load balancer is restricted to the specified CIDR ranges. This field is applicable only for load balancer type services 
and is ignored if the cloud provider does not support the feature.
`

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass

