### PR TITLE
[DOC] Fix terminology error in per-listener certificates documentation

### DIFF
--- a/documentation/modules/ref-sample-kafka-resource-config.adoc
+++ b/documentation/modules/ref-sample-kafka-resource-config.adoc
@@ -120,7 +120,7 @@ spec:
 <6> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:assembly-configuring-kafka-broker-listeners-{context}[configured as `plain` (without encryption), `tls` or `external`].
 <7> Listener authentication mechanisms may be configured for each listener, and xref:assembly-kafka-broker-listener-authentication-{context}[specified as mutual TLS or SCRAM-SHA].
 <8> External listener configuration specifies xref:assembly-kafka-broker-external-listeners-{context}[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
-<9> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a public key. Kafka listener certificates can also be configured for TLS listeners.
+<9> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` property specifies a `Secret` that holds a server certificate and a private key. Kafka listener certificates can also be configured for TLS listeners.
 <10> Authorization xref:ref-kafka-authorization-{context}[enables `simple` authorization on the Kafka broker using the `SimpleAclAuthorizer` Kafka plugin].
 <11> Config specifies the broker configuration. xref:ref-kafka-broker-configuration-{context}[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by {ProductName}].
 <12> Storage is xref:assembly-storage-{context}[configured as `ephemeral`, `persistent-claim` or `jbod`].

--- a/documentation/modules/security/con-kafka-listener-certificates.adoc
+++ b/documentation/modules/security/con-kafka-listener-certificates.adoc
@@ -6,7 +6,7 @@
 
 = Kafka listener certificates
 
-You can provide your own server certificates and public keys for the following types of listeners:
+You can provide your own server certificates and private keys for the following types of listeners:
 
 * TLS listeners for inter-cluster communication
 

--- a/documentation/modules/security/proc-installing-certs-per-listener.adoc
+++ b/documentation/modules/security/proc-installing-certs-per-listener.adoc
@@ -5,7 +5,7 @@
 [id='proc-installing-certs-per-listener-{context}']
 = Providing your own Kafka listener certificates
 
-This procedure shows how to configure a listener to use your own public key and server certificate, called a xref:kafka-listener-certificates-{context}[Kafka listener certificate].
+This procedure shows how to configure a listener to use your own private key and server certificate, called a xref:kafka-listener-certificates-{context}[Kafka listener certificate].
 
 Your client applications should use the CA public key as a trusted certificate in order to verify the identity of the Kafka broker.
 
@@ -21,14 +21,14 @@ For more information, see xref:ref-alternative-subjects-certs-for-listeners-{con
 
 .Procedure
 
-. Create a `Secret` containing your public key and server certificate:
+. Create a `Secret` containing your private key and server certificate:
 +
 [source,shell,subs="+quotes"]
 ----
 kubectl create secret generic _my-secret_ --from-file=_my-listener-key.key_ --from-file=_my-listener-certificate.crt_
 ----
 
-. Edit the `Kafka` resource for your cluster. Configure the listener to use your `Secret`, certificate file, and public key file in the `configuration.brokerCertChainAndKey` property.
+. Edit the `Kafka` resource for your cluster. Configure the listener to use your `Secret`, certificate file, and private key file in the `configuration.brokerCertChainAndKey` property.
 +
 .Example configuration for a `loadbalancer` external listener with TLS encryption enabled
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

This pull request updates the documentation on Kafka listener certificates, which was added in #2414 , to correct the terminology for the user-provided key.

- Change "public key" to "private key" throughout; for example, "You can provide your own server certificates and _private keys_ for the following types of listeners...".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

