### PR TITLE
feat: Add app.kubernetes.io/part-of label to Strimzi components

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -194,6 +194,7 @@ public abstract class AbstractModel {
         this.labels = labels.withCluster(cluster)
                             .withKubernetesName()
                             .withKubernetesInstance(cluster)
+                            .withKubernetesPartOf(cluster)
                             .withKubernetesManagedBy(STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -537,6 +537,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withCluster(reconciliation.name())
                     .withKubernetesName()
                     .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesPartOf(reconciliation.name())
                     .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
             Promise<ReconciliationState> resultPromise = Promise.promise();
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
@@ -3045,6 +3046,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withCluster(reconciliation.name())
                     .withKubernetesName()
                     .withKubernetesInstance(reconciliation.name())
+                    .withKubernetesPartOf(reconciliation.name())
                     .withKubernetesManagedBy(AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
 
             OwnerReference ownerRef = new OwnerReferenceBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -93,6 +93,7 @@ public class KafkaBridgeClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaBridge.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -172,6 +172,7 @@ public class KafkaClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -117,6 +117,7 @@ public class KafkaConnectClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -122,6 +122,7 @@ public class KafkaConnectS2IClusterTest {
             Labels.STRIMZI_KIND_LABEL, KafkaConnectS2I.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -98,6 +98,7 @@ public class KafkaExporterTest {
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -127,6 +127,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -119,6 +119,7 @@ public class KafkaMirrorMakerClusterTest {
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
                 Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+                Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
                 Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -134,6 +134,7 @@ public class ZookeeperClusterTest {
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
+            Labels.KUBERNETES_PART_OF_LABEL, this.cluster,
             Labels.KUBERNETES_MANAGED_BY_LABEL, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -212,7 +212,7 @@ public class Labels {
     public Labels withCluster(String cluster) {
         return with(STRIMZI_CLUSTER_LABEL, cluster);
     }
-    
+
     /**
      * The same labels as this instance, but with the application name {@code strimzi} for the {@code app.kubernetes.io/name} key.
      * @return A new instance with the given kubernetes application name added.
@@ -231,12 +231,12 @@ public class Labels {
     }
 
     /**
-     * The same labels as this instance, but with the given {@code instance} for the {@code app.kubernetes.io/instance} key.
-     * @param instance The instance to add.
-     * @return A new instance with the given kubernetes application instance added.
+     * The same labels as this instance, but with the given {@code part-of} for the {@code app.kubernetes.io/part-of} key.
+     * @param partof The partof label to add.
+     * @return A new instance with the given kubernetes application part-of label added.
      */
-    public Labels withKubernetesPartOf(String instance) {
-        return with(Labels.KUBERNETES_PART_OF_LABEL, getOrValidInstanceLabelValue(instance));
+    public Labels withKubernetesPartOf(String partof) {
+        return with(Labels.KUBERNETES_PART_OF_LABEL, getOrValidInstanceLabelValue(partof));
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -64,6 +64,7 @@ public class Labels {
 
     public static final String KUBERNETES_NAME_LABEL = KUBERNETES_DOMAIN + "name";
     public static final String KUBERNETES_INSTANCE_LABEL = KUBERNETES_DOMAIN + "instance";
+    public static final String KUBERNETES_PART_OF_LABEL = KUBERNETES_DOMAIN + "part-of";
     public static final String KUBERNETES_MANAGED_BY_LABEL = KUBERNETES_DOMAIN + "managed-by";
 
     public static final String KUBERNETES_NAME = "strimzi";
@@ -227,6 +228,15 @@ public class Labels {
      */
     public Labels withKubernetesInstance(String instance) {
         return with(Labels.KUBERNETES_INSTANCE_LABEL, getOrValidInstanceLabelValue(instance));
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code instance} for the {@code app.kubernetes.io/instance} key.
+     * @param instance The instance to add.
+     * @return A new instance with the given kubernetes application instance added.
+     */
+    public Labels withKubernetesPartOf(String instance) {
+        return with(Labels.KUBERNETES_PART_OF_LABEL, getOrValidInstanceLabelValue(instance));
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -126,6 +126,7 @@ public class LabelsTest {
         userLabels.put(Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME);
         userLabels.put("key1", "value1");
         userLabels.put(Labels.KUBERNETES_INSTANCE_LABEL, "my-cluster");
+        userLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "my-cluster");
         userLabels.put("key2", "value2");
         userLabels.put(Labels.KUBERNETES_MANAGED_BY_LABEL, "my-operator");
         String validLabelContainingKubernetesDomainSubstring = "foo/" + Labels.KUBERNETES_DOMAIN;
@@ -188,6 +189,7 @@ public class LabelsTest {
         Map<String, String> userLabels = new HashMap<String, String>(5);
         userLabels.put(Labels.KUBERNETES_NAME_LABEL, Labels.KUBERNETES_NAME);
         userLabels.put(Labels.KUBERNETES_INSTANCE_LABEL, "my-cluster");
+        userLabels.put(Labels.KUBERNETES_PART_OF_LABEL, "my-cluster");
         userLabels.put(Labels.KUBERNETES_MANAGED_BY_LABEL, "my-operator");
         userLabels.put("key1", "value1");
         userLabels.put("key2", "value2");

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -79,6 +79,7 @@ public class KafkaUserModel {
         this.name = name;
         this.labels = labels.withKubernetesName()
             .withKubernetesInstance(name)
+            .withKubernetesPartOf(name)
             .withKubernetesManagedBy(KAFKA_USER_OPERATOR_NAME);
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -150,6 +150,7 @@ public class ResourceUtils {
                     .withLabels(Labels.userLabels(LABELS)
                         .withKubernetesName()
                         .withKubernetesInstance(NAME)
+                        .withKubernetesPartOf(NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .toMap())

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -53,6 +53,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         assertThat(model.authentication.getType(), is(KafkaUserTlsClientAuthentication.TYPE_TLS));
 
@@ -70,6 +71,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         KafkaUserQuotas quotas = quotasUser.getSpec().getQuotas();
         assertThat(model.getQuotas().getConsumerByteRate(), is(quotas.getConsumerByteRate()));
@@ -88,6 +90,7 @@ public class KafkaUserModelTest {
                 .withKind(KafkaUser.RESOURCE_KIND)
                 .withKubernetesName()
                 .withKubernetesInstance(ResourceUtils.NAME)
+                .withKubernetesPartOf(ResourceUtils.NAME)
                 .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)));
         KafkaUserQuotas quotas = quotasUserWithNulls.getSpec().getQuotas();
         assertThat(model.getQuotas().getConsumerByteRate(), is(quotas.getConsumerByteRate()));
@@ -109,6 +112,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
         // Check owner reference
@@ -218,6 +222,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
 
@@ -241,6 +246,7 @@ public class KafkaUserModelTest {
                 is(Labels.userLabels(ResourceUtils.LABELS)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .toMap()));
@@ -264,6 +270,7 @@ public class KafkaUserModelTest {
                         .withKind(KafkaUser.RESOURCE_KIND)
                         .withKubernetesName()
                         .withKubernetesInstance(ResourceUtils.NAME)
+                        .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -116,6 +116,7 @@ public class KafkaUserOperatorTest {
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .toMap())));
             context.verify(() -> assertThat(new String(Base64.getDecoder().decode(captured.getData().get("ca.crt"))), is("clients-ca-crt")));
@@ -453,6 +454,7 @@ public class KafkaUserOperatorTest {
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .toMap())));
             context.verify(() -> assertThat(new String(Base64.getDecoder().decode(captured.getData().get("ca.crt"))), is("clients-ca-crt")));
@@ -535,6 +537,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));
@@ -741,6 +744,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));
@@ -824,6 +828,7 @@ public class KafkaUserOperatorTest {
                     is(Labels.userLabels(user.getMetadata().getLabels())
                             .withKubernetesName()
                             .withKubernetesInstance(ResourceUtils.NAME)
+                            .withKubernetesPartOf(ResourceUtils.NAME)
                             .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                             .withKind(KafkaUser.RESOURCE_KIND)
                             .toMap())));


### PR DESCRIPTION
This commit adds app.kubernetes.io/part-of to the standard labels that
Strimzi operators add. It's set to match what we're currently using
for app.kubernetes.io/instance and is set in the same way.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>