### PR TITLE
ST: Add namespace to command which collects logs about CR

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -91,7 +91,7 @@ public class LogCollector {
 
     public void collectStrimzi() {
         LOGGER.info("Collecting CR in namespaces {}", namespace);
-        String crData = cmdKubeClient().exec(false, "get", "strimzi", "-o", "yaml").out();
+        String crData = cmdKubeClient().exec(false, "get", "strimzi", "-o", "yaml", "-n", namespace).out();
         writeFile(logDir + "/strimzi-custom-resources.log", crData);
     }
 }

--- a/test/src/main/java/io/strimzi/test/executor/Exec.java
+++ b/test/src/main/java/io/strimzi/test/executor/Exec.java
@@ -163,6 +163,7 @@ public class Exec {
             ret = executor.execute(input, command, timeout);
             synchronized (LOCK) {
                 if (logToOutput) {
+                    LOGGER.info("Command: {}", command);
                     LOGGER.info("Return code: {}", ret);
                     LOGGER.info("stdout: \n{}", executor.out());
                     LOGGER.info("stderr: \n{}", executor.err());


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

_Select the type of your PR_

- Bugfix

### Description

It seems that command which is executed for collect CR info when ST fail doesn't count with specific namespace which looks like:
```
2020-03-20 22:28:28 INFO [LogCollector:93] Collecting CR in namespaces kafka-listeners-cluster-test
2020-03-20 22:28:29 INFO [Exec:166] Return code: 0
2020-03-20 22:28:29 INFO [Exec:167] stdout: 
apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""
  selfLink: 
```

instead of CRs active in the namespace. This PR add `-n` option to that command. Executor log info also prints executed command.

### Checklist

- [x] Make sure all tests pass

