### PR TITLE
fix: Allow MM2 cluster with empty tls property

### DIFF
--- a/docker-images/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -63,4 +63,4 @@ if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi
 
-./kafka_connect_run.sh
+exec ./kafka_connect_run.sh


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

 - This PR updates the MirrorMaker 2.0 assembly operator to support
clusters with empty `tls` properties (i.e. no trustedCertificates list).
This allows the MM2 operator to connect to clusters that use SSL without
requiring the server certificates. For example:
```
apiVersion: kafka.strimzi.io/v1alpha1
kind: KafkaMirrorMaker2
metadata:
  name: my-cluster
spec:
  clusters:
  - alias: on-cloud
    bootstrapServers: broker-0.server.com:9093,broker-1.server.com:9093,broker-2.server.com:9093,
    tls: {}
    config:
      ssl.endpoint.identification.algorithm: https
    authentication:
      passwordSecret:
        secretName: my-cluster-oncloud-api-secret
        password: password
      username: token
      type: plain
...
```
Without this fix the above CR causes the following exception:
```
2020-03-17 15:56:26,017 ERROR Modification time of key store could not be obtained: /tmp/kafka/clusters/on-cloud.truststore.p12 (org.apache.kafka.common.security.ssl.SslEngineBuilder) [creating internal topics]
java.nio.file.NoSuchFileException: /tmp/kafka/clusters/on-cloud.truststore.p12
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
	at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
	at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.nio.file.Files.readAttributes(Files.java:1737)
	at java.nio.file.Files.getLastModifiedTime(Files.java:2266)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder$SecurityStore.lastModifiedMs(SslEngineBuilder.java:298)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder$SecurityStore.<init>(SslEngineBuilder.java:275)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder.createTruststore(SslEngineBuilder.java:182)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder.<init>(SslEngineBuilder.java:100)
	at org.apache.kafka.common.security.ssl.SslFactory.configure(SslFactory.java:95)
	at org.apache.kafka.common.network.SaslChannelBuilder.configure(SaslChannelBuilder.java:154)
	at org.apache.kafka.common.network.ChannelBuilders.create(ChannelBuilders.java:146)
	at org.apache.kafka.common.network.ChannelBuilders.clientChannelBuilder(ChannelBuilders.java:67)
	at org.apache.kafka.clients.ClientUtils.createChannelBuilder(ClientUtils.java:99)
	at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:426)
	at org.apache.kafka.clients.admin.Admin.create(Admin.java:69)
	at org.apache.kafka.connect.util.TopicAdmin.<init>(TopicAdmin.java:169)
	at org.apache.kafka.connect.mirror.MirrorUtils.createCompactedTopic(MirrorUtils.java:108)
	at org.apache.kafka.connect.mirror.MirrorUtils.createSinglePartitionCompactedTopic(MirrorUtils.java:114)
	at org.apache.kafka.connect.mirror.MirrorCheckpointConnector.createInternalTopics(MirrorCheckpointConnector.java:149)
```
 - It also fixes the Tini warning seen in the MM2 pod logs by exec'ing
the call to start Kafka Connect:
```
[WARN  tini (41)] Tini is not running as PID 1 and isn't registered as
a child subreaper. Zombie processes will not be re-parented to Tini, so
zombie reaping won't work
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ x ] Make sure all tests pass
- [ x ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

