### PR TITLE
Make sure the node affinity added to the Kafka STS works as AND and not OR

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
@@ -1550,15 +1551,7 @@ public class KafkaCluster extends AbstractModel {
         Affinity userAffinity = getUserAffinity();
         AffinityBuilder builder = new AffinityBuilder(userAffinity == null ? new Affinity() : userAffinity);
         if (rack != null) {
-            NodeSelectorTerm selector = new NodeSelectorTermBuilder()
-                    .withMatchExpressions(new NodeSelectorRequirementBuilder()
-                            .withNewOperator("Exists")
-                            .withNewKey(rack.getTopologyKey())
-                            .build())
-                    .build();
-
             // If there's a rack config, we need to add a podAntiAffinity to spread the brokers among the racks
-            // and node affinity to make sure the pods are scheduled only on nodes with the rack label
             builder = builder
                     .editOrNewPodAntiAffinity()
                         .addNewPreferredDuringSchedulingIgnoredDuringExecution()
@@ -1571,13 +1564,48 @@ public class KafkaCluster extends AbstractModel {
                                 .endLabelSelector()
                             .endPodAffinityTerm()
                         .endPreferredDuringSchedulingIgnoredDuringExecution()
-                    .endPodAntiAffinity()
-                    .editOrNewNodeAffinity()
-                        .editOrNewRequiredDuringSchedulingIgnoredDuringExecution()
-                            .addToNodeSelectorTerms(selector)
-                        .endRequiredDuringSchedulingIgnoredDuringExecution()
-                    .endNodeAffinity();
+                    .endPodAntiAffinity();
+
+            // We also need to add node affinity to make sure the pods are scheduled only on nodes with the rack label
+            NodeSelectorRequirement selector = new NodeSelectorRequirementBuilder()
+                    .withNewOperator("Exists")
+                    .withNewKey(rack.getTopologyKey())
+                    .build();
+
+            if (userAffinity != null
+                    && userAffinity.getNodeAffinity() != null
+                    && userAffinity.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution() != null
+                    && userAffinity.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms() != null) {
+                // User has specified some Node Selector Terms => we should enhance them
+                List<NodeSelectorTerm> oldTerms = userAffinity.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms();
+                List<NodeSelectorTerm> enhancedTerms = new ArrayList<>(oldTerms.size());
+
+                for (NodeSelectorTerm term : oldTerms) {
+                    NodeSelectorTerm enhancedTerm = new NodeSelectorTermBuilder(term)
+                            .addToMatchExpressions(selector)
+                            .build();
+                    enhancedTerms.add(enhancedTerm);
+                }
+
+                builder = builder
+                        .editOrNewNodeAffinity()
+                            .withNewRequiredDuringSchedulingIgnoredDuringExecution()
+                                .withNodeSelectorTerms(enhancedTerms)
+                            .endRequiredDuringSchedulingIgnoredDuringExecution()
+                        .endNodeAffinity();
+            } else {
+                // User has not specified any selector terms => we add our own
+                builder = builder
+                        .editOrNewNodeAffinity()
+                            .editOrNewRequiredDuringSchedulingIgnoredDuringExecution()
+                                .addNewNodeSelectorTerm()
+                                    .withMatchExpressions(selector)
+                                .endNodeSelectorTerm()
+                            .endRequiredDuringSchedulingIgnoredDuringExecution()
+                        .endNodeAffinity();
+            }
         }
+
         return builder.build();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -577,6 +577,13 @@ public class KafkaClusterTest {
     }
 
     @Test
+    public void withRackAndAffinityWithMoreTerms() throws IOException {
+        ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinityWithMoreTerms");
+        resourceTester.assertDesiredResource("-STS.yaml",
+                kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+    }
+
+    @Test
     public void withRackAndAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinity");
         resourceTester.assertDesiredResource("-STS.yaml",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -580,7 +580,7 @@ public class KafkaClusterTest {
     public void withRackAndAffinityWithMoreTerms() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, KafkaCluster::fromCrd, this.getClass().getSimpleName() + ".withRackAndAffinityWithMoreTerms");
         resourceTester.assertDesiredResource("-STS.yaml",
-                kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            kc -> kc.generateStatefulSet(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @Test

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinityWithMoreTerms-Kafka.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinityWithMoreTerms-Kafka.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    rack:
+      topologyKey: "failure-domain.beta.kubernetes.io/zone"
+    template:
+      pod:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/e2e-az-name
+                  operator: In
+                  values:
+                  - e2e-az1
+                  - e2e-az2
+              - matchExpressions:
+                - key: kubernetes.io/e2e-az-name
+                  operator: In
+                  values:
+                    - e2e-az3
+                    - e2e-az4
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: another-node-label-key
+                  operator: In
+                  values:
+                  - another-node-label-value

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinityWithMoreTerms-STS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndAffinityWithMoreTerms-STS.yaml
@@ -18,6 +18,14 @@ nodeAffinity:
         - "e2e-az2"
       - key: "failure-domain.beta.kubernetes.io/zone"
         operator: "Exists"
+    - matchExpressions:
+      - key: "kubernetes.io/e2e-az-name"
+        operator: "In"
+        values:
+        - "e2e-az3"
+        - "e2e-az4"
+      - key: "failure-domain.beta.kubernetes.io/zone"
+        operator: "Exists"
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndOldAffinity-STS.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaClusterTest.withRackAndOldAffinity-STS.yaml
@@ -16,7 +16,6 @@ nodeAffinity:
         values:
         - "e2e-az1"
         - "e2e-az2"
-    - matchExpressions:
       - key: "failure-domain.beta.kubernetes.io/zone"
         operator: "Exists"
 podAntiAffinity:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When rack awareness is configured, we add our own affinity rules:
* Pod anti-affinity to dsitribute the KAfka pods accross racks (zones)
* Node affinity to make sure the pods are scheduled only on nodes with the rack label

However, the node-affinity was added as a new `NodeSelectorTerm`. But with multiple `NodeSelectorTerms`, the terms are _ORed_. That means that this might mean that the user rules will be ignored. This PR fixes that and adds the rule as a new `matchExpressions`. Multiple `matchExpressions` are _ANDed_, so both our and users expression would be applied.

This closes #2720.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging