### PR TITLE
feat: yq check enforce bash usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ endif
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init docker-images helm-charts install examples
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
-all: yq_check $(SUBDIRS)
+all: prerequisites_check $(SUBDIRS)
 clean: $(SUBDIRS) docu_clean
-$(DOCKER_TARGETS): yq_check $(SUBDIRS)
+$(DOCKER_TARGETS): prerequisites_check $(SUBDIRS)
 release: release_prepare release_version release_helm_version release_maven $(SUBDIRS) release_docu release_single_file release_pkg release_helm_repo docu_clean
 
 next_version:
@@ -157,11 +157,7 @@ $(SUBDIRS):
 systemtest_make:
 	$(MAKE) -C systemtest $(MAKECMDGOALS)
 
-RED=\033[0;31m
-NO_COLOUR=\033[0m
-YQ_VERSION = $(shell yq --version | $(SED) 's/^.* //g')
+prerequisites_check:
+	SED=$(SED) ./prerequisites-check.sh
 
-yq_check: $(eval SHELL:=/bin/bash)
-	if [[ $(YQ_VERSION) != "3."* ]]; then echo "$(RED)yq version is $(YQ_VERSION), version must be 3.*$(NO_COLOUR)" && exit 1; fi
-
-.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check yq_check
+.PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check prerequisites_check

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ RED=\033[0;31m
 NO_COLOUR=\033[0m
 YQ_VERSION = $(shell yq --version | $(SED) 's/^.* //g')
 
-yq_check:
+yq_check: $(eval SHELL:=/bin/bash)
 	if [[ $(YQ_VERSION) != "3."* ]]; then echo "$(RED)yq version is $(YQ_VERSION), version must be 3.*$(NO_COLOUR)" && exit 1; fi
 
 .PHONY: all $(SUBDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check yq_check

--- a/prerequisites-check.sh
+++ b/prerequisites-check.sh
@@ -3,14 +3,14 @@
 RED="\033[0;31m"
 NO_COLOUR="\033[0m"
 
-function check_commend_present() {
+function check_command_present() {
     command -v "${1}" >/dev/null 2>&1 || { echo -e >&2 "${RED}I require ${1} but it's not installed.  Aborting.${NO_COLOUR}"; exit 1; }
 }
 
-check_commend_present yq
-check_commend_present mvn
-check_commend_present git
-check_commend_present docker
+check_command_present yq
+check_command_present mvn
+check_command_present git
+check_command_present docker
 
 YQ_VERSION="$(yq --version | ${SED} 's/^.* //g')"
 if [[ ${YQ_VERSION} != "3."* ]]; then

--- a/prerequisites-check.sh
+++ b/prerequisites-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+RED="\033[0;31m"
+NO_COLOUR="\033[0m"
+
+function check_commend_present() {
+    command -v "${1}" >/dev/null 2>&1 || { echo -e >&2 "${RED}I require ${1} but it's not installed.  Aborting.${NO_COLOUR}"; exit 1; }
+}
+
+check_commend_present yq
+check_commend_present mvn
+check_commend_present git
+check_commend_present docker
+
+YQ_VERSION="$(yq --version | ${SED} 's/^.* //g')"
+if [[ ${YQ_VERSION} != "3."* ]]; then
+  echo -e "${RED}yq vesion is ${YQ_VERSION}, version must be 3.*${NO_COLOUR}"
+  exit 1
+fi


### PR DESCRIPTION
Some build machines or distributions of linux do not have bash as the
default shell, when the if check is ran on regular shell it always
fails. We enforce the usage of bash when running this command so
that the check does not fail on these environments

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

