### PR TITLE
Added Kind to HACKING.md and added HACKING-cli-image.md

### DIFF
--- a/HACKING-cli-image.md
+++ b/HACKING-cli-image.md
@@ -1,0 +1,98 @@
+Strimzi Development CLI image
+=============================
+
+Strimzi Development CLI image is a CentOS 7 based image that contains Java 8 and all the build dependencies and tools needed to build and deploy Strimzi.
+
+In order to build Strimzi Kafka Operator project you need a running Docker daemon.
+
+If you also want to try them out, deploy the Strimzi Cluster Operator, and run a test Kafka cluster on Kubernetes, you'll need access to Kubernetes API server.
+
+There are several locally running options for Kubernetes as explained in [Strimzi Quickstarts](https://strimzi.io/quickstarts/).
+
+Look for instructions on installing Docker, Kubernetes in those documents or on web.
+
+For using Strimzi Development CLI image you only need a working Docker daemon, and `docker` client.
+
+
+Starting the session
+--------------------
+
+First, make sure that you have the latest version of image (best to do this every time):
+
+    docker pull quay.io/mstruk/strimzi-dev-cli
+
+Second, you may have to prepare some configurations for accessing Docker daemon, Kubernetes API server, Maven repository ... from within your Docker container session.
+
+For example, if you're using Kind you'll want to export its configuration specifically for use from within Docker containers:
+
+    kind get kubeconfig --internal > ~/.kube/internal-kubeconfig
+
+Finally, run the interactive shell mounting local directories you want to share with your container session as volumes.
+
+For example:
+* if using Kind for Kubernetes, you'll want to make kube configuration file available inside container
+* if using local Docker daemon over UNIX socket, you'll want to make the socket file available inside container
+* typically you want to mount the local directory that contains your strimzi-kafka-operator project so that you can make changes using your locally running IDE
+* you may want to use local directory for storing downloaded maven artifacts (although I/O operations on mounted volumes might be slower than on container's private filesystem)
+
+```
+# set DEV_DIR to point to directory where you have your cloned git repositories
+# You'll be able to access this directory from within Strimzi Dev CLI container
+export DEV_DIR=$HOME/devel
+
+# Run the container interactively
+docker run -ti --name strimzi-dev-cli -v $HOME/.kube:/root/.kube -v /var/run/docker.sock:/var/run/docker.sock -v $DEV_DIR:/root/devel -v $HOME/.m2:/root/.m2:cached quay.io/mstruk/strimzi-dev-cli /bin/sh
+```
+
+Note: If you exit the container or it gets shut down, as long as it's not manually deleted you can reattach and continue interactive session:
+
+    docker start strimzi-dev-cli
+    docker attach strimzi-dev-cli
+
+Having starterd the interactive session you are now in the development environment where you have all the necessary tools including `docker`, `kind`, `kubectl`, `git`, `mvn` and all the rest you need to build Strimzi project.
+
+If you're using Kind for your local Kubernetes cluster you may want to check that everything works:
+
+```
+export KUBECONFIG=~/.kube/internal-kubeconfig
+kubectl get ns
+docker ps
+```
+
+Also, if running a local Docker Registry as another docker container [as explained here](HACKING.md#local-build-with-push-to-docker-registry-used-by-kind), you'll want to make sure that you can push to it from your interactive container:
+
+```
+# Set REGISTRY_IP to the same value you configured on Docker daemon
+export REGISTRY_IP=<enter-the-ip-of-your-en0-or-docker0>
+
+export REGISTRY_PORT=5000
+
+# test docker push to local repository
+docker tag gcr.io/google-samples/hello-app:1.0 $REGISTRY_IP:$REGISTRY_PORT/hello-app:1.0
+docker push $REGISTRY_IP:$REGISTRY_PORT/hello-app:1.0
+```
+
+Building the project
+--------------------
+
+Change to the directory with your sources (you may need to clone the project if you haven't already):
+
+    cd ~/devel/strimzi-kafka-operator
+
+The quickest way to build the project is to run:
+
+    MVN_ARGS="-DskipTests -Dcheckstyle.skip -Dmaven.javadoc.skip" make clean docker_build
+
+You then push the images to Docker Registry, which depends on your environment. For example:
+
+    export DOCKER_REG=$REGISTRY_IP:$REGISTRY_PORT
+    DOCKER_REGISTRY=$DOCKER_REG DOCKER_ORG=strimzi make docker_push
+
+
+See [HACKING.md](HACKING.md#make-targets) for build targets, and other build instructions.
+
+
+Deploying the operator and the cluster
+--------------------------------------
+
+See instructions in [HACKING.md](HACKING.md#building-strimzi) dependening on your environment.

--- a/HACKING-cli-image.md
+++ b/HACKING-cli-image.md
@@ -5,7 +5,7 @@ Strimzi Development CLI image is a CentOS 7 based image that contains Java 8 and
 
 In order to build Strimzi Kafka Operator project you need a running Docker daemon.
 
-If you also want to try them out, deploy the Strimzi Cluster Operator, and run a test Kafka cluster on Kubernetes, you'll need access to Kubernetes API server.
+If you also want to try them out, deploy the Strimzi Cluster Operator, and run a test Kafka cluster on Kubernetes, you'll need access to a Kubernetes API server.
 
 There are several locally running options for Kubernetes as explained in [Strimzi Quickstarts](https://strimzi.io/quickstarts/).
 
@@ -30,10 +30,10 @@ For example, if you're using Kind you'll want to export its configuration specif
 Finally, run the interactive shell mounting local directories you want to share with your container session as volumes.
 
 For example:
-* if using Kind for Kubernetes, you'll want to make kube configuration file available inside container
-* if using local Docker daemon over UNIX socket, you'll want to make the socket file available inside container
+* if using Kind for Kubernetes, you'll want to make the kube configuration file available inside the container
+* if using your local Docker daemon over a UNIX domain socket, you'll want to make the socket file available inside the container
 * typically you want to mount the local directory that contains your strimzi-kafka-operator project so that you can make changes using your locally running IDE
-* you may want to use local directory for storing downloaded maven artifacts (although I/O operations on mounted volumes might be slower than on container's private filesystem)
+* you may want to use a local directory for storing downloaded maven artifacts (although I/O operations on mounted volumes might be slower than on container's private filesystem)
 
 ```
 # set DEV_DIR to point to directory where you have your cloned git repositories
@@ -44,12 +44,12 @@ export DEV_DIR=$HOME/devel
 docker run -ti --name strimzi-dev-cli -v $HOME/.kube:/root/.kube -v /var/run/docker.sock:/var/run/docker.sock -v $DEV_DIR:/root/devel -v $HOME/.m2:/root/.m2:cached quay.io/mstruk/strimzi-dev-cli /bin/sh
 ```
 
-Note: If you exit the container or it gets shut down, as long as it's not manually deleted you can reattach and continue interactive session:
+Note: If you exit the container or it gets shut down, as long as it's not manually deleted you can reattach and continue the interactive session:
 
     docker start strimzi-dev-cli
     docker attach strimzi-dev-cli
 
-Having starterd the interactive session you are now in the development environment where you have all the necessary tools including `docker`, `kind`, `kubectl`, `git`, `mvn` and all the rest you need to build Strimzi project.
+Having started the interactive session you are now in the development environment where you have all the necessary tools including `docker`, `kind`, `kubectl`, `git`, `mvn` and all the rest you need to build the Strimzi project.
 
 If you're using Kind for your local Kubernetes cluster you may want to check that everything works:
 
@@ -83,7 +83,7 @@ The quickest way to build the project is to run:
 
     MVN_ARGS="-DskipTests -Dcheckstyle.skip -Dmaven.javadoc.skip" make clean docker_build
 
-You then push the images to Docker Registry, which depends on your environment. For example:
+You then push the images to your Docker Registry, which depends on your environment. For example:
 
     export DOCKER_REG=$REGISTRY_IP:$REGISTRY_PORT
     DOCKER_REGISTRY=$DOCKER_REG DOCKER_ORG=strimzi make docker_push

--- a/HACKING-cli-image.md
+++ b/HACKING-cli-image.md
@@ -17,7 +17,7 @@ For using Strimzi Development CLI image you only need a working Docker daemon, a
 Starting the session
 --------------------
 
-First, make sure that you have the latest version of image (best to do this every time):
+First, make sure that you have the latest version of the image (best to do this every time you start a new session):
 
     docker pull quay.io/mstruk/strimzi-dev-cli
 
@@ -59,7 +59,7 @@ kubectl get ns
 docker ps
 ```
 
-Also, if running a local Docker Registry as another docker container [as explained here](HACKING.md#local-build-with-push-to-docker-registry-used-by-kind), you'll want to make sure that you can push to it from your interactive container:
+Also, if running a local Docker Registry as another docker container [as explained here](HACKING.md#local-build-pushing-to-the-docker-registry-used-by-kind), you'll want to make sure that you can push to it from your interactive container:
 
 ```
 # Set REGISTRY_IP to the same value you configured on Docker daemon

--- a/HACKING.md
+++ b/HACKING.md
@@ -133,7 +133,7 @@ Other build options:
  - [Local build with push to Docker Hub](#local-build-with-push-to-docker-hub)
  - [Local build with push to Minishift Docker registry](#local-build-with-push-to-minishift-docker-registry)
  - [Local build on Minishift or Minikube](#local-build-on-minishift-or-minikube)
- - [Local build with push to Docker registry used by Kind](#local-build-with-push-to-docker-registry-used-by-kind)
+ - [Local build pushing to the Docker registry used by Kind](#local-build-pushing-to-the-docker-registry-used-by-kind)
 
 #### Kafka versions
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -119,7 +119,7 @@ The docker images can be built with an alternative container OS version by addin
 
 In order to build Strimzi images you need a running Docker daemon (either local or remote).
 
-If you also want to run tests or deploy Strimzi CRDs and the Strimzi Cluster Operator you need access to Kubernetes API server.
+If you also want to run tests or deploy Strimzi CRDs and the Strimzi Cluster Operator you need access to a Kubernetes API server.
 
 The `make all` target can be used to trigger both the `docker_build` and the `docker_push` targets described above. This will build the Docker images, tag them and push them to the configured repository.
 
@@ -236,9 +236,9 @@ or
 
 The images will then be built and stored in the cluster VM's local image store and then pushed to your configured Docker registry. 
 
-#### Local build with push to Docker registry used by Kind
+#### Local build pushing to the Docker registry used by Kind
 
-When developing locally you might want to push the docker images to the docker repository running as container in your Docker daemon and used by your Kind cluster deployed in the same Docker daemon. This can be quicker and more convenient than pushing to Docker Hub and works even without a network connection.
+When developing locally you might want to push the docker images to the docker repository running as a container in your Docker daemon and used by your Kind cluster deployed in the same Docker daemon. This can be quicker and more convenient than pushing to Docker Hub and works even without a network connection.
 
 1. Determine the IP where your Docker Registry can be reached from both your local environment and from docker containers.
 
@@ -260,7 +260,7 @@ When developing locally you might want to push the docker images to the docker r
 
        docker run -d --restart=always -p "$REGISTRY_PORT:$REGISTRY_PORT" --name "$REGISTRY_NAME" registry:2
 
-   Using `-p` exposes the registry on port 5000 on localhost, but also on the network interface with $REGISTRY_IP address, making it available from your local host as well as from Docker daemon running in a VM, and also from Docker containers running inside Docker daemon (such as Kind cluster running as `kind-control-plane` container).
+   Using `-p` exposes the registry on port 5000 on localhost, but also on the network interface with $REGISTRY_IP address, making it available from your local host as well as from the Docker daemon running in a VM, and also from Docker containers running inside the Docker daemon (such as the Kind cluster running as the `kind-control-plane` container).
 
 3. Configure your Docker daemon to trust your Docker Registry.
 
@@ -284,7 +284,7 @@ When developing locally you might want to push the docker images to the docker r
 
    After changing this configuration you have to restart the Docker daemon.
 
-4. Make sure you can push locally to Docker Registry
+4. Make sure you can push locally to your Docker Registry
 
    Execute the following, to make sure your Docker daemon can work with your Docker Registry
 
@@ -311,7 +311,7 @@ When developing locally you might want to push the docker images to the docker r
    EOF
    ```
 
-   Note, how we use `http` in `endpoint` value, which makes Kind work with your 'insecure' registry.
+   Note, how we use `http` in the `endpoint` value, which makes Kind work with your 'insecure' registry.
 
 6. Make sure Kind can deploy images from your Docker Registry
 
@@ -363,7 +363,7 @@ When developing locally you might want to push the docker images to the docker r
 
         kubectl create -f install/cluster-operator
 
-    You can follow it's status by executing:
+    You can follow its status by executing:
         
         kubectl get events -w | grep operator
         

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See our [website][strimzi] for more details about the project.
 
 ## Quickstart
 
-To get up and running quickly, check our Quickstart guides for [OKD (OpenShift Origin)](https://strimzi.io/quickstarts/okd/) and [Minikube](https://strimzi.io/quickstarts/minikube/). 
+To get up and running quickly, check our Quickstart guides for [OKD (OpenShift Origin)](https://strimzi.io/quickstarts/okd/), [Minikube](https://strimzi.io/quickstarts/minikube/), and [Kubernetes Kind](https://strimzi.io/quickstarts/kind/). 
 
 ## Documentation
 


### PR DESCRIPTION
Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

This PR depends on https://github.com/strimzi/strimzi.github.io/pull/126

### Type of change

_Select the type of your PR_

- Documentation

### Description

Additional documentation in HACKING.md, describing how to use Kubernetes Kind, and adding documentation for so called Strimzi Development CLI image which is a CentOS 7 based interactive shell with all the tooling needed to quickly build and deploy Strimzi project without having to install all the build dependencies to your local machine.
 
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

