### PR TITLE
[ADD] tcp- for zookeeper port names

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -57,11 +57,11 @@ import static java.util.Arrays.asList;
 
 public class ZookeeperCluster extends AbstractModel {
     public static final int CLIENT_PORT = 2181;
-    protected static final String CLIENT_PORT_NAME = "clients";
+    protected static final String CLIENT_PORT_NAME = "tcp-clients";
     public static final int CLUSTERING_PORT = 2888;
-    protected static final String CLUSTERING_PORT_NAME = "clustering";
+    protected static final String CLUSTERING_PORT_NAME = "tcp-clustering";
     public static final int LEADER_ELECTION_PORT = 3888;
-    protected static final String LEADER_ELECTION_PORT_NAME = "leader-election";
+    protected static final String LEADER_ELECTION_PORT_NAME = "tcp-leader-election";
 
     public static final String ZOOKEEPER_NAME = "zookeeper";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -61,7 +61,7 @@ public class ZookeeperCluster extends AbstractModel {
     public static final int CLUSTERING_PORT = 2888;
     protected static final String CLUSTERING_PORT_NAME = "tcp-clustering";
     public static final int LEADER_ELECTION_PORT = 3888;
-    protected static final String LEADER_ELECTION_PORT_NAME = "tcp-leader-election";
+    protected static final String LEADER_ELECTION_PORT_NAME = "tcp-election";
 
     public static final String ZOOKEEPER_NAME = "zookeeper";
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #2238 and #2747 tcp- prefix for the services ports was introduced. This PR adds the same for the zookeeper part.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

