### PR TITLE
Fixes VSCode compiler error related to Scala code

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -202,7 +202,7 @@ public class SimpleAclOperator {
             throw e;
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = getResourceAclsIterator(rules);
+        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = resourceAclsIterator(rules);
         while (iter.hasNext())  {
             Tuple2<Resource, scala.collection.immutable.Set<Acl>> tuple = iter.next();
             SimpleAclRuleResource resource = SimpleAclRuleResource.fromKafkaResource(tuple._1());
@@ -217,7 +217,7 @@ public class SimpleAclOperator {
         return result;
     }
 
-    private Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> getResourceAclsIterator(scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules) {
+    private Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> resourceAclsIterator(scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules) {
         // this cast fixes an error with VSCode compiler (using the Eclipse JDT Language Server)
         // error details: The method iterator() is ambiguous for the type Map<Resource,Set<Acl>>
         return ((scala.collection.GenIterableLike<Tuple2<Resource, scala.collection.immutable.Set<Acl>>, ?>) rules).iterator();
@@ -243,7 +243,7 @@ public class SimpleAclOperator {
             return result;
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = getResourceAclsIterator(rules);
+        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = resourceAclsIterator(rules);
         while (iter.hasNext())  {
             scala.collection.immutable.Set<Acl> acls = iter.next()._2();
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -220,7 +220,7 @@ public class SimpleAclOperator {
     private Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> getResourceAclsIterator(scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules) {
         // this cast fixes an error with VSCode compiler (using the Eclipse JDT Language Server)
         // error details: The method iterator() is ambiguous for the type Map<Resource,Set<Acl>>
-        return ((scala.collection.GenIterableLike<Tuple2<Resource,scala.collection.immutable.Set<Acl>>, ?>)rules).iterator();
+        return ((scala.collection.GenIterableLike<Tuple2<Resource, scala.collection.immutable.Set<Acl>>, ?>) rules).iterator();
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -202,7 +202,7 @@ public class SimpleAclOperator {
             throw e;
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = rules.iterator();
+        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = getResourceAclsIterator(rules);
         while (iter.hasNext())  {
             Tuple2<Resource, scala.collection.immutable.Set<Acl>> tuple = iter.next();
             SimpleAclRuleResource resource = SimpleAclRuleResource.fromKafkaResource(tuple._1());
@@ -215,6 +215,12 @@ public class SimpleAclOperator {
         }
 
         return result;
+    }
+
+    private Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> getResourceAclsIterator(scala.collection.immutable.Map<Resource, scala.collection.immutable.Set<Acl>> rules) {
+        // this cast fixes an error with VSCode compiler (using the Eclipse JDT Language Server)
+        // error details: The method iterator() is ambiguous for the type Map<Resource,Set<Acl>>
+        return ((scala.collection.GenIterableLike<Tuple2<Resource,scala.collection.immutable.Set<Acl>>, ?>)rules).iterator();
     }
 
     /**
@@ -237,7 +243,7 @@ public class SimpleAclOperator {
             return result;
         }
 
-        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = rules.iterator();
+        Iterator<Tuple2<Resource, scala.collection.immutable.Set<Acl>>> iter = getResourceAclsIterator(rules);
         while (iter.hasNext())  {
             scala.collection.immutable.Set<Acl> acls = iter.next()._2();
 


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

The VSCode compiler, using the Eclipse JDT Language Server, raises the following error when we get an iterator for the `rules` collection in the `SimpleAclOperator`:

```
The method iterator() is ambiguous for the type Map<Resource,Set<Acl>>
```

This PR fixes such an error with an explicit cast.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

