### PR TITLE
feat: Convert to context succeeding Part 2

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
@@ -20,12 +22,13 @@ import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClusterOperatorConfigTest {
 
-    private static Map<String, String> envVars = new HashMap<>(4);
-
+    private static Map<String, String> envVars = new HashMap<>(8);
     static {
         envVars.put(ClusterOperatorConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(ClusterOperatorConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "30000");
@@ -85,7 +88,7 @@ public class ClusterOperatorConfigTest {
     }
 
     private Map<String, String> envWithImages() {
-        Map<String, String> envVars = new HashMap<>(2);
+        Map<String, String> envVars = new HashMap<>(5);
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, KafkaVersionTestUtils.getKafkaImagesEnvVarString());
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString());
         envVars.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES, KafkaVersionTestUtils.getKafkaConnectS2iImagesEnvVarString());
@@ -156,12 +159,12 @@ public class ClusterOperatorConfigTest {
     }
 
     @Test
-    public void testImagePullPolicyNotDefined() {
+    public void testImagePullPolicyWithEnvVarNotDefined() {
         assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullPolicy(), is(nullValue()));
     }
 
     @Test
-    public void testImagePullPolicyValidValues() {
+    public void testImagePullPolicyWithValidValues() {
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "Always");
         assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS));
@@ -174,7 +177,7 @@ public class ClusterOperatorConfigTest {
     }
 
     @Test
-    public void testImagePullPolicyUpperLowerCase() {
+    public void testImagePullPolicyWithUpperLowerCase() {
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "ALWAYS");
         assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS));
@@ -187,12 +190,12 @@ public class ClusterOperatorConfigTest {
     }
 
     @Test
-    public void testInvalidImagePullPolicy() {
-        assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
-            envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "Sometimes");
+    public void testInvalidImagePullPolicyThrowsInvalidConfigurationException() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_POLICY, "Sometimes");
 
-            ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
+        assertThrows(InvalidConfigurationException.class, () -> {
+            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
         });
     }
 
@@ -200,27 +203,31 @@ public class ClusterOperatorConfigTest {
     public void testImagePullSecrets() {
         Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
         envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS, "secret1,  secret2 ,  secret3    ");
-        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().size(), is(3));
-        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().contains(new LocalObjectReferenceBuilder().withName("secret1").build()), is(true));
-        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().contains(new LocalObjectReferenceBuilder().withName("secret2").build()), is(true));
-        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().contains(new LocalObjectReferenceBuilder().withName("secret3").build()), is(true));
+
+        List<LocalObjectReference> imagePullSecrets = ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets();
+        assertThat(imagePullSecrets, hasSize(3));
+        assertThat(imagePullSecrets, hasItems(new LocalObjectReferenceBuilder().withName("secret1").build(),
+            new LocalObjectReferenceBuilder().withName("secret2").build(),
+            new LocalObjectReferenceBuilder().withName("secret3").build()));
     }
 
     @Test
-    public void testImagePullSecretsInvalidCharacter() {
+    public void testImagePullSecretsThrowsWithInvalidCharacter() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS, "secret1, secret2 , secret_3 ");
+
         assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
-            envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS, "secret1, secret2 , secret_3 ");
-            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().size();
+            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
         });
     }
 
     @Test
-    public void testImagePullSecretsUpperCaseCharacter() {
+    public void testImagePullSecretsThrowsWithUpperCaseCharacter() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
+        envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS, "Secret");
+
         assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.envVars);
-            envVars.put(ClusterOperatorConfig.STRIMZI_IMAGE_PULL_SECRETS, "Secret");
-            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getImagePullSecrets().size();
+            ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup());
         });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -171,73 +172,73 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromCrd(clusterCm, VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaConnectS2I.RESOURCE_KIND, clusterCm.getMetadata().getNamespace(), clusterCm.getMetadata().getName()), clusterCm)
+            .setHandler(context.succeeding(v -> {
 
-            // Verify service
-            List<Service> capturedServices = serviceCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedServices.size(), is(1)));
-            Service service = capturedServices.get(0);
-            context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
-            context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
+                // Verify service
+                List<Service> capturedServices = serviceCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedServices, hasSize(1)));
+                Service service = capturedServices.get(0);
+                context.verify(() -> assertThat(service.getMetadata().getName(), is(connect.getServiceName())));
+                context.verify(() -> assertThat("Services are not equal", service, is(connect.generateService())));
 
-            // Verify Deployment Config
-            List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            DeploymentConfig dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
+                // Verify Deployment Config
+                List<DeploymentConfig> capturedDc = dcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedDc, hasSize(1)));
+                DeploymentConfig dc = capturedDc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                context.verify(() -> assertThat("Deployment Configs are not equal", dc, is(connect.generateDeploymentConfig(annotations, true, null, null))));
 
-            // Verify Build Config
-            List<BuildConfig> capturedBc = bcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedBc.size(), is(1)));
-            BuildConfig bc = capturedBc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
+                // Verify Build Config
+                List<BuildConfig> capturedBc = bcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedBc, hasSize(1)));
+                BuildConfig bc = capturedBc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("Build Configs are not equal", bc, is(connect.generateBuildConfig())));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedPdb, hasSize(1)));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(connect.generatePodDisruptionBudget())));
 
-            // Verify Image Streams
-            List<ImageStream> capturedIs = isCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedIs.size(), is(2)));
-            int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
-            int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                // Verify Image Streams
+                List<ImageStream> capturedIs = isCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedIs, hasSize(2)));
+                int sisIndex = (KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster())).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
+                int tisIndex = (connect.getName()).equals(capturedIs.get(0).getMetadata().getName()) ? 0 : 1;
 
-            ImageStream sis = capturedIs.get(sisIndex);
-            context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
-            context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
+                ImageStream sis = capturedIs.get(sisIndex);
+                context.verify(() -> assertThat(sis.getMetadata().getName(), is(KafkaConnectS2IResources.sourceImageStreamName(connect.getCluster()))));
+                context.verify(() -> assertThat("Source Image Streams are not equal", sis, is(connect.generateSourceImageStream())));
 
-            ImageStream tis = capturedIs.get(tisIndex);
-            context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
-            context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
+                ImageStream tis = capturedIs.get(tisIndex);
+                context.verify(() -> assertThat(tis.getMetadata().getName(), is(connect.getName())));
+                context.verify(() -> assertThat("Target Image Streams are not equal", tis, is(connect.generateTargetImageStream())));
 
-            // Verify status
-            List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
-            context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
+                // Verify status
+                List<KafkaConnectS2I> capturedConnects = connectCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getUrl(), is("http://foo-connect-api.test.svc:8083")));
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getStatus(), is("True")));
+                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConditions().get(0).getType(), is("Ready")));
 
-            if (connectorOperator) {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
+                if (connectorOperator) {
+                    context.verify(() -> assertThat(npCaptor.getValue(), is(notNullValue())));
 
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().size(), is(1)));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
-            } else {
-                context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
-                context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
-            }
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), hasSize(1)));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass")));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getType(), is("sink")));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins().get(0).getVersion(), is("1.0.0")));
+                } else {
+                    context.verify(() -> assertThat(npCaptor.getValue(), is(nullValue())));
+                    context.verify(() -> assertThat(capturedConnects.get(0).getStatus().getConnectorPlugins(), nullValue()));
+                }
 
-            async.flag();
-        });
+                async.flag();
+            }));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -106,15 +106,17 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
         LOGGER.info("Reconciling initially -> create");
         CountDownLatch createAsync = new CountDownLatch(1);
-        kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).setHandler(ar -> {
-            if (ar.failed()) ar.cause().printStackTrace();
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            context.verify(() -> assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue())));
-            context.verify(() -> assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue())));
-            createAsync.countDown();
-        });
+        kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
+            .setHandler(context.succeeding(ar -> {
+                context.verify(() -> {
+                    assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.services().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.serviceName(CLUSTER_NAME)).get(), is(notNullValue()));
+                    assertThat(mockClient.policy().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
+                });
+
+                createAsync.countDown();
+            }));
         if (!createAsync.await(60, TimeUnit.SECONDS)) {
             context.failNow(new Throwable("Test timeout"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -148,40 +148,40 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 VERSIONS);
 
         Checkpoint async = context.checkpoint();
-        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm).setHandler(createResult -> {
-            context.verify(() -> assertThat(createResult.succeeded(), is(true)));
+        ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker.RESOURCE_KIND, clusterCmNamespace, clusterCmName), clusterCm)
+            .setHandler(context.succeeding(createResult -> {
 
-            // No metrics config  => no CMs created
-            Set<String> metricsNames = new HashSet<>();
-            if (mirror.isMetricsEnabled()) {
-                metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName));
-            }
+                // No metrics config  => no CMs created
+                Set<String> metricsNames = new HashSet<>();
+                if (mirror.isMetricsEnabled()) {
+                    metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(clusterCmName));
+                }
 
-            // Verify Deployment
-            List<Deployment> capturedDc = dcCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedDc.size(), is(1)));
-            Deployment dc = capturedDc.get(0);
-            context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirror.getName())));
-            Map annotations = new HashMap();
-            annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
-            context.verify(() -> assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null))));
+                // Verify Deployment
+                List<Deployment> capturedDc = dcCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedDc.size(), is(1)));
+                Deployment dc = capturedDc.get(0);
+                context.verify(() -> assertThat(dc.getMetadata().getName(), is(mirror.getName())));
+                Map annotations = new HashMap();
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, LOGGING_CONFIG);
+                context.verify(() -> assertThat("Deployments are not equal", dc, is(mirror.generateDeployment(annotations, true, null, null))));
 
-            // Verify PodDisruptionBudget
-            List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedPdb.size(), is(1)));
-            PodDisruptionBudget pdb = capturedPdb.get(0);
-            context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
-            context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
+                // Verify PodDisruptionBudget
+                List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedPdb.size(), is(1)));
+                PodDisruptionBudget pdb = capturedPdb.get(0);
+                context.verify(() -> assertThat(pdb.getMetadata().getName(), is(mirror.getName())));
+                context.verify(() -> assertThat("PodDisruptionBudgets are not equal", pdb, is(mirror.generatePodDisruptionBudget())));
 
-            // Verify status
-            List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
-            context.verify(() -> assertThat(capturedMM.size(), is(1)));
-            KafkaMirrorMaker mm = capturedMM.get(0);
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready")));
-            context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
+                // Verify status
+                List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
+                context.verify(() -> assertThat(capturedMM.size(), is(1)));
+                KafkaMirrorMaker mm = capturedMM.get(0);
+                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready")));
+                context.verify(() -> assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True")));
 
-            async.flag();
-        });
+                async.flag();
+            }));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -140,7 +140,7 @@ public class StatefulSetOperatorTest
     }
 
     @Test
-    public void rollingUpdateSuccess() {
+    public void testRollingUpdateSuccess(VertxTestContext context) {
         StatefulSet resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -179,11 +179,13 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
-        assertThat(result.succeeded(), is(true));
+        Checkpoint a = context.checkpoint();
+        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+            .setHandler(context.succeeding(v -> a.flag()));
     }
+
     @Test
-    public void rollingUpdateDeletionTimeout() {
+    public void testRollingUpdateDeletionTimeout(VertxTestContext context) {
         StatefulSet resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -228,13 +230,16 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
-        assertThat(result.failed(), is(true));
-        assertThat(result.cause() instanceof TimeoutException, is(true));
+        Checkpoint a = context.checkpoint();
+        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(TimeoutException.class));
+                a.flag();
+            })));
     }
 
     @Test
-    public void rollingUpdateReadinessTimeout() {
+    public void testRollingUpdateReadinessTimeout(VertxTestContext context) {
         StatefulSet resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -272,13 +277,15 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
-        assertThat(result.failed(), is(true));
-        assertThat(result.cause() instanceof TimeoutException, is(true));
+        Checkpoint a = context.checkpoint();
+        op.maybeRestartPod(resource, "my-pod-0", pod -> true).setHandler(context.failing(e -> context.verify(() -> {
+            assertThat(e, instanceOf(TimeoutException.class));
+            a.flag();
+        })));
     }
 
     @Test
-    public void rollingUpdateReconcileFailed() {
+    public void testRollingUpdateReconcileFailed(VertxTestContext context) {
         StatefulSet resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
@@ -315,9 +322,12 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Future result = op.maybeRestartPod(resource, "my-pod-0", pod -> true);
-        assertThat(result.failed(), is(true));
-        assertThat(result.cause().getMessage().equals("reconcile failed"), is(true));
+        Checkpoint a = context.checkpoint();
+        op.maybeRestartPod(resource, "my-pod-0", pod -> true)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e.getMessage(), is("reconcile failed"));
+                a.flag();
+            })));
     }
 
     @Test
@@ -416,7 +426,7 @@ public class StatefulSetOperatorTest
 
         Checkpoint async = context.checkpoint();
         op.reconcile(sts1.getMetadata().getNamespace(), sts1.getMetadata().getName(), sts2)
-            .setHandler(context.succeeding(state -> {
+            .setHandler(context.succeeding(rrState -> {
                 verify(mockDeletable).delete();
                 async.flag();
             }));
@@ -458,12 +468,12 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Checkpoint async = context.checkpoint();
+        Checkpoint a = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, true)
-            .setHandler(context.succeeding(res -> {
-                context.verify(() -> assertThat(cascadingCaptor.getValue(), is(true)));
-                async.flag();
-            }));
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                assertThat(cascadingCaptor.getValue(), is(true));
+                a.flag();
+            })));
     }
 
     @Test
@@ -502,15 +512,12 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Checkpoint async = context.checkpoint();
-        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
-            if (res.succeeded())    {
-                context.verify(() -> assertThat(cascadingCaptor.getValue(), is(false)));
-            } else {
-                context.failNow(new Throwable());
-            }
-            async.flag();
-        });
+        Checkpoint a = context.checkpoint();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
+            .setHandler(context.succeeding(v -> context.verify(() -> {
+                assertThat(cascadingCaptor.getValue(), is(false));
+                a.flag();
+            })));
     }
 
     @Test
@@ -545,13 +552,9 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Checkpoint async = context.checkpoint();
-        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false).setHandler(res -> {
-            if (res.succeeded())    {
-                context.failNow(new Throwable());
-            }
-            async.flag();
-        });
+        Checkpoint a = context.checkpoint();
+        op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
+            .setHandler(context.failing(e -> a.flag()));
     }
 
     @Test
@@ -589,14 +592,12 @@ public class StatefulSetOperatorTest
             }
         };
 
-        Checkpoint async = context.checkpoint();
+        Checkpoint a = context.checkpoint();
         op.deleteAsync(NAMESPACE, RESOURCE_NAME, false)
-            .setHandler(context.failing(res -> {
-                context.verify(() -> {
-                    assertThat(res, instanceOf(MockitoException.class));
-                    assertThat(res.getMessage(), is("Something failed"));
-                });
-                async.flag();
-            }));
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(MockitoException.class));
+                assertThat(e.getMessage(), is("Something failed"));
+                a.flag();
+            })));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -16,6 +16,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
@@ -49,6 +50,7 @@ import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -132,7 +134,7 @@ public class ZookeeperLeaderFinderTest {
         }
 
         public Future<Integer> start() {
-            Future<Integer> future = Future.future();
+            Promise<Integer> promise = Promise.promise();
 
             netServer.exceptionHandler(ex -> log.error(ex))
                 .connectHandler(socket -> {
@@ -159,36 +161,27 @@ public class ZookeeperLeaderFinderTest {
                 })
                 .listen(ar -> {
                     if (ar.succeeded()) {
-                        future.complete(ar.result().actualPort());
+                        promise.complete(ar.result().actualPort());
                     } else {
-                        future.fail(ar.cause());
+                        promise.fail(ar.cause());
                     }
                 });
-            return future;
+            return promise.future();
         }
     }
 
-    private int[] startMockZks(VertxTestContext context, int num, BiFunction<Integer, Integer, Boolean> fn) throws InterruptedException, ExecutionException, TimeoutException {
+    private int[] startMockZks(VertxTestContext context, int num, BiFunction<Integer, Integer, Boolean> fn) throws InterruptedException {
         int[] result = new int[num];
-        CountDownLatch async = new CountDownLatch(1);
+        CountDownLatch async = new CountDownLatch(num);
         for (int i = 0; i < num; i++) {
             final int id = i;
             FakeZk zk = new FakeZk(id, attempt -> fn.apply(id, attempt));
             zks.add(zk);
-            int finalI = i;
-            zk.start().setHandler(ar -> {
-                if (ar.succeeded()) {
-                    Integer port = ar.result();
-                    log.debug("ZK {} listening on port {}", id, port);
-                    result[id] = port;
-                    if (finalI == num - 1) {
-                        async.countDown();
-                    }
-                } else {
-                    async.countDown();
-                    context.failNow(ar.cause());
-                }
-            });
+            zk.start().setHandler(context.succeeding(port -> {
+                log.debug("ZK {} listening on port {}", id, port);
+                result[id] = port;
+                async.countDown();
+            }));
         }
         if (!async.await(60, TimeUnit.SECONDS)) {
             context.failNow(new Throwable("Test timeout"));
@@ -207,52 +200,71 @@ public class ZookeeperLeaderFinderTest {
         return new Secret();
     }
 
-    @Test
-    public void test0Pods() {
-        ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
-        assertThat(finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        emptyList(), coKeySecret()).result(), is(Integer.valueOf(-1)));
-    }
-
     BackOff backoff() {
         return new BackOff(50, 2, MAX_ATTEMPTS);
     }
 
     @Test
-    public void test1Pods() {
+    public void test0PodsClusterReturnsUnknowLeader(VertxTestContext context) {
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
-        assertThat(finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0)), coKeySecret()).result(), is(Integer.valueOf(0)));
+        Checkpoint a = context.checkpoint();
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, emptyList(), coKeySecret())
+            .setHandler(context.succeeding(leader -> {
+                context.verify(() -> assertThat(leader, is(Integer.valueOf(ZookeeperLeaderFinder.UNKNOWN_LEADER))));
+                a.flag();
+            }));
     }
 
     @Test
-    public void testSecretsNotFound() {
+    public void test1PodClusterReturnsOnlyPodAsLeader(VertxTestContext context) {
+        ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, null, this::backoff);
+        Checkpoint a = context.checkpoint();
+        int firstPodIndex = 0;
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(firstPodIndex)), coKeySecret())
+            .setHandler(context.succeeding(leader -> {
+                context.verify(() -> assertThat(leader, is(Integer.valueOf(firstPodIndex))));
+                a.flag();
+            }));
+    }
+
+    @Test
+    public void testSecretWithMissingClusterOperatorKeyThrowsException(VertxTestContext context) {
         SecretOperator mock = mock(SecretOperator.class);
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, mock, this::backoff);
 
         Mockito.reset(mock);
         when(mock.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER))))
-                .thenReturn(Future.succeededFuture(
-                        new SecretBuilder()
-                                .withNewMetadata()
-                                    .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
-                                    .withNamespace(NAMESPACE)
-                                .endMetadata()
-                                .withData(emptyMap())
-                                .build()));
-        assertThat(finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                        asList(getPod(0), getPod(1)), new SecretBuilder()
-                                .withNewMetadata()
-                                .withName(ClusterOperator.secretName(CLUSTER))
+            .thenReturn(Future.succeededFuture(
+                    new SecretBuilder()
+                            .withNewMetadata()
+                                .withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER))
                                 .withNamespace(NAMESPACE)
-                                .endMetadata()
-                                .withData(emptyMap())
-                                .build()).cause().getMessage(),
-                is("The Secret testns/testcluster-cluster-operator-certs is missing the key cluster-operator.key"));
+                            .endMetadata()
+                            .withData(emptyMap())
+                            .build()));
+
+        Secret secretWithMissingClusterOperatorKey = new SecretBuilder()
+                .withNewMetadata()
+                .withName(ClusterOperator.secretName(CLUSTER))
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withData(emptyMap())
+                .build();
+
+        Checkpoint a = context.checkpoint();
+
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), secretWithMissingClusterOperatorKey)
+            .setHandler(context.failing(e -> context.verify(() -> {
+                assertThat(e, instanceOf(RuntimeException.class));
+                assertThat(e.getMessage(),
+                        is("The Secret testns/testcluster-cluster-operator-certs is missing the key cluster-operator.key"));
+                a.flag();
+            })));
+
     }
 
     @Test
-    public void testSecretsCorrupted() {
+    public void testSecretsCorrupted(VertxTestContext context) {
         SecretOperator mock = mock(SecretOperator.class);
         ZookeeperLeaderFinder finder = new ZookeeperLeaderFinder(vertx, mock, this::backoff);
 
@@ -265,23 +277,31 @@ public class ZookeeperLeaderFinderTest {
                                 .endMetadata()
                                 .withData(map(Ca.CA_CRT, "notacert"))
                                 .build()));
-        Throwable cause = finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                asList(getPod(0), getPod(1)), new SecretBuilder()
-                        .withNewMetadata()
-                        .withName(ClusterOperator.secretName(CLUSTER))
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .withData(map("cluster-operator.key", "notacert",
-                                "cluster-operator.crt", "notacert",
-                                "cluster-operator.p12", "notatruststore",
-                                "cluster-operator.password", "notapassword"))
-                        .build()).cause();
-        assertThat(cause instanceof RuntimeException, is(true));
-        assertThat(cause.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator\\.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
+
+        Secret secretWithBadCertificate = new SecretBuilder()
+                .withNewMetadata()
+                .withName(ClusterOperator.secretName(CLUSTER))
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withData(map("cluster-operator.key", "notacert",
+                        "cluster-operator.crt", "notacert",
+                        "cluster-operator.p12", "notatruststore",
+                        "cluster-operator.password", "notapassword"))
+                .build();
+
+        Checkpoint a = context.checkpoint();
+
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), secretWithBadCertificate)
+                .setHandler(context.failing(e -> context.verify(() -> {
+                    assertThat(e, instanceOf(RuntimeException.class));
+                    assertThat(e.getMessage(), is("Bad/corrupt certificate found in data.cluster-operator\\.crt of Secret testcluster-cluster-operator-certs in namespace testns"));
+                    a.flag();
+                })));
+
     }
 
     @Test
-    public void testTimeout(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReturnUnknownLeaderWhenMaxAttemptsExceeded(VertxTestContext context) throws InterruptedException {
         String coSecretName = ClusterOperator.secretName(CLUSTER);
         when(mock.getAsync(eq(NAMESPACE), eq(coSecretName)))
                 .thenReturn(Future.succeededFuture(
@@ -293,6 +313,7 @@ public class ZookeeperLeaderFinderTest {
                                 .withData(map("cluster-operator.key", "notacert",
                                         "cluster-operator.crt", "notacert"))
                                 .build()));
+
         String clusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(CLUSTER);
         when(mock.getAsync(eq(NAMESPACE), eq(clusterCaSecretName)))
                 .thenReturn(Future.succeededFuture(
@@ -310,20 +331,19 @@ public class ZookeeperLeaderFinderTest {
 
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                    asList(getPod(0), getPod(1)), coKeySecret())
-            .setHandler(context.succeeding(leader -> {
-                context.verify(() -> {
-                    assertThat(leader, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
-                    for (FakeZk zk : zks) {
-                        assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(MAX_ATTEMPTS + 1));
-                    }
-                });
+                asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
+            .setHandler(context.succeeding(leader -> context.verify(() -> {
+                assertThat(leader, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
+                for (FakeZk zk : zks) {
+                    assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(MAX_ATTEMPTS + 1));
+                }
                 a.flag();
-            }));
+            })
+            ));
     }
 
     @Test
-    public void testTimeoutDueToNetworkExceptions(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testReturnUnknownLeaderDuringNetworkExceptions(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
                 .thenReturn(Future.succeededFuture(
                         new SecretBuilder()
@@ -345,28 +365,26 @@ public class ZookeeperLeaderFinderTest {
                                 .build()));
 
         int[] ports = startMockZks(context, 2, (id, attempt) -> false);
-        // Use closed ports
+        // Close ports to ensure closed ports are used so as to mock network problems
         stopZks();
 
         ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
 
         Checkpoint a = context.checkpoint();
         finder.findZookeeperLeader(CLUSTER, NAMESPACE,
-                asList(getPod(0), getPod(1)), coKeySecret())
-                .setHandler(context.succeeding(l -> {
-                    context.verify(() -> {
-                        assertThat(l, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
-                        for (FakeZk zk : zks) {
-                            assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(0));
-                        }
-                    });
-                    a.flag();
-                }));
+                asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
+            .setHandler(context.succeeding(leader -> context.verify(() -> {
+                assertThat(leader, is(ZookeeperLeaderFinder.UNKNOWN_LEADER));
+                for (FakeZk zk : zks) {
+                    assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(0));
+                }
+                a.flag();
+            })));
     }
 
     @Test
-    public void testLeaderFoundThirdAttempt(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        int leader = 1;
+    public void testFinderHandlesFailureByLeaderFoundOnThirdAttempt(VertxTestContext context) throws InterruptedException {
+        int desiredLeaderId = 1;
         int succeedOnAttempt = 2;
         when(mock.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER))))
                 .thenReturn(Future.succeededFuture(
@@ -388,21 +406,19 @@ public class ZookeeperLeaderFinderTest {
                                 .withData(map(Ca.CA_CRT, "notacert"))
                                 .build()));
 
-        int[] ports = startMockZks(context, 2, (id, attempt) -> attempt == succeedOnAttempt && id == leader);
+        int[] ports = startMockZks(context, 2, (id, attempt) -> attempt == succeedOnAttempt && id == desiredLeaderId);
 
         TestingZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
 
         Checkpoint a = context.checkpoint();
-        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(getPod(0), getPod(1)), coKeySecret())
-            .setHandler(context.succeeding(l -> {
-                context.verify(() -> {
-                    assertThat(l, is(leader));
-                    for (FakeZk zk : zks) {
-                        assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(succeedOnAttempt + 1));
-                    }
-                });
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
+            .setHandler(context.succeeding(leader -> context.verify(() -> {
+                assertThat(leader, is(desiredLeaderId));
+                for (FakeZk zk : zks) {
+                    assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(succeedOnAttempt + 1));
+                }
                 a.flag();
-            }));
+            })));
     }
 
     @Test
@@ -433,24 +449,26 @@ public class ZookeeperLeaderFinderTest {
         ZookeeperLeaderFinder finder = new TestingZookeeperLeaderFinder(this::backoff, ports);
 
         Checkpoint a = context.checkpoint();
-        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(getPod(0), getPod(1)), coKeySecret())
-            .setHandler(context.succeeding(l -> {
-                context.verify(() -> {
-                    assertThat(l, is(leader));
-                    for (FakeZk zk : zks) {
-                        assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(1));
-                    }
-                });
+        finder.findZookeeperLeader(CLUSTER, NAMESPACE, asList(createPodWithId(0), createPodWithId(1)), coKeySecret())
+            .setHandler(context.succeeding(l -> context.verify(() -> {
+                assertThat(l, is(leader));
+                for (FakeZk zk : zks) {
+                    assertThat("Unexpected number of attempts for node " + zk.id, zk.attempts.get(), is(1));
+                }
                 a.flag();
-            }));
+            })));
     }
 
-    Pod getPod(int id) {
-        return new PodBuilder().withNewMetadata().withName("my-cluster-kafka-" + id).endMetadata().build();
+    Pod createPodWithId(int id) {
+        return new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-cluster-kafka-" + id)
+                .endMetadata()
+                .build();
     }
 
     @Test
-    public void testGetHost() {
+    public void testGetHostReturnsCorrectHostForGivenPod() {
         Pod pod = new PodBuilder()
                 .withNewMetadata()
                     .withName(ZookeeperCluster.zookeeperPodName("my-cluster", 3))

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.strimzi.operator.common.Util;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -73,24 +72,14 @@ public class PlatformFeaturesAvailabilityTest {
         HttpServer mockHttp = startMockApi(context, version, Collections.EMPTY_LIST);
 
         KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
-        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
 
-        Checkpoint async = context.checkpoint();
+        Checkpoint a = context.checkpoint();
 
-        futurePfa.setHandler(res -> {
-            if (res.succeeded())    {
-                context.verify(() -> assertThat("Versions are not equal", res.result().getKubernetesVersion(), is(KubernetesVersion.V1_9)));
-                async.flag();
-            } else {
-                context.failNow(new Throwable("Failed to create PlatformFeaturesAvailability object"));
-                async.flag();
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        stopMockApi(context, mockHttp);
+        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+            assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_9));
+            stopMockApi(context, mockHttp);
+            a.flag();
+        })));
     }
 
     @Test
@@ -110,24 +99,14 @@ public class PlatformFeaturesAvailabilityTest {
         HttpServer mockHttp = startMockApi(context, version, Collections.EMPTY_LIST);
 
         KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
-        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
 
         Checkpoint async = context.checkpoint();
 
-        futurePfa.setHandler(res -> {
-            if (res.succeeded())    {
-                context.verify(() -> assertThat("Versions are not equal", res.result().getKubernetesVersion(), is(KubernetesVersion.V1_14)));
-                async.flag();
-            } else {
-                context.failNow(new Throwable("Failed to create PlatformFeaturesAvailability object"));
-                async.flag();
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        stopMockApi(context, mockHttp);
+        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+            assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_14));
+            stopMockApi(context, mockHttp);
+            async.flag();
+        })));
     }
 
     @Test
@@ -139,28 +118,17 @@ public class PlatformFeaturesAvailabilityTest {
         HttpServer mockHttp = startMockApi(context, apis);
 
         KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
-        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
 
         Checkpoint async = context.checkpoint();
 
-        futurePfa.setHandler(res -> {
-            if (res.succeeded())    {
-                PlatformFeaturesAvailability pfa = res.result();
-                context.verify(() -> assertThat(pfa.hasRoutes(), is(true)));
-                context.verify(() -> assertThat(pfa.hasBuilds(), is(true)));
-                context.verify(() -> assertThat(pfa.hasImages(), is(false)));
-                context.verify(() -> assertThat(pfa.hasApps(), is(false)));
-                async.flag();
-            } else {
-                context.failNow(new Throwable("Failed to create PlatformFeaturesAvailability object"));
-                async.flag();
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        stopMockApi(context, mockHttp);
+        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+            assertThat(pfa.hasRoutes(), is(true));
+            assertThat(pfa.hasBuilds(), is(true));
+            assertThat(pfa.hasImages(), is(false));
+            assertThat(pfa.hasApps(), is(false));
+            stopMockApi(context, mockHttp);
+            async.flag();
+        })));
     }
 
     @Test
@@ -174,28 +142,17 @@ public class PlatformFeaturesAvailabilityTest {
         HttpServer mockHttp = startMockApi(context, apis);
 
         KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
-        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
 
         Checkpoint async = context.checkpoint();
 
-        futurePfa.setHandler(res -> {
-            if (res.succeeded())    {
-                PlatformFeaturesAvailability pfa = res.result();
-                context.verify(() -> assertThat(pfa.hasRoutes(), is(true)));
-                context.verify(() -> assertThat(pfa.hasBuilds(), is(true)));
-                context.verify(() -> assertThat(pfa.hasImages(), is(true)));
-                context.verify(() -> assertThat(pfa.hasApps(), is(true)));
-                async.flag();
-            } else {
-                context.failNow(new Throwable("Failed to create PlatformFeaturesAvailability object"));
-                async.flag();
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        stopMockApi(context, mockHttp);
+        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+            assertThat(pfa.hasRoutes(), is(true));
+            assertThat(pfa.hasBuilds(), is(true));
+            assertThat(pfa.hasImages(), is(true));
+            assertThat(pfa.hasApps(), is(true));
+            stopMockApi(context, mockHttp);
+            async.flag();
+        })));
     }
 
     @Test
@@ -203,28 +160,17 @@ public class PlatformFeaturesAvailabilityTest {
         HttpServer mockHttp = startMockApi(context, Collections.EMPTY_LIST);
 
         KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
-        Future<PlatformFeaturesAvailability> futurePfa = PlatformFeaturesAvailability.create(vertx, client);
 
         Checkpoint async = context.checkpoint();
 
-        futurePfa.setHandler(res -> {
-            if (res.succeeded())    {
-                PlatformFeaturesAvailability pfa = res.result();
-                context.verify(() -> assertThat(pfa.hasRoutes(), is(false)));
-                context.verify(() -> assertThat(pfa.hasBuilds(), is(false)));
-                context.verify(() -> assertThat(pfa.hasImages(), is(false)));
-                context.verify(() -> assertThat(pfa.hasApps(), is(false)));
-                async.flag();
-            } else {
-                context.failNow(new Throwable("Failed to create PlatformFeaturesAvailability object"));
-                async.flag();
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        stopMockApi(context, mockHttp);
+        PlatformFeaturesAvailability.create(vertx, client).setHandler(context.succeeding(pfa -> context.verify(() -> {
+            assertThat(pfa.hasRoutes(), is(false));
+            assertThat(pfa.hasBuilds(), is(false));
+            assertThat(pfa.hasImages(), is(false));
+            assertThat(pfa.hasApps(), is(false));
+            stopMockApi(context, mockHttp);
+            async.flag();
+        })));
     }
 
     @Test
@@ -241,8 +187,10 @@ public class PlatformFeaturesAvailabilityTest {
 
         VersionInfo vi = new VersionInfo(Util.parseMap(version));
 
-        context.verify(() -> assertThat(vi.getMajor(), is("1")));
-        context.verify(() -> assertThat(vi.getMinor(), is("16")));
+        context.verify(() -> {
+            assertThat(vi.getMajor(), is("1"));
+            assertThat(vi.getMinor(), is("16"));
+        });
         context.completeNow();
     }
 
@@ -289,11 +237,11 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     public void stopMockApi(VertxTestContext context, HttpServer server) throws InterruptedException {
-        Checkpoint stop = context.checkpoint();
+        Checkpoint async = context.checkpoint();
 
         server.close(res -> {
             if (res.succeeded())    {
-                stop.flag();
+                async.flag();
             } else {
                 throw new RuntimeException("Failed to stop Mock HTTP server");
             }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -107,20 +106,16 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<T>> fut = op.createOrUpdate(resource());
-        fut.setHandler(ar -> {
-            if (!ar.succeeded()) {
-                ar.cause().printStackTrace();
-            }
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            verify(mockResource).get();
-            verify(mockResource).patch(any());
-            verify(mockResource, never()).create(any());
-            verify(mockResource, never()).createNew();
-            verify(mockResource, never()).createOrReplace(any());
-            verify(mockCms, never()).createOrReplace(any());
-            async.flag();
-        });
+        op.createOrUpdate(resource())
+            .setHandler(context.succeeding(ar -> {
+                verify(mockResource).get();
+                verify(mockResource).patch(any());
+                verify(mockResource, never()).create(any());
+                verify(mockResource, never()).createNew();
+                verify(mockResource, never()).createOrReplace(any());
+                verify(mockCms, never()).createOrReplace(any());
+                async.flag();
+            }));
     }
 
     @Test

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ClusterRoleOperatorIT.java
@@ -68,11 +68,14 @@ public class ClusterRoleOperatorIT extends AbstractNonNamespacedResourceOperator
 
     @Override
     protected void assertResources(VertxTestContext context, ClusterRole expected, ClusterRole actual)   {
-        context.verify(() -> assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName())));
-        context.verify(() -> assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels())));
-        context.verify(() -> assertThat(actual.getRules().size(), is(expected.getRules().size())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getApiGroups(), is(expected.getRules().get(0).getApiGroups())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getResources(), is(expected.getRules().get(0).getResources())));
-        context.verify(() -> assertThat(actual.getRules().get(0).getVerbs(), is(expected.getRules().get(0).getVerbs())));
+        context.verify(() -> {
+            assertThat(actual.getMetadata().getName(), is(expected.getMetadata().getName()));
+            assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels()));
+            assertThat(actual.getRules().size(), is(expected.getRules().size()));
+            assertThat(actual.getRules().get(0).getApiGroups(), is(expected.getRules().get(0).getApiGroups()));
+            assertThat(actual.getRules().get(0).getResources(), is(expected.getRules().get(0).getResources()));
+            assertThat(actual.getRules().get(0).getVerbs(), is(expected.getRules().get(0).getVerbs()));
+        });
+
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -12,14 +12,13 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
@@ -87,20 +86,16 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
         AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<ServiceAccount>> fut = op.createOrUpdate(resource);
-        fut.setHandler(ar -> {
-            if (!ar.succeeded()) {
-                ar.cause().printStackTrace();
-            }
-            context.verify(() -> assertThat(ar.succeeded(), is(true)));
-            context.verify(() -> assertThat(ar.result() instanceof ReconcileResult.Noop, is(true)));
-            verify(mockResource).get();
-            //verify(mockResource).patch(any());
-            verify(mockResource, never()).create(any());
-            verify(mockResource, never()).createNew();
-            verify(mockResource, never()).createOrReplace(any());
-            verify(mockCms, never()).createOrReplace(any());
-            async.flag();
-        });
+        op.createOrUpdate(resource)
+            .setHandler(context.succeeding(rr -> {
+                context.verify(() -> assertThat(rr, instanceOf(ReconcileResult.Noop.class)));
+                verify(mockResource).get();
+                //verify(mockResource).patch(any());
+                verify(mockResource, never()).create(any());
+                verify(mockResource, never()).createNew();
+                verify(mockResource, never()).createOrReplace(any());
+                verify(mockCms, never()).createOrReplace(any());
+                async.flag();
+            }));
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockKafka.java
@@ -23,6 +23,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 public class MockKafka implements Kafka {
 
@@ -198,19 +201,23 @@ public class MockKafka implements Kafka {
     }
 
     public void assertExists(VertxTestContext context, TopicName topicName) {
-        context.verify(() -> assertThat("The topic "  + topicName + " should exist in " + this, topics.containsKey(topicName), is(true)));
+        context.verify(() -> assertThat("The topic "  + topicName + " should exist in " + this, topics, hasKey(topicName)));
     }
 
     public void assertNotExists(VertxTestContext context, TopicName topicName) {
-        context.verify(() -> assertThat("The topic "  + topicName + " should not exist in " + this, topics.containsKey(topicName), is(false)));
+        context.verify(() -> assertThat("The topic "  + topicName + " should not exist in " + this, topics, not(hasKey(topicName))));
     }
 
     public void assertEmpty(VertxTestContext context) {
-        context.verify(() -> assertThat("No topics should exist in " + this, topics.isEmpty(), is(true)));
+        context.verify(() -> assertThat("No topics should exist in " + this, topics, aMapWithSize(0)));
     }
 
     public void assertContains(VertxTestContext context, Topic topic) {
-        context.verify(() -> assertThat("The topic " + topic.getTopicName() + " either didn't exist, or had unexpected state", topics.get(topic.getTopicName()), is(topic)));
+        context.verify(() -> {
+            TopicName topicName = topic.getTopicName();
+            assertThat("The topic " + topicName + " does not exist", topics, hasKey(topicName));
+            assertThat("The topic " + topicName + " has an unexpected state", topics.get(topicName), is(topic));
+        });
     }
 
     public Topic getTopicState(TopicName topicName) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -42,6 +42,7 @@ import static io.fabric8.kubernetes.client.Watcher.Action.MODIFIED;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -134,7 +135,7 @@ public class TopicOperatorTest {
         Checkpoint async = context.checkpoint();
         topicOperator.onResourceEvent(logContext, kafkaTopic, ADDED).setHandler(ar -> {
             assertFailed(context, ar);
-            context.verify(() -> assertThat(ar.cause() instanceof InvalidTopicException, is(true)));
+            context.verify(() -> assertThat(ar.cause(), instanceOf(InvalidTopicException.class)));
             context.verify(() -> assertThat(ar.cause().getMessage(), is("KafkaTopic's spec.config has invalid entry: The key 'null' of the topic config is invalid: The value corresponding to the key must have a string, number or boolean value but the value was null")));
             mockKafka.assertEmpty(context);
             mockTopicStore.assertEmpty(context);


### PR DESCRIPTION
Switched to use context.succeeding(handler)
This means the boilerplate code of handling failures
is no longer needed in many tests and the Future is
passed to the handler already unwrapped

Also used HamCrest matchers in appropriate places to
increase the verbosity and usefulness of failed test results

Also in this PR:
Minor test renames, variable renames and test cleanup

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

