### PR TITLE
ST: improve log collector for system tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -91,7 +91,7 @@ public class LogCollector {
 
     public void collectStrimzi() {
         LOGGER.info("Collecting CR in namespaces {}", namespace);
-        String crData = cmdKubeClient().exec("get", "strimzi", "-o", "yaml").out();
+        String crData = cmdKubeClient().exec(false, "get", "strimzi", "-o", "yaml").out();
         writeFile(logDir + "/strimzi-custom-resources.log", crData);
     }
 }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -47,7 +47,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     String namespace = defaultNamespace();
 
-    protected abstract String cmd();
+    public abstract String cmd();
 
     @Override
     @SuppressWarnings("unchecked")
@@ -229,10 +229,15 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     public ExecResult exec(String... command) {
+        return exec(true, command);
+    }
+
+    @Override
+    public ExecResult exec(boolean throwError, String... command) {
         List<String> cmd = new ArrayList<>();
         cmd.add(cmd());
         cmd.addAll(asList(command));
-        return Exec.exec(cmd);
+        return Exec.exec(null, cmd, 0, true, throwError);
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -92,6 +92,14 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     ExecResult exec(String... command);
 
     /**
+     * Execute the given {@code command}. You can specify if potential failure will thrown the exception or not.
+     * @param throwError parameter which control thrown exception in case of failure
+     * @param command The command
+     * @return The process result.
+     */
+    ExecResult exec(boolean throwError, String... command);
+
+    /**
      * Wait for the resource with the given {@code name} to be created.
      * @param resourceType The resource type.
      * @param resourceName The resource name.
@@ -153,4 +161,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     Date getResourceCreateTimestamp(String pod, String s);
 
     List<String> listResourcesByLabel(String resourceType, String label);
+
+    String cmd();
 }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Kubectl.java
@@ -33,7 +33,7 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     }
 
     @Override
-    protected String cmd() {
+    public String cmd() {
         return KUBECTL;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/Oc.java
@@ -81,7 +81,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     }
 
     @Override
-    protected String cmd() {
+    public String cmd() {
         return OC;
     }
 


### PR DESCRIPTION

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds two things:

- cmd client can return the current cluster command (`oc` or `kubectl`)
- collecting CR logs will not fail in case that CRDs are already deleted

### Checklist

- [x] Make sure all tests pass

