### PR TITLE
[systemtest] Fix failed tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectS2IST.java
@@ -409,8 +409,7 @@ class ConnectS2IST extends BaseST {
             kc.getMetadata().getAnnotations().remove(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES);
         });
 
-        String execPodName = KafkaResources.kafkaPodName(CLUSTER_NAME, 0);
-        KafkaConnectUtils.createFileSinkConnector(execPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
+        KafkaConnectUtils.createFileSinkConnector(kafkaClientsPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(CLUSTER_NAME, NAMESPACE, 8083));
         KafkaConnectUtils.waitForConnectorCreation(connectS2IPodName, "sink-test");
 
         // Wait for Cluster Operator reconciliation

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -110,6 +110,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @Tag(REGRESSION)
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 class KafkaST extends BaseST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaST.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaTopic;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
@@ -1018,7 +1019,7 @@ class KafkaST extends BaseST {
     }
 
     @Test
-    void testEntityOperatorWithoutUserOperator() {
+        void testEntityOperatorWithoutUserOperator() {
         LOGGER.info("Deploying Kafka cluster without UO in EO");
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_DEPLOYMENT));
         KafkaResource.kafkaEphemeral(CLUSTER_NAME, 3)
@@ -1279,6 +1280,7 @@ class KafkaST extends BaseST {
         verifyVolumeNamesAndLabels(2, 2, 10);
         LOGGER.info("Deleting cluster");
         cmdKubeClient().deleteByName("kafka", CLUSTER_NAME).waitForResourceDeletion("pvc", "data-0-" + KafkaResources.kafkaPodName(CLUSTER_NAME, 0));
+        PersistentVolumeClaimUtils.waitUntilPVCDeletion(CLUSTER_NAME);
         verifyPVCDeletion(2, jbodStorage);
     }
 
@@ -1955,7 +1957,7 @@ class KafkaST extends BaseST {
     @Test
     void testKafkaOffsetsReplicationFactorHigherThanReplicas() {
         int replicas = 3;
-        KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, replicas, 1)
+        Kafka kafka = KafkaResource.kafkaWithoutWait(KafkaResource.defaultKafka(CLUSTER_NAME, replicas, 1)
             .editSpec()
                 .editKafka()
                     .addToConfig("offsets.topic.replication.factor", 4)
@@ -1966,6 +1968,7 @@ class KafkaST extends BaseST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(CLUSTER_NAME, NAMESPACE,
                 "Kafka configuration option .* should be set to " + replicas + " or less because 'spec.kafka.replicas' is " + replicas);
+        KafkaResource.kafkaClient().inNamespace(NAMESPACE).delete(kafka);
     }
 
     protected void checkKafkaConfiguration(String podNamePrefix, Map<String, Object> config, String clusterName) {


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

This PR fix some tests from our downstream job.

```
io.strimzi.systemtest.KafkaST.testKafkaJBODDeleteClaimsTrueFalse - OCP4 - I add dynamic wait for PVC deletion
io.strimzi.systemtest.KafkaST.testEntityOperatorWithoutUserOperator - OCP3, OCP4 - this failed because of not deleted Kafka without wait from last test
io.strimzi.systemtest.ConnectS2IST.testKafkaConnectorWithConnectS2IAndConnectWithSameName - OCP3, OCP4 - bad pod for creation FileSinkConnector - changed to clientsPod
```

### Checklist
- [ ] Make sure all tests pass


