### PR TITLE
ST: Disable zk scaledown test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -34,6 +34,7 @@ import io.vertx.core.cli.annotations.Description;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -343,6 +344,8 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
+    @Disabled("Zookeeper scaleUp/scaleDown is currently covered by manual procedure for Kafka 2.4.x. " +
+            "This should be removed after implementation of Zookeeper Dynamic configuration")
     void testZookeeperScaleUpScaleDown() {
         int messageCount = 50;
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

Test `testZookeeperScaleUpScaleDown` is not working now and it should be disabled until scaleup of ZK pods will be fixed properly.

### Checklist


