### PR TITLE
Fix problem with connector reconciliation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -164,6 +164,10 @@ class ConnectRestException extends RuntimeException {
 @SuppressWarnings({"deprecation"})
 class KafkaConnectApiImpl implements KafkaConnectApi {
     private static final Logger log = LogManager.getLogger(KafkaConnectApiImpl.class);
+    public static final TypeReference<Map<String, Object>> TREE_TYPE = new TypeReference<Map<String, Object>>() {
+    };
+    public static final TypeReference<Map<String, String>> MAP_OF_STRINGS = new TypeReference<Map<String, String>>() {
+    };
     private final Vertx vertx;
 
     public KafkaConnectApiImpl(Vertx vertx) {
@@ -221,7 +225,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             String connectorName) {
         return doGet(host, port, String.format("/connectors/%s", connectorName),
                 new HashSet<>(asList(200, 201)),
-                new TypeReference<Map<String, Object>>() { });
+                TREE_TYPE);
     }
 
     @SuppressWarnings("unchecked")
@@ -267,7 +271,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             String connectorName) {
         return doGet(host, port, String.format("/connectors/%s/config", connectorName),
                 new HashSet<>(asList(200, 201)),
-                new TypeReference<Map<String, String>>() { });
+                MAP_OF_STRINGS);
     }
 
     @Override
@@ -364,7 +368,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     @Override
     public Future<Map<String, Object>> status(String host, int port, String connectorName) {
         String path = "/connectors/" + connectorName + "/status";
-        return doGet(host, port, path, Collections.singleton(200), new TypeReference<Map<String, Object>>() { });
+        return doGet(host, port, path, Collections.singleton(200), TREE_TYPE);
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -196,7 +196,7 @@ public class ConnectorMockTest {
             return remove != null ? Future.succeededFuture() : Future.failedFuture("No such connector " + connectorName);
         });
         when(api.statusWithBackOff(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
-            String host = invocation.getArgument(0);
+            String host = invocation.getArgument(1);
             System.err.println("###### status " + host);
             return kafkaConnectApiStatusMock(invocation.getArgument(1), invocation.getArgument(2), invocation.getArgument(3));
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -32,16 +32,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -77,27 +73,6 @@ public class KafkaConnectorIT {
                 .usingBrokers(cluster)
                 .addConnectNodes(3);
         connectCluster.startup();
-    }
-
-    private void copy(List<File> files, Path directory) throws IOException {
-        for (File f : files) {
-            Path resolve = directory.resolve(f.getName());
-            if (f.isFile()) {
-                Files.copy(f.toPath(), resolve);
-            } else if (f.isDirectory()) {
-                resolve.toFile().mkdirs();
-                copy(asList(f.listFiles()), resolve);
-            }
-        }
-    }
-
-    private void listFiles(File file) {
-        for (File f : file.listFiles()) {
-            log.info("{}", f.getAbsolutePath() + (f.isDirectory() ? "/" : ""));
-            if (f.isDirectory()) {
-                listFiles(f);
-            }
-        }
     }
 
     @AfterEach


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a bug with connector reconciliation. The previous logic was, simply and inexcusably, wrong. In addition we were comparing a `Map` containing a mixture of String and Integer values with one whose values were all Strings. I've tightened up the generics, to at least convey the actual value type, but that wouldn't have caught the error due because the signature of `equals` just isn't very type safe.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

