### PR TITLE
Prevent ZK cluster roll when scaling 3.5.x clusters 

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/Status.java
@@ -12,6 +12,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,13 @@ public abstract class Status implements UnknownPropertyPreserving, Serializable 
 
     public void setConditions(List<Condition> conditions) {
         this.conditions = conditions;
+    }
+
+    public void addCondition(Condition condition) {
+        List<Condition> oldConditions = getConditions();
+        List<Condition> newConditions = oldConditions != null ? new ArrayList<>(oldConditions) : new ArrayList<>();
+        newConditions.add(condition);
+        setConditions(Collections.unmodifiableList(newConditions));
     }
 
     @Description("The generation of the CRD that was last reconciled by the operator.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -29,13 +29,18 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
         FORBIDDEN_OPTIONS.addAll(Arrays.asList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES.split(" *, *")));
         // This option is handled in the Zookeeper container startup script
         FORBIDDEN_OPTIONS.add("snapshot.trust.empty");
+        // This option would prevent scaling beyond 1 node for clusters started with a single node
+        FORBIDDEN_OPTIONS.add("standaloneEnabled");
+        // Reconfiguration needs to be enabled to allow scaling of the cluster
+        FORBIDDEN_OPTIONS.add("reconfigEnabled");
+        // The Cluster Operator requires access to multiple 4LW and access to the nodes is secured by the TLS-Sidecars so we set all allowed
+        FORBIDDEN_OPTIONS.add("4lw.commands.whitelist");
 
         Map<String, String> config = new HashMap<>();
         config.put("tickTime", "2000");
         config.put("initLimit", "5");
         config.put("syncLimit", "2");
         config.put("autopurge.purgeInterval", "1");
-        config.put("4lw.commands.whitelist", "*");
         DEFAULTS = Collections.unmodifiableMap(config);
     }
 

--- a/docker-images/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka/scripts/zookeeper_config_generator.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
+# We need to first identify which version of ZK we are starting in, so we know which config format to use
+ZK_MINOR=$(ls libs | grep -Po 'zookeeper-\K\d+.\d+.\d+' | head -1 | cut -d. -f2)
+
 # Write the config file
 cat <<EOF
 # the directory where the snapshot is stored.
 dataDir=${ZOOKEEPER_DATA_DIR}
-clientPort=$(expr 10 \* 2181 + $ZOOKEEPER_ID - 1)
+EOF
+
+if [[ ZK_MINOR -lt 5 ]]; then
+    echo "clientPort=$(expr 10 \* 2181 + $ZOOKEEPER_ID - 1)"
+else
+    echo "4lw.commands.whitelist=*"
+    echo "standaloneEnabled=false"
+    echo "reconfigEnabled=true"
+fi
+
+cat <<EOF
 
 # Provided configuration
 ${ZOOKEEPER_CONFIGURATION}
@@ -14,7 +27,12 @@ EOF
 NODE=1
 FOLLOWER_PORT=$(expr 10 \* 2888)
 ELECTION_PORT=$(expr 10 \* 3888)
+CLIENT_PORT=$(expr 10 \* 2181)
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
-  echo "server.${NODE}=127.0.0.1:$(expr $FOLLOWER_PORT + $NODE - 1):$(expr $ELECTION_PORT + $NODE - 1)"
-  let NODE=NODE+1
+    if [[ ZK_MINOR -lt 5 ]]; then
+        echo "server.${NODE}=127.0.0.1:$(expr $FOLLOWER_PORT + $NODE - 1):$(expr $ELECTION_PORT + $NODE - 1)"
+    else
+        echo "server.${NODE}=127.0.0.1:$(expr $FOLLOWER_PORT + $NODE - 1):$(expr $ELECTION_PORT + $NODE - 1):participant;127.0.0.1:$(expr $CLIENT_PORT + $NODE - 1)"
+    fi
+    let NODE=NODE+1
 done

--- a/docker-images/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka/scripts/zookeeper_run.sh
@@ -88,5 +88,9 @@ if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi
 
+# We need to disable the native ZK authorisation (we secure ZK through the TLS-Sidecars) to allow use of the reconfiguration options.
+KAFKA_OPTS="$KAFKA_OPTS -Dzookeeper.skipACL=yes"
+export KAFKA_OPTS
+
 # starting Zookeeper with final configuration
 exec /usr/bin/tini -w -e 143 -- sh -c "${KAFKA_HOME}/bin/zookeeper-server-start.sh /tmp/zookeeper.properties"

--- a/documentation/misc/zookeeper-manual-scaling-methods.md
+++ b/documentation/misc/zookeeper-manual-scaling-methods.md
@@ -1,0 +1,147 @@
+# Zookeeper 3.5.x Manual Scaling Procedures
+
+Zookeeper 3.5.x uses a new configuration procedure compare to 3.4.x servers. This [dynamic reconfiguration](https://zookeeper.apache.org/doc/r3.5.7/zookeeperReconfig.html) means that servers need to be added and removed via the Zookeeper command line client (or Admin API) in order to properly maintain a stable Zookeeper cluster. 
+
+The procedures below outline the steps required to scale up (add) and scale down (remove) servers from an existing Strimzi Kafka deployment.
+
+## Scale up procedure
+
+The cluster should be scaled **one server at a time**. 
+
+1) Create an initial Strimzi cluster with n=3 replicas (3 Kafka + 3 Zookeeper servers).
+
+2) Set the replica count to n=4 in the zookeeper section of the Kafka CR.
+
+3) Allow the Zookeeper server (zookeeper-3) to start up normally and establish a link to the existing quorum.
+
+This can be checked with the following command:
+
+```
+kubectl exec -n myproject -it my-cluster-zookeeper-3 -c zookeeper -- bash -c "echo 'srvr' | nc 127.0.0.1 21813 | grep 'Mode:'"
+```
+
+This and the following commands assume that we are running in the `myproject` namespace and the kafka cluster is called `my-cluster`. Note that the index number in the new zookeeper node's name, `zookeeper-x`, matches the final number of the client port in the `nc 127.0.0.1 2181x` command. This command should output something like:
+
+```
+Mode: follower
+```
+
+4) Open a zookeeper-shell session on one of the nodes in the original cluster (in this case nodes 0, 1 or 2):
+
+```
+kubectl exec -n myproject -it my-cluster-zookeeper-0 -c zookeeper -- ./bin/zookeeper-shell.sh localhost:21810
+```
+
+5) Enter the following line to add the new server to the quorum as a voting member:
+
+```
+reconfig -add server.4=127.0.0.1:28883:38883:participant;127.0.0.1:21813
+```
+
+Note that the within the Zookeeper cluster the nodes are indexed from one not zero like in the node names. So the new `zookeeper-3` node is referred to as `server.4` within the Zookeeper configuration. This command should output the new cluster configuration:
+
+```
+server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810
+server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811
+server.3=127.0.0.1:28882:38882:participant;127.0.0.1:21812
+server.4=127.0.0.1:28883:38883:participant;127.0.0.1:21813
+version=100000054
+```
+ 
+This new configuration will then propagate to the other servers in the Zookeeper cluster and the new server should now be a full member of the quorum.
+ 
+6) Increase the replica count by 1 (n=5) in the zookeeper section of the Kafka CR.
+
+7) Allow the Zookeeper server (zookeeper-<n-1>) to start up normally and establish a link to the existing quorum.
+
+This can be checked with the following command:
+
+```
+kubectl exec -n <namespace> -it my-cluster-zookeeper-<n-1> -c zookeeper -- bash -c "echo 'srvr' | nc 127.0.0.1 2181<n-1> | grep 'Mode:'"
+```
+
+Which should show something like:
+
+```
+Mode: follower
+```
+
+8) Open a zookeeper-shell session on one of the nodes in the original cluster (in this case nodes 0 >= i <= n-2):
+
+```
+kubectl exec -n <namespace> -it my-cluster-zookeeper-<i> -c zookeeper -- ./bin/zookeeper-shell.sh localhost:2181<i>
+```
+
+9) Enter the following line to add the new server to the quorum as a voting member:
+
+```
+reconfig -add server.<n>=127.0.0.1:2888<n-1>:3888<n-1>:participant;127.0.0.1:2181<n-1>
+```
+
+10) Repeat steps 6-9 for as many servers as you wish to add.
+
+11) Once you have a cluster of the desired size you will need to signal to the cluster operator that it is safe to roll the Zookeeper cluster again. To do this set the manual-zk-scaling annotation to false (the CO will set this to true automatically once you change the number of Zookeeper replicas):
+
+```
+kubectl -n <namespace> annotate statefulset my-cluster-zookeeper strimzi.io/manual-zk-scaling=false --overwrite
+```
+
+## Scale down procedure
+
+The notes given in [the zookeeper documentation](https://zookeeper.apache.org/doc/r3.5.7/zookeeperReconfig.html#sc_reconfig_general) should be understood when scaling down a Zookeeper cluster.
+
+When removing nodes the highest numbered server will be deleted and so on in descending order. Therefore if you have a 5 node cluster and wish to scale down to 3 you will be removing zookeeper-4 and zookeeper-3 and keeping zookeeper-0, zookeeper-1 and zookeeper-2.
+
+1) Log into the zookeeper-shell on one of the nodes which will be retained after scale down.
+
+```
+kubectl exec -n myproject -it my-cluster-zookeeper-0 -c zookeeper -- ./bin/zookeeper-shell.sh localhost:21810
+```
+
+This command assumes you are running in the `myproject` namespace and the Kafka cluster is called `my-cluster`. Note that the index number in the zookeeper node's name, `zookeeper-x`, matches the final number of the client port in the `zookeeper-shell.sh localhost:2181x` command.
+
+2) Then run the following command to see the current configuration:
+
+```
+config
+```
+
+Assuming you are scaling down from a cluster that initially has 5 Zookeeper nodes, then this command should output something similar to:
+
+```
+server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810
+server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811
+server.3=127.0.0.1:28882:38882:participant;127.0.0.1:21812
+server.4=127.0.0.1:28883:38883:participant;127.0.0.1:21813
+server.5=127.0.0.1:28884:38884:participant;127.0.0.1:21814
+version=100000057
+```
+
+3) We need to remove the highest numbered server first, in this case server.5, to do this issue the following command:
+
+```
+reconfig -remove 5
+```
+
+This will show the new configuration that will be propagated to all other members of the quorum:
+
+```
+server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810
+server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811
+server.3=127.0.0.1:28882:38882:participant;127.0.0.1:21812
+server.4=127.0.0.1:28883:38883:participant;127.0.0.1:21813
+version=200000012
+```
+
+4) Once this has completed, the number of replicas for the zookeeper section of the Kafka CR can be reduced by one. This will shutdown zookeeper-4 (server.5).
+
+5) You can now repeat steps 1-4 to reduce the cluster size. Remember to do this in descending order.
+
+6) Once you have a cluster of the desired size you will need to signal to the cluster operator that it is safe to roll the Zookeeper cluster again. To do this set the manual-zk-scaling annotation to false (the CO will set this to true automatically once you change the number of Zookeeper replicas):
+
+```
+kubectl -n <namespace> annotate statefulset my-cluster-zookeeper strimzi.io/manual-zk-scaling=false --overwrite
+```
+
+Note: It is possible to specify multiple servers to be removed at once, so we could `reconfig -remove 4,5`, to remove the two highest numbered servers at once and scale down from 5 -> 3 in one step. However, doing this can lead to instability and is not recommended.
+

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -20,6 +20,7 @@ public class Annotations {
     public static final String STRIMZI_LOGGING_ANNOTATION = STRIMZI_DOMAIN + "logging";
     public static final String STRIMZI_IO_USE_CONNECTOR_RESOURCES = STRIMZI_DOMAIN + "use-connector-resources";
     public static final String ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE = STRIMZI_DOMAIN + "manual-rolling-update";
+    public static final String ANNO_STRIMZI_IO_MANUAL_ZK_SCALE = STRIMZI_DOMAIN + "manual-zk-scaling";
     @Deprecated
     public static final String ANNO_OP_STRIMZI_IO_MANUAL_ROLLING_UPDATE = "operator." + Annotations.STRIMZI_DOMAIN + "manual-rolling-update";
 


### PR DESCRIPTION
### Type of change

Bugfix

### Description

This PR prevents the CO rolling the ZK (3.5.x) cluster after scaling and allows the user to manually reconfigure the cluster to add or remove ZK nodes. The scaling of ZK 3.4.x clusters is unchanged.

 - Updated settings to allow ZK 3.5.x cluster reconfiguration
 - Made the ZK config gen script support 3.4.x and 3.5.x config format
 - Added annotation to signal that the user has finished manual scaling

Note: This commit will require manual user intervention to scale a 3.5.x cluster.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

