### PR TITLE
feat: Convert to context succeeding

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -171,73 +172,73 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
+            .setHandler(context.succeeding(v -> {
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedServices, hasSize(1)));
+                Service service = capturedServices.get(0);
+                context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
+                context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
 
-            // Verify Deployment Config
-            List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            DeploymentConfig dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
+                // Verify Deployment Config
+                List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedDc, hasSize(1)));
+                DeploymentConfig dc = capturedDc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
 
-            // Verify Build Config
-            List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedBc.size(), is(1)));
-            BuildConfig bc = capturedBc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
+                // Verify Build Config
+                List<BuildConfig> capturedBc = bcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedBc, hasSize(1)));
+                BuildConfig bc = capturedBc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedPdb, hasSize(1)));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
 
-            // Verify Image Streams
-            List<ImageStream> capturedIs = isCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedIs.size(), is(2)));
-            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
-            int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                // Verify Image Streams
+                List<ImageStream> capturedIs = isCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedIs, hasSize(2)));
+                int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
-            ImageStream sis = capturedIs.get(sisIndex);
-            context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
-            context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
+                ImageStream sis = capturedIs.get(sisIndex);
+                context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
+                context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
 
-            ImageStream tis = capturedIs.get(tisIndex);
-            context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
+                ImageStream tis = capturedIs.get(tisIndex);
+                context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
 
-            // Verify status
-            List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                // Verify status
+                List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
 
-            if (connectorOperator) {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
+                if (connectorOperator) {
+                    context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
 
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
-            } else {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
-            }
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), hasSize(1)));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
+                } else {
+                    context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
+                }
 
-            async.flag();
-        });
+                async.flag();
+            }));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -106,15 +106,17 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
         LOGGER.info("Reconciling initially -> create");
         CountDownLatch createAsync = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            context.verify(() -> assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue())));
-            createAsync.countDown();
-        });
+        kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
+            .setHandler(context.succeeding(ar -> {
+                context.verify(() -> {
+                    assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
+                });
+
+                createAsync.countDown();
+            }));
         if (!createAsync.await(60, TimeUnit.SECONDS)) {
             context.failNow(new Throwable("Test timeout"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -148,40 +148,40 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(createResult -> {
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (mirror.isMetricsEnabled()) {
-                metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName));
-            }
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (mirror.isMetricsEnabled()) {
+                    metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName));
+                }
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirror.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null))));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                Deployment dc = capturedDc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirror.getName())));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                context.verify(() -> assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null))));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedPdb.size(), is(1)));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
+                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
 
-            // Verify status
-            List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedMM.size(), is(1)));
-            KafkaMirrorMaker mm = capturedMM.get(0);
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready")));
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
+                // Verify status
+                List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedMM.size(), is(1)));
+                KafkaMirrorMaker mm = capturedMM.get(0);
+                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready")));
+                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
 
-            async.flag();
-        });
+                async.flag();
+            }));
     }
 
     @Test

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -107,20 +106,16 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<T>> fut = op.createOrUpdate(resource());
-        fut.setHandler(ar -> {
-            if (!ar.succeeded()) {
-                ar.cause().printStackTrace();
-            }
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            verify(mockResource).get();
-            verify(mockResource).patch(any());
-            verify(mockResource, never()).create(any());
-            verify(mockResource, never()).createNew();
-            verify(mockResource, never()).createOrReplace(any());
-            verify(mockCms, never()).createOrReplace(any());
-            async.flag();
-        });
+        op.createOrUpdate(resource())
+            .setHandler(context.succeeding(ar -> {
+                verify(mockResource).get();
+                verify(mockResource).patch(any());
+                verify(mockResource, never()).create(any());
+                verify(mockResource, never()).createNew();
+                verify(mockResource, never()).createOrReplace(any());
+                verify(mockCms, never()).createOrReplace(any());
+                async.flag();
+            }));
     }
 
     @Test

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
@@ -68,11 +68,14 @@ public class ClusterRoleOperatorIT extends AbstractNonNamespacedResourceOperator
 
     @Override
     protected void assertResources(VertxTestContext context, ClusterRole expected, ClusterRole actual)   {
-        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
-        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
-        context.verify(() -> assertThat(actual.getRules().size(), is(expected.getRules().size())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getApiGroups(), is(expected.getRules().get(0).getApiGroups())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getResources(), is(expected.getRules().get(0).getResources())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getVerbs(), is(expected.getRules().get(0).getVerbs())));
+        context.verify(() -> {
+            assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName()));
+            assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels()));
+            assertThat(actual.getRules().size(), is(expected.getRules().size()));
+            assertThat(actual.getRules().get(0).getApiGroups(), is(expected.getRules().get(0).getApiGroups()));
+            assertThat(actual.getRules().get(0).getResources(), is(expected.getRules().get(0).getResources()));
+            assertThat(actual.getRules().get(0).getVerbs(), is(expected.getRules().get(0).getVerbs()));
+        });
+
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -12,14 +12,13 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
@@ -87,20 +86,16 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
         AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<ServiceAccount>> fut = op.createOrUpdate(resource);
-        fut.setHandler(ar -> {
-            if (!ar.succeeded()) {
-                ar.cause().printStackTrace();
-            }
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            context.verify(() -> assertThat(ar.result() instanceof ReconcileResult.Noop, is(true)));
-            verify(mockResource).get();
-            //verify(mockResource).patch(any());
-            verify(mockResource, never()).create(any());
-            verify(mockResource, never()).createNew();
-            verify(mockResource, never()).createOrReplace(any());
-            verify(mockCms, never()).createOrReplace(any());
-            async.flag();
-        });
+        op.createOrUpdate(resource)
+            .setHandler(context.succeeding(rr -> {
+                context.verify(() -> assertThat(rr, instanceOf(ReconcileResult.Noop.class)));
+                verify(mockResource).get();
+                //verify(mockResource).patch(any());
+                verify(mockResource, never()).create(any());
+                verify(mockResource, never()).createNew();
+                verify(mockResource, never()).createOrReplace(any());
+                verify(mockCms, never()).createOrReplace(any());
+                async.flag();
+            }));
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -23,6 +23,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 public class MockKafka implements Kafka {
 
@@ -198,19 +201,23 @@ public class MockKafka implements Kafka {
     }
 
     public void assertExists(VertxTestContext context, TopicName topicName) {
-        context.verify(() -> assertThat("The topic "  + topicName + " should exist in " + this, topics.containsKey(topicName), is(true)));
+        context.verify(() -> assertThat("The topic "  + topicName + " should exist in " + this, topics, hasKey(topicName)));
     }
 
     public void assertNotExists(VertxTestContext context, TopicName topicName) {
-        context.verify(() -> assertThat("The topic "  + topicName + " should not exist in " + this, topics.containsKey(topicName), is(false)));
+        context.verify(() -> assertThat("The topic "  + topicName + " should not exist in " + this, topics, not(hasKey(topicName))));
     }
 
     public void assertEmpty(VertxTestContext context) {
-        context.verify(() -> assertThat("No topics should exist in " + this, topics.isEmpty(), is(true)));
+        context.verify(() -> assertThat("No topics should exist in " + this, topics, aMapWithSize(0)));
     }
 
     public void assertContains(VertxTestContext context, Topic topic) {
-        context.verify(() -> assertThat("The topic " + topic.getTopicName() + " either didn't exist, or had unexpected state", topics.get(topic.getTopicName()), is(topic)));
+        context.verify(() -> {
+            TopicName topicName = topic.getTopicName();
+            assertThat("The topic " + topicName + " does not exist", topics, hasKey(topicName));
+            assertThat("The topic " + topicName + " has an unexpected state", topics.get(topicName), is(topic));
+        });
     }
 
     public Topic getTopicState(TopicName topicName) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -42,6 +42,7 @@ import static io.fabric8.kubernetes.client.Watcher.Action.MODIFIED;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -134,7 +135,7 @@ public class TopicOperatorTest {
         Checkpoint async = context.checkpoint();
         topicOperator.onResourceEvent(logContext, kafkaTopic, ADDED).setHandler(ar -> {
             assertFailed(context, ar);
-            context.verify(() -> assertThat(ar.cause() instanceof InvalidTopicException, is(true)));
+            context.verify(() -> assertThat(ar.cause(), instanceOf(InvalidTopicException.class)));
             context.verify(() -> assertThat(ar.cause().getMessage(), is("KafkaTopic's spec.config has invalid entry: The key 'null' of the topic config is invalid: The value corresponding to the key must have a string, number or boolean value but the value was null")));
             mockKafka.assertEmpty(context);
             mockTopicStore.assertEmpty(context);


### PR DESCRIPTION
Switched to use context.succeeding(handler)
This means the boilerplate code of handling failures
is no longer needed in many tests and the Future is
passed to the handler already unwrapped

Also used HamCrest matchers in appropriate places to
increase the verbosity and usefulness of failed test results

Contributes to: #2647

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

