### PR TITLE
ST: Remove redundant logs checks in UserST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.DoneableKafkaUser;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserBuilder;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -78,6 +79,7 @@ public class KafkaUserResource {
     private static KafkaUser waitFor(KafkaUser kafkaUser) {
         LOGGER.info("Waiting for Kafka User {}", kafkaUser.getMetadata().getName());
         SecretUtils.waitForSecretReady(kafkaUser.getMetadata().getName());
+        KafkaUserUtils.waitForKafkaUserCreation(kafkaUser.getMetadata().getName());
         LOGGER.info("Kafka User {} is ready", kafkaUser.getMetadata().getName());
         return kafkaUser;
     }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR removes redundant checks for user secrets and status, which should be done in `ResourceManager`. I also removed some unnecessary checks for logs, because checking logs is an overall problem in tests because kubernetes can strip the log from time to time.

### Checklist

- [x] Make sure all tests pass

