### PR TITLE
[systemtest] Fix failing tests and add new functions for status check

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -48,7 +48,7 @@ public class KafkaUtils {
                             .get().getStatus().getConditions().stream().filter(condition -> !condition.getType().equals("Warning"))
                             .collect(Collectors.toList());
 
-            for(Condition condition : conditions) {
+            for (Condition condition : conditions) {
                 if (!condition.getType().matches(state))
                     return false;
             }

--- a/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/SecurityST.java
@@ -32,6 +32,7 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -1241,6 +1242,8 @@ class SecurityST extends BaseST {
                     .withValidityDays(3)
                 .endClusterCa()
             .endSpec().done();
+
+        KafkaUtils.waitUntilKafkaStatus(CLUSTER_NAME, "Ready");
 
         String userName = "alice";
         KafkaUser user = KafkaUserResource.tlsUser(CLUSTER_NAME, userName).done();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR gonna fix some of our failing tests and add functions for getting right state from Kafka/KafkaUser status:

```
[systemtest] KafkaUserUtils - add waitForKafkaUserStatus
[systemtest] KafkaUtils - change waitUntilKafkaStatus
io.strimzi.systemtest.KafkaST.testCustomAndUpdatedValues - fix wrong checking kafka conditions
io.strimzi.systemtest.CustomResourceStatusST.testKafkaStatus - same here
io.strimzi.systemtest.CustomResourceStatusST.testKafkaUserStatusNotReady - fix wrong checking of KafkaUser conditions
```

### Checklist

- [x] Make sure all tests pass


