### PR TITLE
ST: Check kafka status conditions in tests properly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -50,8 +50,13 @@ public class KafkaUtils {
     public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {
         TestUtils.waitFor("Kafka status contains exception with non-existing secret name",
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-                Condition condition = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions().get(0);
-                return condition.getMessage().matches(message);
+                List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
+                for (Condition condition : conditions) {
+                    if (condition.getMessage().matches(message)) {
+                        return true;
+                    }
+                }
+                return false;
             });
     }
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR fix tests, which was affected by adding new conditions to Kafka status in https://github.com/strimzi/strimzi-kafka-operator/pull/2663.

### Checklist

- [x] Make sure all tests pass

