### PR TITLE
Fix SpecChecker test timezone issues

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import org.junit.jupiter.api.Test;
 
@@ -77,7 +78,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
     }
@@ -100,7 +101,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaStorage"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A Kafka cluster with a single replica and ephemeral storage will lose topic messages after any restart or rolling update."));
     }
@@ -121,7 +122,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperStorage"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used."));
     }
@@ -134,7 +135,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with two nodes is not advisable as both replicas will be needed to avoid downtime. It is recommended that a minimum of three replicas are used."));
     }
@@ -147,7 +148,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("ZooKeeperReplicas"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("Running ZooKeeper with an odd number of replicas is recommended."));
     }
@@ -170,7 +171,7 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
         assertThat(warning.getReason(), is("KafkaLogMessageFormatVersion"));
-        assertThat(warning.getLastTransitionTime(), is("2018-11-26T09:12:00+0000"));
+        assertThat(warning.getLastTransitionTime(), is(ModelUtils.formatTimestamp(dateSupplier())));
         assertThat(warning.getStatus(), is("True"));
         assertThat(warning.getMessage(), is("log.message.format.version does not match the Kafka cluster version, which suggests that an upgrade is incomplete."));
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The tests for KafkaSpecChecker are currently failing when run on a PC with timezone whihc is not `+0000`. This PR fixes that to make sure the tests can pass everywhere.