### PR TITLE
Use connector reconciliation in MM2 operator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -382,7 +382,9 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         Map<String, String> desired = new HashMap<>(connectorSpec.getConfig().size());
         // The actual which comes from Connect API includes tasks.max, connector.class and name,
         // which connectorSpec.getConfig() does not
-        desired.put("tasks.max", connectorSpec.getTasksMax().toString());
+        if (connectorSpec.getTasksMax() != null) {
+            desired.put("tasks.max", connectorSpec.getTasksMax().toString());
+        }
         desired.put("name", connectorName);
         desired.put("connector.class", connectorSpec.getClassName());
         for (Map.Entry<String, Object> entry : connectorSpec.getConfig().entrySet()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -375,7 +375,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     }
 
     private Future<Map<String, Object>> reconcileMirrorMaker2Connector(Reconciliation reconciliation, KafkaMirrorMaker2 mirrorMaker2, KafkaConnectApi apiClient, String host, String connectorName, KafkaConnectorSpec connectorSpec, KafkaMirrorMaker2Status mirrorMaker2Status) {
-        return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
+        return maybeCreateOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
                 .setHandler(result -> {
                     if (result.succeeded()) {
                         mirrorMaker2Status.getConnectors().add(result.result());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement

### Description

 - This PR updates the MM2 assembly operator to use the
maybeCreateOrUpdateConnector() method to retrieve and compare the MM2
connector configs from connect instead of always overwriting them on each
reconcile loop.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ x ] Make sure all tests pass
- [ x ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

