### PR TITLE
Use reconcile to delete resource in IT

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaBridgeCrdOperatorIT.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -120,17 +119,6 @@ public class KafkaBridgeCrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaBridgeOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaBridgeOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaBridge deletion = kafkaBridgeOperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -201,7 +189,7 @@ public class KafkaBridgeCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaBridgeOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -265,7 +253,7 @@ public class KafkaBridgeCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaBridgeOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -359,7 +347,7 @@ public class KafkaBridgeCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaBridgeOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectCrdOperatorIT.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -119,17 +118,6 @@ public class KafkaConnectCrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaConnectOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaConnectOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaConnect deletion = kafkaConnectOperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -200,7 +188,7 @@ public class KafkaConnectCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -264,7 +252,7 @@ public class KafkaConnectCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -358,7 +346,7 @@ public class KafkaConnectCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaConnectS2IcrdOperatorIT.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -119,17 +118,6 @@ public class KafkaConnectS2IcrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaConnectS2Ioperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaConnectS2Ioperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaConnectS2I deletion = kafkaConnectS2Ioperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
         log.info("Getting Kubernetes version");
@@ -200,7 +188,7 @@ public class KafkaConnectS2IcrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectS2Ioperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -264,7 +252,7 @@ public class KafkaConnectS2IcrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectS2Ioperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -358,7 +346,7 @@ public class KafkaConnectS2IcrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaConnectS2Ioperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorIT.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -133,17 +132,6 @@ public class KafkaCrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            Kafka deletion = kafkaOperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -214,7 +202,7 @@ public class KafkaCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -278,7 +266,7 @@ public class KafkaCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -383,7 +371,7 @@ public class KafkaCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMaker2CrdOperatorIT.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -119,17 +118,6 @@ public class KafkaMirrorMaker2CrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaMirrorMaker2Operator.operation().inNamespace(namespace).withName(RESOURCE_NAME).delete();
-
-        return kafkaMirrorMaker2Operator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaMirrorMaker2 deletion = kafkaMirrorMaker2Operator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -200,7 +188,7 @@ public class KafkaMirrorMaker2CrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMaker2Operator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -264,7 +252,7 @@ public class KafkaMirrorMaker2CrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMaker2Operator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -357,7 +345,7 @@ public class KafkaMirrorMaker2CrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMaker2Operator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaMirrorMakerCrdOperatorIT.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -120,17 +119,6 @@ public class KafkaMirrorMakerCrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaMirrorMakerOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaMirrorMakerOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaMirrorMaker deletion = kafkaMirrorMakerOperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -201,7 +189,7 @@ public class KafkaMirrorMakerCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMakerOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -265,7 +253,7 @@ public class KafkaMirrorMakerCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMakerOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -359,7 +347,7 @@ public class KafkaMirrorMakerCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaMirrorMakerOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaUserCrdOperatorIT.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -119,17 +118,6 @@ public class KafkaUserCrdOperatorIT {
                 .build();
     }
 
-    private Future<Void> deleteResource()    {
-        // The resource has to be deleted this was and not using reconcile due to https://github.com/fabric8io/kubernetes-client/pull/1325
-        // Fix this override when project is using fabric8 version > 4.1.1
-        kafkaUserOperator.operation().inNamespace(namespace).withName(RESOURCE_NAME).cascading(true).delete();
-
-        return kafkaUserOperator.waitFor(namespace, RESOURCE_NAME, 1_000, 60_000, (ignore1, ignore2) -> {
-            KafkaUser deletion = kafkaUserOperator.get(namespace, RESOURCE_NAME);
-            return deletion == null;
-        });
-    }
-
     @Test
     public void testUpdateStatus(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         log.info("Getting Kubernetes version");
@@ -200,7 +188,7 @@ public class KafkaUserCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaUserOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -264,7 +252,7 @@ public class KafkaUserCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaUserOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {
@@ -358,7 +346,7 @@ public class KafkaUserCrdOperatorIT {
 
         log.info("Deleting resource");
         CountDownLatch deleteAsync = new CountDownLatch(1);
-        deleteResource().setHandler(res -> {
+        kafkaUserOperator.reconcile(namespace, RESOURCE_NAME, null).setHandler(res -> {
             if (res.succeeded()) {
                 deleteAsync.countDown();
             } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement 
### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/2659
Thanks to the newer version of fabric8 client we can use fixed behaviour of cascading delete.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

