### PR TITLE
feat: Fail make docker_build if yq version not 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
-$(DOCKER_TARGETS): $(SUBDIRS)
+$(DOCKER_TARGETS): yq_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 
 next_version:
@@ -157,4 +157,11 @@ $(SUBDIRS):
 systemtest_make:
 	$(MAKE) -C systemtest $(MAKECMDGOALS)
 
-.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check
+RED=\033[0;31m
+NO_COLOUR=\033[0m
+YQ_VERSION = $(shell yq --version | $(SED) 's/^.* //g')
+
+yq_check:
+	if [[ $(YQ_VERSION) != "3."* ]]; then echo "$(RED)yq version is $(YQ_VERSION), version must be 3.*$(NO_COLOUR)" && exit 1; fi
+
+.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check yq_check

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
-all: $(SUBDIRS)
+all: yq_check $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
 $(DOCKER_TARGETS): yq_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean


### PR DESCRIPTION
Multiple people myself included have been bitten by having
the wrong yq version. The docs have been updated to reflect
this, but considering the builds will fail with obscure
mistemplated file errors it would be better to check upfront
the yq version.
If a user does not have yq version 3.*.* then it will fail
the build and print the warning in red.

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

