### PR TITLE
Connector conditional put

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -144,6 +144,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
             <scope>test</scope>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -355,20 +355,20 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return apiClient.getConnectorConfig(new BackOff(200L, 2, 6), host, port, connectorName).compose(
             config -> {
                 if (!needsReconfiguring(reconciliation, connectorName, connectorSpec, config)) {
-                    log.info("{}: Connector {} exists and has desired config, {}=={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
+                    log.debug("{}: Connector {} exists and has desired config, {}=={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
                     return apiClient.status(host, port, connectorName)
                         .compose(status -> {
                             return pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status);
                         });
                 } else {
-                    log.info("{}: Connector {} exists but does not have desired config, {}!={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
+                    log.debug("{}: Connector {} exists but does not have desired config, {}!={}", reconciliation, connectorName, connectorSpec.getConfig(), config);
                     return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec);
                 }
             },
             error -> {
                 if (error instanceof ConnectRestException
                         && ((ConnectRestException) error).getStatusCode() == 404) {
-                    log.info("{}: Connector {} does not exist", reconciliation, connectorName);
+                    log.debug("{}: Connector {} does not exist", reconciliation, connectorName);
                     return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec);
                 } else {
                     return Future.failedFuture(error);
@@ -384,8 +384,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         desired.put("name", connectorName);
         desired.put("connector.class", connectorSpec.getClassName());
         if (log.isDebugEnabled()) {
-            log.info("{}: Desired: {}", reconciliation, desired);
-            log.info("{}: Actual:  {}", reconciliation, new TreeMap<>(actual));
+            log.debug("{}: Desired: {}", reconciliation, desired);
+            log.debug("{}: Actual:  {}", reconciliation, new TreeMap<>(actual));
         }
         return connectorSpec.getConfig().equals(actual);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -25,14 +25,107 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A Java client for the Kafka Connect REST API.
+ */
 public interface KafkaConnectApi {
+    /**
+     * Make a {@code PUT} request to {@code /connectors/${connectorName}/config}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to create or update.
+     * @param configJson The connectors configuration.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns information about the connector, including its name, config and tasks.
+     */
     Future<Map<String, Object>> createOrUpdatePutRequest(String host, int port, String connectorName, JsonObject configJson);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to get the config of.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the connector's config.
+     */
+    Future<Map<String, Object>> getConnectorConfig(String host, int port, String connectorName);
+
+    public Future<Map<String, Object>> getConnectorConfig(BackOff backOff, String host, int port, String connectorName);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to create or update.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns information about the connector, including its name, config and tasks.
+     */
+    Future<Map<String, Object>> getConnector(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code DELETE} request to {@code /connectors/${connectorName}}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to delete.
+     * @return A Future which completes with the result of the request.
+     */
     Future<Void> delete(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to get the status of.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the connector's status.
+     */
     Future<Map<String, Object>> status(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}/status}, retrying according to {@code backoff}.
+     * @param backOff The backoff parameters.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to get the status of.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the connector's status.
+     */
     Future<Map<String, Object>> statusWithBackOff(BackOff backOff, String host, int port, String connectorName);
+
+    /**
+     * Make a {@code PUT} request to {@code /connectors/${connectorName}/pause}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to pause.
+     * @return A Future which completes with the result of the request.
+     */
     Future<Void> pause(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code PUT} request to {@code /connectors/${connectorName}/resume}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to resume.
+     * @return A Future which completes with the result of the request.
+     */
     Future<Void> resume(String host, int port, String connectorName);
+
+    /**
+     * Make a {@code GET} request to {@code /connectors}
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the list of connectors.
+     */
     Future<List<String>> list(String host, int port);
+
+    /**
+     * Make a {@code GET} request to {@code /connector-plugins}.
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @return A Future which completes with the result of the request. If the request was successful,
+     * this returns the list of connector plugins.
+     */
     Future<List<ConnectorPlugin>> listConnectorPlugins(String host, int port);
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -178,7 +178,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
         Buffer data = configJson.toBuffer();
         String path = "/connectors/" + connectorName + "/config";
-        log.info("Making PUT request to {} with body {}", path, configJson);
+        log.debug("Making PUT request to {} with body {}", path, configJson);
         vertx.createHttpClient(options)
                 .put(port, host, path, response -> {
                     response.exceptionHandler(error -> {
@@ -189,7 +189,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             ObjectMapper mapper = new ObjectMapper();
                             try {
                                 Map t = mapper.readValue(buffer.getBytes(), Map.class);
-                                log.info("Got {} response to PUT request to {}: {}", response.statusCode(), path, t);
+                                log.debug("Got {} response to PUT request to {}: {}", response.statusCode(), path, t);
                                 result.complete(t);
                             } catch (IOException e) {
                                 result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
@@ -197,7 +197,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         });
                     } else {
                         // TODO Handle 409 (Conflict) indicating a rebalance in progress
-                        log.info("Got {} response to PUT request to {}", response.statusCode(), path);
+                        log.debug("Got {} response to PUT request to {}", response.statusCode(), path);
                         response.bodyHandler(buffer -> {
                             JsonObject x = buffer.toJsonObject();
                             result.fail(new ConnectRestException(response, x.getString("message")));
@@ -225,7 +225,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     private Future<Map<String, Object>> doGet(String host, int port, String path, Set<Integer> okStatusCodes) {
         Future<Map<String, Object>> result = Future.future();
         HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
-        log.info("Making GET request to {}", path);
+        log.debug("Making GET request to {}", path);
         vertx.createHttpClient(options)
                 .get(port, host, path, response -> {
                     response.exceptionHandler(error -> {
@@ -236,7 +236,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             ObjectMapper mapper = new ObjectMapper();
                             try {
                                 Map t = mapper.readValue(buffer.getBytes(), Map.class);
-                                log.info("Got {} response to GET request to {}: {}", response.statusCode(), path, t);
+                                log.debug("Got {} response to GET request to {}: {}", response.statusCode(), path, t);
                                 result.complete(t);
                             } catch (IOException e) {
                                 result.fail(new ConnectRestException(response, "Could not deserialize response: " + e));
@@ -244,7 +244,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         });
                     } else {
                         // TODO Handle 409 (Conflict) indicating a rebalance in progress
-                        log.info("Got {} response to GET request to {}", response.statusCode(), path);
+                        log.debug("Got {} response to GET request to {}", response.statusCode(), path);
                         response.bodyHandler(buffer -> {
                             JsonObject x = buffer.toJsonObject();
                             result.fail(new ConnectRestException(response, x.getString("message")));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -72,7 +72,13 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                                         ResourceOperatorSupplier supplier,
                                         ClusterOperatorConfig config,
                                         Function<Vertx, KafkaConnectApi> connectClientProvider) {
-        super(vertx, pfa, KafkaConnect.RESOURCE_KIND, supplier.connectOperator, supplier, config, connectClientProvider);
+        this(vertx, pfa, supplier, config, connectClientProvider, KafkaConnectCluster.REST_API_PORT);
+    }
+    public KafkaConnectAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
+                                        ResourceOperatorSupplier supplier,
+                                        ClusterOperatorConfig config,
+                                        Function<Vertx, KafkaConnectApi> connectClientProvider, int port) {
+        super(vertx, pfa, KafkaConnect.RESOURCE_KIND, supplier.connectOperator, supplier, config, connectClientProvider, port);
         this.deploymentOperations = supplier.deploymentOperations;
         this.connectS2IOperations = supplier.connectS2IOperator;
         this.networkPolicyOperator = supplier.networkPolicyOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperator.java
@@ -82,7 +82,7 @@ public class KafkaConnectS2IAssemblyOperator extends AbstractConnectOperator<Ope
                                            ResourceOperatorSupplier supplier,
                                            ClusterOperatorConfig config,
                                            Function<Vertx, KafkaConnectApi> connectClientProvider) {
-        super(vertx, pfa, KafkaConnectS2I.RESOURCE_KIND, supplier.connectS2IOperator, supplier, config, connectClientProvider);
+        super(vertx, pfa, KafkaConnectS2I.RESOURCE_KIND, supplier.connectS2IOperator, supplier, config, connectClientProvider, KafkaConnectCluster.REST_API_PORT);
         this.deploymentConfigOperations = supplier.deploymentConfigOperations;
         this.imagesStreamOperations = supplier.imagesStreamOperations;
         this.buildConfigOperations = supplier.buildConfigOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -107,7 +107,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                                         ResourceOperatorSupplier supplier,
                                         ClusterOperatorConfig config,
                                         Function<Vertx, KafkaConnectApi> connectClientProvider) {
-        super(vertx, pfa, KafkaMirrorMaker2.RESOURCE_KIND, supplier.mirrorMaker2Operator, supplier, config, connectClientProvider);
+        super(vertx, pfa, KafkaMirrorMaker2.RESOURCE_KIND, supplier.mirrorMaker2Operator, supplier, config, connectClientProvider, KafkaConnectCluster.REST_API_PORT);
         this.deploymentOperations = supplier.deploymentOperations;
         this.networkPolicyOperator = supplier.networkPolicyOperator;
         this.versions = config.versions();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import org.apache.kafka.connect.cli.ConnectDistributed;
+import io.debezium.kafka.KafkaCluster;
+import org.apache.kafka.connect.runtime.Connect;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class ConnectCluster {
+
+    private static final int STARTING_PORT = 8083;
+
+    private int numNodes;
+    private String brokerList;
+    private List<Connect> connectInstances = new ArrayList<>();
+    private List<String> pluginPath = new ArrayList<>();
+
+    ConnectCluster addConnectNodes(int numNodes) {
+        this.numNodes = numNodes;
+        return this;
+    }
+
+    ConnectCluster usingBrokers(KafkaCluster kafkaCluster) {
+        this.brokerList = kafkaCluster.brokerList();
+        return this;
+    }
+
+    ConnectCluster addToPluginPath(File file) {
+        this.pluginPath.add(file.getAbsolutePath());
+        return this;
+    }
+
+    public void startup() throws IOException, InterruptedException {
+        File tempDirectory = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+        for (int i = 0; i < numNodes; i++) {
+            Map<String, String> workerProps = new HashMap<>();
+            workerProps.put("listeners", "http://localhost:" + (STARTING_PORT + i));
+            workerProps.put("plugin.path", String.join(",", pluginPath));
+            workerProps.put("group.id", toString());
+            workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
+            workerProps.put("key.converter.schemas.enable", "false");
+            workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+            workerProps.put("value.converter.schemas.enable", "false");
+            workerProps.put("offset.storage.topic", getClass().getSimpleName() + "-offsets");
+            workerProps.put("offset.storage.replication.factor", "3");
+            workerProps.put("config.storage.topic", getClass().getSimpleName() + "-config");
+            workerProps.put("config.storage.replication.factor", "3");
+            workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
+            workerProps.put("status.storage.replication.factor", "3");
+            workerProps.put("bootstrap.servers", brokerList);
+            //DistributedConfig config = new DistributedConfig(workerProps);
+            //RestServer rest = new RestServer(config);
+            //rest.initializeServer();
+            CountDownLatch l = new CountDownLatch(1);
+            Thread thread = new Thread(() -> {
+                ConnectDistributed connectDistributed = new ConnectDistributed();
+                Connect connect = connectDistributed.startConnect(workerProps);
+                l.countDown();
+                connectInstances.add(connect);
+                connect.awaitStop();
+            });
+            thread.setDaemon(false);
+            thread.start();
+            l.await();
+
+        }
+    }
+
+    public void shutdown() {
+        for (Connect t : connectInstances) {
+            t.stop();
+        }
+        for (Connect t : connectInstances) {
+            t.awaitStop();
+        }
+    }
+
+    public int getPort() {
+        return STARTING_PORT;
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -1,18 +1,6 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -37,7 +37,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -34,11 +34,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -64,28 +64,6 @@ public class KafkaConnectorIT {
 
     @BeforeEach
     public void before() throws IOException, InterruptedException {
-        Class<?> c = TestingConnector.class;
-        ClassLoader cl = c.getClassLoader();
-        File file = null;
-        if (cl instanceof URLClassLoader) {
-            URLClassLoader urlCl = (URLClassLoader) cl;
-            URL[] urls = urlCl.getURLs();
-            List<File> files = new ArrayList<>();
-            for (URL url : urls) {
-                log.info("{}", url.getFile());
-                if (url.getFile().endsWith("/cluster-operator/target/test-classes/")
-                        || url.getFile().contains("log4j")
-                        || url.getFile().contains("slf4j")) {
-                    files.add(new File(url.getFile()));
-                }
-            }
-            Path tempDirectory = Files.createTempDirectory(getClass().getName());
-            copy(files, tempDirectory);
-            file = tempDirectory.toFile();
-            listFiles(file);
-        }
-
-
         vertx = Vertx.vertx();
 
         // Start a 3 node Kafka cluster
@@ -100,8 +78,7 @@ public class KafkaConnectorIT {
         // Start a N node connect cluster
         connectCluster = new ConnectCluster()
                 .usingBrokers(cluster)
-                .addConnectNodes(3)
-                .addToPluginPath(file);
+                .addConnectNodes(3);
         connectCluster.startup();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -186,15 +186,13 @@ public class KafkaConnectorIT {
                         null, null, null, null, null, null, null, null, null, null, null,
                         null, connectCrdOperator, null, null, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-                connect -> new KafkaConnectApiImpl(vertx),
-                connectCluster.getPort() + 2) {
-
-        };
+            connect -> new KafkaConnectApiImpl(vertx),
+            connectCluster.getPort() + 2) { };
 
         operator.reconcileConnector(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
                 "localhost", connectClient, true, connectorName,
-                connector)
-        .compose(r -> {
+                connector
+        ).compose(r -> {
             return connectorIsRunning(context, kubeClient, namespace, connectorName);
         }).compose(ignored -> {
             config.remove(TestingConnector.START_TIME_MS, 1_000);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.debezium.kafka.KafkaCluster;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.model.DoneableKafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.operator.KubernetesVersion;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.mockkube.MockKube;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaConnectorIT {
+
+    private static final Logger log = LogManager.getLogger(KafkaConnectorIT.class.getName());
+
+    private KafkaCluster cluster;
+    private static Vertx vertx;
+    private ConnectCluster connectCluster;
+
+    @BeforeEach
+    public void before() throws IOException, InterruptedException {
+        Class<?> c = TestingConnector.class;
+        ClassLoader cl = c.getClassLoader();
+        File file = null;
+        if (cl instanceof URLClassLoader) {
+            URLClassLoader urlCl = (URLClassLoader) cl;
+            URL[] urls = urlCl.getURLs();
+            List<File> files = new ArrayList<>();
+            for (URL url : urls) {
+                log.info("{}", url.getFile());
+                if (url.getFile().endsWith("/cluster-operator/target/test-classes/")
+                        || url.getFile().contains("log4j")
+                        || url.getFile().contains("slf4j")) {
+                    files.add(new File(url.getFile()));
+                }
+            }
+            Path tempDirectory = Files.createTempDirectory(getClass().getName());
+            copy(files, tempDirectory);
+            file = tempDirectory.toFile();
+            listFiles(file);
+        }
+
+
+        vertx = Vertx.vertx();
+
+        // Start a 3 node Kafka cluster
+        cluster = new KafkaCluster();
+        cluster.addBrokers(3);
+        cluster.deleteDataPriorToStartup(true);
+        cluster.deleteDataUponShutdown(true);
+        cluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
+        cluster.startup();
+        cluster.createTopics(getClass().getSimpleName() + "-offsets", getClass().getSimpleName() + "-config", getClass().getSimpleName() + "-status");
+
+        // Start a N node connect cluster
+        connectCluster = new ConnectCluster()
+                .usingBrokers(cluster)
+                .addConnectNodes(3)
+                .addToPluginPath(file);
+        connectCluster.startup();
+    }
+
+    private void copy(List<File> files, Path directory) throws IOException {
+        for (File f : files) {
+            Path resolve = directory.resolve(f.getName());
+            if (f.isFile()) {
+                Files.copy(f.toPath(), resolve);
+            } else if (f.isDirectory()) {
+                resolve.toFile().mkdirs();
+                copy(asList(f.listFiles()), resolve);
+            }
+        }
+    }
+
+    private void listFiles(File file) {
+        for (File f : file.listFiles()) {
+            log.info("{}", f.getAbsolutePath() + (f.isDirectory() ? "/" : ""));
+            if (f.isDirectory()) {
+                listFiles(f);
+            }
+        }
+    }
+
+    @AfterEach
+    public void after() {
+        if (connectCluster != null) {
+            connectCluster.shutdown();
+        }
+        if (cluster != null) {
+            cluster.shutdown();
+        }
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
+    }
+
+    @Test
+    public void test(VertxTestContext context) throws InterruptedException {
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+
+        KubernetesClient kubeClient = new MockKube()
+                .withCustomResourceDefinition(Crds.kafkaConnector(), KafkaConnector.class,
+                        KafkaConnectorList.class, DoneableKafkaConnector.class).end()
+                .build();
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_14);
+        String namespace = "ns";
+        String connectorName = "my-connector";
+        LinkedHashMap<String, Object> config = new LinkedHashMap<>();
+        config.put(TestingConnector.START_TIME_MS, 1_000);
+        config.put(TestingConnector.STOP_TIME_MS, 0);
+        config.put(TestingConnector.TASK_START_TIME_MS, 1_000);
+        config.put(TestingConnector.TASK_STOP_TIME_MS, 0);
+        config.put(TestingConnector.TASK_POLL_TIME_MS, 1_000);
+        config.put(TestingConnector.TASK_POLL_RECORDS, 100);
+        config.put(TestingConnector.NUM_PARTITIONS, 1);
+        config.put(TestingConnector.TOPIC_NAME, "my-topic");
+        KafkaConnector connector = makeConnectorWithConfig(namespace, connectorName, config);
+        Crds.kafkaConnectorOperation(kubeClient).inNamespace(namespace).create(connector);
+        // We have to bridge between CrdOperator and MockKube, because there's no Fabric8 API for status update
+        // So we intercept stuff CrdOperator level
+        CrdOperator connectCrdOperator = mock(CrdOperator.class);
+        when(connectCrdOperator.updateStatusAsync(any())).thenAnswer(invocation -> {
+            try {
+                return Future.succeededFuture(Crds.kafkaConnectorOperation(kubeClient).inNamespace(namespace).withName(connectorName).patch(invocation.getArgument(0)));
+            } catch (Exception e) {
+                return Future.failedFuture(e);
+            }
+        });
+        when(connectCrdOperator.getAsync(any(), any())).thenAnswer(invocationOnMock -> {
+            try {
+                return Future.succeededFuture(Crds.kafkaConnectorOperation(kubeClient).inNamespace(namespace).withName(connectorName).get());
+            } catch (Exception e) {
+                return Future.failedFuture(e);
+            }
+        });
+        KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa,
+                new ResourceOperatorSupplier(
+                        null, null, null, null, null, null, null, null, null, null, null,
+                        null, null, null, null, null, null, null, null, null, null, null,
+                        null, connectCrdOperator, null, null, null),
+                ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
+                connect -> new KafkaConnectApiImpl(vertx),
+                connectCluster.getPort() + 2) {
+
+        };
+
+        operator.reconcileConnector(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
+                "localhost", connectClient, true, connectorName,
+                connector)
+        .compose(r -> {
+            return connectorIsRunning(context, kubeClient, namespace, connectorName);
+        }).compose(ignored -> {
+            config.remove(TestingConnector.START_TIME_MS, 1_000);
+            config.put(TestingConnector.START_TIME_MS, 1_000);
+            Crds.kafkaConnectorOperation(kubeClient).inNamespace(namespace).withName(connectorName).patch(makeConnectorWithConfig(namespace, connectorName, config));
+            return operator.reconcileConnector(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
+                    "localhost", connectClient, true, connectorName,
+                    connector);
+        }).compose(r -> {
+            return connectorIsRunning(context, kubeClient, namespace, connectorName);
+        }).setHandler(context.succeeding(v -> {
+            context.completeNow();
+        }));
+    }
+
+    private KafkaConnector makeConnectorWithConfig(String namespace, String connectorName, LinkedHashMap<String, Object> config) {
+        return new KafkaConnectorBuilder()
+                    .withNewMetadata()
+                        .withName(connectorName)
+                        .withNamespace(namespace)
+                    .endMetadata()
+                    .withNewSpec()
+                        .withClassName(TestingConnector.class.getName())
+                        .withTasksMax(1)
+                        .withConfig(config)
+                    .endSpec()
+                    .build();
+    }
+
+    private Future<Void> connectorIsRunning(VertxTestContext context, KubernetesClient kubeClient, String namespace, String connectorName) {
+        Promise<Void> p = Promise.promise();
+        KafkaConnector kafkaConnector = Crds.kafkaConnectorOperation(kubeClient).inNamespace(namespace).withName(connectorName).get();
+        assertThat(kafkaConnector, notNullValue());
+        assertThat(kafkaConnector.getStatus(), notNullValue());
+        assertThat(kafkaConnector.getStatus().getConnectorStatus(), notNullValue());
+        assertThat(kafkaConnector.getStatus().getConnectorStatus().get("connector"), instanceOf(Map.class));
+        assertThat(((Map) kafkaConnector.getStatus().getConnectorStatus().get("connector")).get("state"), is("RUNNING"));
+        p.complete();
+        return p.future();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A source connection used for testing which can be configured to be slow at doing things.
+ */
+public class TestingConnector extends SourceConnector {
+
+    private static final Logger LOGGER = LogManager.getLogger(TestingConnector.class);
+    public static final String START_TIME_MS = "start.time.ms";
+    public static final String STOP_TIME_MS = "stop.time.ms";
+    public static final String TASK_START_TIME_MS = "task.start.time.ms";
+    public static final String TASK_STOP_TIME_MS = "task.stop.time.ms";
+    public static final String TASK_POLL_TIME_MS = "task.poll.time.ms";
+    public static final String TASK_POLL_RECORDS = "task.poll.records";
+    public static final String TOPIC_NAME = "topic.name";
+    public static final String NUM_PARTITIONS = "num.partitions";
+
+    private long stopTime;
+    private long taskStartTime;
+    private long taskStopTime;
+    private long taskPollTime;
+    private long taskPollRecords;
+    private String topicName;
+    private int numPartitions;
+
+    public static class TestingTask extends SourceTask {
+
+        private long taskStopTime;
+        private long taskPollTime;
+        private long record;
+        private long taskPollRecords;
+        private String topicName;
+        private int numPartitions;
+
+        @Override
+        public String version() {
+            return "0.0.1";
+        }
+
+        @Override
+        public void start(Map<String, String> map) {
+            LOGGER.info("Starting task {}", this);
+            long taskStartTime = getLong(map, "task.start.time.ms");
+            taskStopTime = getLong(map, "task.stop.time.ms");
+            taskPollTime = getLong(map, "task.poll.time.ms");
+            taskPollRecords = getLong(map, "task.poll.records");
+            topicName = map.get("topic.name");
+            numPartitions = Integer.parseInt(map.get("num.partitions"));
+            LOGGER.info("Sleeping for {}ms", taskStartTime);
+            sleep(taskStartTime);
+            LOGGER.info("Started task {}", this);
+        }
+
+        @Override
+        public List<SourceRecord> poll() throws InterruptedException {
+            LOGGER.info("Poll {}", this);
+            LOGGER.info("Sleeping for {}ms in poll", taskPollTime);
+            sleep(taskPollTime);
+            Schema valueSchema = new SchemaBuilder(Schema.Type.INT64).valueSchema();
+            List<SourceRecord> records = new ArrayList<>();
+            for (int i = 0; i < taskPollRecords; i++) {
+                records.add(new SourceRecord(Collections.singletonMap("", ""),
+                        Collections.singletonMap("", ""),
+                        topicName, (int) record % numPartitions,
+                        null, null,
+                        valueSchema, record++));
+            }
+            LOGGER.warn("Returning {} records for topic {} from poll", taskPollRecords, topicName);
+            return records;
+        }
+
+        @Override
+        public void stop() {
+            LOGGER.info("Stopping task {}", this);
+            sleep(taskStopTime);
+        }
+    }
+
+    @Override
+    public void start(Map<String, String> map) {
+        LOGGER.info("Starting connector {}", this);
+        long startTime = getLong(map, START_TIME_MS);
+        stopTime = getLong(map, STOP_TIME_MS);
+        taskStartTime = getLong(map, TASK_START_TIME_MS);
+        taskStopTime = getLong(map, TASK_STOP_TIME_MS);
+        taskPollTime = getLong(map, TASK_POLL_TIME_MS);
+        taskPollRecords = getLong(map, TASK_POLL_RECORDS);
+        topicName = map.get(TOPIC_NAME);
+        numPartitions = Integer.parseInt(map.get(NUM_PARTITIONS));
+        sleep(startTime);
+        LOGGER.info("Started connector {}", this);
+    }
+
+    private static void sleep(long ms) {
+        if (ms > 0) {
+            try {
+                Thread.sleep(ms);
+            } catch (InterruptedException e) {
+                LOGGER.warn("Interrupted during sleep", e);
+            }
+        }
+    }
+
+    private static long getLong(Map<String, String> map, String configName) {
+        return Long.parseLong(map.get(configName));
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return TestingTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int count) {
+        Map<String, String> taskConfig = new HashMap<>();
+        taskConfig.put(TASK_START_TIME_MS, Long.toString(taskStartTime));
+        taskConfig.put(TASK_STOP_TIME_MS, Long.toString(taskStopTime));
+        taskConfig.put(TASK_POLL_TIME_MS, Long.toString(taskPollTime));
+        taskConfig.put(TASK_POLL_RECORDS, Long.toString(taskPollRecords));
+        taskConfig.put(TOPIC_NAME, topicName);
+        taskConfig.put(NUM_PARTITIONS, Integer.toString(numPartitions));
+        List<Map<String, String>> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(taskConfig);
+        }
+        return result;
+    }
+
+    @Override
+    public void stop() {
+        LOGGER.info("Stopping connector {}", this);
+        sleep(stopTime);
+        LOGGER.info("Stopped connector {}", this);
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef()
+                .define(START_TIME_MS, ConfigDef.Type.LONG, 5_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The time that start() should take to return")
+                .define(STOP_TIME_MS, ConfigDef.Type.LONG, 5_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The time that stop() should take to return")
+                .define(TASK_START_TIME_MS, ConfigDef.Type.LONG, 5_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The time that the task start() should take to return")
+                .define(TASK_STOP_TIME_MS, ConfigDef.Type.LONG, 5_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The time that the task stop() should take to return")
+                .define(TASK_POLL_TIME_MS, ConfigDef.Type.LONG, 5_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The time that the task poll() should take to return")
+                .define(TASK_POLL_RECORDS, ConfigDef.Type.LONG, 1_000L, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The number of records that the task poll() should return")
+                .define(TOPIC_NAME, ConfigDef.Type.STRING, "my-topic", new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The name of the topic which the records are sent to")
+                .define(NUM_PARTITIONS, ConfigDef.Type.INT, 1, new ConfigDef.NonNullValidator(),
+                        ConfigDef.Importance.MEDIUM, "The number of partitions which the records are send to");
+    }
+
+    @Override
+    public String version() {
+        return "0.0.1";
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
@@ -1,18 +1,6 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;
 

--- a/cluster-operator/src/test/resources/log4j2-test.properties
+++ b/cluster-operator/src/test/resources/log4j2-test.properties
@@ -9,3 +9,19 @@ rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
+
+logger.reflections.name = org.reflections
+logger.reflections.level = ERROR
+logger.reflections.additivity = false
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = WARN
+logger.zookeeper.additivity = false
+
+logger.broker.name = kafka
+logger.broker.level = WARN
+logger.broker.additivity = false
+
+logger.abstractindex.name = kafka.log.AbstractIndex
+logger.abstractindex.level = OFF
+logger.abstractindex.additivity = false

--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,11 @@
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.strimzi</groupId>
                 <artifactId>kafka-oauth-server</artifactId>
                 <version>${strimzi-oauth.version}</version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #2688 and adds a test for it. The fix is pretty simple: Get the connector config from the REST API and only update if the config differs. To do this I had to add a new method to the REST API client.

The PR also adds an integration test which runs the `reconcileConnector()` method against a real Kafka Connect cluster. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

