### PR TITLE
[MO] - [bug] -> wrong selected timeout 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -50,6 +50,7 @@ public interface Constants {
     long GLOBAL_TRACING_TIMEOUT =  Duration.ofMinutes(7).toMillis();
 
     long GLOBAL_CLIENTS_TIMEOUT = Duration.ofMinutes(2).toMillis();
+    long GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT = Duration.ofSeconds(10).toMillis();
 
     long CO_OPERATION_TIMEOUT_DEFAULT = Duration.ofMinutes(5).toMillis();
     long CO_OPERATION_TIMEOUT_SHORT = Duration.ofSeconds(30).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthKafkaClient.java
@@ -32,7 +32,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
  * The OauthKafkaClient for sending and receiving messages using access token provided by authorization server.
  * The client is using an external listeners.
  */
-public class OauthKafkaClient implements IKafkaClient<Future<Integer>>, AutoCloseable {
+public class OauthKafkaClient implements IKafkaClient<Future<Integer>> {
 
     private Vertx vertx = Vertx.vertx();
     private static final Logger LOGGER = LogManager.getLogger(KafkaClient.class);
@@ -41,13 +41,6 @@ public class OauthKafkaClient implements IKafkaClient<Future<Integer>>, AutoClos
     private String clientId;
     private String clientSecretName;
     private String oauthTokenEndpointUri;
-
-    @Override
-    public void close() {
-        if (vertx != null) {
-            vertx.close();
-        }
-    }
 
     public Future<Integer> sendMessages(String topicName, String namespace, String clusterName, int messageCount) throws IOException {
         return sendMessages(topicName, namespace, clusterName, messageCount, Constants.GLOBAL_CLIENTS_TIMEOUT);

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/OauthKafkaClient.java
@@ -32,7 +32,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
  * The OauthKafkaClient for sending and receiving messages using access token provided by authorization server.
  * The client is using an external listeners.
  */
-public class OauthKafkaClient implements IKafkaClient<Future<Integer>> {
+public class OauthKafkaClient implements IKafkaClient<Future<Integer>>, AutoCloseable {
 
     private Vertx vertx = Vertx.vertx();
     private static final Logger LOGGER = LogManager.getLogger(KafkaClient.class);
@@ -41,6 +41,13 @@ public class OauthKafkaClient implements IKafkaClient<Future<Integer>> {
     private String clientId;
     private String clientSecretName;
     private String oauthTokenEndpointUri;
+
+    @Override
+    public void close() {
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
 
     public Future<Integer> sendMessages(String topicName, String namespace, String clusterName, int messageCount) throws IOException {
         return sendMessages(topicName, namespace, clusterName, messageCount, Constants.GLOBAL_CLIENTS_TIMEOUT);

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthAuthorizationST.java
@@ -81,8 +81,8 @@ public class OauthAuthorizationST extends OauthBaseST {
 
         assertThrows(Exception.class, () -> {
             Future<Integer> invalidProducer = teamAOauthKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE,
-                    CLUSTER_NAME, TEAM_A_CLIENT, MESSAGE_COUNT, "SSL", TIMEOUT_SEND_RECV_MESSAGES);
-            invalidProducer.get(TIMEOUT_SEND_RECV_MESSAGES, TimeUnit.SECONDS);
+                    CLUSTER_NAME, TEAM_A_CLIENT, MESSAGE_COUNT, "SSL", Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT);
+            invalidProducer.get(Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT, TimeUnit.MILLISECONDS);
         });
 
         String topicXName = TOPIC_X + "-example-1";
@@ -116,15 +116,14 @@ public class OauthAuthorizationST extends OauthBaseST {
 
         assertThrows(Exception.class, () -> {
             Future<Integer> invalidConsumer = teamAOauthKafkaClient.receiveMessagesTls(TOPIC_A, NAMESPACE, CLUSTER_NAME,
-                    TEAM_A_CLIENT, MESSAGE_COUNT, "SSL", "bad_consumer_group", TIMEOUT_SEND_RECV_MESSAGES);
-            invalidConsumer.get(TIMEOUT_SEND_RECV_MESSAGES, TimeUnit.SECONDS);
+                    TEAM_A_CLIENT, MESSAGE_COUNT, "SSL", "bad_consumer_group", Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT);
+            invalidConsumer.get(Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT, TimeUnit.MILLISECONDS);
         });
 
-        Future<Integer> consumerWithCorrectConsumerGroup = teamAOauthKafkaClient.receiveMessagesTls(TOPIC_A, NAMESPACE, CLUSTER_NAME, TEAM_A_CLIENT,
-                MESSAGE_COUNT, "SSL", "a_correct_consumer_group");
+        Future<Integer> consumerWithCorrectConsumerGroup = teamAOauthKafkaClient.receiveMessagesTls(TOPIC_A, NAMESPACE,
+                CLUSTER_NAME, TEAM_A_CLIENT, MESSAGE_COUNT, "SSL", "a_correct_consumer_group");
 
         assertThat(consumerWithCorrectConsumerGroup.get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS), is(MESSAGE_COUNT));
-
     }
 
     @Description("As a member of team B, I should be able to write and read from topics that starts with b-")
@@ -135,8 +134,8 @@ public class OauthAuthorizationST extends OauthBaseST {
         // Producer will not produce messages because authorization topic will failed. Team A can write only to topic starting with 'x-'
         assertThrows(Exception.class, () -> {
             Future<Integer> invalidProducer = teamBOauthKafkaClient.sendMessagesTls(TOPIC_NAME, NAMESPACE, CLUSTER_NAME,
-                    TEAM_B_CLIENT, MESSAGE_COUNT, "SSL", TIMEOUT_SEND_RECV_MESSAGES);
-            invalidProducer.get(TIMEOUT_SEND_RECV_MESSAGES, TimeUnit.SECONDS);
+                    TEAM_B_CLIENT, MESSAGE_COUNT, "SSL", Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT);
+            invalidProducer.get(Constants.GLOBAL_CLIENTS_EXCEPT_ERROR_TIMEOUT, TimeUnit.MILLISECONDS);
         });
 
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, TOPIC_B);


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR adding closing `Vertx` session client. It should fixed 
- `io.strimzi.systemtest.AllNamespaceST.testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO` test where in log were 

```
2020-03-10 01:38:24 &amp#27;[1;31mERROR&amp#27;[m [OAuthBearerLoginModule:318] Failed to connect to: https://ip-address:port/auth/realms/kafka-authz/protocol/openid-connect/token
java.io.IOException: Failed to connect to: https://ip-address:port/auth/realms/kafka-authz/protocol/openid-connect/token
	at io.strimzi.kafka.oauth.common.HttpUtil.request(HttpUtil.java:119) ~[kafka-oauth-common-0.3.0.jar:?]
	at io.strimzi.kafka.oauth.common.HttpUtil.post(HttpUtil.java:61) ~[kafka-oauth-common-0.3.0.jar:?]
	at io.strimzi.kafka.oauth.common.OAuthAuthenticator.post(OAuthAuthenticator.java:87) ~[kafka-oauth-common-0.3.0.jar:?]
	at io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientSecret(OAuthAuthenticator.java:60) ~[kafka-oauth-common-0.3.0.jar:?]
	at 
```
meaning that the connection was still open.

### Checklist

- [ ] Make sure all tests pass

