### PR TITLE
feat: Context succeeding - Part 5 KafkaUser

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramShaCredentials.java
@@ -73,7 +73,7 @@ public class ScramShaCredentials {
 
         if (data != null)   {
             log.debug("Deleting {} credentials for user {}", mechanism.mechanismName(), username);
-            JsonObject deletedJson = deleteUserJson(data);
+            JsonObject deletedJson = removeScramCredentialsFromUserJson(data);
             if (configJsonIsEmpty(deletedJson)) {
                 zkClient.deleteRecursive("/config/users/" + username);
             } else {
@@ -227,7 +227,7 @@ public class ScramShaCredentials {
      *
      * @return  Returns the updated JSON without the SCRAM credentials
      */
-    protected JsonObject deleteUserJson(byte[] user)   {
+    protected JsonObject removeScramCredentialsFromUserJson(byte[] user)   {
         JsonObject json = new JsonObject(new String(user, Charset.defaultCharset()));
 
         validateJsonVersion(json);

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -166,9 +166,9 @@ public class ResourceUtils {
     public static Secret createUserSecretScramSha()  {
         return new SecretBuilder()
                 .withNewMetadata()
-                .withName(NAME)
-                .withNamespace(NAMESPACE)
-                .withLabels(Labels.userLabels(LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap())
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                    .withLabels(Labels.userLabels(LABELS).withKind(KafkaUser.RESOURCE_KIND).toMap())
                 .endMetadata()
                 .addToData("password", Base64.getEncoder().encodeToString("my-password".getBytes()))
                 .build();

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UserOperatorConfigTest {
-    private static Map<String, String> envVars = new HashMap<>(5);
+    private static Map<String, String> envVars = new HashMap<>(8);
     private static Labels expectedLabels;
 
     static {
@@ -50,22 +50,22 @@ public class UserOperatorConfigTest {
     }
 
     @Test
-    public void testMissingNamespace()  {
-        assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
-            envVars.remove(UserOperatorConfig.STRIMZI_NAMESPACE);
+    public void testNamespaceEnvVarMissingThrows()  {
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+        envVars.remove(UserOperatorConfig.STRIMZI_NAMESPACE);
 
-            UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
+        assertThrows(InvalidConfigurationException.class, () -> {
+            UserOperatorConfig.fromMap(envVars);
         });
     }
 
     @Test
     public void testMissingCaName()  {
-        assertThrows(InvalidConfigurationException.class, () -> {
-            Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
-            envVars.remove(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME);
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+        envVars.remove(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME);
 
-            UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
+        assertThrows(InvalidConfigurationException.class, () -> {
+            UserOperatorConfig.fromMap(envVars);
         });
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
@@ -6,11 +6,10 @@ package io.strimzi.operator.user.model.acl;
 
 import io.strimzi.api.kafka.model.AclResourcePatternType;
 import io.strimzi.api.kafka.model.AclRuleClusterResource;
-import io.strimzi.api.kafka.model.AclRuleGroupResource;
+import io.strimzi.api.kafka.model.AclRuleGroupResourceBuilder;
 import io.strimzi.api.kafka.model.AclRuleResource;
-import io.strimzi.api.kafka.model.AclRuleTopicResource;
-
-import io.strimzi.api.kafka.model.AclRuleTransactionalIdResource;
+import io.strimzi.api.kafka.model.AclRuleTopicResourceBuilder;
+import io.strimzi.api.kafka.model.AclRuleTransactionalIdResourceBuilder;
 import kafka.security.auth.Cluster$;
 import kafka.security.auth.Group$;
 import kafka.security.auth.Resource;
@@ -25,57 +24,62 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SimpleAclRuleResourceTest {
     @Test
-    public void testTopicFromCrd()   {
+    public void testFromCrdWithTopicResource()   {
         // Regular topic
-        AclRuleResource resource = new AclRuleTopicResource();
-        ((AclRuleTopicResource) resource).setName("my-topic");
-        ((AclRuleTopicResource) resource).setPatternType(AclResourcePatternType.LITERAL);
+        AclRuleResource regularTopic = new AclRuleTopicResourceBuilder()
+            .withName("my-topic")
+            .withPatternType(AclResourcePatternType.LITERAL)
+            .build();
 
-        SimpleAclRuleResource simple = SimpleAclRuleResource.fromCrd(resource);
+        SimpleAclRuleResource simple = SimpleAclRuleResource.fromCrd(regularTopic);
         assertThat(simple.getName(), is("my-topic"));
         assertThat(simple.getType(), is(SimpleAclRuleResourceType.TOPIC));
         assertThat(simple.getPattern(), is(AclResourcePatternType.LITERAL));
 
         // Prefixed topic
-        resource = new AclRuleTopicResource();
-        ((AclRuleTopicResource) resource).setName("my-");
-        ((AclRuleTopicResource) resource).setPatternType(AclResourcePatternType.PREFIX);
+        AclRuleResource prefixedTopic = new AclRuleTopicResourceBuilder()
+            .withName("my-")
+            .withPatternType(AclResourcePatternType.PREFIX)
+            .build();
 
-        simple = SimpleAclRuleResource.fromCrd(resource);
+        simple = SimpleAclRuleResource.fromCrd(prefixedTopic);
         assertThat(simple.getName(), is("my-"));
         assertThat(simple.getType(), is(SimpleAclRuleResourceType.TOPIC));
         assertThat(simple.getPattern(), is(AclResourcePatternType.PREFIX));
     }
 
     @Test
-    public void testGroupFromCrd()   {
+    public void testFromCrdWithGroupResource()   {
         // Regular group
-        AclRuleResource resource = new AclRuleGroupResource();
-        ((AclRuleGroupResource) resource).setName("my-group");
-        ((AclRuleGroupResource) resource).setPatternType(AclResourcePatternType.LITERAL);
+        AclRuleResource regularGroup = new AclRuleGroupResourceBuilder()
+            .withName("my-group")
+            .withPatternType(AclResourcePatternType.LITERAL)
+            .build();
 
-        SimpleAclRuleResource simple = SimpleAclRuleResource.fromCrd(resource);
+        SimpleAclRuleResource simple = SimpleAclRuleResource.fromCrd(regularGroup);
         assertThat(simple.getName(), is("my-group"));
         assertThat(simple.getType(), is(SimpleAclRuleResourceType.GROUP));
         assertThat(simple.getPattern(), is(AclResourcePatternType.LITERAL));
 
         // Prefixed group
-        resource = new AclRuleGroupResource();
-        ((AclRuleGroupResource) resource).setName("my-");
-        ((AclRuleGroupResource) resource).setPatternType(AclResourcePatternType.PREFIX);
+        AclRuleResource prefixedGroup = new AclRuleGroupResourceBuilder()
+            .withName("my-")
+            .withPatternType(AclResourcePatternType.PREFIX)
+            .build();
 
-        simple = SimpleAclRuleResource.fromCrd(resource);
+        simple = SimpleAclRuleResource.fromCrd(prefixedGroup);
         assertThat(simple.getName(), is("my-"));
         assertThat(simple.getType(), is(SimpleAclRuleResourceType.GROUP));
         assertThat(simple.getPattern(), is(AclResourcePatternType.PREFIX));
     }
 
     @Test
-    public void testTransactionalIdFromCrd()   {
+    public void testFromCrdWithTransactionalIdResource()   {
         // Regular transactionalId
-        AclRuleResource resource = new AclRuleTransactionalIdResource();
+        AclRuleResource resource = new AclRuleTransactionalIdResourceBuilder()
+            .withName("my-transactionalId")
+            .build();
 
-        ((AclRuleTransactionalIdResource) resource).setName("my-transactionalId");
         SimpleAclRuleResource simple = SimpleAclRuleResource.fromCrd(resource);
         assertThat(simple.getName(), is("my-transactionalId"));
         assertThat(simple.getType(), is(SimpleAclRuleResourceType.TRANSACTIONAL_ID));
@@ -83,7 +87,7 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testClusterFromCrd()   {
+    public void testFromCrdWithClusterResource()   {
         // Regular cluster
         AclRuleResource resource = new AclRuleClusterResource();
 
@@ -94,101 +98,101 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testTopicToKafka()  {
+    public void testToKafkaResourceForTopicResource()  {
         // Regular topic
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        SimpleAclRuleResource topicResourceRules = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
+        Resource expectedKafkaResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        assertThat(topicResourceRules.toKafkaResource(), is(expectedKafkaResource));
 
         // Prefixed topic
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
-        kafka = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        topicResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
+        expectedKafkaResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
+        assertThat(topicResourceRules.toKafkaResource(), is(expectedKafkaResource));
     }
 
     @Test
-    public void testGroupToKafka()  {
+    public void testToKafkaResourceForGroupResource()  {
         // Regular group
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        SimpleAclRuleResource groupResourceRules = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
+        Resource expectedKafkaResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
+        assertThat(groupResourceRules.toKafkaResource(), is(expectedKafkaResource));
 
         // Prefixed group
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
-        kafka = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        groupResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
+        expectedKafkaResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
+        assertThat(groupResourceRules.toKafkaResource(), is(expectedKafkaResource));
     }
 
     @Test
-    public void testClusterToKafka()  {
+    public void testToKafkaResourceForClusterResource()  {
         // Regular cluster
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource(null, SimpleAclRuleResourceType.CLUSTER, null);
-        Resource kafka = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        SimpleAclRuleResource clusterResourceRules = new SimpleAclRuleResource(null, SimpleAclRuleResourceType.CLUSTER, null);
+        Resource expectedKafkaResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        assertThat(clusterResourceRules.toKafkaResource(), is(expectedKafkaResource));
     }
 
     @Test
-    public void testTransactionalIdToKafka()  {
+    public void testToKafkaResourceForTransactionalIdResource()  {
         // Regular transactionalId
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, null);
-        Resource kafka = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        SimpleAclRuleResource transactionalIdResourceRules = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, null);
+        Resource expectedKafkaResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
+        assertThat(transactionalIdResourceRules.toKafkaResource(), is(expectedKafkaResource));
 
         // Prefixed transactionalId
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
-        kafka = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(strimzi.toKafkaResource(), is(kafka));
+        transactionalIdResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
+        expectedKafkaResource = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
+        assertThat(transactionalIdResourceRules.toKafkaResource(), is(expectedKafkaResource));
     }
 
     @Test
-    public void testTopicFromKafka()  {
+    public void testFromKafkaResourceWithTopicResource()  {
         // Regular topic
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        Resource kafkaTopicResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        SimpleAclRuleResource expectedTopicResourceRules = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTopicResource), is(expectedTopicResourceRules));
 
         // Prefixed topic
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
-        kafka = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        kafkaTopicResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
+        expectedTopicResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.PREFIX);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTopicResource), is(expectedTopicResourceRules));
     }
 
     @Test
-    public void testGroupFromKafka()  {
+    public void testFromKafkaResourceWithGroupResource()  {
         // Regular group
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        Resource kafkaGroupResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
+        SimpleAclRuleResource expectedGroupResourceRules = new SimpleAclRuleResource("my-group", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaGroupResource), is(expectedGroupResourceRules));
 
         // Prefixed group
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
-        kafka = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        kafkaGroupResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
+        expectedGroupResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.GROUP, AclResourcePatternType.PREFIX);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaGroupResource), is(expectedGroupResourceRules));
     }
 
     @Test
-    public void testClusterFromKafka()  {
-        // Regular topic
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("kafka-cluster", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+    public void testFromKafkaResourceWithClusterResource()  {
+        // Regular cluster
+        Resource kafkaClusterResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        SimpleAclRuleResource expectedClusterResourceRules = new SimpleAclRuleResource("kafka-cluster", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaClusterResource), is(expectedClusterResourceRules));
     }
 
     @Test
-    public void testTransactionalIdFromKafka()  {
+    public void testFromKafkaResourceWithTransactionalIdResource()  {
         // Regular transactionalId
-        SimpleAclRuleResource strimzi = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        Resource kafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
+        SimpleAclRuleResource expectedTransactionalIdResourceRules = new SimpleAclRuleResource("my-transactionalId", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTransactionalIdResource), is(expectedTransactionalIdResourceRules));
 
         // Prefixed transactionalId
-        strimzi = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
-        kafka = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromKafkaResource(kafka), is(strimzi));
+        kafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-", PatternType.PREFIXED);
+        expectedTransactionalIdResourceRules = new SimpleAclRuleResource("my-", SimpleAclRuleResourceType.TRANSACTIONAL_ID, AclResourcePatternType.PREFIX);
+        assertThat(SimpleAclRuleResource.fromKafkaResource(kafkaTransactionalIdResource), is(expectedTransactionalIdResourceRules));
     }
 
     @Test
-    public void testTopicRoundTrip()    {
+    public void testFromKafkaResourceToKafkaResourceRoundTripForTopicResource()    {
         // Regular group
         Resource kafka = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
         assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
@@ -199,7 +203,7 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testGroupRoundTrip()  {
+    public void testFromKafkaResourceToKafkaResourceRoundTripForGroupResource()  {
         // Regular group
         Resource kafka = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
         assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
@@ -210,14 +214,14 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testClusterRoundTrip()  {
+    public void testFromKafkaResourceToKafkaResourceRoundTripForClusterResource()  {
         // Regular cluster
         Resource kafka = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
         assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
     }
 
     @Test
-    public void testTransactionIDRoundTrip()  {
+    public void testFromKafkaResourceToKafkaResourceRoundTripForTransactionalIdResource()  {
         // Regular transactionID
         Resource kafka = new Resource(TransactionalId$.MODULE$, "my-transactionID", PatternType.LITERAL);
         assertThat(SimpleAclRuleResource.fromKafkaResource(kafka).toKafkaResource(), is(kafka));
@@ -228,53 +232,58 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testTopicPassthrough()    {
+    public void testFromCrdToKafkaResourceForTopicResource()    {
         // Regular group
-        AclRuleResource resource = new AclRuleTopicResource();
-        ((AclRuleTopicResource) resource).setName("my-topic");
-        ((AclRuleTopicResource) resource).setPatternType(AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        AclRuleResource resource = new AclRuleTopicResourceBuilder()
+            .withName("my-topic")
+            .withPatternType(AclResourcePatternType.LITERAL)
+            .build();
+        Resource expectedKafkaTopicResource = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTopicResource));
 
         // Prefixed topic
-        resource = new AclRuleTopicResource();
-        ((AclRuleTopicResource) resource).setName("my-");
-        ((AclRuleTopicResource) resource).setPatternType(AclResourcePatternType.PREFIX);
-        kafka = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        resource = new AclRuleTopicResourceBuilder()
+            .withName("my-")
+            .withPatternType(AclResourcePatternType.PREFIX)
+            .build();
+        expectedKafkaTopicResource = new Resource(Topic$.MODULE$, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTopicResource));
     }
 
     @Test
-    public void testGroupPassthrough()  {
+    public void testFromCrdToKafkaResourceForGroupResource()  {
         // Regular group
-        AclRuleResource resource = new AclRuleGroupResource();
-        ((AclRuleGroupResource) resource).setName("my-group");
-        ((AclRuleGroupResource) resource).setPatternType(AclResourcePatternType.LITERAL);
-        Resource kafka = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        AclRuleResource resource = new AclRuleGroupResourceBuilder()
+            .withName("my-group")
+            .withPatternType(AclResourcePatternType.LITERAL)
+            .build();
+        Resource expectedKafkaGroupResource = new Resource(Group$.MODULE$, "my-group", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaGroupResource));
 
         // Prefixed group
-        resource = new AclRuleGroupResource();
-        ((AclRuleGroupResource) resource).setName("my-");
-        ((AclRuleGroupResource) resource).setPatternType(AclResourcePatternType.PREFIX);
-        kafka = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        resource = new AclRuleGroupResourceBuilder()
+            .withName("my-")
+            .withPatternType(AclResourcePatternType.PREFIX)
+            .build();
+        expectedKafkaGroupResource = new Resource(Group$.MODULE$, "my-", PatternType.PREFIXED);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaGroupResource));
     }
 
     @Test
-    public void testClusterPassthrough()  {
+    public void testFromCrdToKafkaResourceForClusterResource()  {
         // Regular cluster
         AclRuleResource resource = new AclRuleClusterResource();
-        Resource kafka = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        Resource expectedKafkaClusterResource = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaClusterResource));
     }
 
     @Test
-    public void testTransactionalIdPassthrough()  {
+    public void testFromCrdToKafkaResourceForTransactionalIdResource()  {
         // Regular transactionalId
-        AclRuleResource resource = new AclRuleTransactionalIdResource();
-        ((AclRuleTransactionalIdResource) resource).setName("my-transactionalId");
-        Resource kafka = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
-        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(kafka));
+        AclRuleResource resource = new AclRuleTransactionalIdResourceBuilder()
+            .withName("my-transactionalId")
+            .build();
+        Resource expectedKafkaTransactionalIdResource = new Resource(TransactionalId$.MODULE$, "my-transactionalId", PatternType.LITERAL);
+        assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResource(), is(expectedKafkaTransactionalIdResource));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -178,41 +178,41 @@ public class KafkaUserOperatorTest {
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
             .setHandler(context.succeeding(v -> context.verify(() -> {
 
-            List<String> capturedNames = secretNameCaptor.getAllValues();
-            assertThat(capturedNames, hasSize(1));
-            assertThat(capturedNames.get(0), is(ResourceUtils.NAME));
+                List<String> capturedNames = secretNameCaptor.getAllValues();
+                assertThat(capturedNames, hasSize(1));
+                assertThat(capturedNames.get(0), is(ResourceUtils.NAME));
 
-            List<String> capturedNamespaces = secretNamespaceCaptor.getAllValues();
-            assertThat(capturedNamespaces, hasSize(1));
-            assertThat(capturedNamespaces.get(0), is(ResourceUtils.NAMESPACE));
+                List<String> capturedNamespaces = secretNamespaceCaptor.getAllValues();
+                assertThat(capturedNamespaces, hasSize(1));
+                assertThat(capturedNamespaces.get(0), is(ResourceUtils.NAMESPACE));
 
-            List<Secret> capturedSecrets = secretCaptor.getAllValues();
-            assertThat(capturedSecrets, hasSize(1));
+                List<Secret> capturedSecrets = secretCaptor.getAllValues();
+                assertThat(capturedSecrets, hasSize(1));
 
-            Secret captured = capturedSecrets.get(0);
-            assertThat(captured.getMetadata().getName(), is(userCert.getMetadata().getName()));
-            assertThat(captured.getMetadata().getNamespace(), is(userCert.getMetadata().getNamespace()));
-            assertThat(captured.getMetadata().getLabels(), is(userCert.getMetadata().getLabels()));
-            assertThat(captured.getData().get("ca.crt"), is(userCert.getData().get("ca.crt")));
-            assertThat(captured.getData().get("user.crt"), is(userCert.getData().get("user.crt")));
-            assertThat(captured.getData().get("user.key"), is(userCert.getData().get("user.key")));
+                Secret captured = capturedSecrets.get(0);
+                assertThat(captured.getMetadata().getName(), is(userCert.getMetadata().getName()));
+                assertThat(captured.getMetadata().getNamespace(), is(userCert.getMetadata().getNamespace()));
+                assertThat(captured.getMetadata().getLabels(), is(userCert.getMetadata().getLabels()));
+                assertThat(captured.getData().get("ca.crt"), is(userCert.getData().get("ca.crt")));
+                assertThat(captured.getData().get("user.crt"), is(userCert.getData().get("user.crt")));
+                assertThat(captured.getData().get("user.key"), is(userCert.getData().get("user.key")));
 
-            List<String> capturedAclNames = aclNameCaptor.getAllValues();
-            assertThat(capturedAclNames, hasSize(2));
-            assertThat(capturedAclNames.get(0), is(KafkaUserModel.getTlsUserName(ResourceUtils.NAME)));
-            assertThat(capturedAclNames.get(1), is(KafkaUserModel.getScramUserName(ResourceUtils.NAME)));
+                List<String> capturedAclNames = aclNameCaptor.getAllValues();
+                assertThat(capturedAclNames, hasSize(2));
+                assertThat(capturedAclNames.get(0), is(KafkaUserModel.getTlsUserName(ResourceUtils.NAME)));
+                assertThat(capturedAclNames.get(1), is(KafkaUserModel.getScramUserName(ResourceUtils.NAME)));
 
-            List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
+                List<Set<SimpleAclRule>> capturedAcls = aclRulesCaptor.getAllValues();
 
-            assertThat(capturedAcls, hasSize(2));
-            Set<SimpleAclRule> aclRules = capturedAcls.get(0);
+                assertThat(capturedAcls, hasSize(2));
+                Set<SimpleAclRule> aclRules = capturedAcls.get(0);
 
-            assertThat(aclRules, hasSize(ResourceUtils.createExpectedSimpleAclRules(user).size()));
-            assertThat(aclRules, is(ResourceUtils.createExpectedSimpleAclRules(user)));
-            assertThat(capturedAcls.get(1), is(nullValue()));
+                assertThat(aclRules, hasSize(ResourceUtils.createExpectedSimpleAclRules(user).size()));
+                assertThat(aclRules, is(ResourceUtils.createExpectedSimpleAclRules(user)));
+                assertThat(capturedAcls.get(1), is(nullValue()));
 
-            async.flag();
-        })));
+                async.flag();
+            })));
     }
 
     /**
@@ -929,7 +929,7 @@ public class KafkaUserOperatorTest {
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user)
-            .setHandler(context.succeeding(v -> context.verify(() -> {
+            .setHandler(context.failing(e -> context.verify(() -> {
                 List<KafkaUser> capturedStatuses = userCaptor.getAllValues();
                 assertThat(capturedStatuses.get(0).getStatus().getUsername(), is("CN=user"));
                 assertThat(capturedStatuses.get(0).getStatus().getConditions().get(0).getStatus(), is("True"));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -7,18 +7,9 @@ package io.strimzi.operator.user.operator;
 import io.strimzi.api.kafka.model.AclOperation;
 import io.strimzi.api.kafka.model.AclResourcePatternType;
 import io.strimzi.api.kafka.model.AclRuleType;
-import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 import io.strimzi.operator.user.model.acl.SimpleAclRuleResource;
 import io.strimzi.operator.user.model.acl.SimpleAclRuleResourceType;
-
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -40,11 +31,17 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import scala.collection.Iterator;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,7 +65,6 @@ public class SimpleAclOperatorTest {
         SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
         SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
 
-        Checkpoint async = context.checkpoint();
         KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
         Acl fooAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
         KafkaPrincipal bar = new KafkaPrincipal("User", "CN=bar");
@@ -88,13 +84,13 @@ public class SimpleAclOperatorTest {
 
         ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
         when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
-        async.flag();
 
-        context.verify(() -> assertThat(aclOp.getUsersWithAcls(), is(new HashSet(asList("foo", "bar", "baz")))));
+        assertThat(aclOp.getUsersWithAcls(), is(new HashSet(asList("foo", "bar", "baz"))));
+        context.completeNow();
     }
 
     @Test
-    public void testInternalCreate(VertxTestContext context) throws InterruptedException {
+    public void testReconcileInternalCreateAddsAclsToAuthorizer(VertxTestContext context) {
         SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
         SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
 
@@ -106,75 +102,40 @@ public class SimpleAclOperatorTest {
         ArgumentCaptor<Resource> resourceCaptor = ArgumentCaptor.forClass(Resource.class);
         doNothing().when(mockAuthorizer).addAcls(aclCaptor.capture(), resourceCaptor.capture());
 
-        SimpleAclRuleResource resource1 = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
-        SimpleAclRuleResource resource = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
-        SimpleAclRule rule1 = new SimpleAclRule(AclRuleType.ALLOW, resource, "*", AclOperation.READ);
-        SimpleAclRule rule2 = new SimpleAclRule(AclRuleType.ALLOW, resource, "*", AclOperation.WRITE);
-        SimpleAclRule rule3 = new SimpleAclRule(AclRuleType.ALLOW, resource1, "*", AclOperation.DESCRIBE);
+        SimpleAclRuleResource ruleResource1 = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
+        SimpleAclRuleResource ruleResource2 = new SimpleAclRuleResource("my-topic", SimpleAclRuleResourceType.TOPIC, AclResourcePatternType.LITERAL);
+        SimpleAclRule resource1DescribeRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource1, "*", AclOperation.DESCRIBE);
+        SimpleAclRule resource2ReadRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource2, "*", AclOperation.READ);
+        SimpleAclRule resource2WriteRule = new SimpleAclRule(AclRuleType.ALLOW, ruleResource2, "*", AclOperation.WRITE);
 
         KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl acl1 = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set1<>(acl1);
-        Acl acl2 = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
-        scala.collection.immutable.Set<Acl> set2 = new scala.collection.immutable.Set.Set1<>(acl2);
-        Resource res1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        Acl acl3 = new Acl(foo, Allow$.MODULE$, "*", Describe$.MODULE$);
-        scala.collection.immutable.Set<Acl> set3 = new scala.collection.immutable.Set.Set1<>(acl3);
-        Resource res2 = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
+        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
+        Acl writeAcl = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
+        Acl describeAcl = new Acl(foo, Allow$.MODULE$, "*", Describe$.MODULE$);
+        scala.collection.immutable.Set<Acl> expectedResource1RuleSet = new scala.collection.immutable.Set.Set1<>(describeAcl);
+        scala.collection.immutable.Set<Acl> expectedResource2RuleSet = new scala.collection.immutable.Set.Set2<>(readAcl, writeAcl);
+
+        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        Resource resource2 = new Resource(Cluster$.MODULE$, "kafka-cluster", PatternType.LITERAL);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<Set<SimpleAclRule>>> fut = aclOp.reconcile("CN=foo", new LinkedHashSet<>(asList(rule1, rule2, rule3)));
-        fut.setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(true)));
+        aclOp.reconcile("CN=foo", new LinkedHashSet<>(asList(resource2ReadRule, resource2WriteRule, resource1DescribeRule)))
+            .setHandler(context.succeeding(rr -> context.verify(() -> {
+                List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
+                List<Resource> capturedResource = resourceCaptor.getAllValues();
 
-            List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
-            List<Resource> capturedResource = resourceCaptor.getAllValues();
+                assertThat(capturedAcls, hasSize(2));
+                assertThat(capturedResource, hasSize(2));
 
-            context.verify(() -> assertThat(capturedAcls.size(), is(2)));
-            context.verify(() -> assertThat(capturedResource.size(), is(2)));
+                assertThat(capturedResource, hasItems(resource1, resource2));
+                assertThat(capturedAcls, hasItems(expectedResource1RuleSet, expectedResource2RuleSet));
 
-            context.verify(() -> assertThat(res1.equals(capturedResource.get(0)) && res2.equals(capturedResource.get(1)) || res1.equals(capturedResource.get(1)) && res2.equals(capturedResource.get(0)), is(true)));
-
-            if (capturedAcls.get(0).size() == 1) {
-                context.verify(() -> assertThat(capturedAcls.get(0), is(set3)));
-            } else {
-                // the order can be changed
-                if (capturedAcls.get(0).size() == 2) {
-                    Iterator<Acl> iter = capturedAcls.get(0).iterator();
-                    Acl aclFromSet1 = set1.head();
-                    Acl aclFromSet2 = set2.head();
-
-                    Acl capturedAcl1 = iter.next();
-                    Acl capturedAcl2 = iter.next();
-
-                    context.verify(() -> assertThat(aclFromSet1.equals(capturedAcl1) && aclFromSet2.equals(capturedAcl2) || aclFromSet1.equals(capturedAcl2) && aclFromSet1.equals(capturedAcl2), is(true)));
-                }
-            }
-
-            if (capturedAcls.get(1).size() == 1) {
-                context.verify(() -> assertThat(capturedAcls.get(1), is(set3)));
-            } else {
-                // the order can be changed
-                if (capturedAcls.get(1).size() == 2) {
-                    Iterator<Acl> iter = capturedAcls.get(1).iterator();
-                    Acl aclFromSet1 = set1.head();
-                    Acl aclFromSet2 = set2.head();
-
-                    Acl capturedAcl1 = iter.next();
-                    Acl capturedAcl2 = iter.next();
-
-                    context.verify(() -> assertThat(aclFromSet1.equals(capturedAcl1) && aclFromSet2.equals(capturedAcl2) || aclFromSet1.equals(capturedAcl2) && aclFromSet1.equals(capturedAcl2), is(true)));
-                }
-            }
-            async.flag();
-        });
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+                async.flag();
+            })));
     }
 
     @Test
-    public void testInternalUpdate(VertxTestContext context) throws InterruptedException {
+    public void testReconcileInternalUpdateCreatesNewAclsAndDeletesOldAcls(VertxTestContext context) {
         SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
         SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
 
@@ -182,14 +143,15 @@ public class SimpleAclOperatorTest {
         SimpleAclRule rule1 = new SimpleAclRule(AclRuleType.ALLOW, resource, "*", AclOperation.WRITE);
 
         KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl acl1 = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set1<>(acl1);
-        Acl acl2 = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
-        scala.collection.immutable.Set<Acl> set2 = new scala.collection.immutable.Set.Set1<>(acl2);
-        Resource res1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
-        Resource res2 = new Resource(Topic$.MODULE$, "my-topic2", PatternType.LITERAL);
+        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
+        scala.collection.immutable.Set<Acl> readAclSet = new scala.collection.immutable.Set.Set1<>(readAcl);
+        Acl writeAcl = new Acl(foo, Allow$.MODULE$, "*", Write$.MODULE$);
+        scala.collection.immutable.Set<Acl> writeAclSet = new scala.collection.immutable.Set.Set1<>(writeAcl);
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(res1, set1);
+        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        Resource resource2 = new Resource(Topic$.MODULE$, "my-topic2", PatternType.LITERAL);
+
+        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(resource1, readAclSet);
         ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
         when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
 
@@ -202,44 +164,40 @@ public class SimpleAclOperatorTest {
         when(mockAuthorizer.removeAcls(deleteAclCaptor.capture(), deleterResourceCaptor.capture())).thenReturn(true);
 
         Checkpoint async = context.checkpoint();
-        Future<Void> fut = aclOp.reconcile("CN=foo", new LinkedHashSet(asList(rule1)));
-        fut.setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(true)));
+        aclOp.reconcile("CN=foo", new LinkedHashSet(asList(rule1)))
+            .setHandler(context.succeeding(rr -> context.verify(() -> {
+                List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
+                List<Resource> capturedResource = resourceCaptor.getAllValues();
+                List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
+                List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
 
-            List<scala.collection.immutable.Set<Acl>> capturedAcls = aclCaptor.getAllValues();
-            List<Resource> capturedResource = resourceCaptor.getAllValues();
-            List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
-            List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
+                // Create Write rule for resource 2
+                assertThat(capturedAcls, hasSize(1));
+                assertThat(capturedAcls, hasItem(writeAclSet));
+                assertThat(capturedResource, hasSize(1));
+                assertThat(capturedResource, hasItem(resource2));
 
-            context.verify(() -> assertThat(capturedAcls.size(), is(1)));
-            context.verify(() -> assertThat(capturedResource.size(), is(1)));
-            context.verify(() -> assertThat(deleteCapturedAcls.size(), is(1)));
-            context.verify(() -> assertThat(deleteCapturedResource.size(), is(1)));
+                // Delete read rule for resource 1
+                assertThat(deleteCapturedAcls, hasSize(1));
+                assertThat(deleteCapturedAcls, hasItem(readAclSet));
+                assertThat(deleteCapturedResource, hasSize(1));
+                assertThat(deleteCapturedResource, hasItem(resource1));
 
-            context.verify(() -> assertThat(capturedResource.get(0), is(res2)));
-            context.verify(() -> assertThat(deleteCapturedResource.get(0), is(res1)));
-
-            context.verify(() -> assertThat(capturedAcls.get(0), is(set2)));
-            context.verify(() -> assertThat(deleteCapturedAcls.get(0), is(set1)));
-            async.flag();
-
-        });
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+                async.flag();
+            })));
     }
 
     @Test
-    public void testInternalDelete(VertxTestContext context) throws InterruptedException {
+    public void testReconcileInternalDelete(VertxTestContext context) throws InterruptedException {
         SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
         SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
 
         KafkaPrincipal foo = new KafkaPrincipal("User", "CN=foo");
-        Acl acl1 = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
-        scala.collection.immutable.Set<Acl> set1 = new scala.collection.immutable.Set.Set1<>(acl1);
-        Resource res1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
+        Acl readAcl = new Acl(foo, Allow$.MODULE$, "*", Read$.MODULE$);
+        scala.collection.immutable.Set<Acl> readAclSet = new scala.collection.immutable.Set.Set1<>(readAcl);
+        Resource resource1 = new Resource(Topic$.MODULE$, "my-topic", PatternType.LITERAL);
 
-        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(res1, set1);
+        scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> map = new scala.collection.immutable.Map.Map1<>(resource1, readAclSet);
         ArgumentCaptor<KafkaPrincipal> principalCaptor = ArgumentCaptor.forClass(KafkaPrincipal.class);
         when(mockAuthorizer.getAcls(principalCaptor.capture())).thenReturn(map);
 
@@ -248,24 +206,18 @@ public class SimpleAclOperatorTest {
         when(mockAuthorizer.removeAcls(deleteAclCaptor.capture(), deleterResourceCaptor.capture())).thenReturn(true);
 
         Checkpoint async = context.checkpoint();
-        Future<ReconcileResult<Set<SimpleAclRule>>> fut = aclOp.reconcile("CN=foo", null);
-        fut.setHandler(res -> {
-            context.verify(() -> assertThat(res.succeeded(), is(true)));
+        aclOp.reconcile("CN=foo", null)
+            .setHandler(context.succeeding(rr -> context.verify(() -> {
+                List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
+                List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
 
-            List<scala.collection.immutable.Set<Acl>> deleteCapturedAcls = deleteAclCaptor.getAllValues();
-            List<Resource> deleteCapturedResource = deleterResourceCaptor.getAllValues();
+                // Delete correct read rule for resource 1
+                assertThat(deleteCapturedAcls, hasSize(1));
+                assertThat(deleteCapturedAcls, hasItem(readAclSet));
+                assertThat(deleteCapturedResource, hasSize(1));
+                assertThat(deleteCapturedResource, hasItem(resource1));
 
-            context.verify(() -> assertThat(deleteCapturedAcls.size(), is(1)));
-            context.verify(() -> assertThat(deleteCapturedResource.size(), is(1)));
-
-            context.verify(() -> assertThat(deleteCapturedResource.get(0), is(res1)));
-
-            context.verify(() -> assertThat(deleteCapturedAcls.get(0), is(set1)));
-
-            async.flag();
-        });
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
+                async.flag();
+            })));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -188,7 +188,7 @@ public class SimpleAclOperatorTest {
     }
 
     @Test
-    public void testReconcileInternalDelete(VertxTestContext context) throws InterruptedException {
+    public void testReconcileInternalDelete(VertxTestContext context) {
         SimpleAclAuthorizer mockAuthorizer = mock(SimpleAclAuthorizer.class);
         SimpleAclOperator aclOp = new SimpleAclOperator(vertx, mockAuthorizer);
 


### PR DESCRIPTION
For this Pull request I have continued the context
succeeding work, and taken the opportunity to remove
unneeded concurrency based dependencies.
minor test renames, hamcrest additions and variable
renames to improve clarity.

Updated a method to removeScramCredentialsFromUserJson
this is to match a similar call from the KafkaUserQuota class
as well as delete in the method name being misleading.

Contributes to: #2647

Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

