### PR TITLE
ST: Add another fix for cover access form clients pod to connet with NP

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.resources;
 import io.fabric8.kubernetes.api.model.DoneableService;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
@@ -332,7 +333,7 @@ public class KubernetesResource {
      */
     public static void allowNetworkPolicySettingsForResource(HasMetadata resource, String deploymentName, String clusterName) {
         String clientsDeploymentName = clusterName + "-" + Constants.KAFKA_CLIENTS;
-        Map<String, String> labels = kubeClient().listPodsByPrefixInName(clientsDeploymentName).get(0).getMetadata().getLabels();
+        LabelSelector labelSelector = kubeClient().getDeployment(clientsDeploymentName).getSpec().getSelector();
 
         LOGGER.info("Apply NetworkPolicy access to {} from {}", deploymentName, clientsDeploymentName);
 
@@ -345,7 +346,7 @@ public class KubernetesResource {
                 .withNewSpec()
                     .addNewIngress()
                         .addNewFrom()
-                            .withPodSelector(new LabelSelectorBuilder().addToMatchLabels(labels).build())
+                            .withPodSelector(labelSelector)
                         .endFrom()
                         .addNewPort()
                             .withNewPort(8083)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/KubernetesResource.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.DoneableService;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AllNamespaceST.java
@@ -83,6 +83,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
+        KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
         KafkaConnectResource.kafkaConnect(SECOND_CLUSTER_NAME, 1)
             .editMetadata()
@@ -98,6 +99,7 @@ class AllNamespaceST extends AbstractNamespaceST {
     void testDeployKafkaConnectS2IAndKafkaConnectorInOtherNamespaceThanCO() {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
         String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
+        KafkaClientsResource.deployKafkaClients(false, SECOND_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).done();
         // Deploy Kafka Connect in other namespace than CO
         KafkaConnectS2IResource.kafkaConnectS2I(SECOND_CLUSTER_NAME, SECOND_CLUSTER_NAME, 1)
             .editMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/CustomResourceStatusST.java
@@ -36,6 +36,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectS2IResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
@@ -376,6 +377,7 @@ class CustomResourceStatusST extends BaseST {
             .done();
 
         KafkaTopicResource.topic(CLUSTER_NAME, TOPIC_NAME).done();
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
     }
 
     void logCurrentStatus(Condition kafkaCondition, String resource) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/LogSettingST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.resources.KubernetesResource;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
@@ -412,6 +413,8 @@ class LogSettingST extends BaseST {
                 .endEntityOperator()
             .endSpec()
             .done();
+
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
 
         KafkaConnectResource.kafkaConnect(CONNECT_NAME, CLUSTER_NAME, 1)
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -200,6 +200,7 @@ public class MetricsST extends BaseST {
         // 050-Deployment
         KubernetesResource.clusterOperator(NAMESPACE).done();
         KafkaResource.kafkaWithMetrics(CLUSTER_NAME, 3, 3).done();
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
         KafkaConnectResource.kafkaConnectWithMetrics(CLUSTER_NAME, 1, false).done();
         KafkaTopicResource.topic(CLUSTER_NAME, "test-topic", 7, 2).done();
         // Wait for Metrics refresh/values change

--- a/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/oauth/OauthTlsST.java
@@ -13,6 +13,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.ClientFactory;
 import io.strimzi.systemtest.kafkaclients.EClientType;
 import io.strimzi.systemtest.kafkaclients.externalClients.OauthKafkaClient;
+import io.strimzi.systemtest.resources.crd.KafkaClientsResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
@@ -88,6 +89,8 @@ public class OauthTlsST extends OauthBaseST {
 
         assertThat(producer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
         assertThat(consumer.get(2, TimeUnit.MINUTES), is(MESSAGE_COUNT));
+
+        KafkaClientsResource.deployKafkaClients(false, KAFKA_CLIENTS_NAME).done();
 
         KafkaConnectResource.kafkaConnect(CLUSTER_NAME, 1)
                 .editMetadata()


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

Unfortunately, yesterday I forget to add deployment of Kafka CLients as an access point to connect resources. This PR fix all occurrences of this issue (hopefully for last time).

We decided with Maros, that current approach will be just a temporary solution and we will try to find better way for 0.18.

### Checklist

- [x] Make sure all tests pass

