### PR TITLE
ST: change and improve log collection from components during system tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -88,4 +88,10 @@ public class LogCollector {
         LOGGER.info("Collecting ReplicaSet in namespaces {}", namespace);
         writeFile(logDir + "/replicasets.log", cmdKubeClient().list("replicaset").toString());
     }
+
+    public void collectStrimzi() {
+        LOGGER.info("Collecting CR in namespaces {}", namespace);
+        String crData = cmdKubeClient().exec("get", "strimzi", "-o", "yaml").out();
+        writeFile(logDir + "/strimzi-custom-resources.log", crData);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -7,7 +7,6 @@ package io.strimzi.systemtest.logs;
 import io.strimzi.systemtest.Environment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -18,14 +19,15 @@ import java.util.TimeZone;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
-public class TestExecutionWatcher implements AfterTestExecutionCallback, LifecycleMethodExecutionExceptionHandler {
+public class TestExecutionWatcher implements TestExecutionExceptionHandler, LifecycleMethodExecutionExceptionHandler {
     private static final Logger LOGGER = LogManager.getLogger(TestExecutionWatcher.class);
 
     @Override
-    public void afterTestExecution(ExtensionContext extensionContext) {
+    public void handleTestExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
         String testClass = extensionContext.getRequiredTestClass().getName();
         String testMethod = extensionContext.getRequiredTestMethod().getName();
         collectLogs(testClass, testMethod);
+        throw throwable;
     }
 
     @Override
@@ -46,17 +48,7 @@ public class TestExecutionWatcher implements AfterTestExecutionCallback, Lifecyc
     @Override
     public void handleAfterAllMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
         String testClass = extensionContext.getRequiredTestClass().getName();
-
-        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String currentDate = simpleDateFormat.format(Calendar.getInstance().getTime());
-        String logDir = Environment.TEST_LOG_DIR + testClass + "_" + currentDate;
-
-        LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
-        logCollector.collectDeployments();
-        logCollector.collectStatefulSets();
-        logCollector.collectReplicaSets();
-
+        collectLogs(testClass, "");
         throw throwable;
     }
 
@@ -67,11 +59,15 @@ public class TestExecutionWatcher implements AfterTestExecutionCallback, Lifecyc
         String currentDate = simpleDateFormat.format(Calendar.getInstance().getTime());
         String logDir = !testMethod.isEmpty() ?
                 Environment.TEST_LOG_DIR + testClass + "." + testMethod + "_" + currentDate
-                : Environment.TEST_LOG_DIR + currentDate;
+                : Environment.TEST_LOG_DIR + testClass + currentDate;
 
         LogCollector logCollector = new LogCollector(kubeClient(), new File(logDir));
         logCollector.collectEvents();
         logCollector.collectConfigMaps();
         logCollector.collectLogsFromPods();
+        logCollector.collectDeployments();
+        logCollector.collectStatefulSets();
+        logCollector.collectReplicaSets();
+        logCollector.collectStrimzi();
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR change component log collection for sytem tests:

- remove log collection after each test, instead of this collect logs only in case of failure (the reason for this is it will save some time and some storage in jenkins)
- collect yamls of CRs to see the statuses and configuration of each CR

### Checklist

- [x] Make sure all tests pass
