### PR TITLE
Doc edits from QE check

### DIFF
--- a/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
+++ b/documentation/assemblies/mirrormaker2/assembly-mirrormaker.adoc
@@ -21,5 +21,8 @@ NOTE: MirrorMaker 2.0 has features not supported by the previous version of Mirr
 //Describes the underlying archiecture and how it is used in replication
 include::modules/con-mirrormaker-replication.adoc[leveloffset=+1]
 
+//Handling of ACLs in replication
+include::modules/con-mirrormaker-acls.adoc[leveloffset=+1]
+
 //Procedure to set up the configuration
 include::modules/proc-mirrormaker-replication.adoc[leveloffset=+1]

--- a/documentation/modules/mirrormaker2/con-mirrormaker-acls.adoc
+++ b/documentation/modules/mirrormaker2/con-mirrormaker-acls.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// assembly-mirrormaker.adoc
+
+[id='con-mirrormaker-acls{context}']
+= ACL rules synchronization
+
+ACL access to remote topics is possible if you are *not* using the User Operator.
+
+If `SimpleAclAuthorizer` is being used, without the User Operator, ACL rules that manage access to brokers also apply to remote topics.
+Users that can read a source topic can read its remote equivalent.
+
+NOTE: {oauth} authorization does not support access to remote topics in this way.

--- a/documentation/modules/mirrormaker2/con-mirrormaker-replication.adoc
+++ b/documentation/modules/mirrormaker2/con-mirrormaker-replication.adoc
@@ -53,15 +53,6 @@ Consumers can subscribe to source and remote topics within the same cluster, wit
 Topic configuration is automatically synchronized between source and target clusters.
 By synchronizing configuration properties, the need for rebalancing is reduced.
 
-== ACL rules synchronization
-
-ACL access to remote topics is possible if you are *not* using the User Operator.
-
-If `SimpleAclAuthorizer` is being used, without the User Operator, ACL rules that manage access to brokers also apply to remote topics.
-Users that can read a source topic can read its remote equivalent.
-
-NOTE: {oauth} authorization does not support access to remote topics in this way.
-
 == Data integrity
 
 MirrorMaker 2.0 monitors source topics and propagates any configuration changes to remote topics, checking for and creating missing partitions.

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -115,7 +115,7 @@ spec:
 [[con-oauth-authentication-broker-intro-local]]
 == {oauth} introspection endpoint configuration
 
-Token validation using {oauth} as an introspection endpoint treats a received access token as opaque.
+Token validation using an {oauth} introspection endpoint treats a received access token as opaque.
 The Kafka broker sends an access token to the introspection endpoint, which responds with the token information necessary for validation.
 Importantly, it returns up-to-date information if the specific access token is valid, and also information about when the token expires.
 

--- a/documentation/modules/proc-upgrading-the-cluster-operator.adoc
+++ b/documentation/modules/proc-upgrading-the-cluster-operator.adoc
@@ -5,7 +5,7 @@
 [id='proc-upgrading-the-co-{context}']
 = Upgrading the Cluster Operator to a later version
 
-This procedure describes how to upgrade a Cluster Operator deployment to a later version
+This procedure describes how to upgrade a Cluster Operator deployment to a later version.
 
 .Prerequisites
 

--- a/documentation/modules/proc-upgrading-the-cluster-operator.adoc
+++ b/documentation/modules/proc-upgrading-the-cluster-operator.adoc
@@ -10,7 +10,7 @@ This procedure describes how to upgrade a Cluster Operator deployment to a later
 .Prerequisites
 
 * An existing Cluster Operator deployment is available.
-* The installation files have been xref:downloads-{context}[downloaded for the new version].
+* You have xref:downloads-{context}[downloaded the installation files for the new version].
 
 .Procedure
 

--- a/documentation/modules/proc-upgrading-the-cluster-operator.adoc
+++ b/documentation/modules/proc-upgrading-the-cluster-operator.adoc
@@ -5,11 +5,12 @@
 [id='proc-upgrading-the-co-{context}']
 = Upgrading the Cluster Operator to a later version
 
-This procedure describes how to upgrade a Cluster Operator deployment to a later version.
+This procedure describes how to upgrade a Cluster Operator deployment to a later version
 
 .Prerequisites
 
-* An existing Cluster Operator deployment.
+* An existing Cluster Operator deployment is available.
+* The installation files have been xref:downloads-{context}[downloaded for the new version].
 
 .Procedure
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -21,7 +21,7 @@
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 2.4.0
-:KafkaVersionLower: 2.3.0
+:KafkaVersionLower: 2.3.1
 :KafkaVersionHigher: 2.4.0
 
 //log message format version

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -21,7 +21,7 @@
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 2.4.0
-:KafkaVersionLower: 2.3.1
+:KafkaVersionLower: 2.3.0
 :KafkaVersionHigher: 2.4.0
 
 //log message format version


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Documentation

Couple of small edits following QE check of install and upgrade procedures.

1. Upgrading the Cluster Operator to a later version now includes link to download latest install files in prereqs.
2. Plus - I've moved a mirrormaker2 sub-section, to make reuse easier.
3. Edit for oauth to make a sentence clearer.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

