### PR TITLE
ST: Fix check for status message in case of unsupported kafka

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -131,7 +131,7 @@ public class SpecificST extends BaseST {
     @Tag(REGRESSION)
     void testDeployUnsupportedKafka() {
         String nonExistingVersion = "6.6.6";
-        String nonExistingVersionMessage = "Version " + nonExistingVersion + " is not supported.*";
+        String nonExistingVersionMessage = "Unsupported Kafka.spec.kafka.version: " + nonExistingVersion + ". Supported versions are.*";
 
         KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, 1, 1)
                 .editSpec()


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fix check for unssuported Kafka version in Kafka CR status. THe log was probalby changed recently, but tests still looking for old log.

### Checklist

- [x] Make sure all tests pass

