### PR TITLE
Revert back to use PEM for the CA truststore for admin client

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -22,8 +22,8 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
 
     @Override
     public Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
-        PasswordGenerator pg = new PasswordGenerator(12);
         Admin ac;
+        PasswordGenerator pg = new PasswordGenerator(12);
         String trustStorePassword = pg.generate();
         File truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
         try {

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -22,10 +22,10 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
 
     @Override
     public Admin createAdminClient(String hostname, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
-
+        PasswordGenerator pg = new PasswordGenerator(12);
         Admin ac;
-        String trustStorePassword = new String(Util.decodeFromSecret(clusterCaCertSecret, Ca.CA_STORE_PASSWORD), StandardCharsets.US_ASCII);
-        File truststoreFile = Util.createFileStore(getClass().getName(), "ts", Util.decodeFromSecret(clusterCaCertSecret, Ca.CA_STORE));
+        String trustStorePassword = pg.generate();
+        File truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
         try {
             String keyStorePassword = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".password"), StandardCharsets.US_ASCII);
             File keystoreFile = Util.createFileStore(getClass().getName(), "ts", Util.decodeFromSecret(keyCertSecret, keyCertName + ".p12"));

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -200,23 +200,26 @@ public class Util {
             trustStore = KeyStore.getInstance("PKCS12");
             trustStore.load(null, password);
             trustStore.setEntry(certificate.getSubjectDN().getName(), new KeyStore.TrustedCertificateEntry(certificate), null);
-
-            File f = null;
-            try {
-                f = File.createTempFile(prefix, suffix);
-                f.deleteOnExit();
-                try (OutputStream os = new BufferedOutputStream(new FileOutputStream(f))) {
-                    trustStore.store(os, password);
-                }
-                return f;
-            } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException | RuntimeException e) {
-                if (f != null && !f.delete()) {
-                    LOGGER.warn("Failed to delete temporary file in exception handler");
-                }
-                throw e;
-            }
+            return store(prefix, suffix, trustStore, password);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static File store(String prefix, String suffix, KeyStore trustStore, char[] password) throws Exception {
+        File f = null;
+        try {
+            f = File.createTempFile(prefix, suffix);
+            f.deleteOnExit();
+            try (OutputStream os = new BufferedOutputStream(new FileOutputStream(f))) {
+                trustStore.store(os, password);
+            }
+            return f;
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException | RuntimeException e) {
+            if (f != null && !f.delete()) {
+                LOGGER.warn("Failed to delete temporary file in exception handler");
+            }
+            throw e;
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

The current use of the P12 for the cluster CA during the AdminClient creation is a breaking change because users could use a custom CA cert into a Secret not containing such a P12 (+ password) keystore.
This PR addresses this reverting back the usage of the PEM file from the Secret and then creating the needed P12 truststore "on fly".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

