### PR TITLE
ST: Parse protocol version from kafka-versions.yaml

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -125,7 +125,7 @@ public class KafkaResource {
                 .editKafka()
                     .withVersion(Environment.ST_KAFKA_VERSION)
                     .withReplicas(kafkaReplicas)
-                    .addToConfig("log.message.format.version", TestKafkaVersion.getInstance().getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
+                    .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -27,12 +27,14 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public class KafkaResource {
@@ -124,7 +126,7 @@ public class KafkaResource {
                 .editKafka()
                     .withVersion(Environment.ST_KAFKA_VERSION)
                     .withReplicas(kafkaReplicas)
-                    .addToConfig("log.message.format.version", Environment.ST_KAFKA_VERSION.substring(0, 3))
+                    .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -34,7 +34,6 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.function.Consumer;
 
 public class KafkaResource {
@@ -126,7 +125,7 @@ public class KafkaResource {
                 .editKafka()
                     .withVersion(Environment.ST_KAFKA_VERSION)
                     .withReplicas(kafkaReplicas)
-                    .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
+                    .addToConfig("log.message.format.version", TestKafkaVersion.getInstance().getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -21,22 +21,15 @@ import java.util.stream.Collectors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
-    private static TestKafkaVersion instance;
     private static List<TestKafkaVersion> kafkaVersions;
 
-    public static synchronized TestKafkaVersion getInstance() {
-        if (instance == null) {
-            instance = new TestKafkaVersion();
-            try {
-                kafkaVersions = parseKafkaVersions();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+    static {
+        try {
+            kafkaVersions = parseKafkaVersions();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-        return instance;
     }
-
-    private TestKafkaVersion() {}
 
     @JsonProperty("version")
     String version;
@@ -128,10 +121,6 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return version.equals(that.version);
     }
 
-    public List<TestKafkaVersion> getKafkaVersions() {
-        return kafkaVersions;
-    }
-
     /**
      * Parse the version information present in the {@code /kafka-versions} classpath resource and return a sorted list
      * from earliest to latest kafka version.
@@ -154,13 +143,17 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return testKafkaVersions;
     }
 
+    public static List<TestKafkaVersion> getKafkaVersions() {
+        return kafkaVersions;
+    }
+
     /**
      * Parse the version information present in the {@code /kafka-versions} classpath resource and return a map
      * of kafka versions data with a version as key
      *
      * @return A map of the kafka versions listed in the kafka-versions.yaml file where key is specific version
      */
-    public Map<String, TestKafkaVersion> getKafkaVersionsInMap() {
+    public static Map<String, TestKafkaVersion> getKafkaVersionsInMap() {
         return kafkaVersions.stream().collect(Collectors.toMap(TestKafkaVersion::version, i -> i));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -27,17 +27,16 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
     public static synchronized TestKafkaVersion getInstance() {
         if (instance == null) {
             instance = new TestKafkaVersion();
+            try {
+                kafkaVersions = parseKafkaVersions();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
         return instance;
     }
 
-    private TestKafkaVersion() {
-        try {
-            kafkaVersions = parseKafkaVersions();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+    private TestKafkaVersion() {}
 
     @JsonProperty("version")
     String version;
@@ -129,7 +128,7 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return version.equals(that.version);
     }
 
-    public static List<TestKafkaVersion> getKafkaVersions() {
+    public List<TestKafkaVersion> getKafkaVersions() {
         return kafkaVersions;
     }
 
@@ -161,7 +160,7 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
      *
      * @return A map of the kafka versions listed in the kafka-versions.yaml file where key is specific version
      */
-    public static Map<String, TestKafkaVersion> getKafkaVersionsInMap() {
+    public Map<String, TestKafkaVersion> getKafkaVersionsInMap() {
         return kafkaVersions.stream().collect(Collectors.toMap(TestKafkaVersion::version, i -> i));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -15,9 +15,29 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
+
+    private static TestKafkaVersion instance;
+    private static List<TestKafkaVersion> kafkaVersions;
+
+    public static synchronized TestKafkaVersion getInstance() {
+        if (instance == null) {
+            instance = new TestKafkaVersion();
+        }
+        return instance;
+    }
+
+    private TestKafkaVersion() {
+        try {
+            kafkaVersions = parseKafkaVersions();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     @JsonProperty("version")
     String version;
@@ -109,13 +129,17 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return version.equals(that.version);
     }
 
+    public static List<TestKafkaVersion> getKafkaVersions() {
+        return kafkaVersions;
+    }
+
     /**
      * Parse the version information present in the {@code /kafka-versions} classpath resource and return a sorted list
      * from earliest to latest kafka version.
      *
      * @return A list of the kafka versions listed in the kafka-versions.yaml file
      */
-    public static List<TestKafkaVersion> parseKafkaVersions() throws IOException {
+    private static List<TestKafkaVersion> parseKafkaVersions() throws IOException {
 
         YAMLMapper mapper = new YAMLMapper();
 
@@ -129,5 +153,15 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         Collections.sort(testKafkaVersions);
 
         return testKafkaVersions;
+    }
+
+    /**
+     * Parse the version information present in the {@code /kafka-versions} classpath resource and return a map
+     * of kafka versions data with a version as key
+     *
+     * @return A map of the kafka versions listed in the kafka-versions.yaml file where key is specific version
+     */
+    public static Map<String, TestKafkaVersion> getKafkaVersionsInMap() {
+        return kafkaVersions.stream().collect(Collectors.toMap(TestKafkaVersion::version, i -> i));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -38,7 +38,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterUpgrade(TestInfo testinfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.parseKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 2);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 1);
@@ -48,7 +48,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterDowngrade(TestInfo testInfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.parseKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 1);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 2);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -38,7 +38,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterUpgrade(TestInfo testinfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getInstance().getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 2);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 1);
@@ -48,7 +48,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterDowngrade(TestInfo testInfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getInstance().getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 1);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 2);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/ZookeeperUpgradeST.java
@@ -38,7 +38,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterUpgrade(TestInfo testinfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getInstance().getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 2);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 1);
@@ -48,7 +48,7 @@ public class ZookeeperUpgradeST extends BaseST {
 
     @Test
     void testKafkaClusterDowngrade(TestInfo testInfo) throws IOException, InterruptedException {
-        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getKafkaVersions();
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getInstance().getKafkaVersions();
 
         TestKafkaVersion initialVersion = sortedVersions.get(sortedVersions.size() - 1);
         TestKafkaVersion newVersion = sortedVersions.get(sortedVersions.size() - 2);

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
@@ -5,15 +5,16 @@
 package io.strimzi.systemtest.utils;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaVersionUtilsTest {
 
     @Test
     public void parsingTest() throws Exception {
-        List<TestKafkaVersion> versions = TestKafkaVersion.parseKafkaVersions();
+        List<TestKafkaVersion> versions = TestKafkaVersion.getInstance().getKafkaVersions();
         assertTrue(versions.size() > 0);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/utils/KafkaVersionUtilsTest.java
@@ -14,7 +14,7 @@ public class KafkaVersionUtilsTest {
 
     @Test
     public void parsingTest() throws Exception {
-        List<TestKafkaVersion> versions = TestKafkaVersion.getInstance().getKafkaVersions();
+        List<TestKafkaVersion> versions = TestKafkaVersion.getKafkaVersions();
         assertTrue(versions.size() > 0);
     }
 }


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR parse properly value for `log.message.format` from `kafka-versions.yaml` instead only from `ST_KAFKA_VERSION`.

### Checklist

- [x] Make sure all tests pass

