### PR TITLE
Fix upgrade test after some changes connected to dynamic configuration

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -123,12 +123,13 @@ public class ZookeeperUpgradeST extends BaseST {
 
         kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaPods);
         LOGGER.info("2nd Kafka roll (update) is complete");
-        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaReplicas, kafkaPods);
-        LOGGER.info("3rd Kafka roll (update) is complete");
 
         if (testInfo.getDisplayName().contains("Upgrade")) {
             StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), zkReplicas, zkPods);
             LOGGER.info("2nd Zookeeper roll (update) is complete");
+        } else if (testInfo.getDisplayName().contains("Downgrade")) {
+            kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), kafkaReplicas, kafkaPods);
+            LOGGER.info("3rd Kafka roll (update) is complete");
         }
 
         LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fix upgrade test after some changes connected to Kafka Rolling update. Problem was in one additional wait for rolling update which is not needed anymore.

### Checklist

- [x] Make sure all tests pass

