### PR TITLE
Metrics svc with tcp prefix

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -124,7 +124,7 @@ public abstract class AbstractModel {
     protected String name;
 
     protected static final int METRICS_PORT = 9404;
-    protected static final String METRICS_PORT_NAME = "prometheus";
+    protected static final String METRICS_PORT_NAME = "tcp-prometheus";
     protected boolean isMetricsEnabled;
 
     protected static final int JMX_PORT = 9999;

--- a/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
+++ b/examples/metrics/prometheus-install/strimzi-service-monitor.yaml
@@ -16,7 +16,7 @@ spec:
   # configured in additional secret
 
   #### job_name: kube-state-metrics
-  - port: prometheus
+  - port: tcp-prometheus
     honorLabels: true
     interval: 10s
     scrapeTimeout: 10s
@@ -64,7 +64,7 @@ spec:
       action: replace
 
   #### job_name: node-exporter
-  - port: prometheus
+  - port: tcp-prometheus
     honorLabels: true
     interval: 10s
     scrapeTimeout: 10s


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
In https://github.com/strimzi/strimzi-kafka-operator/pull/2238 `tcp-` prefix for the services ports was introduced. This PR adds the same for the metrics port 9404.

### Checklist
- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

