### PR TITLE
Add more metrics to our cluster and user operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add possibility to set Java System Properties for User Operator and Topic Operator via `Kafka` CR.
 * Make it possible to configure PodManagementPolicy for StatefulSets
 * Update build system to use `yq` version 3 (https://github.com/mikefarah/yq)
+* Add more metrics to Cluster and User Operators
+* New Grafana dashboard for Operator monitoring 
 
 ## 0.17.0
 

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -217,17 +217,14 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-micrometer-metrics</artifactId>
-            <version>${vertx.version}</version>
         </dependency>
     </dependencies>
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -138,7 +138,8 @@ public class Main {
                     kafkaConnectS2IClusterOperations,
                     kafkaMirrorMakerAssemblyOperator,
                     kafkaMirrorMaker2AssemblyOperator,
-                    kafkaBridgeAssemblyOperator);
+                    kafkaBridgeAssemblyOperator,
+                    resourceOperatorSupplier.metricsProvider);
             vertx.deployVerticle(operator,
                 res -> {
                     if (res.succeeded()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -75,7 +75,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
                                        AbstractWatchableResourceOperator<C, T, L, D, R> resourceOperator,
                                        ResourceOperatorSupplier supplier,
                                        ClusterOperatorConfig config) {
-        super(vertx, kind, resourceOperator);
+        super(vertx, kind, resourceOperator, supplier.metricsProvider);
         this.pfa = pfa;
         this.certManager = certManager;
         this.passwordGenerator = passwordGenerator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -127,23 +127,23 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         // Setup metrics for connectors
         Tags metricTags = Tags.of(Tag.of("kind", KafkaConnector.RESOURCE_KIND));
 
-        connectorsReconciliationsCounter = metrics.counter("strimzi.reconciliations",
+        connectorsReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations",
                 "Number of reconciliations done by the operator for individual resources",
                 metricTags);
 
-        connectorsFailedReconciliationsCounter = metrics.counter("strimzi.reconciliations.failed",
+        connectorsFailedReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.failed",
                 "Number of reconciliations done by the operator for individual resources which failed",
                 metricTags);
 
-        connectorsSuccessfulReconciliationsCounter = metrics.counter("strimzi.reconciliations.successful",
+        connectorsSuccessfulReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.successful",
                 "Number of reconciliations done by the operator for individual resources which were successful",
                 metricTags);
 
-        connectorsResourceCounter = metrics.gauge("strimzi.resources",
+        connectorsResourceCounter = metrics.gauge(METRICS_PREFIX + "resources",
                 "Number of custom resources the operator sees",
                 metricTags);
 
-        connectorsReconciliationsTimer = metrics.timer("strimzi.reconciliations.duration",
+        connectorsReconciliationsTimer = metrics.timer(METRICS_PREFIX + "reconciliations.duration",
                 "The time the reconciliation takes to complete",
                 metricTags);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -71,7 +71,7 @@ public class ClusterOperatorTest {
     }
 
     @BeforeAll
-    public static void createClient() {
+    public static void before() {
         vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
@@ -80,7 +80,7 @@ public class ClusterOperatorTest {
     }
 
     @AfterAll
-    public static void closeClient() {
+    public static void after() {
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -15,6 +15,11 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.RouteBuilder;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeBuilder;
@@ -60,6 +65,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperSetOperator;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -107,6 +113,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
@@ -643,6 +650,36 @@ public class ResourceUtils {
         };
     }
 
+    public static MetricsProvider metricsProvider() {
+        return new MetricsProvider() {
+            @Override
+            public MeterRegistry meterRegistry() {
+                MeterRegistry mockRegistry = mock(MeterRegistry.class);
+                MeterRegistry.Config mockConfig = mock(MeterRegistry.Config.class);
+                Clock mockClock = mock(Clock.class);
+                when(mockConfig.clock()).thenReturn(mockClock);
+                when(mockRegistry.config()).thenReturn(mockConfig);
+
+                return mockRegistry;
+            }
+
+            @Override
+            public Counter counter(String name, String description, Tags tags) {
+                return mock(Counter.class);
+            }
+
+            @Override
+            public Timer timer(String name, String description, Tags tags) {
+                return mock(Timer.class);
+            }
+
+            @Override
+            public AtomicInteger gauge(String name, String description, Tags tags) {
+                return new AtomicInteger(0);
+            }
+        };
+    }
+
     public static ResourceOperatorSupplier supplierWithMocks(boolean openShift) {
         RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
 
@@ -655,7 +692,7 @@ public class ResourceUtils {
                 mock(IngressOperator.class), mock(ImageStreamOperator.class), mock(BuildConfigOperator.class),
                 mock(DeploymentConfigOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
                 mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class), mock(CrdOperator.class),
-                mock(StorageClassOperator.class), mock(NodeOperator.class), zookeeperScalerProvider());
+                mock(StorageClassOperator.class), mock(NodeOperator.class), zookeeperScalerProvider(), metricsProvider());
         when(supplier.serviceAccountOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.roleBindingOperations.reconcile(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
         when(supplier.clusterRoleBindingOperator.reconcile(anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -109,12 +109,12 @@ public class CertificateRenewalTest {
     }
 
     @BeforeAll
-    public static void initVertx() {
+    public static void before() {
         vertx = Vertx.vertx();
     }
 
     @AfterAll
-    public static void closeVertx() {
+    public static void after() {
         if (vertx != null) {
             vertx.close();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -124,7 +124,7 @@ public class JbodStorageTest {
                 new ResourceOperatorSupplier(this.vertx, this.mockClient,
                         ResourceUtils.zookeeperLeaderFinder(this.vertx, this.mockClient),
                         ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
-                        pfa, 60_000L);
+                        ResourceUtils.metricsProvider(), pfa, 60_000L);
 
         this.kao = new KafkaAssemblyOperator(this.vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"), ros, ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 2_000));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -10,6 +10,8 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -20,8 +22,18 @@ import java.util.concurrent.ArrayBlockingQueue;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiMockTest {
-    private Vertx vertx = Vertx.vertx();
+    private static Vertx vertx;
     private BackOff backOff = new BackOff(1L, 2, 3);
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
 
     @Test
     public void testStatusWithBackOffSuccedingImmediatelly(VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -19,6 +19,7 @@ import org.apache.kafka.connect.cli.ConnectDistributed;
 import org.apache.kafka.connect.runtime.Connect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,8 +53,7 @@ public class KafkaConnectApiTest {
     private static final int PORT = 18083;
 
     @BeforeEach
-    public void before() throws IOException, InterruptedException {
-        vertx = Vertx.vertx();
+    public void beforeEach() throws IOException, InterruptedException {
         // Start a 3 node Kafka cluster
         cluster = new KafkaCluster();
         cluster.addBrokers(3);
@@ -93,7 +93,7 @@ public class KafkaConnectApiTest {
     }
 
     @AfterEach
-    public void after() {
+    public void afterEach() {
         if (connect != null) {
             connect.stop();
             connect.awaitStop();
@@ -101,8 +101,13 @@ public class KafkaConnectApiTest {
         cluster.shutdown();
     }
 
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
     @AfterAll
-    public static void closeVertx() {
+    public static void after() {
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -24,8 +24,13 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.resource.DefaultZookeeperScalerProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -34,8 +39,9 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -69,12 +75,17 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
     private KubernetesClient mockClient;
 
-    private Vertx vertx;
+    private static Vertx vertx;
     private MockKube mockKube;
 
-    @BeforeEach
-    public void before() {
-        this.vertx = Vertx.vertx();
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
     }
 
     private void setConnectResource(KafkaConnect connectResource) {
@@ -94,17 +105,23 @@ public class KafkaConnectAssemblyOperatorMockTest {
     }
 
     @AfterEach
-    public void after() {
+    public void afterEach() {
         if (mockClient != null) {
             mockClient.close();
         }
-        this.vertx.close();
     }
 
 
     private KafkaConnectAssemblyOperator createConnectCluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi)  throws InterruptedException, ExecutionException, TimeoutException {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
-        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);
+        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, this.mockClient,
+                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, this.mockClient),
+                    // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
+                    () -> new BackOff(5_000, 2, 4)),
+                new DefaultAdminClientProvider(),
+                new DefaultZookeeperScalerProvider(),
+                ResourceUtils.metricsProvider(),
+                pfa, 60_000L);
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         KafkaConnectAssemblyOperator kco = new KafkaConnectAssemblyOperator(vertx, pfa,
             supplier,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -17,6 +17,7 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.AbstractOperator;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
@@ -176,12 +177,12 @@ public class KafkaConnectorIT {
             // Assert metrics from Connector Operator
             MeterRegistry registry = metrics.meterRegistry();
 
-            assertThat(registry.get("strimzi.reconciliations").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
-            assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
-            assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(0.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(0.0));
 
-            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().count(), CoreMatchers.is(2L));
-            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().count(), CoreMatchers.is(2L));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
             context.completeNow();
         })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -18,8 +18,13 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.resource.DefaultZookeeperScalerProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
+import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -28,8 +33,9 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -63,12 +69,17 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
     private KubernetesClient mockClient;
 
-    private Vertx vertx;
+    private static Vertx vertx;
     private MockKube mockKube;
 
-    @BeforeEach
-    public void before() {
-        this.vertx = Vertx.vertx();
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
     }
 
     private void setMirrorMaker2Resource(KafkaMirrorMaker2 mirrorMaker2Resource) {
@@ -84,17 +95,24 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
     }
 
     @AfterEach
-    public void after() {
+    public void afterEach() {
         if (mockClient != null) {
             mockClient.close();
         }
-        this.vertx.close();
     }
 
 
     private KafkaMirrorMaker2AssemblyOperator createMirrorMaker2Cluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi)  throws InterruptedException, ExecutionException, TimeoutException {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9);
-        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(this.vertx, this.mockClient, pfa, 60_000L);
+        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, this.mockClient,
+                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, this.mockClient),
+                    // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
+                    () -> new BackOff(5_000, 2, 4)),
+                new DefaultAdminClientProvider(),
+                new DefaultZookeeperScalerProvider(),
+                ResourceUtils.metricsProvider(),
+                pfa, 60_000L);
+
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         KafkaMirrorMaker2AssemblyOperator kco = new KafkaMirrorMaker2AssemblyOperator(vertx, pfa,
             supplier,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -82,9 +82,7 @@ public class KafkaStatusTest {
 
     @AfterAll
     public static void after() {
-        if (vertx != null) {
-            vertx.close();
-        }
+        vertx.close();
     }
 
     public Kafka getKafkaCrd() throws ParseException {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -37,7 +37,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,7 +62,7 @@ public class PartialRollingUpdateTest {
     private static final String CLUSTER_NAME = "my-cluster";
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
-    private Vertx vertx;
+    private static Vertx vertx;
     private Kafka cluster;
     private StatefulSet kafkaSts;
     private StatefulSet zkSts;
@@ -81,10 +81,18 @@ public class PartialRollingUpdateTest {
     private Secret clientsCaCert;
     private Secret clientsCaKey;
 
-    @BeforeEach
-    public void before(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        this.vertx = Vertx.vertx();
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
 
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @BeforeEach
+    public void beforeEach(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         this.cluster = new KafkaBuilder()
                 .withMetadata(new ObjectMetaBuilder().withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
@@ -154,16 +162,12 @@ public class PartialRollingUpdateTest {
         context.completeNow();
     }
 
-    @AfterEach
-    public void afterEach() {
-        vertx.close();
-    }
-
     ResourceOperatorSupplier supplier(KubernetesClient bootstrapClient) {
         return new ResourceOperatorSupplier(vertx, bootstrapClient,
                 ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient),
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
-                new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9), 60_000L);
+                ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(true, KubernetesVersion.V1_9),
+                60_000L);
     }
 
     private void startKube() {

--- a/documentation/assemblies/assembly-metrics-setup.adoc
+++ b/documentation/assemblies/assembly-metrics-setup.adoc
@@ -5,7 +5,7 @@
 [id='assembly-metrics-setup-{context}']
 = Introducing Metrics
 
-This section describes how to monitor {ProductName} Kafka, ZooKeeper and Kafka Connect clusters using Prometheus to provide monitoring data for example Grafana dashboards.
+This section describes how to monitor {ProductName} Kafka, ZooKeeper, Kafka Connect, and Kafka Mirror Maker2 clusters using Prometheus to provide monitoring data for example Grafana dashboards.
 
 In order to run the example Grafana dashboards, you must:
 
@@ -20,6 +20,12 @@ If you require further support on configuring and running Prometheus or Grafana 
 When you have Prometheus and Grafana enabled, you can also use Kafka Exporter to provide additional monitoring related to consumer lag.
 For more information, see xref:assembly-kafka-exporter-{context}[].
 
+.Operators
+Prometheus and Grafana can be also used to monitor the operators.
+The example Grafana dashboard for operators provides:
+
+* Information about the operator such as the number of reconciliations or number of Custom Resources they are processing
+* JVM metrics from the operators
 
 .Additional resources
 * For more information about Prometheus, see the link:https://prometheus.io/docs/introduction/overview/[Prometheus documentation].

--- a/documentation/assemblies/assembly-operators-monitoring.adoc
+++ b/documentation/assemblies/assembly-operators-monitoring.adoc
@@ -1,0 +1,9 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-operators.adoc
+
+[id='assembly-operators-monitoring-{context}']
+
+= Monitoring Operators
+
+include::../modules/con-operators-prometheus-metrics.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-operators.adoc
+++ b/documentation/assemblies/assembly-operators.adoc
@@ -11,3 +11,5 @@ include::assembly-operators-cluster-operator.adoc[leveloffset=+1]
 include::assembly-deploying-the-topic-operator.adoc[leveloffset=+1]
 
 include::assembly-user-operator.adoc[leveloffset=+1]
+
+include::assembly-operators-monitoring.adoc[leveloffset=+1]

--- a/documentation/modules/con-metrics-grafana-options.adoc
+++ b/documentation/modules/con-metrics-grafana-options.adoc
@@ -17,6 +17,8 @@ Example dashboards are also provided as JSON files:
 * `strimzi-kafka-connect.json`
 * `strimzi-zookeeper.json`
 * `strimzi-kafka-mirror-maker-2.json`
+* `strimzi-kafka-exporter.json`
+* `strimzi-operators.json`
 
 The example dashboards are a good starting point for monitoring key metrics, but they do not represent all available metrics.
 You may need to modify the example dashboards or add other metrics, depending on your infrastructure.

--- a/documentation/modules/con-metrics-prometheus-options.adoc
+++ b/documentation/modules/con-metrics-prometheus-options.adoc
@@ -15,6 +15,7 @@ Additional Prometheus-related configuration is also provided in the following fi
 
 * `prometheus-additional.yaml`
 * `prometheus-rules.yaml`
+* `strimzi-pod-monitor.yaml`
 * `strimzi-service-monitor.yaml`
 
 For Prometheus to obtain monitoring data:

--- a/documentation/modules/con-operators-prometheus-metrics.adoc
+++ b/documentation/modules/con-operators-prometheus-metrics.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// assembly-operators-monitoring.adoc
+
+[id='con-operators-prometheus-metrics-{context}']
+
+= Prometheus metrics
+
+{ProductName} operators expose Prometheus metrics.
+The metrics are automatically enabled and contain information about:
+
+* Number of reconciliations
+* Number of Custom Resources the operator is processing
+* Duration of reconciliations
+* JVM metrics from the operators
+
+Additionally, we provide an example Grafana dashboard.
+
+For more information about Prometheus, see the xref:assembly-metrics-setup-{context}[introduction to metrics].

--- a/documentation/modules/proc-metrics-deploying-prometheus.adoc
+++ b/documentation/modules/proc-metrics-deploying-prometheus.adoc
@@ -30,8 +30,10 @@ On MacOS, use:
 sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
 
 . Edit the `ServiceMonitor` resource in `strimzi-service-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from services.
+`ServiceMonitor` is used to scrape metrics through services and is used for Apache Kafka, ZooKeeper.
 
 . Edit the `PodMonitor` resource in `strimzi-pod-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from pods.
+`PodMonitor` is used to scrape data directly from pods and is used for Operators.
 
 . To use another role:
 

--- a/documentation/modules/proc-metrics-deploying-prometheus.adoc
+++ b/documentation/modules/proc-metrics-deploying-prometheus.adoc
@@ -29,7 +29,9 @@ On MacOS, use:
 [source,shell,subs="+quotes,attributes"]
 sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
 
-. Edit the `ServiceMonitor` resource in `strimzi-service-monitor.yaml` to define Prometheus jobs that will scrape the metrics data.
+. Edit the `ServiceMonitor` resource in `strimzi-service-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from services.
+
+. Edit the `PodMonitor` resource in `strimzi-pod-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from pods.
 
 . To use another role:
 
@@ -44,5 +46,6 @@ kubectl create secret generic additional-scrape-configs --from-file=prometheus-a
 +
 [source,shell,subs="+quotes,attributes"]
 kubectl apply -f strimzi-service-monitor.yaml
+kubectl apply -f strimzi-pod-monitor.yaml
 kubectl apply -f prometheus-rules.yaml
 kubectl apply -f prometheus.yaml

--- a/documentation/modules/ref-metrics-config-files.adoc
+++ b/documentation/modules/ref-metrics-config-files.adoc
@@ -16,7 +16,9 @@ metrics
 ├── grafana-dashboards <2>
 │   ├── strimzi-kafka-connect.json
 │   ├── strimzi-kafka.json
-│   └── strimzi-zookeeper.json
+│   ├── strimzi-zookeeper.json
+│   ├── strimzi-kafka-mirror-maker-2.json
+│   ├── strimzi-operators.json
 │   └── strimzi-kafka-exporter.json <3>
 ├── kafka-connect-metrics.yaml <4>
 ├── kafka-metrics.yaml <5>
@@ -28,11 +30,12 @@ metrics
     ├── alert-manager.yaml <8>
     ├── prometheus-rules.yaml <9>
     ├── prometheus.yaml <10>
-    └── strimzi-service-monitor.yaml <11>
+    ├── strimzi-pod-monitor.yaml <11>
+    └── strimzi-service-monitor.yaml <12>
 --
 <1> Installation file for the Grafana image
-<2> Grafana dashboard configuration
-<3> Grafana dashboard configuration specific to xref:assembly-kafka-exporter-{context}[Kafka Exporter]
+<2> Grafana dashboards
+<3> Grafana dashboard specific to xref:assembly-kafka-exporter-{context}[Kafka Exporter]
 <4> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for Kafka Connect
 <5> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for Kafka and ZooKeeper
 <6> Configuration to add roles for service monitoring
@@ -40,4 +43,5 @@ metrics
 <8> Resources for deploying and configuring Alertmanager
 <9> Alerting rules examples for use with Prometheus Alertmanager (deployed with Prometheus)
 <10> Installation file for the Prometheus image
-<11> Prometheus job definitions to scrape metrics data
+<11> Prometheus job definitions to scrape metrics data from pods
+<12> Prometheus job definitions to scrape metrics data from services

--- a/examples/metrics/grafana-dashboards/strimzi-operators.json
+++ b/examples/metrics/grafana-dashboards/strimzi-operators.json
@@ -1,0 +1,1705 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Custom Resources",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"Kafka\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Kafka CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 11,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaConnect\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connect CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 14,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaConnectS2I\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connect S2I CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 1
+      },
+      "id": 54,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaConnector\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connector CRs",
+      "type": "singlestat",
+      "valueFontSize": "200%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 1
+      },
+      "id": 15,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaUser\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "User CRs",
+      "type": "singlestat",
+      "valueFontSize": "200%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
+      "id": 50,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaTopic\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Topics CRs",
+      "type": "singlestat",
+      "valueFontSize": "200%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 4
+      },
+      "id": 13,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaBridge\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bridge CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 4
+      },
+      "id": 12,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaMirrorMaker\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mirror Maker CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 4
+      },
+      "id": 16,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(strimzi_resources{kind=\"KafkaMirrorMaker2\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mirror Maker 2 CRs",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Reconciliations",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(strimzi_reconciliations_successful_total[1h])) by (kind)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Successful Reconciliation per hour",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
+      "id": 49,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(strimzi_reconciliations_failed_total[1h])) by (kind)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Failed Reconciliation per hour",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "id": 51,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(strimzi_reconciliations_locked_total[1h])) by (kind)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Reconciliation without Lock per hour",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(strimzi_reconciliations_total[1h])) by (kind)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Started Reconciliation per hour",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 46,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(strimzi_reconciliations_periodical_total[1h])) by (kind)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Periodical Reconciliation per hour",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "hideTimeOverride": false,
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(strimzi_reconciliations_duration_seconds_max) by (kind)",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Maximum reconciliation time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "hideTimeOverride": false,
+      "id": 53,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(strimzi_reconciliations_duration_seconds_sum / strimzi_reconciliations_duration_seconds_count) by (kind)",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average reconciliation time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 18,
+      "panels": [],
+      "title": "JVM",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{container=~\"user-operator|topic-operator|strimzi-cluster-operator\"}) by (container)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "JVM Memory Used",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(jvm_gc_pause_seconds_sum{container=~\"user-operator|topic-operator|strimzi-cluster-operator\"}[5m])) by (container)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "JVM GC Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(jvm_gc_pause_seconds_count{container=~\"user-operator|topic-operator|strimzi-cluster-operator\"}[5m])) by (container)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "JVM GC Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Strimzi Operators",
+  "uid": "ISIAR7rWz",
+  "version": 1
+}

--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -58,6 +58,9 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       app: strimzi
+  podMonitorSelector:
+    matchLabels:
+      app: strimzi
   resources:
     requests:
       memory: 400Mi

--- a/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-pod-monitor.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-operator-metrics
+  labels:
+    app: strimzi
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: cluster-operator
+  namespaceSelector:
+    matchNames:
+      - myproject
+  podMetricsEndpoints:
+  - path: /metrics
+    port: http
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: entity-operator-metrics
+  labels:
+    app: strimzi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: entity-operator
+  namespaceSelector:
+    matchNames:
+      - myproject
+  podMetricsEndpoints:
+  - path: /metrics
+    port: healthcheck

--- a/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/050-Deployment-strimzi-cluster-operator.yaml
@@ -28,6 +28,9 @@ spec:
       containers:
         - name: strimzi-cluster-operator
           image: {{ default .Values.image.repository .Values.imageRepositoryOverride }}/{{ .Values.image.name }}:{{ default .Values.image.tag .Values.imageTagOverride }}
+          ports:
+            - containerPort: 8080
+              name: http
           {{- if .Values.image.imagePullPolicy }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           {{- end }}
@@ -78,13 +81,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthy
-              port: 8080
+              port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: 8080
+              port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -20,6 +20,9 @@ spec:
       containers:
       - name: strimzi-cluster-operator
         image: strimzi/operator:latest
+        ports:
+        - containerPort: 8080
+          name: http
         args:
         - /opt/strimzi/bin/cluster_operator_run.sh
         env:
@@ -73,13 +76,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthy
-            port: 8080
+            port: http
           initialDelaySeconds: 10
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /ready
-            port: 8080
+            port: http
           initialDelaySeconds: 10
           periodSeconds: 30
         resources:

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -124,6 +124,19 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-micrometer-metrics</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -59,6 +59,7 @@ public abstract class AbstractOperator<
     private static final Logger log = LogManager.getLogger(AbstractOperator.class);
 
     protected static final int LOCK_TIMEOUT_MS = 10000;
+    public static final String METRICS_PREFIX = "strimzi.";
 
     protected final Vertx vertx;
     protected final S resourceOperator;
@@ -82,31 +83,31 @@ public abstract class AbstractOperator<
         // Setup metrics
         Tags metricTags = Tags.of(Tag.of("kind", kind()));
 
-        periodicReconciliationsCounter = metrics.counter("strimzi.reconciliations.periodical",
+        periodicReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.periodical",
                 "Number of periodical reconciliations done by the operator",
                 metricTags);
 
-        reconciliationsCounter = metrics.counter("strimzi.reconciliations",
+        reconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations",
                 "Number of reconciliations done by the operator for individual resources",
                 metricTags);
 
-        failedReconciliationsCounter = metrics.counter("strimzi.reconciliations.failed",
+        failedReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.failed",
                 "Number of reconciliations done by the operator for individual resources which failed",
                 metricTags);
 
-        successfulReconciliationsCounter = metrics.counter("strimzi.reconciliations.successful",
+        successfulReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.successful",
                 "Number of reconciliations done by the operator for individual resources which were successful",
                 metricTags);
 
-        lockedReconciliationsCounter = metrics.counter("strimzi.reconciliations.locked",
+        lockedReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.locked",
                 "Number of reconciliations skipped because another reconciliation for the same resource was still running",
                 metricTags);
 
-        resourceCounter = metrics.gauge("strimzi.resources",
+        resourceCounter = metrics.gauge(METRICS_PREFIX + "resources",
                 "Number of custom resources the operator sees",
                 metricTags);
 
-        reconciliationsTimer = metrics.timer("strimzi.reconciliations.duration",
+        reconciliationsTimer = metrics.timer(METRICS_PREFIX + "reconciliations.duration",
                 "The time the reconciliation takes to complete",
                 metricTags);
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -8,6 +8,10 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.ResourceVisitor;
@@ -25,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -59,10 +64,51 @@ public abstract class AbstractOperator<
     protected final S resourceOperator;
     private final String kind;
 
-    public AbstractOperator(Vertx vertx, String kind, S resourceOperator) {
+    protected final MetricsProvider metrics;
+    private final Counter periodicReconciliationsCounter;
+    private final Counter reconciliationsCounter;
+    private final Counter failedReconciliationsCounter;
+    private final Counter successfulReconciliationsCounter;
+    private final Counter lockedReconciliationsCounter;
+    private final AtomicInteger resourceCounter;
+    private final Timer reconciliationsTimer;
+
+    public AbstractOperator(Vertx vertx, String kind, S resourceOperator, MetricsProvider metrics) {
         this.vertx = vertx;
         this.kind = kind;
         this.resourceOperator = resourceOperator;
+        this.metrics = metrics;
+
+        // Setup metrics
+        Tags metricTags = Tags.of(Tag.of("kind", kind()));
+
+        periodicReconciliationsCounter = metrics.counter("strimzi.reconciliations.periodical",
+                "Number of periodical reconciliations done by the operator",
+                metricTags);
+
+        reconciliationsCounter = metrics.counter("strimzi.reconciliations",
+                "Number of reconciliations done by the operator for individual resources",
+                metricTags);
+
+        failedReconciliationsCounter = metrics.counter("strimzi.reconciliations.failed",
+                "Number of reconciliations done by the operator for individual resources which failed",
+                metricTags);
+
+        successfulReconciliationsCounter = metrics.counter("strimzi.reconciliations.successful",
+                "Number of reconciliations done by the operator for individual resources which were successful",
+                metricTags);
+
+        lockedReconciliationsCounter = metrics.counter("strimzi.reconciliations.locked",
+                "Number of reconciliations skipped because another reconciliation for the same resource was still running",
+                metricTags);
+
+        resourceCounter = metrics.gauge("strimzi.resources",
+                "Number of custom resources the operator sees",
+                metricTags);
+
+        reconciliationsTimer = metrics.timer("strimzi.reconciliations.duration",
+                "The time the reconciliation takes to complete",
+                metricTags);
     }
 
     @Override
@@ -115,6 +161,10 @@ public abstract class AbstractOperator<
     public final Future<Void> reconcile(Reconciliation reconciliation) {
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
+
+        reconciliationsCounter.increment();
+        Timer.Sample reconciliationTimerSample = Timer.start(metrics.meterRegistry());
+
         Future<Void> handler = withLock(reconciliation, LOCK_TIMEOUT_MS, () -> {
             T cr = resourceOperator.get(namespace, name);
             if (cr != null) {
@@ -139,11 +189,13 @@ public abstract class AbstractOperator<
                 });
             }
         });
+
         Promise<Void> result = Promise.promise();
         handler.setHandler(reconcileResult -> {
-            handleResult(reconciliation, reconcileResult);
+            handleResult(reconciliation, reconcileResult, reconciliationTimerSample);
             result.handle(reconcileResult);
         });
+
         return result.future();
     }
 
@@ -257,17 +309,32 @@ public abstract class AbstractOperator<
     /**
      * Log the reconciliation outcome.
      */
-    private void handleResult(Reconciliation reconciliation, AsyncResult<Void> result) {
+    private void handleResult(Reconciliation reconciliation, AsyncResult<Void> result, Timer.Sample reconciliationTimerSample) {
         if (result.succeeded()) {
+            successfulReconciliationsCounter.increment();
+            reconciliationTimerSample.stop(reconciliationsTimer);
             log.info("{}: reconciled", reconciliation);
         } else {
             Throwable cause = result.cause();
             if (cause instanceof InvalidConfigParameterException) {
+                failedReconciliationsCounter.increment();
+                reconciliationTimerSample.stop(reconciliationsTimer);
                 log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
-            } else if (!(cause instanceof UnableToAcquireLockException)) {
+            } else if (cause instanceof UnableToAcquireLockException) {
+                lockedReconciliationsCounter.increment();
+            } else  {
+                failedReconciliationsCounter.increment();
+                reconciliationTimerSample.stop(reconciliationsTimer);
                 log.warn("{}: Failed to reconcile", reconciliation, cause);
             }
         }
     }
 
+    public Counter getPeriodicReconciliationsCounter() {
+        return periodicReconciliationsCounter;
+    }
+
+    public AtomicInteger getResourceCounter() {
+        return resourceCounter;
+    }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public interface MetricsProvider {
     /**
-     * Returns the Mircometer MeterRegistry with all metrics
+     * Returns the Micrometer MeterRegistry with all metrics
      *
      * @return  MeterRegistry
      */

--- a/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
@@ -12,14 +12,43 @@ import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Interface to be implemented for returning an instance of Kafka Admin interface
+ * Interface for providing metrics or their mocks
  */
 public interface MetricsProvider {
+    /**
+     * Returns the Mircometer MeterRegistry with all metrics
+     *
+     * @return  MeterRegistry
+     */
     MeterRegistry meterRegistry();
 
+    /**
+     * Creates new Counter type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              Counter metric
+     */
     Counter counter(String name, String description, Tags tags);
 
+    /**
+     * Creates new Timer type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              Timer metric
+     */
     Timer timer(String name, String description, Tags tags);
 
+    /**
+     * Creates new Gauge type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              AtomicInteger which represents the Gauge metric
+     */
     AtomicInteger gauge(String name, String description, Tags tags);
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MetricsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Interface to be implemented for returning an instance of Kafka Admin interface
+ */
+public interface MetricsProvider {
+    MeterRegistry meterRegistry();
+
+    Counter counter(String name, String description, Tags tags);
+
+    Timer timer(String name, String description, Tags tags);
+
+    AtomicInteger gauge(String name, String description, Tags tags);
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -13,18 +13,37 @@ import io.vertx.micrometer.backends.BackendRegistries;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Wraps creation of Micrometer metrics.
+ */
 public class MicrometerMetricsProvider implements MetricsProvider {
     private final MeterRegistry metrics;
 
+    /**
+     * Constructor of the Micrometer metrics provider
+     */
     public MicrometerMetricsProvider() {
         this.metrics = BackendRegistries.getDefaultNow();
     }
 
+    /**
+     * Returns the Mircometer MeterRegistry with all metrics
+     *
+     * @return  MeterRegistry
+     */
     @Override
     public MeterRegistry meterRegistry() {
         return metrics;
     }
 
+    /**
+     * Creates new Counter type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              Counter metric
+     */
     @Override
     public Counter counter(String name, String description, Tags tags) {
         return Counter.builder(name)
@@ -33,6 +52,14 @@ public class MicrometerMetricsProvider implements MetricsProvider {
                 .register(metrics);
     }
 
+    /**
+     * Creates new Timer type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              Timer metric
+     */
     @Override
     public Timer timer(String name, String description, Tags tags) {
         return Timer.builder(name)
@@ -41,6 +68,14 @@ public class MicrometerMetricsProvider implements MetricsProvider {
                 .register(metrics);
     }
 
+    /**
+     * Creates new Gauge type metric
+     *
+     * @param name          Name of the metric
+     * @param description   Description of the metric
+     * @param tags          Tags used for the metric
+     * @return              AtomicInteger which represents the Gauge metric
+     */
     @Override
     public AtomicInteger gauge(String name, String description, Tags tags) {
         AtomicInteger gauge = new AtomicInteger(0);

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -27,7 +27,7 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     }
 
     /**
-     * Returns the Mircometer MeterRegistry with all metrics
+     * Returns the Micrometer MeterRegistry with all metrics
      *
      * @return  MeterRegistry
      */

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MicrometerMetricsProvider implements MetricsProvider {
+    private final MeterRegistry metrics;
+
+    public MicrometerMetricsProvider() {
+        this.metrics = BackendRegistries.getDefaultNow();
+    }
+
+    @Override
+    public MeterRegistry meterRegistry() {
+        return metrics;
+    }
+
+    @Override
+    public Counter counter(String name, String description, Tags tags) {
+        return Counter.builder(name)
+                .description(description)
+                .tags(tags)
+                .register(metrics);
+    }
+
+    @Override
+    public Timer timer(String name, String description, Tags tags) {
+        return Timer.builder(name)
+                .description(description)
+                .tags(tags)
+                .register(metrics);
+    }
+
+    @Override
+    public AtomicInteger gauge(String name, String description, Tags tags) {
+        AtomicInteger gauge = new AtomicInteger(0);
+        Gauge.builder(name, () -> gauge)
+                .description(description)
+                .tags(tags)
+                .register(metrics);
+
+        return gauge;
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.common;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.micrometer.core.instrument.Counter;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Abstraction of an operator which is driven by resources of a given {@link #kind()}.
@@ -51,6 +53,7 @@ public interface Operator {
         allResourceNames(namespace).setHandler(ar -> {
             if (ar.succeeded()) {
                 reconcileThese(trigger, ar.result(), handler);
+                getPeriodicReconciliationsCounter().increment();
             } else {
                 handler.handle(ar.map((Void) null));
             }
@@ -60,16 +63,18 @@ public interface Operator {
     default void reconcileThese(String trigger, Set<NamespaceAndName> desiredNames, Handler<AsyncResult<Void>> handler) {
         if (desiredNames.size() > 0) {
             List<Future> futures = new ArrayList<>();
+            getResourceCounter().set(desiredNames.size());
+
             for (NamespaceAndName resourceRef : desiredNames) {
                 Reconciliation reconciliation = new Reconciliation(trigger, kind(), resourceRef.getNamespace(), resourceRef.getName());
                 futures.add(reconcile(reconciliation));
             }
             CompositeFuture.join(futures).map((Void) null).setHandler(handler);
         } else {
+            getResourceCounter().set(0);
             handler.handle(Future.succeededFuture());
         }
     }
-
 
     /**
      * Returns a future which completes with the names of all the resources to be reconciled by
@@ -87,4 +92,8 @@ public interface Operator {
     default Optional<LabelSelector> selector() {
         return Optional.empty();
     }
+
+    Counter getPeriodicReconciliationsCounter();
+
+    AtomicInteger getResourceCounter();
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.strimzi.operator.common.model.NamespaceAndName;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ExtendWith(VertxExtension.class)
+public class OperatorMetricsTest {
+    private static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+                new MicrometerMetricsOptions()
+                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setEnabled(true)
+        ));
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testSuccessfulReconcile(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableResourceOperator resourceOperator = resourceOperatorWithExistingResource();
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+            @Override
+            protected Future<Void> createOrUpdate(Reconciliation reconciliation, HasMetadata resource) {
+                return Future.succeededFuture();
+            }
+
+            protected void validate(HasMetadata resource) {
+                // Do nothing
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                return null;
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
+                .setHandler(context.succeeding(v -> context.verify(() -> {
+                    MeterRegistry registry = metrics.meterRegistry();
+
+                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testFailingReconcile(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableResourceOperator resourceOperator = resourceOperatorWithExistingResource();
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+            @Override
+            protected Future<Void> createOrUpdate(Reconciliation reconciliation, HasMetadata resource) {
+                return Future.failedFuture(new RuntimeException("Test error"));
+            }
+
+            protected void validate(HasMetadata resource) {
+                // Do nothing
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                return null;
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
+                .setHandler(context.failing(v -> context.verify(() -> {
+                    MeterRegistry registry = metrics.meterRegistry();
+
+                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testFailingWithLockReconcile(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableResourceOperator resourceOperator = resourceOperatorWithExistingResource();
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+            @Override
+            protected Future<Void> createOrUpdate(Reconciliation reconciliation, HasMetadata resource) {
+                return Future.failedFuture(new UnableToAcquireLockException());
+            }
+
+            protected void validate(HasMetadata resource) {
+                // Do nothing
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                return null;
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
+                .setHandler(context.failing(v -> context.verify(() -> {
+                    MeterRegistry registry = metrics.meterRegistry();
+
+                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(1.0));
+
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(0L));
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testDeleteCountsReconcile(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableResourceOperator resourceOperator = new AbstractWatchableResourceOperator(vertx, null, "TestResource") {
+            @Override
+            protected MixedOperation operation() {
+                return null;
+            }
+
+            @Override
+            public HasMetadata get(String namespace, String name) {
+                return null;
+            }
+        };
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+            @Override
+            protected Future<Void> createOrUpdate(Reconciliation reconciliation, HasMetadata resource) {
+                return null;
+            }
+
+            protected void validate(HasMetadata resource) {
+                // Do nothing
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                return Future.succeededFuture(Boolean.TRUE);
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
+                .setHandler(context.succeeding(v -> context.verify(() -> {
+                    MeterRegistry registry = metrics.meterRegistry();
+
+                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testReconcileAll(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableResourceOperator resourceOperator = resourceOperatorWithExistingResource();
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics) {
+            @Override
+            protected Future<Void> createOrUpdate(Reconciliation reconciliation, HasMetadata resource) {
+                return Future.succeededFuture();
+            }
+
+            public Future<Set<NamespaceAndName>> allResourceNames(String namespace) {
+                Set<NamespaceAndName> resources = new HashSet<>(3);
+                resources.add(new NamespaceAndName("my-namespace", "avfc"));
+                resources.add(new NamespaceAndName("my-namespace", "vtid"));
+                resources.add(new NamespaceAndName("my-namespace", "utv"));
+
+                return Future.succeededFuture(resources);
+            }
+
+            protected void validate(HasMetadata resource) {
+                // Do nothing
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                return null;
+            }
+        };
+
+        Promise<Void> reconcileAllPromise = Promise.promise();
+        operator.reconcileAll("test", "my-namespace", reconcileAllPromise);
+
+        Checkpoint async = context.checkpoint();
+        reconcileAllPromise.future().setHandler(context.succeeding(v -> context.verify(() -> {
+            MeterRegistry registry = metrics.meterRegistry();
+
+            assertThat(registry.get("strimzi.reconciliations.periodical").tag("kind", "TestResource").counter().count(), is(1.0));
+            assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(3.0));
+            assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(3.0));
+            assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+            assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+
+            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(3L));
+            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+            async.flag();
+        })));
+    }
+
+    /**
+     * Created new MetricsProvider and makes sure it doesn't contain any metrics from previous tests.
+     *
+     * @return  Clean MetricsProvider
+     */
+    public MetricsProvider createCleanMetricsProvider() {
+        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MeterRegistry registry = metrics.meterRegistry();
+
+        registry.forEachMeter(meter -> {
+            registry.remove(meter);
+        });
+
+        return metrics;
+    }
+
+    private AbstractWatchableResourceOperator resourceOperatorWithExistingResource()    {
+        return new AbstractWatchableResourceOperator(vertx, null, "TestResource") {
+            @Override
+            protected MixedOperation operation() {
+                return null;
+            }
+
+            @Override
+            public HasMetadata get(String namespace, String name) {
+                return new HasMetadata() {
+                    @Override
+                    public ObjectMeta getMetadata() {
+                        return null;
+                    }
+
+                    @Override
+                    public void setMetadata(ObjectMeta objectMeta) {
+
+                    }
+
+                    @Override
+                    public String getKind() {
+                        return "TestResource";
+                    }
+
+                    @Override
+                    public String getApiVersion() {
+                        return "v1";
+                    }
+
+                    @Override
+                    public void setApiVersion(String s) {
+
+                    }
+                };
+            }
+        };
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -77,13 +77,13 @@ public class OperatorMetricsTest {
                 .setHandler(context.succeeding(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
                     async.flag();
                 })));
@@ -116,13 +116,13 @@ public class OperatorMetricsTest {
                 .setHandler(context.failing(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
                     async.flag();
                 })));
@@ -155,13 +155,13 @@ public class OperatorMetricsTest {
                 .setHandler(context.failing(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(1.0));
 
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(0L));
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(0L));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
 
                     async.flag();
                 })));
@@ -204,13 +204,13 @@ public class OperatorMetricsTest {
                 .setHandler(context.succeeding(v -> context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
-                    assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
                     async.flag();
                 })));
@@ -254,14 +254,14 @@ public class OperatorMetricsTest {
         reconcileAllPromise.future().setHandler(context.succeeding(v -> context.verify(() -> {
             MeterRegistry registry = metrics.meterRegistry();
 
-            assertThat(registry.get("strimzi.reconciliations.periodical").tag("kind", "TestResource").counter().count(), is(1.0));
-            assertThat(registry.get("strimzi.reconciliations").tag("kind", "TestResource").counter().count(), is(3.0));
-            assertThat(registry.get("strimzi.reconciliations.successful").tag("kind", "TestResource").counter().count(), is(3.0));
-            assertThat(registry.get("strimzi.reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-            assertThat(registry.get("strimzi.reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.periodical").tag("kind", "TestResource").counter().count(), is(1.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(3.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(3.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().count(), is(3L));
-            assertThat(registry.get("strimzi.reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(3L));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
             async.flag();
         })));

--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,16 @@
                 <version>${strimzi-oauth.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-prometheus</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${jupiter.version}</version>
@@ -604,6 +614,11 @@
                 <artifactId>vertx-junit5</artifactId>
                 <version>${vertx-juni5.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-micrometer-metrics</artifactId>
+                <version>${vertx.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -868,6 +883,7 @@
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:connect-file</ignoredUnusedDeclaredDependency>
                                 <ignoredDependency>org.junit.jupiter</ignoredDependency>
                                 <ignoredDependency>org.junit.platform</ignoredDependency>
+                                <ignoredUnusedDeclaredDependency>io.micrometer:micrometer-registry-prometheus</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -134,17 +134,14 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-micrometer-metrics</artifactId>
-            <version>${vertx.version}</version>
         </dependency>
     </dependencies>
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.status.KafkaUserStatus;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.common.AbstractOperator;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -82,7 +83,7 @@ public class KafkaUserOperator extends AbstractOperator<KafkaUser,
                              ScramShaCredentialsOperator scramShaCredentialOperator,
                              KafkaUserQuotasOperator kafkaUserQuotasOperator,
                              SimpleAclOperator aclOperations, String caCertName, String caKeyName, String caNamespace) {
-        super(vertx, "User", crdOperator);
+        super(vertx, "KafkaUser", crdOperator, new MicrometerMetricsProvider());
         this.certManager = certManager;
         Map<String, String> matchLabels = labels.toMap();
         this.selector = matchLabels.isEmpty() ? Optional.empty() : Optional.of(new LabelSelector(null, matchLabels));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorTest.java
@@ -19,9 +19,12 @@ import io.strimzi.operator.user.model.acl.SimpleAclRule;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,7 +59,11 @@ public class KafkaUserOperatorTest {
 
     @BeforeAll
     public static void before() {
-        vertx = Vertx.vertx();
+        vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+                new MicrometerMetricsOptions()
+                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setEnabled(true)
+        ));
     }
 
     @AfterAll


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Our operators currently provides only the basic metrics for JVM, Vert.x etc. Thsi PR adds some additional metrics from the operator world to Cluster and User Operators:
* Number of custom resources seen by the operator
* Number of periodical reconciliations
* Number of started individual reconciliations
* Number of failed reocnciliations
* Number of successful reconciliations
* Number of reconciliations which failed because of lock
* Average and max reconciliation times

It also adds new dashabord for operators (see attachement).

Metrics for Topic Oeprator will be added in separate PR. This PR does only some initial preparation to collect them from the Topic Operator container and to show the information in the dashabord.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md

-----

![Screenshot 2020-03-31 at 21 28 04](https://user-images.githubusercontent.com/5658439/78067398-f7543100-7396-11ea-8c7e-fb54aec43a19.png)
![Screenshot 2020-03-31 at 21 28 22](https://user-images.githubusercontent.com/5658439/78067412-fae7b800-7396-11ea-8f95-c27cbbf40a9f.png)
