### PR TITLE
Add automatic scaling of Zookeeper 3.5

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -197,6 +197,19 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper-jute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <scope>test</scope>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -125,6 +125,7 @@ public class ClusterCa extends Ca {
             sbjAltNames.put("DNS.3", String.format("%s.%s.svc", ZookeeperCluster.serviceName(cluster), namespace));
             sbjAltNames.put("DNS.4", String.format("%s.%s.svc.%s", ZookeeperCluster.serviceName(cluster), namespace, ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN));
             sbjAltNames.put("DNS.5", ZookeeperCluster.podDnsName(namespace, cluster, i));
+            sbjAltNames.put("DNS.6", ZookeeperCluster.podDnsNameWithoutSuffix(namespace, cluster, i));
 
             Subject subject = new Subject();
             subject.setOrganizationName("io.strimzi");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -434,31 +434,4 @@ public class ModelUtils {
         }
         return String.join(" ", javaSystemPropertiesList);
     }
-
-    /**
-     * Detects the StatefulSet pod index from the Pod resource.
-     * When the Pod doesn't have name of metadata, it returns null
-     *
-     * @param pod   Pod from which the name should be extracted
-     * @return      The index of the pod within the STS
-     */
-    public static Integer getIndexFromPod(Pod pod)    {
-        if (pod != null
-                && pod.getMetadata() != null
-                && pod.getMetadata().getName() != null)    {
-            return getIndexFromPodName(pod.getMetadata().getName());
-        }
-
-        return null;
-    }
-
-    /**
-     * Gets the index from STS pod Name name
-     *
-     * @param podName   Name of the STS pod
-     * @return          The index of the pod within the STS
-     */
-    private static int getIndexFromPodName(String podName)    {
-        return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
-    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -56,15 +56,14 @@ import java.util.Map;
 import static java.util.Arrays.asList;
 
 public class ZookeeperCluster extends AbstractModel {
-
-    protected static final int CLIENT_PORT = 2181;
+    public static final int CLIENT_PORT = 2181;
     protected static final String CLIENT_PORT_NAME = "clients";
-    protected static final int CLUSTERING_PORT = 2888;
+    public static final int CLUSTERING_PORT = 2888;
     protected static final String CLUSTERING_PORT_NAME = "clustering";
-    protected static final int LEADER_ELECTION_PORT = 3888;
+    public static final int LEADER_ELECTION_PORT = 3888;
     protected static final String LEADER_ELECTION_PORT_NAME = "leader-election";
 
-    protected static final String ZOOKEEPER_NAME = "zookeeper";
+    public static final String ZOOKEEPER_NAME = "zookeeper";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
     protected static final String TLS_SIDECAR_NODES_VOLUME_NAME = "zookeeper-nodes";
     protected static final String TLS_SIDECAR_NODES_VOLUME_MOUNT = "/etc/tls-sidecar/zookeeper-nodes/";
@@ -124,6 +123,13 @@ public class ZookeeperCluster extends AbstractModel {
                 ZookeeperCluster.headlessServiceName(cluster),
                 namespace,
                 ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
+    }
+
+    public static String podDnsNameWithoutSuffix(String namespace, String cluster, int podId) {
+        return String.format("%s.%s.%s.svc",
+                ZookeeperCluster.zookeeperPodName(cluster, podId),
+                ZookeeperCluster.headlessServiceName(cluster),
+                namespace);
     }
 
     public static String zookeeperPodName(String cluster, int pod) {
@@ -679,4 +685,5 @@ public class ZookeeperCluster extends AbstractModel {
     public void disableSnapshotChecks() {
         this.isSnapshotCheckEnabled = false;
     }
+
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -117,6 +117,17 @@ public class ZookeeperCluster extends AbstractModel {
         return cluster + ZookeeperCluster.HEADLESS_SERVICE_NAME_SUFFIX;
     }
 
+    /**
+     * Generates the full DNS name of the pod including the cluster suffix
+     * (i.e. usually with the cluster.local - but can be different on different clusters)
+     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc.cluster.local
+     *
+     * @param namespace     Namespace of the pod
+     * @param cluster       Name of the cluster
+     * @param podId         Id of the pod within the STS
+     *
+     * @return              Full DNS name
+     */
     public static String podDnsName(String namespace, String cluster, int podId) {
         return String.format("%s.%s.%s.svc.%s",
                 ZookeeperCluster.zookeeperPodName(cluster, podId),
@@ -125,6 +136,17 @@ public class ZookeeperCluster extends AbstractModel {
                 ModelUtils.KUBERNETES_SERVICE_DNS_DOMAIN);
     }
 
+    /**
+     * Generates the full DNS name of the pod without the cluster suffix
+     * (i.e. usually without the cluster.local - but can be different on different clusters)
+     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc
+     *
+     * @param namespace     Namespace of the pod
+     * @param cluster       Name of the cluster
+     * @param podId         Id of the pod within the STS
+     *
+     * @return              Full DNS name
+     */
     public static String podDnsNameWithoutSuffix(String namespace, String cluster, int podId) {
         return String.format("%s.%s.%s.svc",
                 ZookeeperCluster.zookeeperPodName(cluster, podId),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1464,7 +1464,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                         if (res.succeeded())    {
                                             scalingPromise.complete(res.result());
                                         } else {
-                                            log.warn("{}: Failed to scale Zookeeper", res.cause());
+                                            log.warn("{}: Failed to scale Zookeeper", reconciliation, res.cause());
                                             scalingPromise.fail(res.cause());
                                         }
                                     });
@@ -1509,7 +1509,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                         if (res.succeeded())    {
                                             scalingPromise.complete(res.result());
                                         } else {
-                                            log.warn("{}: Failed to scale Zookeeper", res.cause());
+                                            log.warn("{}: Failed to scale Zookeeper", reconciliation, res.cause());
                                             scalingPromise.fail(res.cause());
                                         }
                                     });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -35,6 +35,7 @@ import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.KafkaListeners;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
@@ -73,11 +74,14 @@ import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.KafkaSpecChecker;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperScaler;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperScalerProvider;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -154,6 +158,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private final StorageClassOperator storageClassOperator;
     private final NodeOperator nodeOperator;
     private final CrdOperator<KubernetesClient, Kafka, KafkaList, DoneableKafka> crdOperator;
+    private final ZookeeperScalerProvider zooScalerProvider;
 
     /**
      * @param vertx The Vertx instance
@@ -181,6 +186,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         this.storageClassOperator = supplier.storageClassOperations;
         this.crdOperator = supplier.kafkaOperator;
         this.nodeOperator = supplier.nodeOperator;
+        this.zooScalerProvider = supplier.zooScalerProvider;
     }
 
     @Override
@@ -255,17 +261,18 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.zkVersionChange())
                 .compose(state -> state.zookeeperServiceAccount())
                 .compose(state -> state.zkPvcs())
-                .compose(state -> state.zkScalingSetup())
-                .compose(state -> state.zkScaleDown())
                 .compose(state -> state.zkService())
                 .compose(state -> state.zkHeadlessService())
                 .compose(state -> state.zkAncillaryCm())
                 .compose(state -> state.zkNodesSecret(this::dateSupplier))
                 .compose(state -> state.zkPodDisruptionBudget())
                 .compose(state -> state.zkStatefulSet())
-                .compose(state -> state.zkScaleUp())
+                .compose(state -> state.zkScaling34())
+                .compose(state -> state.zkScalingDown35())
                 .compose(state -> state.zkRollingUpdate())
                 .compose(state -> state.zkPodsReady())
+                .compose(state -> state.zkScalingUp35())
+                .compose(state -> state.zkScalingCheck35())
                 .compose(state -> state.zkServiceEndpointReadiness())
                 .compose(state -> state.zkHeadlessServiceEndpointReadiness())
                 .compose(state -> state.zkPersistentClaimDeletion())
@@ -368,9 +375,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private Service zkHeadlessService;
         private ConfigMap zkMetricsAndLogsConfigMap;
         /* test */ ReconcileResult<StatefulSet> zkDiffs;
-        private boolean zkScalingUp = false;
-        private boolean zkScalingDown = false;
-        private boolean zkManualScaling = false;
+        private Integer zkCurrentReplicas = null;
 
         private KafkaCluster kafkaCluster = null;
         /* test */ KafkaStatus kafkaStatus = new KafkaStatus();
@@ -1281,6 +1286,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         this.zkService = zkCluster.generateService();
                         this.zkHeadlessService = zkCluster.generateHeadlessService();
 
+                        if (sts != null && sts.getSpec() != null)   {
+                            this.zkCurrentReplicas = sts.getSpec().getReplicas();
+                        }
+
                         if (zkCluster.getLogging() instanceof  ExternalLogging) {
                             return configMapOperations.getAsync(kafkaAssembly.getMetadata().getNamespace(), ((ExternalLogging) zkCluster.getLogging()).getName());
                         } else {
@@ -1312,10 +1321,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return withVoid(serviceAccountOperations.reconcile(namespace,
                     ZookeeperCluster.containerServiceAccountName(zkCluster.getCluster()),
                     zkCluster.generateServiceAccount()));
-        }
-
-        Future<ReconciliationState> zkScaleDown() {
-            return withVoid(zkSetOperations.scaleDown(namespace, zkCluster.getName(), zkCluster.getReplicas()));
         }
 
         Future<ReconciliationState> zkService() {
@@ -1371,125 +1376,229 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             StatefulSet zkSts = zkCluster.generateStatefulSet(pfa.isOpenshift(), imagePullPolicy, imagePullSecrets);
             Annotations.annotations(zkSts.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(getCaCertGeneration(this.clusterCa)));
             Annotations.annotations(zkSts.getSpec().getTemplate()).put(AbstractModel.ANNO_STRIMZI_LOGGING_HASH, zkLoggingHash);
-            Annotations.annotations(zkSts).put(Annotations.ANNO_STRIMZI_IO_MANUAL_ZK_SCALE, String.valueOf(zkManualScaling));
             return withZkDiff(zkSetOperations.reconcile(namespace, zkCluster.getName(), zkSts));
         }
 
         Future<ReconciliationState> zkRollingUpdate() {
-            if (zkManualScaling && (KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") > 0)) {
-                log.info("Skipping cluster roll due to ongoing manual scaling operations. " +
-                        "If you have completed the manual scaling operation then set the " +
-                        Annotations.ANNO_STRIMZI_IO_MANUAL_ZK_SCALE + " to false to re-enable rolling updates.");
-                return Future.succeededFuture(this);
-            } else {
-                log.debug("No manual scaling operation detected, continuing with ZK cluster roll");
-                return withVoid(zkSetOperations.maybeRollingUpdate(zkDiffs.resource(), pod ->
-                        isPodToRestart(zkDiffs.resource(), pod, existingZookeeperCertsChanged, this.clusterCa)));
-            }
+            // Scale-down and Scale-up might have change the STS. we should get a fresh one.
+            return zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name))
+                    .compose(sts -> zkSetOperations.maybeRollingUpdate(sts,
+                        pod -> isPodToRestart(zkDiffs.resource(), pod, existingZookeeperCertsChanged, this.clusterCa)))
+                    .map(this);
         }
 
         /**
-         * This method setups to the scaling behaviour for the zookeeper cluster.
+         * Prepares the Zookeeper connectionString
+         * The format is host1:port1,host2:port2,...
          *
-         * For 3.4.x clusters the scale by one -> roll cluster -> scale by one -> roll cluster method used.
-         * Scaling up from N to M (N > 0 and M>N) replicas is done in M-N steps.
-         * Each step performs scale up by one replica and full rolling update of Zookeeper cluster.
-         * This approach ensures a valid configuration of each Zk pod.
-         * Together with modified `maybeRollingUpdate` the quorum is not lost after the scale up operation is performed.
-         * There is one special case of scaling from standalone (single one) Zookeeper pod.
-         * In this case quorum cannot be preserved.
+         * USed by the Zookeeper 3.5 Admin client for scaling
          *
-         * For 3.5.x clusters scaling is limited to one server at a time (or an exception is thrown) and currently
-         * requires user intervention to manually add/remove servers to/from the quorum.
+         * @param connectToReplicas     Number of replicas form the ZK STS which should be used
+         * @return                      The generated Zookeeper connection string
          */
-        Future<ReconciliationState> zkScalingSetup() {
-            return zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name))
-                    .compose(sts -> {
-                        if (sts != null) {
-                            int currentReplicas = sts.getSpec().getReplicas();
-                            int desiredReplicas = zkCluster.getReplicas();
-                            int replicaDiff = Math.abs(currentReplicas - desiredReplicas);
-                            boolean isZK35x = KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") > 0;
+        String zkConnectionString(int connectToReplicas)  {
+            // Prepare Zoo connection string. We want to connect only to nodes which existed before
+            // scaling and will exist after it is finished
+            List<String> zooNodes = new ArrayList<>(connectToReplicas);
 
-                            if (isZK35x && replicaDiff > 1) {
-                                // If the user is scaling a 3.5.x cluster and has specified as scale up or down of more than one
-                                // then log the error and throw an exception halting the reconciliation.
-                                String scaleErrorMessage = String.format(
-                                        "Scaling of Zookeeper 3.5.x clusters must be done in steps of one only. " +
-                                                "A change of %d was specified. Please set the Zookeeper replica count " +
-                                                "to one greater or lesser than the original value (%d).",
-                                        replicaDiff, currentReplicas);
+            for (int i = 0; i < connectToReplicas; i++)   {
+                zooNodes.add(String.format("%s.%s.%s.svc:%d", zkCluster.getPodName(i), KafkaResources.zookeeperHeadlessServiceName(name), namespace, ZookeeperCluster.CLIENT_PORT));
+            }
 
-                                log.error(scaleErrorMessage);
+            return  String.join(",", zooNodes);
+        }
 
-                                return Future.failedFuture(new IllegalArgumentException(scaleErrorMessage));
-                            } else if (desiredReplicas > currentReplicas) {
-                                // If this is a scale up of a 3.4.x cluster we want to scale in steps of one at a time
-                                // automatically. If it is 3.5 then it is limited to one at a time anyway by the check
-                                // in the clause above.
-                                zkCluster.setReplicas(currentReplicas + 1);
-                                zkScalingUp = true;
-                            } else if (desiredReplicas < currentReplicas) {
-                                zkScalingDown = true;
-                            }
+        /**
+         * Helper method for getting the required secrets with certificates and creating the ZookeeperScaler instance
+         * for given cluster. The ZookeeperScaler instance created by this method should be clsoe dmanually after it is
+         * not used anymore.
+         *
+         * @param connectToReplicas     Number of pods from the Zookeeper STS which the scaler should use
+         * @return                      Zookeeper scaler instance.
+         */
+        Future<ZookeeperScaler> zkScaler(int connectToReplicas)  {
+            Future<Secret> clusterCaCertSecretFuture = secretOperations.getAsync(namespace, KafkaResources.clusterCaCertificateSecretName(name));
+            Future<Secret> coKeySecretFuture = secretOperations.getAsync(namespace, ClusterOperator.secretName(name));
 
-                            ConditionBuilder zkManualScalingCondition = null;
-
-                            if ((zkScalingUp || zkScalingDown) && isZK35x) {
-                                // This is a scale up or down of a ZK 3.5.x cluster
-                                String scaleMessage = String.format(
-                                        "Scaling Zookeeper 3.5.x cluster: Rolling updates will be skipped and the manual " +
-                                        "update process defined in the documentation should be followed. When finished set " +
-                                         "%s annotation on the Zookeeper StatefulSet to false.",
-                                        Annotations.ANNO_STRIMZI_IO_MANUAL_ZK_SCALE);
-
-                                log.info(scaleMessage);
-
-                                zkManualScalingCondition = new ConditionBuilder()
-                                        .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
-                                        .withType("ZK-Manual-Scaling")
-                                        .withReason("replicaChange")
-                                        .withStatus("True")
-                                        .withMessage(scaleMessage);
-
-                                // Setting this will add the annotation to the STS in the state.zkStatefulSet() method
-                                zkManualScaling = true;
-                            } else if (Annotations.booleanAnnotation(sts, Annotations.ANNO_STRIMZI_IO_MANUAL_ZK_SCALE, false)) {
-                                // This is an on-going manual scaling operation. Once the annotation has been set to true by the operator
-                                // only the user can set it to false.
-                                String scaleMessage = String.format("Detected manual Zookeeper 3.5.x scaling operation in progress. " +
-                                                "After following the manual process defined in the documentation, set %s annotation on the " +
-                                                "Zookeeper stateful set to false.",
-                                        Annotations.ANNO_STRIMZI_IO_MANUAL_ZK_SCALE);
-
-                                log.info(scaleMessage);
-
-                                zkManualScalingCondition = new ConditionBuilder()
-                                        .withLastTransitionTime(ModelUtils.formatTimestamp(dateSupplier()))
-                                        .withType("ZK-Manual-Scaling")
-                                        .withReason("manualScaleAnnotationSet")
-                                        .withStatus("True")
-                                        .withMessage(scaleMessage);
-
-                                zkManualScaling = true;
-                            } else {
-                                // Either this is a ZK 3.4.x cluster or the user is not manually scaling the 3.5.x cluster.
-                                zkManualScaling = false;
-                            }
-
-                            if (zkManualScalingCondition != null && isZK35x) {
-                                this.kafkaStatus.addCondition(zkManualScalingCondition.build());
-                            }
+            return CompositeFuture.join(clusterCaCertSecretFuture, coKeySecretFuture)
+                    .compose(compositeFuture -> {
+                        // Handle Cluster CA for connecting to Zoo
+                        Secret clusterCaCertSecret = compositeFuture.resultAt(0);
+                        if (clusterCaCertSecret == null) {
+                            return Future.failedFuture(Util.missingSecretException(namespace, KafkaCluster.clusterCaKeySecretName(name)));
                         }
-                        return Future.succeededFuture(this);
+
+                        // Handle CO key for connecting to Zoo
+                        Secret coKeySecret = compositeFuture.resultAt(1);
+                        if (coKeySecret == null) {
+                            return Future.failedFuture(Util.missingSecretException(namespace, ClusterOperator.secretName(name)));
+                        }
+
+                        ZookeeperScaler zooScaler = zooScalerProvider.createZookeeperScaler(vertx, zkConnectionString(connectToReplicas), clusterCaCertSecret, coKeySecret, operationTimeoutMs);
+
+                        return Future.succeededFuture(zooScaler);
                     });
         }
 
-        Future<ReconciliationState> zkScaleUp() {
-            if (zkScalingUp) {
-                return zkSetOperations.scaleUp(namespace, zkCluster.getName(), zkCluster.getReplicas())
-                        .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(zkCluster.getReplicas() - 1), 1_000, operationTimeoutMs))
-                        .map(this);
+        Future<ReconciliationState> zkScalingUp35() {
+            int desired = zkCluster.getReplicas();
+
+            if (zkCurrentReplicas != null
+                    && zkCurrentReplicas < desired
+                    && KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") > 0) {
+                // Zoo 3.5 or higher with scaling
+                log.info("{}: Scaling Zookeeper up from {} to {} replicas", reconciliation, zkCurrentReplicas, desired);
+
+                return zkScaler(zkCurrentReplicas)
+                        .compose(zooScaler -> {
+                            Promise<ReconciliationState> scalingPromise = Promise.promise();
+
+                            zkScalingUp35ByOne(zooScaler, zkCurrentReplicas, desired)
+                                    .setHandler(res -> {
+                                        zooScaler.close();
+
+                                        if (res.succeeded())    {
+                                            scalingPromise.complete(res.result());
+                                        } else {
+                                            log.warn("{}: Failed to scale Zookeeper", res.cause());
+                                            scalingPromise.fail(res.cause());
+                                        }
+                                    });
+
+                            return scalingPromise.future();
+                        });
+            } else {
+                // No scaling up or not on Zookeeper 3.5 => do nothing
+                return Future.succeededFuture(this);
+            }
+        }
+
+        Future<ReconciliationState> zkScalingUp35ByOne(ZookeeperScaler zooScaler, int current, int desired) {
+            if (current < desired) {
+                return zkSetOperations.scaleUp(namespace, zkCluster.getName(), current + 1)
+                        .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(current), 1_000, operationTimeoutMs))
+                        .compose(ignore -> zooScaler.scale(current + 1))
+                        .compose(ignore -> zkScalingUp35ByOne(zooScaler, current + 1, desired));
+            } else {
+                return Future.succeededFuture(this);
+            }
+        }
+
+        Future<ReconciliationState> zkScalingDown35() {
+            int desired = zkCluster.getReplicas();
+
+            if (zkCurrentReplicas != null
+                    && zkCurrentReplicas > desired
+                    && KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") > 0) {
+                // Zoo 3.5 or higher with scaling
+                log.info("{}: Scaling Zookeeper down from {} to {} replicas", reconciliation, zkCurrentReplicas, desired);
+
+                // No need to check for pod readiness since we run right after the readiness check
+                return zkScaler(desired)
+                        .compose(zooScaler -> {
+                            Promise<ReconciliationState> scalingPromise = Promise.promise();
+
+                            zkScalingDown35ByOne(zooScaler, zkCurrentReplicas, desired)
+                                    .setHandler(res -> {
+                                        zooScaler.close();
+
+                                        if (res.succeeded())    {
+                                            scalingPromise.complete(res.result());
+                                        } else {
+                                            log.warn("{}: Failed to scale Zookeeper", res.cause());
+                                            scalingPromise.fail(res.cause());
+                                        }
+                                    });
+
+                            return scalingPromise.future();
+                        });
+            } else {
+                // No scaling down or not on Zookeeper 3.5 => do nothing
+                return Future.succeededFuture(this);
+            }
+        }
+
+        Future<ReconciliationState> zkScalingDown35ByOne(ZookeeperScaler zooScaler, int current, int desired) {
+            if (current > desired) {
+                return podsReady(zkCluster, current - 1)
+                        .compose(ignore -> zooScaler.scale(current - 1))
+                        .compose(ignore -> zkSetOperations.scaleDown(namespace, zkCluster.getName(), current - 1))
+                        .compose(ignore -> zkScalingDown35ByOne(zooScaler, current - 1, desired));
+            } else {
+                return Future.succeededFuture(this);
+            }
+        }
+
+
+        Future<ReconciliationState> zkScalingCheck35() {
+            // No scaling, but we should check the configuration
+            // This can cover any previous failures in the Zookeeper reconfiguration
+            if (KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") > 0) {
+                // Zoo 3.5 or higher
+                log.debug("{}: Verifying that Zookeeper is configured to run with {} replicas", reconciliation, zkCurrentReplicas);
+
+                // No need to check for pod readiness since we run right after the readiness check
+                return zkScaler(zkCluster.getReplicas())
+                        .compose(zooScaler -> {
+                            Promise<ReconciliationState> scalingPromise = Promise.promise();
+
+                            zooScaler.scale(zkCluster.getReplicas()).setHandler(res -> {
+                                zooScaler.close();
+
+                                if (res.succeeded())    {
+                                    scalingPromise.complete(this);
+                                } else {
+                                    log.warn("{}: Failed to verify Zookeeper configuration", res.cause());
+                                    scalingPromise.fail(res.cause());
+                                }
+                            });
+
+                            return scalingPromise.future();
+                        });
+            } else {
+                // Not Zookeeper 3.5 => do nothing
+                return Future.succeededFuture(this);
+            }
+        }
+
+        Future<ReconciliationState> zkScaling34() {
+            int desired = zkCluster.getReplicas();
+
+            if (zkCurrentReplicas != null
+                    && zkCurrentReplicas != desired
+                    && KafkaVersion.compareDottedVersions(zkCluster.getVersion(), "3.4.99") <= 0) {
+                // Zookeeper 3.4
+                if (zkCurrentReplicas > desired) {
+                    // Scale-down
+                    log.info("{}: Scaling Zookeeper 3.4 down from {} to {} replicas", reconciliation, zkCurrentReplicas, desired);
+                    return zk34ScaleDown(desired);
+                } else {
+                    // Scale-up
+                    log.info("{}: Scaling Zookeeper 3.4 up from {} to {} replicas", reconciliation, zkCurrentReplicas, desired);
+                    return zk34ScaleUp(zkCurrentReplicas, desired);
+                }
+            } else {
+                // No scaling or not on Zookeeper 3.4 => do nothing
+                return Future.succeededFuture(this);
+            }
+        }
+
+        Future<ReconciliationState> zk34ScaleDown(int desired) {
+            return zkSetOperations.scaleDown(namespace, zkCluster.getName(), desired)
+                    .map(this);
+        }
+
+        Future<ReconciliationState> zk34ScaleUp(int current, int desired) {
+            if (current < desired) {
+                return zkSetOperations.scaleUp(namespace, zkCluster.getName(), current + 1)
+                        .compose(ignore -> podOperations.readiness(namespace, zkCluster.getPodName(current), 1_000, operationTimeoutMs))
+                        .compose(ignore -> zkSetOperations.getAsync(namespace, ZookeeperCluster.zookeeperClusterName(name)))
+                        .compose(sts -> zkSetOperations.maybeRollingUpdate(sts, pod -> {
+                            String env = ModelUtils.getPodEnv(pod, ZookeeperCluster.ZOOKEEPER_NAME, ZookeeperCluster.ENV_VAR_ZOOKEEPER_NODE_COUNT);
+                            // If the Pod is not yet configured for current+1 nodes, we need to roll it
+                            return !String.valueOf(current + 1).equals(env);
+                        }))
+                        .compose(ignore -> zk34ScaleUp(current + 1, desired));
             } else {
                 return Future.succeededFuture(this);
             }
@@ -2336,7 +2445,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkPodsReady() {
-            return podsReady(zkCluster);
+            if (zkCurrentReplicas != null)  {
+                // When scaling up we wait only for old pods to be ready, the new ones were not created yet
+                return podsReady(zkCluster, zkCurrentReplicas);
+            } else {
+                return podsReady(zkCluster);
+            }
         }
 
         Future<ReconciliationState> kafkaPodsReady() {
@@ -2345,6 +2459,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         Future<ReconciliationState> podsReady(AbstractModel model) {
             int replicas = model.getReplicas();
+            return podsReady(model, replicas);
+        }
+
+        Future<ReconciliationState> podsReady(AbstractModel model, int replicas) {
             List<Future> podFutures = new ArrayList<>(replicas);
 
             for (int i = 0; i < replicas; i++) {
@@ -2948,6 +3066,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         private boolean isPodToRestart(StatefulSet sts, Pod pod,
                                        boolean nodeCertsChange,
                                        Ca... cas) {
+            if (pod == null)    {
+                // When the Pod doesn't exist, it doesn't need to be restarted.
+                // It will be created with new configuration.
+                return false;
+            }
+
             boolean isPodUpToDate = isPodUpToDate(sts, pod);
             boolean isCustomCertTlsListenerUpToDate = isCustomCertUpToDate(sts, pod, KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_TLS_LISTENER);
             boolean isCustomCertExternalListenerUpToDate = isCustomCertUpToDate(sts, pod, KafkaCluster.ANNO_STRIMZI_CUSTOM_CERT_THUMBPRINT_EXTERNAL_LISTENER);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZooKeeperAdminProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZooKeeperAdminProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+import java.io.IOException;
+
+/**
+ * Class to provide the real ZooKeeperAdmin which connects to actual Zookeeper
+ */
+public class DefaultZooKeeperAdminProvider implements ZooKeeperAdminProvider {
+    /**
+     * Creates an instance of ZooKeeperAdmin
+     *
+     * @param connectString     Connection String used to connect to Zookeeper
+     * @param sessionTimeout    Session timeout
+     * @param watcher           Watcher which will be notified about watches and connection changes
+     * @param conf              Zookeeper client configuration
+     *
+     * @return  ZooKeeperAdmin instance
+     */
+    @Override
+    public ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+        return new ZooKeeperAdmin(connectString, sessionTimeout, watcher, conf);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.vertx.core.Vertx;
+
+/**
+ * Class to provide the real ZookeeperScaler which connects to actual Zookeeper
+ */
+public class DefaultZookeeperScalerProvider implements ZookeeperScalerProvider {
+    private static ZooKeeperAdminProvider zooAdminProvider = new DefaultZooKeeperAdminProvider();
+
+    /**
+     * Creates an instance of ZookeeperScaler
+     *
+     * @param vertx                         Vertx instance
+     * @param zookeeperConnectionString     Connection string to connect to the right Zookeeper
+     * @param clusterCaCertSecret           Secret with Kafka cluster CA public key
+     * @param coKeySecret                   Secret with Cluster Operator public and private key
+     * @param operationTimeoutMs            Operation timeout
+     *
+     * @return  ZookeeperScaler instance
+     */
+    public ZookeeperScaler createZookeeperScaler(Vertx vertx, String zookeeperConnectionString, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs) {
+        return new ZookeeperScaler(vertx, zooAdminProvider, zookeeperConnectionString, clusterCaCertSecret, coKeySecret, operationTimeoutMs);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -82,6 +82,7 @@ public class ResourceOperatorSupplier {
     public final DeploymentConfigOperator deploymentConfigOperations;
     public final StorageClassOperator storageClassOperations;
     public final NodeOperator nodeOperator;
+    public final ZookeeperScalerProvider zooScalerProvider;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client,
@@ -89,11 +90,12 @@ public class ResourceOperatorSupplier {
             // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
                 () -> new BackOff(5_000, 2, 4)),
                     new DefaultAdminClientProvider(),
+                    new DefaultZookeeperScalerProvider(),
                     pfa, operationTimeoutMs);
     }
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf,
-                                    AdminClientProvider adminClientProvider,
+                                    AdminClientProvider adminClientProvider, ZookeeperScalerProvider zooScalerProvider,
                                     PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
                 pfa.hasRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
@@ -121,7 +123,8 @@ public class ResourceOperatorSupplier {
                 new CrdOperator<>(vertx, client, KafkaConnector.class, KafkaConnectorList.class, DoneableKafkaConnector.class),
                 new CrdOperator<>(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, DoneableKafkaMirrorMaker2.class),
                 new StorageClassOperator(vertx, client, operationTimeoutMs),
-                new NodeOperator(vertx, client, operationTimeoutMs));
+                new NodeOperator(vertx, client, operationTimeoutMs),
+                zooScalerProvider);
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
@@ -150,7 +153,8 @@ public class ResourceOperatorSupplier {
                                     CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList, DoneableKafkaConnector> kafkaConnectorOperator,
                                     CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List, DoneableKafkaMirrorMaker2> mirrorMaker2Operator,
                                     StorageClassOperator storageClassOperator,
-                                    NodeOperator nodeOperator) {
+                                    NodeOperator nodeOperator,
+                                    ZookeeperScalerProvider zooScalerProvider) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
@@ -178,5 +182,6 @@ public class ResourceOperatorSupplier {
         this.kafkaConnectorOperator = kafkaConnectorOperator;
         this.mirrorMaker2Operator = mirrorMaker2Operator;
         this.nodeOperator = nodeOperator;
+        this.zooScalerProvider = zooScalerProvider;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -82,7 +82,7 @@ public class ResourceOperatorSupplier {
     public final DeploymentConfigOperator deploymentConfigOperations;
     public final StorageClassOperator storageClassOperations;
     public final NodeOperator nodeOperator;
-    public final ZookeeperScalerProvider zooScalerProvider;
+    public final ZookeeperScalerProvider zkScalerProvider;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client,
@@ -95,7 +95,7 @@ public class ResourceOperatorSupplier {
     }
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf,
-                                    AdminClientProvider adminClientProvider, ZookeeperScalerProvider zooScalerProvider,
+                                    AdminClientProvider adminClientProvider, ZookeeperScalerProvider zkScalerProvider,
                                     PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
                 pfa.hasRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
@@ -124,7 +124,7 @@ public class ResourceOperatorSupplier {
                 new CrdOperator<>(vertx, client, KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class, DoneableKafkaMirrorMaker2.class),
                 new StorageClassOperator(vertx, client, operationTimeoutMs),
                 new NodeOperator(vertx, client, operationTimeoutMs),
-                zooScalerProvider);
+                zkScalerProvider);
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
@@ -154,7 +154,7 @@ public class ResourceOperatorSupplier {
                                     CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List, DoneableKafkaMirrorMaker2> mirrorMaker2Operator,
                                     StorageClassOperator storageClassOperator,
                                     NodeOperator nodeOperator,
-                                    ZookeeperScalerProvider zooScalerProvider) {
+                                    ZookeeperScalerProvider zkScalerProvider) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
@@ -182,6 +182,6 @@ public class ResourceOperatorSupplier {
         this.kafkaConnectorOperator = kafkaConnectorOperator;
         this.mirrorMaker2Operator = mirrorMaker2Operator;
         this.nodeOperator = nodeOperator;
-        this.zooScalerProvider = zooScalerProvider;
+        this.zkScalerProvider = zkScalerProvider;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperAdminProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperAdminProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+import java.io.IOException;
+
+/**
+ * Helper interface to pass different ZooKeeperAdmin implementations
+ */
+public interface ZooKeeperAdminProvider {
+    /**
+     * Creates an instance of ZooKeeperAdmin
+     *
+     * @throws      IOException might be thrown
+     *
+     * @param connectString     Connection String used to connect to Zookeeper
+     * @param sessionTimeout    Session timeout
+     * @param watcher           Watcher which will be notified about watches and connection changes
+     * @param conf              Zookeeper client configuration
+     *
+     * @return  ZooKeeperAdmin instance
+     */
+    ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException;
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -11,6 +11,7 @@ import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.Future;
@@ -117,7 +118,7 @@ public class ZookeeperLeaderFinder {
                                             "cluster-operator.key", "cluster-operator.crt",
                                         "cluster-operator.p12", "cluster-operator.password");
         if (coCertKey == null) {
-            throw StatefulSetOperator.missingSecretFuture(coCertKeySecret.getMetadata().getNamespace(), coCertKeySecret.getMetadata().getName());
+            throw Util.missingSecretException(coCertKeySecret.getMetadata().getNamespace(), coCertKeySecret.getMetadata().getName());
         }
         CertificateFactory x509 = x509Factory();
         try {
@@ -143,7 +144,7 @@ public class ZookeeperLeaderFinder {
         Future<Secret> clusterCaKeySecretFuture = secretOperator.getAsync(namespace, clusterCaSecretName);
         return clusterCaKeySecretFuture.compose(clusterCaCertificateSecret -> {
             if (clusterCaCertificateSecret  == null) {
-                return Future.failedFuture(StatefulSetOperator.missingSecretFuture(namespace, clusterCaSecretName));
+                return Future.failedFuture(Util.missingSecretException(namespace, clusterCaSecretName));
             }
             try {
                 NetClientOptions netClientOptions = clientOptions(coKeySecret, clusterCaCertificateSecret);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -100,8 +100,7 @@ public class ZookeeperScaler implements AutoCloseable {
     }
 
     /**
-     * Close the ZookeeperScaler instance. This closes the Zookeeper connection in case it was left open and deletes
-     * the certificate files.
+     * Close the ZookeeperScaler instance. This deletes the certificate files.
      */
     @Override
     public void close() {
@@ -155,82 +154,6 @@ public class ZookeeperScaler implements AutoCloseable {
 
         return connected.future();
     }
-
-    /**
-     * Internal method used to create the Zookeeper Admin client and connect it to Zookeeper
-     *
-     * @return      Future indicating success or failure
-     */
-    /*private Future<ZooKeeperAdmin> connect()    {
-        Promise<ZooKeeperAdmin> connected = Promise.promise();
-
-        ZooKeeperAdmin zkAdmin = null;
-
-        try {
-            long timer = vertx.setTimer(operationTimeoutMs, ignored -> {
-                if (!connected.future().isComplete()) {
-                    log.debug("Failed to connected to {} to scale Zookeeper for {} ms. The connection will be closed.", this.zookeeperConnectionString, operationTimeoutMs);
-                    closeConnection(zkAdmin);
-                    connected.tryFail(new ZookeeperScalingException("Failed to connect to Zookeeper " + this.zookeeperConnectionString + " for " + operationTimeoutMs + " ms"));
-                }
-            });
-
-            zkAdmin = zooAdminProvider.createZookeeperAdmin(this.zookeeperConnectionString, 10_000, watchedEvent -> {
-                switch (watchedEvent.getState()) {
-                    case SyncConnected:
-                        if (!connected.future().isComplete()) {
-                            log.debug("Successfully connected to {} to scale Zookeeper", zookeeperConnectionString);
-                            connected.tryComplete(zkAdmin);
-                        }
-                        break;
-                    default:
-                        if (!connected.future().isComplete()) {
-                            log.warn("Failed to connect to {} to scale Zookeeper because of state {}", zookeeperConnectionString, watchedEvent.getState());
-                            closeConnection(zkAdmin);
-                            connected.tryFail(new ZookeeperScalingException("Failed to connect to Zookeeper " + zookeeperConnectionString + " - got state " + watchedEvent.getState()));
-                        }
-                }
-
-                vertx.cancelTimer(timer);
-            }, getClientConfig());
-        } catch (IOException e)   {
-            log.warn("Failed to connect to {} to scale Zookeeper", zookeeperConnectionString, e);
-            connected.tryFail(new ZookeeperScalingException("Failed to connect to Zookeeper " + zookeeperConnectionString, e));
-        }
-
-        return connected.future();
-    }*/
-
-    /*private Watcher connectionWatch(ZooKeeperAdmin zkAdmin, Promise connected)   {
-        return new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getState()) {
-                    case SyncConnected:
-                        event.getWrapper().
-                        if (!connected.future().isComplete()) {
-                            log.debug("Successfully connected to {} to scale Zookeeper", zookeeperConnectionString);
-                            connected.tryComplete(zkAdmin);
-                        }
-                        break;
-                    default:
-                        if (!connected.future().isComplete()) {
-                            log.warn("Failed to connect to {} to scale Zookeeper because of state {}", zookeeperConnectionString, watchedEvent.getState());
-                            closeConnection(zkAdmin);
-                            connected.tryFail(new ZookeeperScalingException("Failed to connect to Zookeeper " + zookeeperConnectionString + " - got state " + watchedEvent.getState()));
-                        }
-                }
-            }
-        };
-    }*/
-
-    /*private void connectionTimoutTimer(ZooKeeperAdmin zkAdmin, Promise connected) {
-        if (!connected.future().isComplete()) {
-            log.debug("Failed to connected to {} to scale Zookeeper for {} ms. The connection will be closed.", this.zookeeperConnectionString, operationTimeoutMs);
-            closeConnection(zkAdmin);
-            connected.tryFail(new ZookeeperScalingException("Failed to connect to Zookeeper " + this.zookeeperConnectionString + " for " + operationTimeoutMs + " ms"));
-        }
-    }*/
 
     /**
      * Internal method to scale Zookeeper up or down or check configuration. It will:
@@ -410,15 +333,5 @@ public class ZookeeperScaler implements AutoCloseable {
         }
 
         return servers;
-    }
-
-    class ClientAndConfig {
-        final ZooKeeperAdmin zkAdmin;
-        final Map<String, String> configuration;
-
-        public ClientAndConfig(ZooKeeperAdmin zkAdmin, Map<String, String> configuration) {
-            this.zkAdmin = zkAdmin;
-            this.configuration = configuration;
-        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.vertx.core.Vertx;
+
+/**
+ * Helper interface to pass different ZookeeperScaler implementations
+ */
+public interface ZookeeperScalerProvider {
+    /**
+     * Creates an instance of ZookeeperScaler
+     *
+     * @param vertx                         Vertx instance
+     * @param zookeeperConnectionString     Connection string to connect to the right Zookeeper
+     * @param clusterCaCertSecret           Secret with Kafka cluster CA public key
+     * @param coKeySecret                   Secret with Cluster Operator public and private key
+     * @param operationTimeoutMs            Operation timeout
+     *
+     * @return  ZookeeperScaler instance
+     */
+    ZookeeperScaler createZookeeperScaler(Vertx vertx, String zookeeperConnectionString, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs);
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalingException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalingException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+/**
+ * Thrown for exceptional circumstances when scaling Zookeeper clusters up or down fails.
+ */
+public class ZookeeperScalingException extends RuntimeException {
+    public ZookeeperScalingException() {
+        super();
+    }
+    public ZookeeperScalingException(String s) {
+        super(s);
+    }
+    public ZookeeperScalingException(Throwable cause) {
+        super(cause);
+    }
+    public ZookeeperScalingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -47,11 +47,6 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
     }
 
     public static boolean needsRollingUpdate(StatefulSetDiff diff) {
-        // Because for ZK the brokers know about each other via the config, and rescaling requires a rolling update
-        if (diff.changesSpecReplicas()) {
-            log.debug("Changed #replicas => needs rolling update");
-            return true;
-        }
         if (diff.changesLabels()) {
             log.debug("Changed labels => needs rolling update");
             return true;

--- a/cluster-operator/src/main/resources/log4j2.properties
+++ b/cluster-operator/src/main/resources/log4j2.properties
@@ -14,3 +14,10 @@ rootLogger.additivity = false
 logger.kafka.name = org.apache.kafka
 logger.kafka.level = ${env:STRIMZI_AC_LOG_LEVEL:-WARN}
 logger.kafka.additivity = false
+
+# ZooKeeper ZKTrustManager throws annoying DEBUG messages with exceptions
+# when first veryfing hostnames by IP address and only later by hostname
+# It really has single debug message and two error messages
+logger.zookeepertrustmanager.name = org.apache.zookeeper.common.ZKTrustManager
+logger.zookeepertrustmanager.level = ${env:STRIMZI_ZOOKEEPERTRUSTMANAGER_LOG_LEVEL:-INFO}
+logger.zookeepertrustmanager.additivity = false

--- a/cluster-operator/src/main/resources/log4j2.properties
+++ b/cluster-operator/src/main/resources/log4j2.properties
@@ -15,9 +15,7 @@ logger.kafka.name = org.apache.kafka
 logger.kafka.level = ${env:STRIMZI_AC_LOG_LEVEL:-WARN}
 logger.kafka.additivity = false
 
-# ZooKeeper ZKTrustManager throws annoying DEBUG messages with exceptions
-# when first veryfing hostnames by IP address and only later by hostname
-# It really has single debug message and two error messages
-#logger.zookeepertrustmanager.name = org.apache.zookeeper
-#logger.zookeepertrustmanager.level = ${env:STRIMZI_ZOOKEEPER_LOG_LEVEL:-WARN}
-#logger.zookeepertrustmanager.additivity = false
+# Zookeeper is very verbose even on INFO level -> We set it to WARN by default
+logger.zookeepertrustmanager.name = org.apache.zookeeper
+logger.zookeepertrustmanager.level = ${env:STRIMZI_ZOOKEEPER_LOG_LEVEL:-WARN}
+logger.zookeepertrustmanager.additivity = false

--- a/cluster-operator/src/main/resources/log4j2.properties
+++ b/cluster-operator/src/main/resources/log4j2.properties
@@ -18,6 +18,6 @@ logger.kafka.additivity = false
 # ZooKeeper ZKTrustManager throws annoying DEBUG messages with exceptions
 # when first veryfing hostnames by IP address and only later by hostname
 # It really has single debug message and two error messages
-logger.zookeepertrustmanager.name = org.apache.zookeeper.common.ZKTrustManager
-logger.zookeepertrustmanager.level = ${env:STRIMZI_ZOOKEEPERTRUSTMANAGER_LOG_LEVEL:-INFO}
-logger.zookeepertrustmanager.additivity = false
+#logger.zookeepertrustmanager.name = org.apache.zookeeper
+#logger.zookeepertrustmanager.level = ${env:STRIMZI_ZOOKEEPER_LOG_LEVEL:-WARN}
+#logger.zookeepertrustmanager.additivity = false

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -637,10 +637,7 @@ public class ResourceUtils {
             @Override
             public ZookeeperScaler createZookeeperScaler(Vertx vertx, String zookeeperConnectionString, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs) {
                 ZookeeperScaler mockZooScaler = mock(ZookeeperScaler.class);
-
                 when(mockZooScaler.scale(anyInt())).thenReturn(Future.succeededFuture());
-                //when(mockZooScaler.close()).thenReturn(Future.succeededFuture());
-
                 return mockZooScaler;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -52,6 +52,8 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperScaler;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperScalerProvider;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.cluster.operator.resource.KafkaSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -110,6 +112,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -629,6 +632,20 @@ public class ResourceUtils {
         };
     }
 
+    public static ZookeeperScalerProvider zookeeperScalerProvider() {
+        return new ZookeeperScalerProvider() {
+            @Override
+            public ZookeeperScaler createZookeeperScaler(Vertx vertx, String zookeeperConnectionString, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs) {
+                ZookeeperScaler mockZooScaler = mock(ZookeeperScaler.class);
+
+                when(mockZooScaler.scale(anyInt())).thenReturn(Future.succeededFuture());
+                //when(mockZooScaler.close()).thenReturn(Future.succeededFuture());
+
+                return mockZooScaler;
+            }
+        };
+    }
+
     public static ResourceOperatorSupplier supplierWithMocks(boolean openShift) {
         RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
 
@@ -641,7 +658,7 @@ public class ResourceUtils {
                 mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
                 mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
                 mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(StorageClassOperator.class), mock(NodeOperator.class));
+                mock(StorageClassOperator.class), mock(NodeOperator.class), zookeeperScalerProvider());
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -362,6 +362,7 @@ public class ZookeeperClusterTest {
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-zookeeper, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+                asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc.cluster.local"),
                 asList(2, "foo-zookeeper-client"),
                 asList(2, "foo-zookeeper-client.test"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -123,7 +123,7 @@ public class JbodStorageTest {
         ResourceOperatorSupplier ros =
                 new ResourceOperatorSupplier(this.vertx, this.mockClient,
                         ResourceUtils.zookeeperLeaderFinder(this.vertx, this.mockClient),
-                        ResourceUtils.adminClientProvider(),
+                        ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                         pfa, 60_000L);
 
         this.kao = new KafkaAssemblyOperator(this.vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"), ros, ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 2_000));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -251,7 +251,7 @@ public class KafkaAssemblyOperatorMockTest {
     private ResourceOperatorSupplier supplierWithMocks() {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, mockClient);
         return new ResourceOperatorSupplier(vertx, mockClient, leaderFinder,
-                ResourceUtils.adminClientProvider(),
+                ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                 new PlatformFeaturesAvailability(true, kubernetesVersion), 2_000);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -29,6 +29,7 @@ import io.strimzi.api.kafka.model.KafkaExporterSpec;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxOptions;
 import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.TopicOperatorSpec;
 import io.strimzi.api.kafka.model.TopicOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.listener.KafkaListeners;
@@ -565,6 +566,12 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.getAsync(anyString(), any())).thenReturn(
                 Future.succeededFuture(null)
         );
+        when(mockSecretOps.getAsync(clusterCmNamespace, KafkaResources.clusterCaCertificateSecretName(clusterCmName))).thenReturn(
+                Future.succeededFuture(new Secret())
+        );
+        when(mockSecretOps.getAsync(clusterCmNamespace, ClusterOperator.secretName(clusterCmName))).thenReturn(
+                Future.succeededFuture(new Secret())
+        );
 
         Set<String> createdOrUpdatedSecrets = new HashSet<>();
         when(mockSecretOps.reconcile(anyString(), anyString(), any())).thenAnswer(invocation -> {
@@ -1018,6 +1025,12 @@ public class KafkaAssemblyOperatorTest {
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaExporter.secretName(clusterName))).thenReturn(
                 Future.succeededFuture()
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.clusterCaCertificateSecretName(clusterName))).thenReturn(
+                Future.succeededFuture(new Secret())
+        );
+        when(mockSecretOps.getAsync(clusterNamespace, ClusterOperator.secretName(clusterName))).thenReturn(
+                Future.succeededFuture(new Secret())
         );
 
         // Mock NetworkPolicy get

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -133,7 +133,7 @@ public class KafkaConnectorIT {
                 new ResourceOperatorSupplier(
                         null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null, null, null,
-                        null, connectCrdOperator, null, null, null),
+                        null, connectCrdOperator, null, null, null, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
             connect -> new KafkaConnectApiImpl(vertx),
             connectCluster.getPort() + 2) { };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -162,7 +162,7 @@ public class PartialRollingUpdateTest {
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {
         return new ResourceOperatorSupplier(vertx, bootstrapClient,
                 ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient),
-                ResourceUtils.adminClientProvider(),
+                ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                 new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 60_000L);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.operator.cluster.model.Ca;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class ZookeeperScalerTest {
+    private static Vertx vertx;
+
+    @BeforeAll
+    public static void initVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void closeVertx() {
+        vertx.close();
+    }
+
+    @Test
+    public void testIsNotDifferent()   {
+        Map<String, String> current = new HashMap<>(3);
+        current.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        current.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        current.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        Map<String, String> desired = new HashMap<>(3);
+        desired.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        desired.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        desired.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        assertThat(ZookeeperScaler.isDifferent(current, desired), is(false));
+
+        Map<String, String> desired2 = new HashMap<>(3);
+        desired2.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        desired2.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+        desired2.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+
+        assertThat(ZookeeperScaler.isDifferent(current, desired2), is(false));
+    }
+
+    @Test
+    public void testIsDifferent()   {
+        Map<String, String> current = new HashMap<>(3);
+        current.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        current.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        current.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        Map<String, String> desired = new HashMap<>(3);
+        desired.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        desired.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        desired.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+        desired.put("server.4", "127.0.0.1:28883:38883:participant;127.0.0.1:21813");
+
+        assertThat(ZookeeperScaler.isDifferent(current, desired), is(true));
+
+        Map<String, String> desired2 = new HashMap<>(3);
+        desired2.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        desired2.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+
+        assertThat(ZookeeperScaler.isDifferent(current, desired2), is(true));
+
+        Map<String, String> desired3 = new HashMap<>(3);
+        desired3.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        desired3.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        assertThat(ZookeeperScaler.isDifferent(current, desired3), is(true));
+    }
+
+    @Test
+    public void testGenerateConfigOneNode() {
+        Map<String, String> expected = new HashMap<>(3);
+        expected.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+
+        assertThat(ZookeeperScaler.generateConfig(1), is(expected));
+    }
+
+    @Test
+    public void testGenerateConfigThreeNodes() {
+        Map<String, String> expected = new HashMap<>(3);
+        expected.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        expected.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        expected.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        assertThat(ZookeeperScaler.generateConfig(3), is(expected));
+    }
+
+    @Test
+    public void testParseConfig() {
+        String config = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                        "server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811\n" +
+                        "server.3=127.0.0.1:28882:38882:participant;127.0.0.1:21812\n" +
+                        "version=100000000b";
+
+        Map<String, String> expected = new HashMap<>(3);
+        expected.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        expected.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        expected.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        assertThat(ZookeeperScaler.parseConfig(config.getBytes(StandardCharsets.US_ASCII)), is(expected));
+    }
+
+    @Test
+    public void testMapToList() {
+        Map<String, String> servers = new HashMap<>(3);
+        servers.put("server.1", "127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        servers.put("server.2", "127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        servers.put("server.3", "127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        List<String> expected = new ArrayList<>(3);
+        expected.add("server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810");
+        expected.add("server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811");
+        expected.add("server.3=127.0.0.1:28882:38882:participant;127.0.0.1:21812");
+
+        assertThat(ZookeeperScaler.serversMapToList(servers), containsInAnyOrder(expected.toArray()));
+    }
+
+    @Test
+    public void testTimeoutingConnection(VertxTestContext context)  {
+        String dummyBase64Value = Base64.getEncoder().encodeToString("dummy".getBytes(StandardCharsets.US_ASCII));
+        Secret dummyCaSecret = new SecretBuilder()
+                .addToData(Ca.CA_STORE_PASSWORD, dummyBase64Value)
+                .addToData(Ca.CA_STORE, dummyBase64Value)
+                .build();
+        Secret dummyCoSecret = new SecretBuilder()
+                .addToData("cluster-operator.password", dummyBase64Value)
+                .addToData("cluster-operator.p12", dummyBase64Value)
+                .build();
+
+        ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
+            @Override
+            public ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+                ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
+                return mockZooAdmin;
+            }
+        };
+
+        ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", dummyCaSecret, dummyCoSecret, 1_000);
+
+        Checkpoint check = context.checkpoint();
+        scaler.scale(5).setHandler(context.failing(cause -> context.verify(() -> {
+            assertThat(cause.getMessage(), is("Failed to connect to Zookeeper zookeeper:2181 for 1000 ms"));
+            check.flag();
+        })));
+    }
+
+    @Test
+    public void testNoChange(VertxTestContext context) throws KeeperException, InterruptedException {
+        String dummyBase64Value = Base64.getEncoder().encodeToString("dummy".getBytes(StandardCharsets.US_ASCII));
+        Secret dummyCaSecret = new SecretBuilder()
+                .addToData(Ca.CA_STORE_PASSWORD, dummyBase64Value)
+                .addToData(Ca.CA_STORE, dummyBase64Value)
+                .build();
+        Secret dummyCoSecret = new SecretBuilder()
+                .addToData("cluster-operator.password", dummyBase64Value)
+                .addToData("cluster-operator.p12", dummyBase64Value)
+                .build();
+
+        String config = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                "version=100000000b";
+
+        ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
+        when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
+
+        ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
+            @Override
+            public ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+                watcher.process(new WatchedEvent(null, Watcher.Event.KeeperState.SyncConnected, null));
+                return mockZooAdmin;
+            }
+        };
+
+        ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", dummyCaSecret, dummyCoSecret, 1_000);
+
+        Checkpoint check = context.checkpoint();
+        scaler.scale(1).setHandler(context.succeeding(res -> context.verify(() -> {
+            verify(mockZooAdmin, never()).reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull());
+            check.flag();
+        })));
+    }
+
+    @Test
+    public void testWithChange(VertxTestContext context) throws KeeperException, InterruptedException {
+        String dummyBase64Value = Base64.getEncoder().encodeToString("dummy".getBytes(StandardCharsets.US_ASCII));
+        Secret dummyCaSecret = new SecretBuilder()
+                .addToData(Ca.CA_STORE_PASSWORD, dummyBase64Value)
+                .addToData(Ca.CA_STORE, dummyBase64Value)
+                .build();
+        Secret dummyCoSecret = new SecretBuilder()
+                .addToData("cluster-operator.password", dummyBase64Value)
+                .addToData("cluster-operator.p12", dummyBase64Value)
+                .build();
+
+        String config = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                "server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811\n" +
+                "version=100000000b";
+
+        String updated = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                "version=100000000b";
+
+        ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
+        when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
+        when(mockZooAdmin.reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull())).thenReturn(updated.getBytes(StandardCharsets.US_ASCII));
+
+        ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
+            @Override
+            public ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+                watcher.process(new WatchedEvent(null, Watcher.Event.KeeperState.SyncConnected, null));
+                return mockZooAdmin;
+            }
+        };
+
+        ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", dummyCaSecret, dummyCoSecret, 1_000);
+
+        Checkpoint check = context.checkpoint();
+        scaler.scale(1).setHandler(context.succeeding(res -> context.verify(() -> {
+            verify(mockZooAdmin, times(1)).reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull());
+            check.flag();
+        })));
+    }
+
+    @Test
+    public void testWhenThrows(VertxTestContext context) throws KeeperException, InterruptedException {
+        String dummyBase64Value = Base64.getEncoder().encodeToString("dummy".getBytes(StandardCharsets.US_ASCII));
+        Secret dummyCaSecret = new SecretBuilder()
+                .addToData(Ca.CA_STORE_PASSWORD, dummyBase64Value)
+                .addToData(Ca.CA_STORE, dummyBase64Value)
+                .build();
+        Secret dummyCoSecret = new SecretBuilder()
+                .addToData("cluster-operator.password", dummyBase64Value)
+                .addToData("cluster-operator.p12", dummyBase64Value)
+                .build();
+
+        String config = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                "server.2=127.0.0.1:28881:38881:participant;127.0.0.1:21811\n" +
+                "version=100000000b";
+
+        String updated = "server.1=127.0.0.1:28880:38880:participant;127.0.0.1:21810\n" +
+                "version=100000000b";
+
+        ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
+        when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
+        when(mockZooAdmin.reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull())).thenThrow(new KeeperException.NewConfigNoQuorum());
+
+        ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
+            @Override
+            public ZooKeeperAdmin createZookeeperAdmin(String connectString, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+                watcher.process(new WatchedEvent(null, Watcher.Event.KeeperState.SyncConnected, null));
+                return mockZooAdmin;
+            }
+        };
+
+        ZookeeperScaler scaler = new ZookeeperScaler(vertx, zooKeeperAdminProvider, "zookeeper:2181", dummyCaSecret, dummyCoSecret, 1_000);
+
+        Checkpoint check = context.checkpoint();
+        scaler.scale(1).setHandler(context.failing(cause -> context.verify(() -> {
+            assertThat(cause.getCause(), instanceOf(KeeperException.class));
+            check.flag();
+        })));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -169,10 +169,7 @@ public class ZookeeperScalerTest {
                 .build();
 
         ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
-        ZooKeeper.States mockZooStates = mock(ZooKeeper.States.class);
-        when(mockZooStates.isAlive()).thenReturn(false);
-        when(mockZooStates.isConnected()).thenReturn(false);
-        when(mockZooAdmin.getState()).thenReturn(mockZooStates);
+        when(mockZooAdmin.getState()).thenReturn(ZooKeeper.States.NOT_CONNECTED);
 
         ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
             @Override
@@ -207,10 +204,7 @@ public class ZookeeperScalerTest {
 
         ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
         when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
-        ZooKeeper.States mockZooStates = mock(ZooKeeper.States.class);
-        when(mockZooStates.isAlive()).thenReturn(true);
-        when(mockZooStates.isConnected()).thenReturn(true);
-        when(mockZooAdmin.getState()).thenReturn(mockZooStates);
+        when(mockZooAdmin.getState()).thenReturn(ZooKeeper.States.CONNECTED);
 
         ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
             @Override
@@ -251,10 +245,7 @@ public class ZookeeperScalerTest {
         ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
         when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
         when(mockZooAdmin.reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull())).thenReturn(updated.getBytes(StandardCharsets.US_ASCII));
-        ZooKeeper.States mockZooStates = mock(ZooKeeper.States.class);
-        when(mockZooStates.isAlive()).thenReturn(true);
-        when(mockZooStates.isConnected()).thenReturn(true);
-        when(mockZooAdmin.getState()).thenReturn(mockZooStates);
+        when(mockZooAdmin.getState()).thenReturn(ZooKeeper.States.CONNECTED);
 
         ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
             @Override
@@ -295,10 +286,7 @@ public class ZookeeperScalerTest {
         ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
         when(mockZooAdmin.getConfig(false, null)).thenReturn(config.getBytes(StandardCharsets.US_ASCII));
         when(mockZooAdmin.reconfigure(isNull(), isNull(), anyList(), anyLong(), isNull())).thenThrow(new KeeperException.NewConfigNoQuorum());
-        ZooKeeper.States mockZooStates = mock(ZooKeeper.States.class);
-        when(mockZooStates.isAlive()).thenReturn(true);
-        when(mockZooStates.isConnected()).thenReturn(true);
-        when(mockZooAdmin.getState()).thenReturn(mockZooStates);
+        when(mockZooAdmin.getState()).thenReturn(ZooKeeper.States.CONNECTED);
 
         ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
             @Override
@@ -349,5 +337,23 @@ public class ZookeeperScalerTest {
             assertThat(cause.getMessage(), is("Failed to connect to Zookeeper i-do-not-exist.com:2181. Connection was not ready in 2000 ms."));
             check.flag();
         })));
+    }
+
+    public enum ConnectedState {
+        CONNECTING, ASSOCIATING, CONNECTED, CONNECTEDREADONLY,
+        CLOSED, AUTH_FAILED, NOT_CONNECTED;
+
+        public boolean isAlive() {
+            return true;
+        }
+
+        /**
+         * Returns whether we are connected to a server (which
+         * could possibly be read-only, if this client is allowed
+         * to go to read-only mode)
+         * */
+        public boolean isConnected() {
+            return true;
+        }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -156,7 +156,7 @@ public class ZookeeperScalerTest {
     }
 
     @Test
-    public void testTimeoutingConnection(VertxTestContext context)  {
+    public void testConnectionTimeout(VertxTestContext context)  {
         String dummyBase64Value = Base64.getEncoder().encodeToString("dummy".getBytes(StandardCharsets.US_ASCII));
         Secret dummyCaSecret = new SecretBuilder()
                 .addToData(Ca.CA_STORE_PASSWORD, dummyBase64Value)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatorTest.java
@@ -60,9 +60,9 @@ public class ZookeeperSetOperatorTest {
     }
 
     @Test
-    public void testNeedsRollingUpdateReplicas() {
+    public void testNotNeedsRollingUpdateReplicas() {
         a.getSpec().setReplicas(b.getSpec().getReplicas() + 1);
-        assertThat(ZookeeperSetOperator.needsRollingUpdate(diff()), is(true));
+        assertThat(ZookeeperSetOperator.needsRollingUpdate(diff()), is(false));
     }
 
     @Test

--- a/cluster-operator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/cluster-operator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/cluster-operator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/cluster-operator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -143,7 +143,7 @@ public class Util {
     }
 
     /**
-     * Created file with Keystore or Truststore from the byte arrays passed as param.
+     * Create a file with Keystore or Truststore from the given {@code bytes}.
      * The file will be set to get deleted when the JVM exist.
      *
      * @param prefix    Prefix which will be used for the filename

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.common;
 
+import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -12,6 +13,12 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -122,5 +129,53 @@ public class Util {
         } else {
             return Collections.emptyMap();
         }
+    }
+
+    /**
+     * Returns exception when secret is missing. This is used from several different methods to provide identical exception.
+     *
+     * @param namespace     Namespace of the Secret
+     * @param secretName    Name of the Secret
+     * @return              RuntimeException
+     */
+    public static RuntimeException missingSecretException(String namespace, String secretName) {
+        return new RuntimeException("Secret " + namespace + "/" + secretName + " does not exist");
+    }
+
+    /**
+     * Created file with Keystore or Truststore from the byte arrays passed as param.
+     * The file will be set to get deleted when the JVM exist.
+     *
+     * @param prefix    Prefix which will be used for the filename
+     * @param suffix    Suffix which will be used for the filename
+     * @param bytes     Byte array with the certificate store
+     * @return          File with the certificate store
+     */
+    public static File createFileStore(String prefix, String suffix, byte[] bytes) {
+        File f = null;
+        try {
+            f = File.createTempFile(prefix, suffix);
+            f.deleteOnExit();
+            try (OutputStream os = new BufferedOutputStream(new FileOutputStream(f))) {
+                os.write(bytes);
+            }
+            return f;
+        } catch (IOException e) {
+            if (f != null && !f.delete()) {
+                LOGGER.warn("Failed to delete temporary file in exception handler");
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Decode binary item from Kubernetes Secret from base64 into byte array
+     *
+     * @param secret    Kubernetes Secret
+     * @param key       Key which should be retrived and decoded
+     * @return          Decoded bytes
+     */
+    public static byte[] decodeFromSecret(Secret secret, String key) {
+        return Base64.getDecoder().decode(secret.getData().get(key));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,12 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+            <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-web-common</artifactId>
                 <version>${vertx.version}</version>
@@ -857,6 +863,7 @@
                                 <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-api:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.glassfish:javax.json:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka_2.12:jar</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.netty:netty-transport-native-epoll:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredDependency>org.junit.platform</ignoredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:connect-file</ignoredUnusedDeclaredDependency>
                                 <ignoredDependency>org.junit.jupiter</ignoredDependency>

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -34,7 +34,6 @@ import io.vertx.core.cli.annotations.Description;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -342,14 +341,18 @@ class RollingUpdateST extends BaseST {
     }
 
     @Test
-    @Disabled("Zookeeper scaleUp/scaleDown is currently covered by manual procedure for Kafka 2.4.x. " +
-            "This should be removed after implementation of Zookeeper Dynamic configuration")
     void testZookeeperScaleUpScaleDown() {
         int messageCount = 50;
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
-        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3).done();
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)
+                .editSpec()
+                    .editKafka()
+                        .withVersion("2.3.1")
+                    .endKafka()
+                .endSpec()
+                .done();
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
 
         String userName = "alice";

--- a/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RollingUpdateST.java
@@ -346,13 +346,7 @@ class RollingUpdateST extends BaseST {
         String topicName = "test-topic-" + new Random().nextInt(Integer.MAX_VALUE);
 
         timeMeasuringSystem.setOperationID(timeMeasuringSystem.startTimeMeasuring(Operation.CLUSTER_RECOVERY));
-        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3)
-                .editSpec()
-                    .editKafka()
-                        .withVersion("2.3.1")
-                    .endKafka()
-                .endSpec()
-                .done();
+        KafkaResource.kafkaPersistent(CLUSTER_NAME, 3).done();
         KafkaTopicResource.topic(CLUSTER_NAME, topicName).done();
 
         String userName = "alice";


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR fixes the manual scaling of Zookeeper 3.5 limitation. When Zookeeper 3.5 is used, it now uses the ZooKeeperAdmin API to configure the members of the cluster dynamically. They mostly follow the manual guide by @tomncooper.

The scaling methods are separate for 3.4 and 3.5. That should make it easy to remvoe 3.4 in the future. We should anyway get back to this after support for 3.4 is dropped. One of the big limitations this PR needed to work around were the TLS sidecars which need restart to reconfigure (=> to add new nodes). Once we support 3.5 only, we should try to get rid of the sidecars and make the scaling restart less.

This PR also adds some tests - but the actual scalign is done mainly in system tests. The unit tests use mostly mocks. The tests are based on two separate providers whcih allow to inject mocked ZookeeperScaler and mocked ZooKeeperAdmin to test different parts of the operator.

As part of this I did some smaller notable changes:
* Some helper methods from the `DefaultAdminClientProvider` were moved to `Util` so that they can be reused
* Zoo doesn't roll based on changes in `spec.replicas`. This is not needed, because the number of replicas is covered in environment variable. It was also causing unnecessary rolling updates the initial reconciliation failed.
* I added a dependency with the Lunux x86_64 epoll for Netty
* New hostname was added to the Zoo certificates to allow the connections to specific nodes
* I surpressed some log messages from the ZooKeeperAdmin client. It by default first verifies hostname ased on IP and only than based on hostame. The IP validation always fails and prints an exception in log every reconciliation at DEBUG level. This looked ugly and distracting, so I got rid of it since it was anyway expected exception.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally