### PR TITLE
Fix the path check for OAuth certificates in MM1

### DIFF
--- a/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
@@ -45,7 +45,7 @@ if [ -n "$tls_auth_cert" ] && [ -n "$tls_auth_key" ]; then
     echo "Preparing keystore is complete"
 fi
 
-if [ -d $oauth_certs_paths ]; then
+if [ -d $oauth_certs_path ]; then
   echo "Preparing truststore for OAuth"
   # Add each certificate to the trust store
   STORE=/tmp/kafka/oauth.truststore.p12


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Mirror Maker 1 startup scripts have a typo when checking the OAuth path. This results in following error when starting the container without OAuth configuration:

```
Preparing truststore for OAuth
Adding /opt/kafka/consumer-oauth-certs/**/* to truststore /tmp/kafka/consumer-oauth.keystore.p12 with alias oauth-0
keytool error: java.io.FileNotFoundException: /opt/kafka/consumer-oauth-certs/**/* (No such file or directory)
Preparing truststore for OAuth is complete
```

This PR fixes an issue by using the right variable.

Thsi should be cherry-picked for 0.17.0.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally